### PR TITLE
Fix mobile coverage save, GPS timeout, and track recording

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -22,6 +22,8 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
+using Microsoft.Extensions.DependencyInjection;
 using AgValoniaGPS.ViewModels;
 using AgValoniaGPS.Views.Controls;
 using AgValoniaGPS.Views.Behaviors;
@@ -65,6 +67,40 @@ public partial class MainView : UserControl
 
         // Handle view resize to keep panels in bounds
         this.PropertyChanged += MainView_PropertyChanged;
+
+        // Save coverage and settings when view is unloaded (app exit/backgrounded)
+        this.Unloaded += MainView_Unloaded;
+    }
+
+    private void MainView_Unloaded(object? sender, RoutedEventArgs e)
+    {
+        if (App.Services == null) return;
+
+        SavePanelPositions();
+
+        if (_viewModel != null)
+        {
+            var display = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Display;
+            display.GridVisible = _viewModel.IsGridOn;
+        }
+
+        var configService = App.Services.GetRequiredService<IConfigurationService>();
+        configService.SaveAppSettings();
+
+        var fieldService = App.Services.GetRequiredService<IFieldService>();
+        var coverageService = App.Services.GetRequiredService<ICoverageMapService>();
+        if (fieldService.ActiveField != null && !string.IsNullOrEmpty(fieldService.ActiveField.DirectoryPath))
+        {
+            try
+            {
+                coverageService.SaveToFile(fieldService.ActiveField.DirectoryPath);
+                System.Diagnostics.Debug.WriteLine($"[Coverage] Saved coverage on app close to {fieldService.ActiveField.DirectoryPath}");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[Coverage] Error saving coverage on close: {ex.Message}");
+            }
+        }
     }
 
     private void MainView_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -22,6 +22,8 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
+using Microsoft.Extensions.DependencyInjection;
 using AgValoniaGPS.ViewModels;
 using AgValoniaGPS.Views.Controls;
 using AgValoniaGPS.Views.Behaviors;
@@ -65,6 +67,40 @@ public partial class MainView : UserControl
 
         // Handle window resize to keep panels in view
         this.PropertyChanged += MainView_PropertyChanged;
+
+        // Save coverage and settings when view is unloaded (app exit/backgrounded)
+        this.Unloaded += MainView_Unloaded;
+    }
+
+    private void MainView_Unloaded(object? sender, RoutedEventArgs e)
+    {
+        if (App.Services == null) return;
+
+        SavePanelPositions();
+
+        if (_viewModel != null)
+        {
+            var display = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Display;
+            display.GridVisible = _viewModel.IsGridOn;
+        }
+
+        var configService = App.Services.GetRequiredService<IConfigurationService>();
+        configService.SaveAppSettings();
+
+        var fieldService = App.Services.GetRequiredService<IFieldService>();
+        var coverageService = App.Services.GetRequiredService<ICoverageMapService>();
+        if (fieldService.ActiveField != null && !string.IsNullOrEmpty(fieldService.ActiveField.DirectoryPath))
+        {
+            try
+            {
+                coverageService.SaveToFile(fieldService.ActiveField.DirectoryPath);
+                System.Diagnostics.Debug.WriteLine($"[Coverage] Saved coverage on app close to {fieldService.ActiveField.DirectoryPath}");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[Coverage] Error saving coverage on close: {ex.Message}");
+            }
+        }
     }
 
     private void MainView_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)

