### PR TITLE
Add About dialog, Smooth AB Curve, and metric/imperial units

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,6 @@ Thank you for your interest in contributing to AgValoniaGPS! This document lists
 
 These features are good starting points for new contributors.
 
-#### About Dialog
-- **Button location**: File Menu Panel
-- **File**: `Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml` (Line 96)
-- **Task**: Create an About dialog showing app version, credits, and links
-- **Skills needed**: XAML, basic ViewModel
-
 #### Help Documentation
 - **Button location**: File Menu Panel
 - **File**: `Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml` (Line 95)
@@ -80,7 +74,6 @@ These features are good starting points for new contributors.
   - Auto Day/Night brightness, Svenn Arrow, Start Fullscreen
   - Elevation Log, Field Texture, Grid, Extra Guidelines
   - Line Smooth, Direction Markers, Section Lines
-  - Metric/Imperial units
 - **Skills needed**: DrawingContext rendering, MainViewModel integration
 
 #### Additional Options - Wire Up Settings
@@ -133,11 +126,6 @@ These features require more understanding of the codebase.
 - **Task**: Import track/guidance line data from external files (KML, shapefile, etc.)
 - **Skills needed**: File parsing, coordinate systems, Track model
 
-#### Smooth AB Curve
-- **Button location**: Bottom Navigation Panel (AB Line Options section)
-- **File**: `Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml` (Line 255)
-- **Task**: Implement SmoothABLineCommand to smooth/simplify curve points
-- **Skills needed**: Geometry algorithms, Track model
 
 #### Delete Contours
 - **Button location**: Bottom Navigation Panel (AB Line Options section)

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -63,6 +63,7 @@ public class UIState : ReactiveObject
                 this.RaisePropertyChanged(nameof(IsErrorDialogVisible));
                 this.RaisePropertyChanged(nameof(IsAppDirectoriesDialogVisible));
                 this.RaisePropertyChanged(nameof(IsHotkeyConfigDialogVisible));
+                this.RaisePropertyChanged(nameof(IsAboutDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -96,6 +97,7 @@ public class UIState : ReactiveObject
     public bool IsErrorDialogVisible => ActiveDialog == DialogType.Error;
     public bool IsAppDirectoriesDialogVisible => ActiveDialog == DialogType.AppDirectories;
     public bool IsHotkeyConfigDialogVisible => ActiveDialog == DialogType.HotkeyConfig;
+    public bool IsAboutDialogVisible => ActiveDialog == DialogType.About;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -208,7 +210,8 @@ public enum DialogType
     Confirmation,
     Error,
     AppDirectories,
-    HotkeyConfig
+    HotkeyConfig,
+    About
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -36,6 +36,16 @@ public partial class MainViewModel
             State.UI.CloseDialog();
         });
 
