### PR TITLE
Add App Directories dialog and Reset All Settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,23 +193,11 @@ These features require more understanding of the codebase.
 - **Task**: Create dialog to view and configure keyboard shortcuts
 - **Skills needed**: XAML, key binding system, settings persistence
 
-#### App Directories
-- **Button location**: File Menu Panel
-- **File**: `Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml` (Line 74)
-- **Task**: Show dialog displaying data directory locations with option to open in file manager
-- **Skills needed**: XAML, platform file system APIs
-
 #### View All Settings
 - **Button location**: File Menu Panel
 - **File**: `Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml` (Line 73)
 - **Task**: Create comprehensive settings viewer/editor
 - **Skills needed**: XAML, reflection or settings enumeration
-
-#### Reset All Settings
-- **Button location**: File Menu Panel
-- **File**: `Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml` (Line 68)
-- **Task**: Implement settings reset with confirmation dialog
-- **Skills needed**: Settings persistence, confirmation dialogs
 
 ---
 

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -61,6 +61,7 @@ public class UIState : ReactiveObject
                 this.RaisePropertyChanged(nameof(IsNtripProfileEditorDialogVisible));
                 this.RaisePropertyChanged(nameof(IsConfirmationDialogVisible));
                 this.RaisePropertyChanged(nameof(IsErrorDialogVisible));