--- a/Shared/AgValoniaGPS.Services/GpsService.cs
+++ b/Shared/AgValoniaGPS.Services/GpsService.cs
@@ -143,7 +143,14 @@ public class GpsService : IGpsService
     /// </summary>
     public bool IsGpsDataOk()
     {
-        return (DateTime.Now - _lastGpsDataReceived).TotalMilliseconds < GPS_TIMEOUT_MS;
+        bool ok = (DateTime.Now - _lastGpsDataReceived).TotalMilliseconds < GPS_TIMEOUT_MS;
+
+        if (!ok && IsConnected)
+        {
+            IsConnected = false;
+        }
+
+        return ok;
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -145,12 +145,35 @@ public partial class MainViewModel
 
         StartNewABLineCommand = ReactiveCommand.Create(() =>
         {
-            StatusMessage = "Starting new AB Line - not yet implemented";
+            State.UI.CloseDialog();
+            CurrentABCreationMode = ABCreationMode.DriveAB;
+            CurrentABPointStep = ABPointStep.SettingPointA;
+            PendingPointA = null;
+            StatusMessage = "Drive-in AB Line: tap to set Point A at current position";
         });
 
         StartNewABCurveCommand = ReactiveCommand.Create(() =>
         {
-            StatusMessage = "Starting new AB Curve - not yet implemented";
+            State.UI.CloseDialog();
+            CurrentABCreationMode = ABCreationMode.Curve;
+            _recordedCurvePoints.Clear();
+            _lastCurvePoint = null;
+
+            if (Easting != 0 || Northing != 0)
+            {
+                var headingRadians = Heading * Math.PI / 180.0;
+                var firstPoint = new Vec3(Easting, Northing, headingRadians);
+                _recordedCurvePoints.Add(firstPoint);
+                _lastCurvePoint = firstPoint;
+
+                var displayPoints = _recordedCurvePoints.Select(p => (p.Easting, p.Northing)).ToList();
+                _mapService.SetRecordingPoints(displayPoints);
+            }
+
+            StatusMessage = $"Curve recording started ({_recordedCurvePoints.Count} pts) - drive along path, tap when done";
+            this.RaisePropertyChanged(nameof(IsRecordingCurve));
+            this.RaisePropertyChanged(nameof(RecordedCurvePointCount));
+            this.RaisePropertyChanged(nameof(ABCreationInstructions));
         });
 
         StartAPlusLineCommand = ReactiveCommand.Create(() =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -393,6 +393,7 @@ public partial class MainViewModel : ReactiveObject
                 State.Connections.IsMachineDataOk = machineOk;
                 State.Connections.IsImuDataOk = imuOk;
                 State.Connections.IsGpsDataOk = gpsOk;
+                State.Connections.IsGpsConnected = gpsOk;
 
                 // Legacy property updates (for existing bindings - will be removed in Phase 5)
                 IsAutoSteerDataOk = steerOk;

--- a/Tests/AgValoniaGPS.Services.Tests/GpsServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/GpsServiceTests.cs
@@ -1,0 +1,84 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class GpsServiceTests
+{
+    private GpsService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new GpsService();
+    }
+
+    [Test]
+    public void IsGpsDataOk_NoDataReceived_ReturnsFalse()
+    {
+        Assert.That(_service.IsGpsDataOk(), Is.False);
+    }
+
+    [Test]
+    public void IsGpsDataOk_AfterValidUpdate_ReturnsTrue()
+    {
+        _service.UpdateGpsData(new GpsData { IsValid = true });
+        Assert.That(_service.IsGpsDataOk(), Is.True);
+    }
+
+    [Test]
+    public void IsConnected_AfterValidUpdate_IsTrue()
+    {
+        _service.UpdateGpsData(new GpsData { IsValid = true });
+        Assert.That(_service.IsConnected, Is.True);
+    }
+
+    [Test]
+    public void IsConnected_AfterInvalidUpdate_IsFalse()
+    {
+        _service.UpdateGpsData(new GpsData { IsValid = false });
+        Assert.That(_service.IsConnected, Is.False);
+    }
+
+    [Test]
+    public void IsGpsDataOk_SetsDisconnectedOnTimeout()
+    {
+        _service.UpdateGpsData(new GpsData { IsValid = true });
+        Assert.That(_service.IsConnected, Is.True);
+
+        System.Threading.Thread.Sleep(400);
+
+        bool ok = _service.IsGpsDataOk();
+        Assert.That(ok, Is.False);
+        Assert.That(_service.IsConnected, Is.False);
+    }
+
+    [Test]
+    public void IsConnected_RecoverAfterNewData()
+    {
+        _service.UpdateGpsData(new GpsData { IsValid = true });
+        System.Threading.Thread.Sleep(400);
+        _service.IsGpsDataOk();
+        Assert.That(_service.IsConnected, Is.False);
+
+        _service.UpdateGpsData(new GpsData { IsValid = true });
+        Assert.That(_service.IsConnected, Is.True);
+        Assert.That(_service.IsGpsDataOk(), Is.True);
+    }
+
+    [Test]
+    public void Start_SetsConnected()
+    {
+        _service.Start();
+        Assert.That(_service.IsConnected, Is.True);
+    }
+
+    [Test]
+    public void Stop_ClearsConnected()
+    {
+        _service.Start();
+        _service.Stop();
+        Assert.That(_service.IsConnected, Is.False);
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/TrackRecordingTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/TrackRecordingTests.cs
@@ -1,0 +1,31 @@
+using AgValoniaGPS.Models.Track;
+using AgValoniaGPS.Models.Base;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Tests for track recording commands (#45).
+/// </summary>
+[TestFixture]
+public class TrackRecordingTests
+{
+    [Test]
+    public void StartNewABLine_SetsCreationMode()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.StartNewABLineCommand!.Execute(null);
+
+        Assert.That(vm.StatusMessage, Does.Contain("Drive-in AB Line"));
+    }
+
+    [Test]
+    public void StartNewABCurve_StartsCurveRecording()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.StartNewABCurveCommand!.Execute(null);
+
+        Assert.That(vm.StatusMessage, Does.Contain("Curve recording started"));
+    }
+}


### PR DESCRIPTION
## Summary
- **#43 iOS/Android coverage save:** Add `Unloaded` handler to both mobile platforms that saves coverage map, settings, and panel positions on app exit — mirrors Desktop behavior to prevent data loss
- **#44 GPS timeout detection:** `IsGpsDataOk()` now sets `IsConnected=false` when GPS data stops flowing; propagated to `State.Connections.IsGpsConnected` for UI status display
- **#45 Track recording:** `StartNewABLine` enters DriveAB mode with A/B point workflow; `StartNewABCurve` starts curve recording capturing the first GPS point immediately

Fixes #43, fixes #44, fixes #45

## Test plan
- [x] 8 new GPS timeout tests (timeout detection, recovery, start/stop)
- [x] 2 new track recording tests (AB line mode, curve recording start)
- [x] All 198 tests pass (Models: 72, Services: 75, UI: 51)
- [x] Desktop builds with 0 errors
- [ ] Verify on iOS simulator that coverage persists across app restart
- [ ] Verify GPS timeout message appears when GPS disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)