+        ShowAboutDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.ShowDialog(Models.State.DialogType.About);
+        });
+
+        CloseAboutDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.CloseDialog();
+        });
+
         ResetAllSettingsCommand = ReactiveCommand.Create(() =>
         {
             ShowConfirmationDialog(

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -495,7 +495,33 @@ public partial class MainViewModel
 
         SmoothABLineCommand = ReactiveCommand.Create(() =>
         {
-            StatusMessage = "Smooth AB Line - not yet implemented";
+            if (SelectedTrack == null)
+            {
+                StatusMessage = "No track selected";
+                return;
+            }
+            if (SelectedTrack.IsABLine)
+            {
+                StatusMessage = "Cannot smooth AB lines (only 2 points)";
+                return;
+            }
+            if (SelectedTrack.Points.Count < 5)
+            {
+                StatusMessage = "Too few points to smooth (need at least 5)";
+                return;
+            }
+
+            int beforeCount = SelectedTrack.Points.Count;
+            var smoothed = Models.Guidance.CurveProcessing.SmoothWithCatmullRom(SelectedTrack.Points, 4);
+            smoothed = Models.Guidance.CurveProcessing.CalculateHeadings(smoothed);
+            SelectedTrack.Points = smoothed;
+
+            // Invalidate guidance state so it recalculates from the new curve
+            _trackGuidanceState = null;
+            _mapService.SetActiveTrack(SelectedTrack);
+            SaveTracksToFile();
+
+            StatusMessage = $"Smoothed '{SelectedTrack.Name}': {beforeCount} -> {smoothed.Count} points";
         });
 
         // Nudge commands

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
@@ -264,9 +264,18 @@ public partial class MainViewModel
         }
     }
 
-    public string SimulatorSpeedDisplay => _isSimulatorSpeed10x
-        ? $"Speed: {_simulatorSpeedKph * 10:F0} kph (10x)"
-        : $"Speed: {_simulatorSpeedKph:F1} kph";
+    public string SimulatorSpeedDisplay
+    {
+        get
+        {
+            double speed = _isSimulatorSpeed10x ? _simulatorSpeedKph * 10 : _simulatorSpeedKph;
+            string suffix = _isSimulatorSpeed10x ? " (10x)" : "";
+            if (ConfigStore.IsMetric)
+                return $"Speed: {speed:F1} kph{suffix}";
+            else
+                return $"Speed: {speed * 0.621371:F1} mph{suffix}";
+        }
+    }
 
     #endregion
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -216,6 +216,14 @@ public partial class MainViewModel : ReactiveObject
             {
                 NumSections = Models.Configuration.ConfigurationStore.Instance.NumSections;
             }
+            else if (e.PropertyName == nameof(Models.Configuration.ConfigurationStore.IsMetric))
+            {
+                // Refresh all unit-dependent displays
+                this.RaisePropertyChanged(nameof(WorkedAreaDisplay));
+                this.RaisePropertyChanged(nameof(BoundaryAreaDisplay));
+                this.RaisePropertyChanged(nameof(WorkRateDisplay));
+                this.RaisePropertyChanged(nameof(SimulatorSpeedDisplay));
+            }
         };
 
         // Note: FPS subscription is set up in platform code (MainWindow.axaml.cs / MainView.axaml.cs)
@@ -846,13 +854,12 @@ public partial class MainViewModel : ReactiveObject
     {
         get
         {
-            // Use CurrentBoundary area directly (more reliable than pre-calculated field.TotalArea)
             var boundary = State.Field.CurrentBoundary;
             if (boundary != null && boundary.IsValid)
             {
-                return $"{boundary.AreaHectares:F2} ha";
+                return FormatArea(boundary.AreaHectares * 10000); // Convert ha back to m²
             }
-            return "0.00 ha";
+            return ConfigStore.IsMetric ? "0.00 ha" : "0.00 ac";
         }
     }
 
@@ -878,21 +885,25 @@ public partial class MainViewModel : ReactiveObject
         get
         {
             // Rate = Speed (m/h) × Tool Width (m) = m²/h
-            // Convert: Speed is in m/s, need m/h; result in ha/hr
             double speedMetersPerHour = Speed * 3600; // m/s to m/h
-            double toolWidthMeters = ToolWidth; // Already in meters
-            double squareMetersPerHour = speedMetersPerHour * toolWidthMeters;
+            double squareMetersPerHour = speedMetersPerHour * ToolWidth;
             double hectaresPerHour = squareMetersPerHour / 10000.0;
-            return $"{hectaresPerHour:F1} ha/hr";
+
+            if (ConfigStore.IsMetric)
+                return $"{hectaresPerHour:F1} ha/hr";
+            else
+                return $"{hectaresPerHour * 2.47105:F1} ac/hr";
         }
     }
 
-    // Helper method to format area
+    // Helper method to format area with metric/imperial support
     private string FormatArea(double squareMeters)
     {
-        // Convert to hectares
         double hectares = squareMeters * 0.0001;
-        return $"{hectares:F2} ha";
+        if (ConfigStore.IsMetric)
+            return $"{hectares:F2} ha";
+        else
+            return $"{hectares * 2.47105:F2} ac";
     }
 
     /// <summary>
@@ -1402,6 +1413,8 @@ public partial class MainViewModel : ReactiveObject
     // Settings Commands
     public ICommand? ShowAppDirectoriesDialogCommand { get; private set; }
     public ICommand? CloseAppDirectoriesDialogCommand { get; private set; }