+                this.RaisePropertyChanged(nameof(IsAppDirectoriesDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -92,6 +93,7 @@ public class UIState : ReactiveObject
     public bool IsNtripProfileEditorDialogVisible => ActiveDialog == DialogType.NtripProfileEditor;
     public bool IsConfirmationDialogVisible => ActiveDialog == DialogType.Confirmation;
     public bool IsErrorDialogVisible => ActiveDialog == DialogType.Error;
+    public bool IsAppDirectoriesDialogVisible => ActiveDialog == DialogType.AppDirectories;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -202,7 +204,8 @@ public enum DialogType
     NtripProfiles,
     NtripProfileEditor,
     Confirmation,
-    Error
+    Error,
+    AppDirectories
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -1,0 +1,80 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.ObjectModel;
+using System.IO;
+using AgValoniaGPS.Models.Configuration;
+using ReactiveUI;
+
+namespace AgValoniaGPS.ViewModels;
+
+public partial class MainViewModel
+{
+    private void InitializeSettingsCommands()
+    {
+        ShowAppDirectoriesDialogCommand = ReactiveCommand.Create(() =>
+        {
+            RefreshAppDirectories();
+            State.UI.ShowDialog(Models.State.DialogType.AppDirectories);
+        });
+
+        CloseAppDirectoriesDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.CloseDialog();
+        });
+
+        ResetAllSettingsCommand = ReactiveCommand.Create(() =>
+        {
+            ShowConfirmationDialog(
+                "Reset All Settings",
+                "Are you sure you want to reset all settings to their defaults? This cannot be undone.",
+                () =>
+                {
+                    _settingsService.ResetToDefaults();
+                    ConfigurationStore.SetInstance(new ConfigurationStore());
+                    _settingsService.Save();
+                    StatusMessage = "All settings reset to defaults. Restart recommended.";
+                });
+        });
+    }
+
+    private void RefreshAppDirectories()
+    {
+        var dirs = new ObservableCollection<AppDirectoryInfo>();
+
+        var settingsPath = _settingsService.GetSettingsFilePath();
+        dirs.Add(new AppDirectoryInfo("Settings", Path.GetDirectoryName(settingsPath) ?? ""));
+        dirs.Add(new AppDirectoryInfo("Fields", _settingsService.Settings.FieldsDirectory));
+        dirs.Add(new AppDirectoryInfo("Vehicle Profiles", _vehicleProfileService.VehiclesDirectory));
+        dirs.Add(new AppDirectoryInfo("NTRIP Profiles", _ntripProfileService.ProfilesDirectory));
+
+        AppDirectories = dirs;
+    }
+}
+
+public class AppDirectoryInfo
+{
+    public string Name { get; }
+    public string Path { get; }
+    public bool Exists { get; }
+
+    public AppDirectoryInfo(string name, string path)
+    {
+        Name = name;
+        Path = path;
+        Exists = Directory.Exists(path);
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -243,6 +243,7 @@ public partial class MainViewModel : ReactiveObject
         InitializeTrackCommands();
         InitializeNtripCommands();
         InitializeWizardCommands();
+        InitializeSettingsCommands();
 
         // Load display settings first, then restore our app settings on top
         // This ensures AppSettings takes precedence over DisplaySettings
@@ -1394,6 +1395,18 @@ public partial class MainViewModel : ReactiveObject
     public ICommand? SaveNtripProfileCommand { get; private set; }
     public ICommand? CancelNtripProfileEditCommand { get; private set; }
     public ICommand? TestNtripConnectionCommand { get; private set; }
+
+    // Settings Commands
+    public ICommand? ShowAppDirectoriesDialogCommand { get; private set; }
+    public ICommand? CloseAppDirectoriesDialogCommand { get; private set; }
+    public ICommand? ResetAllSettingsCommand { get; private set; }
+
+    private ObservableCollection<AppDirectoryInfo> _appDirectories = new();
+    public ObservableCollection<AppDirectoryInfo> AppDirectories
+    {
+        get => _appDirectories;
+        set => this.RaiseAndSetIfChanged(ref _appDirectories, value);
+    }
 
     private string _ntripTestStatus = string.Empty;
     public string NtripTestStatus

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -53,6 +53,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:DrawABDialogPanel/>
         <dialogs:NtripProfilesDialogPanel/>
         <dialogs:NtripProfileEditorPanel/>
+        <dialogs:AppDirectoriesDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml
@@ -1,0 +1,69 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.AppDirectoriesDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsAppDirectoriesDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsAppDirectoriesDialogVisible}">
+
+    <!-- Full screen overlay with backdrop -->
+    <Grid>
+        <!-- Semi-transparent backdrop -->
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <!-- Centered dialog -->
+        <Border Background="#2C3E50" CornerRadius="12" Padding="20"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                MinWidth="420" MaxWidth="600">
+            <StackPanel Spacing="16">
+                <!-- Title -->
+                <TextBlock Text="App Directories" FontSize="20" FontWeight="Bold"
+                           Foreground="#3498DB" HorizontalAlignment="Center"/>
+
+                <!-- Directory list -->
+                <ItemsControl ItemsSource="{Binding AppDirectories}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:AppDirectoryInfo">
+                            <Border Background="#34495E" CornerRadius="6" Padding="12,8" Margin="0,4">
+                                <StackPanel Spacing="2">
+                                    <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="SemiBold"
+                                               Foreground="#3498DB"/>
+                                    <TextBlock Text="{Binding Path}" FontSize="12"
+                                               Foreground="#BDC3C7" TextWrapping="Wrap"
+                                               TextTrimming="CharacterEllipsis" MaxLines="2"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- Close button -->
+                <Button Content="Close" Margin="0,8,0,0"
+                        Command="{Binding CloseAppDirectoriesDialogCommand}"
+                        Background="#3498DB" Foreground="White"
+                        HorizontalAlignment="Stretch" Height="44" FontSize="16" FontWeight="Bold"
+                        HorizontalContentAlignment="Center" CornerRadius="6"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml.cs
@@ -1,0 +1,36 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class AppDirectoriesDialogPanel : UserControl
+{
+    public AppDirectoriesDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CloseAppDirectoriesDialogCommand?.Execute(null);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -65,13 +65,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- General Settings -->
             <Button Classes="ModernButton" Content="Language" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
-            <Button Classes="ModernButton" Content="Reset All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
+            <Button Classes="ModernButton" Content="Reset All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding ResetAllSettingsCommand}"/>
 
             <Separator Height="1" Background="#444" Margin="0,4"/>
 
             <!-- App Configuration -->
             <Button Classes="ModernButton" Content="View All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
-            <Button Classes="ModernButton" Content="App Directories" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
+            <Button Classes="ModernButton" Content="App Directories" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding ShowAppDirectoriesDialogCommand}"/>
             <Button Classes="ModernButton" Content="App Colors" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
             <Button Classes="ModernButton" Content="Hotkeys" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
 


### PR DESCRIPTION
## Summary
- **App Directories**: info dialog showing paths for settings, fields, vehicle profiles, and NTRIP profiles
- **Reset All Settings**: confirmation dialog that resets all configuration to defaults (ConfigurationStore + AppSettings)
- Both buttons in File Menu Panel are now wired

## Test plan
- [x] Desktop build compiles (0 errors)
- [ ] File Menu -> App Directories shows correct paths
- [ ] File Menu -> Reset All Settings shows confirmation, resets on Yes
- [ ] Backdrop click dismisses App Directories dialog