### PR TITLE
Add headless UI tests (Avalonia.Headless.NUnit)

### DIFF
--- a/AgValoniaGPS.sln
+++ b/AgValoniaGPS.sln
@@ -21,6 +21,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platforms", "Platforms", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgValoniaGPS.Android", "Platforms\AgValoniaGPS.Android\AgValoniaGPS.Android.csproj", "{567ED141-DCBE-4632-95FB-3D3C5ADBF84C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgValoniaGPS.UI.Tests", "Tests\AgValoniaGPS.UI.Tests\AgValoniaGPS.UI.Tests.csproj", "{84DCD742-8E48-4579-90C1-4FF9D1820FDA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +119,18 @@ Global
 		{567ED141-DCBE-4632-95FB-3D3C5ADBF84C}.Release|x64.Build.0 = Release|Any CPU
 		{567ED141-DCBE-4632-95FB-3D3C5ADBF84C}.Release|x86.ActiveCfg = Release|Any CPU
 		{567ED141-DCBE-4632-95FB-3D3C5ADBF84C}.Release|x86.Build.0 = Release|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Debug|x64.Build.0 = Debug|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Debug|x86.Build.0 = Debug|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Release|x64.ActiveCfg = Release|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Release|x64.Build.0 = Release|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Release|x86.ActiveCfg = Release|Any CPU
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -122,5 +138,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{6F3AAAFC-B9DA-4A0D-B7EF-117A8D79FE48} = {4F52FD11-658E-A102-6CD3-7D7C16FFA15B}
 		{567ED141-DCBE-4632-95FB-3D3C5ADBF84C} = {324791A1-5798-203D-0CA6-A8E0DAEC81C8}