+    public ICommand? ShowAboutDialogCommand { get; private set; }
+    public ICommand? CloseAboutDialogCommand { get; private set; }
     public ICommand? ResetAllSettingsCommand { get; private set; }
 
     private ObservableCollection<AppDirectoryInfo> _appDirectories = new();

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -55,6 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:NtripProfileEditorPanel/>
         <dialogs:AppDirectoriesDialogPanel/>
         <dialogs:HotkeyConfigDialogPanel/>
+        <dialogs:AboutDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
@@ -1,0 +1,63 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.AboutDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsAboutDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsAboutDialogVisible}">
+
+    <Grid>
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <Border Background="#2C3E50" CornerRadius="12" Padding="24"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                MinWidth="420" MaxWidth="550">
+            <StackPanel Spacing="12">
+                <TextBlock Text="AgValoniaGPS" FontSize="22" FontWeight="Bold"
+                           Foreground="#3498DB" HorizontalAlignment="Center"/>
+
+                <TextBlock Text="Version 26.2.0" FontSize="16" FontWeight="SemiBold"
+                           Foreground="White" HorizontalAlignment="Center"/>
+
+                <TextBlock Text="Cross-platform agricultural GPS guidance"
+                           FontSize="12" Foreground="#95A5A6" HorizontalAlignment="Center"/>
+
+                <Separator Height="1" Background="#444" Margin="0,4"/>
+
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Based on AgOpenGPS by Brian Tee"
+                               Foreground="#BDC3C7" FontSize="12"/>
+                    <TextBlock Text="Built with Avalonia UI 11.3.9 and .NET 10.0"
+                               Foreground="#BDC3C7" FontSize="12"/>
+                </StackPanel>
+
+                <Separator Height="1" Background="#444" Margin="0,4"/>
+
+                <StackPanel Spacing="4">
+                    <TextBlock Text="License: GNU General Public License v3.0"
+                               Foreground="#BDC3C7" FontSize="12"/>
+                    <TextBlock Text="github.com/chriskinal/AgValoniaGPS3"
+                               Foreground="#3498DB" FontSize="12"/>
+                </StackPanel>
+
+                <Button Content="Close" Margin="0,8,0,0"
+                        Command="{Binding CloseAboutDialogCommand}"
+                        Background="#3498DB" Foreground="White"
+                        HorizontalAlignment="Stretch" Height="44" FontSize="16" FontWeight="Bold"
+                        HorizontalContentAlignment="Center" CornerRadius="6"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
@@ -1,0 +1,28 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class AboutDialogPanel : UserControl
+{
+    public AboutDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CloseAboutDialogCommand?.Execute(null);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -96,7 +96,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Button Classes="ModernButton" Content="AgShare API" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAgShareSettingsDialogCommand}"/>
             <Button Classes="ModernButton" Content="Help" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
-            <Button Classes="ModernButton" Content="About" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
+            <Button Classes="ModernButton" Content="About" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding ShowAboutDialogCommand}"/>
         </StackPanel>
     </Border>
 </UserControl>


### PR DESCRIPTION
## Summary
- **About Dialog** — overlay dialog with version (26.2.0), credits (Brian Tee / AgOpenGPS), license (GPLv3), and repo link. Accessible from File Menu > About.
- **Smooth AB Curve** — uses existing `CurveProcessing.SmoothWithCatmullRom()` + heading recalculation. Validates input (rejects AB lines, requires 5+ points). Saves and refreshes map.
- **Metric/Imperial units** — `FormatArea()`, `WorkRateDisplay`, `BoundaryAreaDisplay`, and `SimulatorSpeedDisplay` now respect `ConfigurationStore.IsMetric`. Displays refresh automatically when toggled in Configuration > Display Options.

Closes #15, closes #26
Partial progress on #19 (metric/imperial toggle wired up; other display options still need renderer work)

## Test plan
- [x] All 188 tests pass (Models: 72, Services: 67, UI: 49)
- [x] Desktop project builds with 0 errors
- [ ] Verify About dialog opens/closes from File Menu
- [ ] Verify Smooth button works on recorded curves
- [ ] Verify unit toggle updates area/speed/work rate displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)