### PR TITLE
Add conditional iOS target framework for non-macOS builds

### DIFF
--- a/Shared/AgValoniaGPS.Services/AgValoniaGPS.Services.csproj
+++ b/Shared/AgValoniaGPS.Services/AgValoniaGPS.Services.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">net10.0;net10.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('OSX'))">net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>14</LangVersion>

--- a/Shared/AgValoniaGPS.ViewModels/AgValoniaGPS.ViewModels.csproj
+++ b/Shared/AgValoniaGPS.ViewModels/AgValoniaGPS.ViewModels.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">net10.0;net10.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('OSX'))">net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>14</LangVersion>

--- a/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
+++ b/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">net10.0;net10.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('OSX'))">net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>14</LangVersion>


### PR DESCRIPTION
Modified shared library projects to conditionally target iOS only on macOS. On Linux and Windows, these projects now build only for net10.0, avoiding iOS SDK requirements and enabling successful builds on non-Apple platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

I don't know if you're taking PRs or not... I also don't know how this will change  how it works on windows, but I know it's necessary to build on Linux.