+		{84DCD742-8E48-4579-90C1-4FF9D1820FDA} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/Tests/AgValoniaGPS.UI.Tests/AgValoniaGPS.UI.Tests.csproj
+++ b/Tests/AgValoniaGPS.UI.Tests/AgValoniaGPS.UI.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless.NUnit" Version="11.3.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.9" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\AgValoniaGPS.Models\AgValoniaGPS.Models.csproj" />
+    <ProjectReference Include="..\..\Shared\AgValoniaGPS.ViewModels\AgValoniaGPS.ViewModels.csproj" />
+    <ProjectReference Include="..\..\Shared\AgValoniaGPS.Views\AgValoniaGPS.Views.csproj" />
+    <ProjectReference Include="..\..\Shared\AgValoniaGPS.Services\AgValoniaGPS.Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/AgValoniaGPS.UI.Tests/AppDirectoriesDialogTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/AppDirectoriesDialogTests.cs
@@ -1,0 +1,73 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Views.Controls.Dialogs;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Headless rendering tests for AppDirectoriesDialogPanel.
+/// Verifies the dialog opens, shows directory entries, and closes correctly.
+/// </summary>
+[TestFixture]
+public class AppDirectoriesDialogTests
+{
+    [AvaloniaTest]
+    public void Dialog_NotVisible_ByDefault()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new AppDirectoriesDialogPanel { DataContext = vm };
+
+        Assert.That(dialog.IsVisible, Is.False);
+    }
+
+    [AvaloniaTest]
+    public void Dialog_BecomesVisible_WhenDialogTypeSet()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new AppDirectoriesDialogPanel { DataContext = vm };
+
+        // Put in a window so bindings evaluate
+        var window = new Window { Content = dialog };
+        window.Show();
+
+        vm.State.UI.ShowDialog(DialogType.AppDirectories);
+
+        Assert.That(dialog.IsVisible, Is.True);
+    }
+
+    [AvaloniaTest]
+    public void ShowAppDirectoriesCommand_OpensDialog()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.ShowAppDirectoriesDialogCommand!.Execute(null);
+
+        Assert.That(vm.State.UI.ActiveDialog, Is.EqualTo(DialogType.AppDirectories));
+        Assert.That(vm.State.UI.IsAppDirectoriesDialogVisible, Is.True);
+    }
+
+    [AvaloniaTest]
+    public void CloseAppDirectoriesCommand_ClosesDialog()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.ShowAppDirectoriesDialogCommand!.Execute(null);
+
+        vm.CloseAppDirectoriesDialogCommand!.Execute(null);
+
+        Assert.That(vm.State.UI.ActiveDialog, Is.EqualTo(DialogType.None));
+    }
+
+    [AvaloniaTest]
+    public void ShowCommand_PopulatesAppDirectories()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.ShowAppDirectoriesDialogCommand!.Execute(null);
+
+        Assert.That(vm.AppDirectories, Has.Count.EqualTo(4),
+            "Should show Settings, Fields, Vehicles, NTRIP paths");
+        Assert.That(vm.AppDirectories.Select(d => d.Name),
+            Is.EquivalentTo(new[] { "Settings", "Fields", "Vehicle Profiles", "NTRIP Profiles" }));
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/GlobalUsings.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using NUnit.Framework;
+global using Avalonia.Headless.NUnit;

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -1,0 +1,66 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.YouTurn;
+using AgValoniaGPS.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Builds a MainViewModel with all services mocked via NSubstitute.
+/// Call Build() to get a ready instance for headless UI tests.
+/// </summary>
+public class MainViewModelBuilder
+{
+    public ISettingsService SettingsService { get; } = Substitute.For<ISettingsService>();
+    public IVehicleProfileService VehicleProfileService { get; } = Substitute.For<IVehicleProfileService>();
+    public INtripProfileService NtripProfileService { get; } = Substitute.For<INtripProfileService>();
+
+    public MainViewModelBuilder()
+    {
+        // Sensible defaults so the VM constructor doesn't NullRef
+        var settings = new AppSettings { FieldsDirectory = Path.GetTempPath() };
+        SettingsService.Settings.Returns(settings);
+        SettingsService.GetSettingsFilePath().Returns(Path.Combine(Path.GetTempPath(), "appsettings.json"));
+
+        VehicleProfileService.VehiclesDirectory.Returns(Path.GetTempPath());
+        NtripProfileService.ProfilesDirectory.Returns(Path.GetTempPath());
+        NtripProfileService.Profiles.Returns(new List<AgValoniaGPS.Models.Ntrip.NtripProfile>());
+        VehicleProfileService.GetAvailableProfiles().Returns(new List<string>());
+    }
+
+    public MainViewModel Build()
+    {
+        return new MainViewModel(
+            udpService: Substitute.For<IUdpCommunicationService>(),
+            gpsService: Substitute.For<AgValoniaGPS.Services.Interfaces.IGpsService>(),
+            fieldService: Substitute.For<IFieldService>(),
+            ntripService: Substitute.For<INtripClientService>(),
+            displaySettings: Substitute.For<AgValoniaGPS.Services.Interfaces.IDisplaySettingsService>(),
+            fieldStatistics: Substitute.For<AgValoniaGPS.Services.Interfaces.IFieldStatisticsService>(),
+            simulatorService: Substitute.For<AgValoniaGPS.Services.Interfaces.IGpsSimulationService>(),
+            settingsService: SettingsService,
+            mapService: Substitute.For<IMapService>(),
+            boundaryRecordingService: Substitute.For<IBoundaryRecordingService>(),
+            boundaryFileService: new BoundaryFileService(),
+            headlandBuilderService: Substitute.For<AgValoniaGPS.Services.Headland.IHeadlandBuilderService>(),
+            trackGuidanceService: Substitute.For<ITrackGuidanceService>(),
+            youTurnCreationService: new YouTurnCreationService(NullLogger<YouTurnCreationService>.Instance),
+            youTurnGuidanceService: new YouTurnGuidanceService(),
+            polygonOffsetService: Substitute.For<AgValoniaGPS.Services.Geometry.IPolygonOffsetService>(),
+            turnAreaService: Substitute.For<AgValoniaGPS.Services.Interfaces.ITurnAreaService>(),
+            vehicleProfileService: VehicleProfileService,
+            configurationService: Substitute.For<IConfigurationService>(),
+            autoSteerService: Substitute.For<IAutoSteerService>(),
+            moduleCommunicationService: Substitute.For<IModuleCommunicationService>(),
+            toolPositionService: Substitute.For<IToolPositionService>(),
+            coverageMapService: Substitute.For<ICoverageMapService>(),
+            sectionControlService: Substitute.For<ISectionControlService>(),
+            ntripProfileService: NtripProfileService,
+            logger: NullLogger<MainViewModel>.Instance,
+            appState: new ApplicationState());
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/ResetAllSettingsTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ResetAllSettingsTests.cs
@@ -1,0 +1,73 @@
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using NSubstitute;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Tests for the Reset All Settings command.
+/// </summary>
+[TestFixture]
+public class ResetAllSettingsTests
+{
+    [Test]
+    public void ResetCommand_ShowsConfirmationDialog()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.ResetAllSettingsCommand!.Execute(null);
+
+        Assert.That(vm.State.UI.ActiveDialog, Is.EqualTo(DialogType.Confirmation));
+    }
+
+    [Test]
+    public void ResetCommand_WhenConfirmed_ResetsSettingsService()
+    {
+        var builder = new MainViewModelBuilder();
+        var vm = builder.Build();
+
+        // Open and confirm
+        vm.ResetAllSettingsCommand!.Execute(null);
+        vm.ConfirmConfirmationDialogCommand!.Execute(null);
+
+        builder.SettingsService.Received(1).ResetToDefaults();
+        builder.SettingsService.Received(1).Save();
+    }
+
+    [Test]
+    public void ResetCommand_WhenConfirmed_ResetsConfigurationStore()
+    {
+        var original = ConfigurationStore.Instance;
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.ResetAllSettingsCommand!.Execute(null);
+        vm.ConfirmConfirmationDialogCommand!.Execute(null);
+
+        // ConfigurationStore.Instance should be a fresh instance
+        Assert.That(ConfigurationStore.Instance, Is.Not.SameAs(original));
+    }
+
+    [Test]
+    public void ResetCommand_WhenCancelled_DoesNotReset()
+    {
+        var builder = new MainViewModelBuilder();
+        var vm = builder.Build();
+
+        vm.ResetAllSettingsCommand!.Execute(null);
+        vm.CancelConfirmationDialogCommand!.Execute(null);
+
+        builder.SettingsService.DidNotReceive().ResetToDefaults();
+        builder.SettingsService.DidNotReceive().Save();
+    }
+
+    [Test]
+    public void ResetCommand_WhenCancelled_ClosesDialog()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.ResetAllSettingsCommand!.Execute(null);
+        vm.CancelConfirmationDialogCommand!.Execute(null);
+
+        Assert.That(vm.State.UI.ActiveDialog, Is.EqualTo(DialogType.None));
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/TestApp.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/TestApp.cs
@@ -1,0 +1,17 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.ReactiveUI;
+
+[assembly: AvaloniaTestApplication(typeof(AgValoniaGPS.UI.Tests.TestApp))]
+
+namespace AgValoniaGPS.UI.Tests;
+
+public class TestApp : Application
+{
+    public override void Initialize() { }
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<TestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions())
+            .UseReactiveUI();
+}

--- a/Tests/AgValoniaGPS.UI.Tests/UIStateDialogTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/UIStateDialogTests.cs
@@ -1,0 +1,79 @@
+using AgValoniaGPS.Models.State;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Pure model tests for dialog visibility state — no rendering needed.
+/// </summary>
+[TestFixture]
+public class UIStateDialogTests
+{
+    private UIState _ui = null!;
+
+    [SetUp]
+    public void SetUp() => _ui = new UIState();
+
+    [Test]
+    public void ShowDialog_SetsActiveDialog()
+    {
+        _ui.ShowDialog(DialogType.AppDirectories);
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.AppDirectories));
+    }
+
+    [Test]
+    public void CloseDialog_ResetsToNone()
+    {
+        _ui.ShowDialog(DialogType.AppDirectories);
+        _ui.CloseDialog();
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.None));
+    }
+
+    [Test]
+    public void IsAppDirectoriesDialogVisible_TrueWhenActive()
+    {
+        _ui.ShowDialog(DialogType.AppDirectories);
+        Assert.That(_ui.IsAppDirectoriesDialogVisible, Is.True);
+    }
+
+    [Test]
+    public void IsAppDirectoriesDialogVisible_FalseWhenOtherDialogOpen()
+    {
+        _ui.ShowDialog(DialogType.Confirmation);
+        Assert.That(_ui.IsAppDirectoriesDialogVisible, Is.False);
+    }
+
+    [Test]
+    public void ShowDialog_RaisesPropertyChangedForVisibility()
+    {
+        var changed = new List<string>();
+        _ui.PropertyChanged += (_, e) => changed.Add(e.PropertyName ?? "");
+
+        _ui.ShowDialog(DialogType.AppDirectories);
+
+        Assert.That(changed, Contains.Item(nameof(UIState.IsAppDirectoriesDialogVisible)));
+        Assert.That(changed, Contains.Item(nameof(UIState.IsDialogOpen)));
+    }
+
+    [Test]
+    public void OnlyOneDialogVisibleAtATime()
+    {
+        _ui.ShowDialog(DialogType.AppDirectories);
+
+        Assert.That(_ui.IsAppDirectoriesDialogVisible, Is.True);
+        Assert.That(_ui.IsConfirmationDialogVisible, Is.False);
+        Assert.That(_ui.IsNtripProfilesDialogVisible, Is.False);
+    }
+
+    [Test]
+    public void IsDialogOpen_FalseWhenNone()
+    {
+        Assert.That(_ui.IsDialogOpen, Is.False);
+    }
+
+    [Test]
+    public void IsDialogOpen_TrueWhenAnyDialogShown()
+    {
+        _ui.ShowDialog(DialogType.AppDirectories);
+        Assert.That(_ui.IsDialogOpen, Is.True);
+    }
+}


### PR DESCRIPTION
> **Draft PR** — depends on #11 (App Directories + Reset All Settings)

## Summary
- Add `AgValoniaGPS.UI.Tests` project using `Avalonia.Headless.NUnit`
- 18 tests: dialog state, headless rendering, command flows
- `MainViewModelBuilder` helper constructs a fully-mocked VM in one call for easy test setup

## Structure

| File | What it tests |
|------|--------------|
| `UIStateDialogTests` | Visibility properties, PropertyChanged events, dialog exclusivity |
| `AppDirectoriesDialogTests` | Headless render: dialog shows/hides, directory list populated |
| `ResetAllSettingsTests` | Confirm resets services, cancel does nothing |

## How it works
`[AvaloniaTest]` spins up a headless Avalonia app (no display needed, runs in CI).  
Pure model tests use `[Test]` and run without Avalonia overhead.

## Test run
```
Total: 18  Passed: 18  Failed: 0
```