### PR TITLE
Add GeoJSON field format and JSON vehicle profiles

### DIFF
--- a/Shared/AgValoniaGPS.Models/GeoJson/GeoJsonModels.cs
+++ b/Shared/AgValoniaGPS.Models/GeoJson/GeoJsonModels.cs
@@ -1,0 +1,114 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace AgValoniaGPS.Models.GeoJson;
+
+/// <summary>
+/// GeoJSON FeatureCollection (RFC 7946).
+/// Top-level container for field data serialization.
+/// </summary>
+public class GeoJsonFeatureCollection
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "FeatureCollection";
+
+    [JsonPropertyName("features")]
+    public List<GeoJsonFeature> Features { get; set; } = new();
+}
+
+/// <summary>
+/// GeoJSON Feature -- wraps a geometry with a properties bag.
+/// </summary>
+public class GeoJsonFeature
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "Feature";
+
+    [JsonPropertyName("geometry")]
+    public GeoJsonGeometry Geometry { get; set; } = new();
+
+    [JsonPropertyName("properties")]
+    public Dictionary<string, object?> Properties { get; set; } = new();
+}
+
+/// <summary>
+/// GeoJSON Geometry -- supports Point, LineString, Polygon, MultiPolygon.
+/// Coordinates use the raw JSON array form; callers convert via typed helpers.
+/// </summary>
+public class GeoJsonGeometry
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "Point";
+
+    /// <summary>
+    /// Raw coordinate data. Shape depends on Type:
+    ///   Point       -> [lon, lat]                          (double[])
+    ///   LineString  -> [[lon, lat], ...]                   (double[][])
+    ///   Polygon     -> [[[lon, lat], ...], ...]            (double[][][])
+    ///   MultiPolygon-> [[[[lon, lat], ...], ...], ...]     (double[][][][])
+    /// Stored as object to allow System.Text.Json polymorphic round-trip.
+    /// Use the typed accessors below for safe reading.
+    /// </summary>
+    [JsonPropertyName("coordinates")]
+    public object? Coordinates { get; set; }
+}
+
+/// <summary>
+/// Well-known GeoJSON geometry type strings.
+/// </summary>
+public static class GeoJsonTypes
+{
+    public const string Point = "Point";
+    public const string LineString = "LineString";
+    public const string Polygon = "Polygon";
+    public const string MultiPolygon = "MultiPolygon";
+}
+
+/// <summary>
+/// Well-known property keys used in AgValoniaGPS field GeoJSON files.
+/// </summary>
+public static class FieldPropertyKeys
+{
+    public const string Role = "role";
+    public const string Name = "name";
+    public const string TrackType = "trackType";
+    public const string IsClosed = "isClosed";
+    public const string NudgeDistance = "nudgeDistance";
+    public const string IsVisible = "isVisible";
+    public const string IsDriveThrough = "isDriveThrough";
+    public const string OriginLatitude = "originLatitude";
+    public const string OriginLongitude = "originLongitude";
+    public const string Convergence = "convergence";
+    public const string AreaHectares = "areaHectares";
+    public const string CreatedDate = "createdDate";
+    public const string LastModifiedDate = "lastModifiedDate";
+}
+
+/// <summary>
+/// Well-known role values stored in the "role" property.
+/// </summary>
+public static class FeatureRoles
+{
+    public const string Metadata = "metadata";
+    public const string OuterBoundary = "outer-boundary";
+    public const string InnerBoundary = "inner-boundary";
+    public const string Headland = "headland";
+    public const string Track = "track";
+    public const string BackgroundImage = "background-image";
+}

--- a/Shared/AgValoniaGPS.Services/Field/GeoJsonFieldService.cs
+++ b/Shared/AgValoniaGPS.Services/Field/GeoJsonFieldService.cs
@@ -1,0 +1,515 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.GeoJson;
+using AgValoniaGPS.Models.Track;
+using AgValoniaGPS.Services.Geometry;
+
+namespace AgValoniaGPS.Services.Field;
+
+/// <summary>
+/// Loads and saves field data as GeoJSON FeatureCollections.
+/// Each field component (boundary, tracks, headland, etc.) becomes a Feature
+/// with a "role" property for identification on load.
+/// </summary>
+public class GeoJsonFieldService
+{
+    private const string FileName = "field.geojson";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Check whether a field directory contains a GeoJSON field file.
+    /// </summary>
+    public static bool Exists(string fieldDirectory)
+    {
+        return File.Exists(Path.Combine(fieldDirectory, FileName));
+    }
+
+    /// <summary>
+    /// Save a field as a GeoJSON FeatureCollection.
+    /// </summary>
+    public static void Save(Models.Field field, IReadOnlyList<Models.Track.Track>? tracks)
+    {
+        if (string.IsNullOrWhiteSpace(field.DirectoryPath))
+            throw new ArgumentException("Field.DirectoryPath must be set", nameof(field));
+
+        if (!Directory.Exists(field.DirectoryPath))
+            Directory.CreateDirectory(field.DirectoryPath);
+
+        var geo = new GeoConversion(field.Origin.Latitude, field.Origin.Longitude);
+        var fc = new GeoJsonFeatureCollection();
+
+        // Metadata feature -- a Point at the field origin
+        fc.Features.Add(BuildMetadataFeature(field));
+
+        // Boundaries
+        if (field.Boundary != null)
+        {
+            if (field.Boundary.OuterBoundary is { IsValid: true })
+                fc.Features.Add(BuildBoundaryFeature(geo, field.Boundary.OuterBoundary, FeatureRoles.OuterBoundary));
+
+            foreach (var inner in field.Boundary.InnerBoundaries)
+            {
+                if (inner.IsValid)
+                    fc.Features.Add(BuildBoundaryFeature(geo, inner, FeatureRoles.InnerBoundary));
+            }
+
+            if (field.Boundary.HeadlandPolygon is { IsValid: true })
+                fc.Features.Add(BuildBoundaryFeature(geo, field.Boundary.HeadlandPolygon, FeatureRoles.Headland));
+        }
+
+        // Tracks
+        if (tracks != null)
+        {
+            foreach (var track in tracks)
+            {
+                if (track.Points.Count >= 2)
+                    fc.Features.Add(BuildTrackFeature(geo, track));
+            }
+        }
+
+        // Background image bounds
+        if (field.BackgroundImage is { IsValid: true })
+            fc.Features.Add(BuildBackgroundImageFeature(geo, field.BackgroundImage));
+
+        var json = JsonSerializer.Serialize(fc, SerializerOptions);
+        File.WriteAllText(Path.Combine(field.DirectoryPath, FileName), json);
+    }
+
+    /// <summary>
+    /// Load a field from a GeoJSON FeatureCollection.
+    /// Returns the field and any tracks found.
+    /// </summary>
+    public static (Models.Field field, List<Models.Track.Track> tracks) Load(string fieldDirectory)
+    {
+        var path = Path.Combine(fieldDirectory, FileName);
+        if (!File.Exists(path))
+            throw new FileNotFoundException("field.geojson not found", path);
+
+        var json = File.ReadAllText(path);
+        var fc = JsonSerializer.Deserialize<GeoJsonFeatureCollection>(json, SerializerOptions)
+            ?? throw new InvalidDataException("Failed to deserialize GeoJSON");
+
+        // We need the origin first to set up coordinate conversion
+        var metaFeature = fc.Features.FirstOrDefault(f => GetStringProp(f, FieldPropertyKeys.Role) == FeatureRoles.Metadata);
+        if (metaFeature == null)
+            throw new InvalidDataException("GeoJSON missing metadata feature");
+
+        double originLat = GetDoubleProp(metaFeature, FieldPropertyKeys.OriginLatitude);
+        double originLon = GetDoubleProp(metaFeature, FieldPropertyKeys.OriginLongitude);
+
+        var field = new Models.Field
+        {
+            Name = Path.GetFileName(fieldDirectory),
+            DirectoryPath = fieldDirectory,
+            Origin = new Position { Latitude = originLat, Longitude = originLon },
+            Convergence = GetDoubleProp(metaFeature, FieldPropertyKeys.Convergence),
+        };
+
+        var nameProp = GetStringProp(metaFeature, FieldPropertyKeys.Name);
+        if (!string.IsNullOrEmpty(nameProp))
+            field.Name = nameProp;
+
+        var createdStr = GetStringProp(metaFeature, FieldPropertyKeys.CreatedDate);
+        if (DateTime.TryParse(createdStr, out var created))
+            field.CreatedDate = created;
+
+        var modifiedStr = GetStringProp(metaFeature, FieldPropertyKeys.LastModifiedDate);
+        if (DateTime.TryParse(modifiedStr, out var modified))
+            field.LastModifiedDate = modified;
+
+        var geo = new GeoConversion(originLat, originLon);
+        var boundary = new Boundary();
+        var tracks = new List<Models.Track.Track>();
+
+        foreach (var feature in fc.Features)
+        {
+            var role = GetStringProp(feature, FieldPropertyKeys.Role);
+            switch (role)
+            {
+                case FeatureRoles.OuterBoundary:
+                    boundary.OuterBoundary = ReadBoundaryPolygon(geo, feature);
+                    break;
+
+                case FeatureRoles.InnerBoundary:
+                    var inner = ReadBoundaryPolygon(geo, feature);
+                    if (inner != null)
+                    {
+                        inner.IsDriveThrough = GetBoolProp(feature, FieldPropertyKeys.IsDriveThrough);
+                        boundary.InnerBoundaries.Add(inner);
+                    }
+                    break;
+
+                case FeatureRoles.Headland:
+                    boundary.HeadlandPolygon = ReadBoundaryPolygon(geo, feature);
+                    break;
+
+                case FeatureRoles.Track:
+                    var track = ReadTrack(geo, feature);
+                    if (track != null)
+                        tracks.Add(track);
+                    break;
+
+                case FeatureRoles.BackgroundImage:
+                    field.BackgroundImage = ReadBackgroundImage(geo, feature);
+                    break;
+            }
+        }
+
+        if (boundary.OuterBoundary != null)
+            field.Boundary = boundary;
+
+        return (field, tracks);
+    }
+
+    // ---------------------------------------------------------------
+    // Feature builders (local -> GeoJSON)
+    // ---------------------------------------------------------------
+
+    private static GeoJsonFeature BuildMetadataFeature(Models.Field field)
+    {
+        return new GeoJsonFeature
+        {
+            Geometry = new GeoJsonGeometry
+            {
+                Type = GeoJsonTypes.Point,
+                Coordinates = new[] { field.Origin.Longitude, field.Origin.Latitude }
+            },
+            Properties = new Dictionary<string, object?>
+            {
+                [FieldPropertyKeys.Role] = FeatureRoles.Metadata,
+                [FieldPropertyKeys.Name] = field.Name,
+                [FieldPropertyKeys.OriginLatitude] = field.Origin.Latitude,
+                [FieldPropertyKeys.OriginLongitude] = field.Origin.Longitude,
+                [FieldPropertyKeys.Convergence] = field.Convergence,
+                [FieldPropertyKeys.AreaHectares] = field.TotalArea,
+                [FieldPropertyKeys.CreatedDate] = field.CreatedDate.ToString("O"),
+                [FieldPropertyKeys.LastModifiedDate] = field.LastModifiedDate.ToString("O"),
+            }
+        };
+    }
+
+    private static GeoJsonFeature BuildBoundaryFeature(GeoConversion geo, BoundaryPolygon polygon, string role)
+    {
+        var ring = BoundaryToGeoJsonRing(geo, polygon);
+        return new GeoJsonFeature
+        {
+            Geometry = new GeoJsonGeometry
+            {
+                Type = GeoJsonTypes.Polygon,
+                Coordinates = new[] { ring }
+            },
+            Properties = new Dictionary<string, object?>
+            {
+                [FieldPropertyKeys.Role] = role,
+                [FieldPropertyKeys.IsDriveThrough] = polygon.IsDriveThrough,
+                [FieldPropertyKeys.AreaHectares] = polygon.AreaHectares,
+            }
+        };
+    }
+
+    private static GeoJsonFeature BuildTrackFeature(GeoConversion geo, Models.Track.Track track)
+    {
+        var coords = geo.ToGeoJsonCoordinates(track.Points);
+        return new GeoJsonFeature
+        {
+            Geometry = new GeoJsonGeometry
+            {
+                Type = GeoJsonTypes.LineString,
+                Coordinates = coords.Select(c => (object)c).ToArray()
+            },
+            Properties = new Dictionary<string, object?>
+            {
+                [FieldPropertyKeys.Role] = FeatureRoles.Track,
+                [FieldPropertyKeys.Name] = track.Name,
+                [FieldPropertyKeys.TrackType] = (int)track.Type,
+                [FieldPropertyKeys.IsClosed] = track.IsClosed,
+                [FieldPropertyKeys.NudgeDistance] = track.NudgeDistance,
+                [FieldPropertyKeys.IsVisible] = track.IsVisible,
+            }
+        };
+    }
+
+    private static GeoJsonFeature BuildBackgroundImageFeature(GeoConversion geo, BackgroundImage img)
+    {
+        // Store image bounds as a polygon (4 corners + closing point)
+        var corners = new List<Vec2>
+        {
+            new(img.MinEasting, img.MinNorthing),
+            new(img.MaxEasting, img.MinNorthing),
+            new(img.MaxEasting, img.MaxNorthing),
+            new(img.MinEasting, img.MaxNorthing),
+        };
+        var ring = geo.ToGeoJsonCoordinates(corners);
+        // Close the ring per GeoJSON spec
+        ring.Add(ring[0]);
+
+        return new GeoJsonFeature
+        {
+            Geometry = new GeoJsonGeometry
+            {
+                Type = GeoJsonTypes.Polygon,
+                Coordinates = new[] { ring.Select(c => (object)c).ToArray() }
+            },
+            Properties = new Dictionary<string, object?>
+            {
+                [FieldPropertyKeys.Role] = FeatureRoles.BackgroundImage,
+            }
+        };
+    }
+
+    /// <summary>
+    /// Convert a BoundaryPolygon to a GeoJSON ring (closed array of [lon, lat, heading]).
+    /// </summary>
+    private static object[] BoundaryToGeoJsonRing(GeoConversion geo, BoundaryPolygon polygon)
+    {
+        var ring = new List<object>(polygon.Points.Count + 1);
+        foreach (var pt in polygon.Points)
+        {
+            var (lat, lon) = geo.ToWgs84(new Vec2(pt.Easting, pt.Northing));
+            ring.Add(new[] { lon, lat, pt.Heading });
+        }
+        // Close the ring
+        if (polygon.Points.Count > 0)
+        {
+            var first = polygon.Points[0];
+            var (lat, lon) = geo.ToWgs84(new Vec2(first.Easting, first.Northing));
+            ring.Add(new[] { lon, lat, first.Heading });
+        }
+        return ring.ToArray();
+    }
+
+    // ---------------------------------------------------------------
+    // Feature readers (GeoJSON -> local)
+    // ---------------------------------------------------------------
+
+    private static BoundaryPolygon? ReadBoundaryPolygon(GeoConversion geo, GeoJsonFeature feature)
+    {
+        var coords = ReadPolygonRing(feature.Geometry, 0);
+        if (coords == null || coords.Count < 3)
+            return null;
+
+        var polygon = new BoundaryPolygon();
+        foreach (var coord in coords)
+        {
+            var local = geo.ToLocal(coord[1], coord[0]);
+            double heading = coord.Length >= 3 ? coord[2] : 0;
+            polygon.Points.Add(new BoundaryPoint(local.Easting, local.Northing, heading));
+        }
+
+        // Remove closing duplicate if present
+        if (polygon.Points.Count > 1)
+        {
+            var first = polygon.Points[0];
+            var last = polygon.Points[^1];
+            if (Math.Abs(first.Easting - last.Easting) < 0.001 &&
+                Math.Abs(first.Northing - last.Northing) < 0.001)
+            {
+                polygon.Points.RemoveAt(polygon.Points.Count - 1);
+            }
+        }
+
+        polygon.UpdateBounds();
+        return polygon;
+    }
+
+    private static Models.Track.Track? ReadTrack(GeoConversion geo, GeoJsonFeature feature)
+    {
+        var coords = ReadLineStringCoords(feature.Geometry);
+        if (coords == null || coords.Count < 2)
+            return null;
+
+        var points = geo.FromGeoJsonCoordinatesVec3(coords);
+
+        var trackTypeInt = GetIntProp(feature, FieldPropertyKeys.TrackType);
+        var trackType = Enum.IsDefined(typeof(TrackType), trackTypeInt)
+            ? (TrackType)trackTypeInt
+            : TrackType.ABLine;
+
+        return new Models.Track.Track
+        {
+            Name = GetStringProp(feature, FieldPropertyKeys.Name) ?? string.Empty,
+            Points = points,
+            Type = trackType,
+            IsClosed = GetBoolProp(feature, FieldPropertyKeys.IsClosed),
+            NudgeDistance = GetDoubleProp(feature, FieldPropertyKeys.NudgeDistance),
+            IsVisible = GetBoolPropDefault(feature, FieldPropertyKeys.IsVisible, true),
+        };
+    }
+
+    private static BackgroundImage? ReadBackgroundImage(GeoConversion geo, GeoJsonFeature feature)
+    {
+        var coords = ReadPolygonRing(feature.Geometry, 0);
+        if (coords == null || coords.Count < 4)
+            return null;
+
+        double minE = double.MaxValue, maxE = double.MinValue;
+        double minN = double.MaxValue, maxN = double.MinValue;
+
+        foreach (var c in coords)
+        {
+            var local = geo.ToLocal(c[1], c[0]);
+            if (local.Easting < minE) minE = local.Easting;
+            if (local.Easting > maxE) maxE = local.Easting;
+            if (local.Northing < minN) minN = local.Northing;
+            if (local.Northing > maxN) maxN = local.Northing;
+        }
+
+        return new BackgroundImage
+        {
+            MinEasting = minE,
+            MaxEasting = maxE,
+            MinNorthing = minN,
+            MaxNorthing = maxN,
+            IsEnabled = true,
+        };
+    }
+
+    // ---------------------------------------------------------------
+    // JSON coordinate extraction helpers
+    // ---------------------------------------------------------------
+
+    /// <summary>
+    /// Read the outer ring (index 0) of a Polygon geometry.
+    /// Coordinates arrive as a JsonElement after deserialization.
+    /// </summary>
+    private static List<double[]>? ReadPolygonRing(GeoJsonGeometry geometry, int ringIndex)
+    {
+        if (geometry.Coordinates is not JsonElement je)
+            return null;
+
+        if (je.ValueKind != JsonValueKind.Array)
+            return null;
+
+        int idx = 0;
+        foreach (var ringElem in je.EnumerateArray())
+        {
+            if (idx == ringIndex)
+                return ParseCoordArray(ringElem);
+            idx++;
+        }
+        return null;
+    }
+
+    private static List<double[]>? ReadLineStringCoords(GeoJsonGeometry geometry)
+    {
+        if (geometry.Coordinates is not JsonElement je)
+            return null;
+
+        if (je.ValueKind != JsonValueKind.Array)
+            return null;
+
+        return ParseCoordArray(je);
+    }
+
+    private static List<double[]> ParseCoordArray(JsonElement arrayElem)
+    {
+        var result = new List<double[]>();
+        foreach (var ptElem in arrayElem.EnumerateArray())
+        {
+            if (ptElem.ValueKind != JsonValueKind.Array)
+                continue;
+
+            var values = new List<double>();
+            foreach (var v in ptElem.EnumerateArray())
+            {
+                if (v.TryGetDouble(out double d))
+                    values.Add(d);
+            }
+            if (values.Count >= 2)
+                result.Add(values.ToArray());
+        }
+        return result;
+    }
+
+    // ---------------------------------------------------------------
+    // Property helpers
+    // ---------------------------------------------------------------
+
+    private static string? GetStringProp(GeoJsonFeature f, string key)
+    {
+        if (f.Properties.TryGetValue(key, out var val))
+        {
+            if (val is JsonElement je && je.ValueKind == JsonValueKind.String)
+                return je.GetString();
+            return val?.ToString();
+        }
+        return null;
+    }
+
+    private static double GetDoubleProp(GeoJsonFeature f, string key)
+    {
+        if (f.Properties.TryGetValue(key, out var val))
+        {
+            if (val is JsonElement je && je.ValueKind == JsonValueKind.Number)
+                return je.GetDouble();
+            if (val is double d)
+                return d;
+            if (double.TryParse(val?.ToString(), out double parsed))
+                return parsed;
+        }
+        return 0;
+    }
+
+    private static int GetIntProp(GeoJsonFeature f, string key)
+    {
+        if (f.Properties.TryGetValue(key, out var val))
+        {
+            if (val is JsonElement je && je.ValueKind == JsonValueKind.Number)
+                return je.GetInt32();
+            if (val is int i)
+                return i;
+            if (int.TryParse(val?.ToString(), out int parsed))
+                return parsed;
+        }
+        return 0;
+    }
+
+    private static bool GetBoolProp(GeoJsonFeature f, string key)
+    {
+        return GetBoolPropDefault(f, key, false);
+    }
+
+    private static bool GetBoolPropDefault(GeoJsonFeature f, string key, bool defaultValue)
+    {
+        if (f.Properties.TryGetValue(key, out var val))
+        {
+            if (val is JsonElement je)
+            {
+                if (je.ValueKind == JsonValueKind.True) return true;
+                if (je.ValueKind == JsonValueKind.False) return false;
+            }
+            if (val is bool b)
+                return b;
+            if (bool.TryParse(val?.ToString(), out bool parsed))
+                return parsed;
+        }
+        return defaultValue;
+    }
+}

--- a/Shared/AgValoniaGPS.Services/FieldService.cs
+++ b/Shared/AgValoniaGPS.Services/FieldService.cs
@@ -109,9 +109,9 @@ public class FieldService : IFieldService
         {
             GeoJsonFieldService.Save(field, tracks: null);
         }
-        catch
+        catch (Exception ex)
         {
-            // GeoJSON save is best-effort during migration; legacy files are authoritative
+            System.Diagnostics.Debug.WriteLine($"GeoJSON save failed: {ex.Message}");
         }
     }
 

--- a/Shared/AgValoniaGPS.Services/FieldService.cs
+++ b/Shared/AgValoniaGPS.Services/FieldService.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using AgValoniaGPS.Models;
+using AgValoniaGPS.Services.Field;
 
 namespace AgValoniaGPS.Services;
 
@@ -61,26 +62,36 @@ public class FieldService : IFieldService
     }
 
     /// <summary>
-    /// Load a complete field (Field.txt, Boundary.txt, BackPic.Txt)
+    /// Load a complete field. Prefers field.geojson when present, falls back to legacy text files.
     /// </summary>
     public Field LoadField(string fieldDirectory)
     {
-        var field = _fieldPlaneService.LoadField(fieldDirectory);
-        field.Boundary = _boundaryService.LoadBoundary(fieldDirectory);
-        field.BackgroundImage = _backgroundImageService.LoadBackgroundImage(fieldDirectory);
-        return field;
+        if (GeoJsonFieldService.Exists(fieldDirectory))
+        {
+            var (field, _) = GeoJsonFieldService.Load(fieldDirectory);
+            // Background image file (BackPic.png) is still loaded from the legacy service
+            // because the image itself is not stored in GeoJSON.
+            field.BackgroundImage ??= _backgroundImageService.LoadBackgroundImage(fieldDirectory);
+            return field;
+        }
+
+        var legacyField = _fieldPlaneService.LoadField(fieldDirectory);
+        legacyField.Boundary = _boundaryService.LoadBoundary(fieldDirectory);
+        legacyField.BackgroundImage = _backgroundImageService.LoadBackgroundImage(fieldDirectory);
+        return legacyField;
     }
 
     /// <summary>
-    /// Save a complete field (Field.txt, Boundary.txt, BackPic.Txt)
+    /// Save a complete field. Writes both GeoJSON and legacy formats for backwards compatibility.
     /// </summary>
-    public void SaveField(Field field)
+    public void SaveField(Models.Field field)
     {
         if (string.IsNullOrWhiteSpace(field.DirectoryPath))
         {
             throw new ArgumentException("Field.DirectoryPath must be set", nameof(field));
         }
 
+        // Legacy files (keep for AgOpenGPS interop)
         _fieldPlaneService.SaveField(field, field.DirectoryPath);
 
         if (field.Boundary != null)
@@ -91,6 +102,16 @@ public class FieldService : IFieldService
         if (field.BackgroundImage != null)
         {
             _backgroundImageService.SaveBackgroundImage(field.BackgroundImage, field.DirectoryPath);
+        }
+
+        // GeoJSON (new canonical format -- tracks saved separately by caller)
+        try
+        {
+            GeoJsonFieldService.Save(field, tracks: null);
+        }
+        catch
+        {
+            // GeoJSON save is best-effort during migration; legacy files are authoritative
         }
     }
 
@@ -138,12 +159,13 @@ public class FieldService : IFieldService
     }
 
     /// <summary>
-    /// Check if a field exists
+    /// Check if a field exists (GeoJSON or legacy)
     /// </summary>
     public bool FieldExists(string fieldDirectory)
     {
         return Directory.Exists(fieldDirectory) &&
-               File.Exists(Path.Combine(fieldDirectory, "Field.txt"));
+               (GeoJsonFieldService.Exists(fieldDirectory) ||
+                File.Exists(Path.Combine(fieldDirectory, "Field.txt")));
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/FieldService.cs
+++ b/Shared/AgValoniaGPS.Services/FieldService.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using AgValoniaGPS.Models;
-using AgValoniaGPS.Services.Field;
+using AgValoniaGPS.Services.GeoJson;
 
 namespace AgValoniaGPS.Services;
 
@@ -84,7 +84,7 @@ public class FieldService : IFieldService
     /// <summary>
     /// Save a complete field. Writes both GeoJSON and legacy formats for backwards compatibility.
     /// </summary>
-    public void SaveField(Models.Field field)
+    public void SaveField(Field field)
     {
         if (string.IsNullOrWhiteSpace(field.DirectoryPath))
         {

--- a/Shared/AgValoniaGPS.Services/GeoJson/GeoJsonFieldService.cs
+++ b/Shared/AgValoniaGPS.Services/GeoJson/GeoJsonFieldService.cs
@@ -25,7 +25,7 @@ using AgValoniaGPS.Models.GeoJson;
 using AgValoniaGPS.Models.Track;
 using AgValoniaGPS.Services.Geometry;
 
-namespace AgValoniaGPS.Services.Field;
+namespace AgValoniaGPS.Services.GeoJson;
 
 /// <summary>
 /// Loads and saves field data as GeoJSON FeatureCollections.

--- a/Shared/AgValoniaGPS.Services/Geometry/GeoConversionExtensions.cs
+++ b/Shared/AgValoniaGPS.Services/Geometry/GeoConversionExtensions.cs
@@ -1,0 +1,86 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+
+namespace AgValoniaGPS.Services.Geometry;
+
+/// <summary>
+/// Batch coordinate conversion helpers that delegate to <see cref="GeoConversion"/>.
+/// </summary>
+public static class GeoConversionExtensions
+{
+    /// <summary>
+    /// Convert a list of local easting/northing points to GeoJSON [lon, lat] arrays.
+    /// </summary>
+    public static List<double[]> ToGeoJsonCoordinates(this GeoConversion geo, IReadOnlyList<Vec2> localPoints)
+    {
+        var coords = new List<double[]>(localPoints.Count);
+        foreach (var pt in localPoints)
+        {
+            var (lat, lon) = geo.ToWgs84(pt);
+            coords.Add(new[] { lon, lat });
+        }
+        return coords;
+    }
+
+    /// <summary>
+    /// Convert a list of local Vec3 points to GeoJSON [lon, lat, heading] arrays.
+    /// Heading is preserved as the third element (radians).
+    /// </summary>
+    public static List<double[]> ToGeoJsonCoordinates(this GeoConversion geo, IReadOnlyList<Vec3> localPoints)
+    {
+        var coords = new List<double[]>(localPoints.Count);
+        foreach (var pt in localPoints)
+        {
+            var (lat, lon) = geo.ToWgs84(new Vec2(pt.Easting, pt.Northing));
+            coords.Add(new[] { lon, lat, pt.Heading });
+        }
+        return coords;
+    }
+
+    /// <summary>
+    /// Convert GeoJSON [lon, lat] arrays back to local Vec2 points.
+    /// </summary>
+    public static List<Vec2> FromGeoJsonCoordinates(this GeoConversion geo, IReadOnlyList<double[]> geoCoords)
+    {
+        var points = new List<Vec2>(geoCoords.Count);
+        foreach (var coord in geoCoords)
+        {
+            if (coord.Length < 2) continue;
+            points.Add(geo.ToLocal(coord[1], coord[0])); // lat = [1], lon = [0]
+        }
+        return points;
+    }
+
+    /// <summary>
+    /// Convert GeoJSON [lon, lat, heading] arrays back to local Vec3 points.
+    /// If only [lon, lat] is provided, heading defaults to 0.
+    /// </summary>
+    public static List<Vec3> FromGeoJsonCoordinatesVec3(this GeoConversion geo, IReadOnlyList<double[]> geoCoords)
+    {
+        var points = new List<Vec3>(geoCoords.Count);
+        foreach (var coord in geoCoords)
+        {
+            if (coord.Length < 2) continue;
+            var local = geo.ToLocal(coord[1], coord[0]);
+            double heading = coord.Length >= 3 ? coord[2] : 0;
+            points.Add(new Vec3(local.Easting, local.Northing, heading));
+        }
+        return points;
+    }
+}

--- a/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
@@ -1,0 +1,327 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Tool;
+
+namespace AgValoniaGPS.Services.Profile;
+
+/// <summary>
+/// Saves and loads vehicle profiles as structured JSON, replacing the flat AgOpenGPS XML format.
+/// Key improvement: dynamic section array (no 17-section hard limit).
+/// </summary>
+public static class ProfileJsonService
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Check whether a JSON profile exists for the given name.
+    /// </summary>
+    public static bool Exists(string vehiclesDirectory, string profileName)
+    {
+        return File.Exists(GetJsonPath(vehiclesDirectory, profileName));
+    }
+
+    /// <summary>
+    /// Save a VehicleProfile as JSON.
+    /// </summary>
+    public static void Save(string vehiclesDirectory, VehicleProfile profile)
+    {
+        if (!Directory.Exists(vehiclesDirectory))
+            Directory.CreateDirectory(vehiclesDirectory);
+
+        var dto = ToDto(profile);
+        var json = JsonSerializer.Serialize(dto, Options);
+        File.WriteAllText(GetJsonPath(vehiclesDirectory, profile.Name), json);
+    }
+
+    /// <summary>
+    /// Load a VehicleProfile from a JSON file. Returns null if the file does not exist.
+    /// </summary>
+    public static VehicleProfile? Load(string vehiclesDirectory, string profileName)
+    {
+        var path = GetJsonPath(vehiclesDirectory, profileName);
+        if (!File.Exists(path))
+            return null;
+
+        var json = File.ReadAllText(path);
+        var dto = JsonSerializer.Deserialize<ProfileDto>(json, Options);
+        if (dto == null)
+            return null;
+
+        return FromDto(dto, profileName, path);
+    }
+
+    private static string GetJsonPath(string vehiclesDirectory, string profileName)
+    {
+        return Path.Combine(vehiclesDirectory, $"{profileName}.json");
+    }
+
+    // ---------------------------------------------------------------
+    // DTO <-> VehicleProfile mapping
+    // ---------------------------------------------------------------
+
+    private static ProfileDto ToDto(VehicleProfile p)
+    {
+        // Trim trailing zeros from section positions
+        int usedPositions = p.NumSections + 1;
+        var sectionPositions = new double[usedPositions];
+        Array.Copy(p.SectionPositions, sectionPositions, Math.Min(usedPositions, p.SectionPositions.Length));
+
+        return new ProfileDto
+        {
+            FormatVersion = 1,
+            Vehicle = new VehicleDto
+            {
+                AntennaHeight = p.Vehicle.AntennaHeight,
+                AntennaPivot = p.Vehicle.AntennaPivot,
+                AntennaOffset = p.Vehicle.AntennaOffset,
+                Wheelbase = p.Vehicle.Wheelbase,
+                TrackWidth = p.Vehicle.TrackWidth,
+                Type = (int)p.Vehicle.Type,
+                MaxSteerAngle = p.Vehicle.MaxSteerAngle,
+                MaxAngularVelocity = p.Vehicle.MaxAngularVelocity,
+            },
+            Guidance = new GuidanceDto
+            {
+                GoalPointLookAheadHold = p.Vehicle.GoalPointLookAheadHold,
+                GoalPointLookAheadMult = p.Vehicle.GoalPointLookAheadMult,
+                GoalPointAcquireFactor = p.Vehicle.GoalPointAcquireFactor,
+                StanleyDistanceErrorGain = p.Vehicle.StanleyDistanceErrorGain,
+                StanleyHeadingErrorGain = p.Vehicle.StanleyHeadingErrorGain,
+                StanleyIntegralGainAB = p.Vehicle.StanleyIntegralGainAB,
+                PurePursuitIntegralGain = p.Vehicle.PurePursuitIntegralGain,
+                IsPurePursuit = p.IsPurePursuit,
+                UTurnCompensation = p.Vehicle.UTurnCompensation,
+            },
+            Tool = new ToolDto
+            {
+                Width = p.Tool.Width,
+                Overlap = p.Tool.Overlap,
+                Offset = p.Tool.Offset,
+                HitchLength = p.Tool.HitchLength,
+                TrailingHitchLength = p.Tool.TrailingHitchLength,
+                TankTrailingHitchLength = p.Tool.TankTrailingHitchLength,
+                TrailingToolToPivotLength = p.Tool.TrailingToolToPivotLength,
+                IsToolTrailing = p.Tool.IsToolTrailing,
+                IsToolTBT = p.Tool.IsToolTBT,
+                IsToolRearFixed = p.Tool.IsToolRearFixed,
+                IsToolFrontFixed = p.Tool.IsToolFrontFixed,
+                MinCoverage = p.Tool.MinCoverage,
+                IsMultiColoredSections = p.Tool.IsMultiColoredSections,
+                IsSectionsNotZones = p.Tool.IsSectionsNotZones,
+                IsSectionOffWhenOut = p.Tool.IsSectionOffWhenOut,
+                IsHeadlandSectionControl = p.Tool.IsHeadlandSectionControl,
+                LookAheadOn = p.Tool.LookAheadOnSetting,
+                LookAheadOff = p.Tool.LookAheadOffSetting,
+                TurnOffDelay = p.Tool.TurnOffDelay,
+            },
+            Sections = new SectionsDto
+            {
+                Count = p.NumSections,
+                Positions = sectionPositions,
+            },
+            YouTurn = new YouTurnDto
+            {
+                TurnRadius = p.YouTurn.TurnRadius,
+                ExtensionLength = p.YouTurn.ExtensionLength,
+                DistanceFromBoundary = p.YouTurn.DistanceFromBoundary,
+                SkipWidth = p.YouTurn.SkipWidth,
+                Style = p.YouTurn.Style,
+                Smoothing = p.YouTurn.Smoothing,
+            },
+            General = new GeneralDto
+            {
+                IsMetric = p.IsMetric,
+                IsSimulatorOn = p.IsSimulatorOn,
+                SimLatitude = p.SimLatitude,
+                SimLongitude = p.SimLongitude,
+            },
+        };
+    }
+
+#pragma warning disable CS0612 // Type or member is obsolete (VehicleProfile/VehicleConfiguration/ToolConfiguration/YouTurnConfiguration)
+    private static VehicleProfile FromDto(ProfileDto dto, string profileName, string filePath)
+    {
+        var sectionPositions = new double[17];
+        if (dto.Sections?.Positions != null)
+            Array.Copy(dto.Sections.Positions, sectionPositions, Math.Min(dto.Sections.Positions.Length, 17));
+
+        return new VehicleProfile
+        {
+            Name = profileName,
+            FilePath = filePath,
+            Vehicle = new VehicleConfiguration
+            {
+                AntennaHeight = dto.Vehicle?.AntennaHeight ?? 3.0,
+                AntennaPivot = dto.Vehicle?.AntennaPivot ?? 0.0,
+                AntennaOffset = dto.Vehicle?.AntennaOffset ?? 0.0,
+                Wheelbase = dto.Vehicle?.Wheelbase ?? 2.5,
+                TrackWidth = dto.Vehicle?.TrackWidth ?? 1.8,
+                Type = (VehicleType)(dto.Vehicle?.Type ?? 0),
+                MaxSteerAngle = dto.Vehicle?.MaxSteerAngle ?? 35.0,
+                MaxAngularVelocity = dto.Vehicle?.MaxAngularVelocity ?? 35.0,
+                GoalPointLookAheadHold = dto.Guidance?.GoalPointLookAheadHold ?? 4.0,
+                GoalPointLookAheadMult = dto.Guidance?.GoalPointLookAheadMult ?? 1.4,
+                GoalPointAcquireFactor = dto.Guidance?.GoalPointAcquireFactor ?? 1.5,
+                StanleyDistanceErrorGain = dto.Guidance?.StanleyDistanceErrorGain ?? 0.8,
+                StanleyHeadingErrorGain = dto.Guidance?.StanleyHeadingErrorGain ?? 1.0,
+                StanleyIntegralGainAB = dto.Guidance?.StanleyIntegralGainAB ?? 0.0,
+                PurePursuitIntegralGain = dto.Guidance?.PurePursuitIntegralGain ?? 0.0,
+                UTurnCompensation = dto.Guidance?.UTurnCompensation ?? 1.0,
+            },
+            Tool = new ToolConfiguration
+            {
+                Width = dto.Tool?.Width ?? 6.0,
+                Overlap = dto.Tool?.Overlap ?? 0.0,
+                Offset = dto.Tool?.Offset ?? 0.0,
+                HitchLength = dto.Tool?.HitchLength ?? -1.8,
+                TrailingHitchLength = dto.Tool?.TrailingHitchLength ?? -2.5,
+                TankTrailingHitchLength = dto.Tool?.TankTrailingHitchLength ?? 3.0,
+                TrailingToolToPivotLength = dto.Tool?.TrailingToolToPivotLength ?? 0.0,
+                IsToolTrailing = dto.Tool?.IsToolTrailing ?? false,
+                IsToolTBT = dto.Tool?.IsToolTBT ?? false,
+                IsToolRearFixed = dto.Tool?.IsToolRearFixed ?? true,
+                IsToolFrontFixed = dto.Tool?.IsToolFrontFixed ?? false,
+                NumOfSections = dto.Sections?.Count ?? 1,
+                MinCoverage = dto.Tool?.MinCoverage ?? 100,
+                IsMultiColoredSections = dto.Tool?.IsMultiColoredSections ?? false,
+                IsSectionsNotZones = dto.Tool?.IsSectionsNotZones ?? true,
+                IsSectionOffWhenOut = dto.Tool?.IsSectionOffWhenOut ?? true,
+                IsHeadlandSectionControl = dto.Tool?.IsHeadlandSectionControl ?? true,
+                LookAheadOnSetting = dto.Tool?.LookAheadOn ?? 1.0,
+                LookAheadOffSetting = dto.Tool?.LookAheadOff ?? 0.5,
+                TurnOffDelay = dto.Tool?.TurnOffDelay ?? 0.0,
+            },
+            YouTurn = new YouTurnConfiguration
+            {
+                TurnRadius = dto.YouTurn?.TurnRadius ?? 8.0,
+                ExtensionLength = dto.YouTurn?.ExtensionLength ?? 20.0,
+                DistanceFromBoundary = dto.YouTurn?.DistanceFromBoundary ?? 2.0,
+                SkipWidth = dto.YouTurn?.SkipWidth ?? 1,
+                Style = dto.YouTurn?.Style ?? 0,
+                Smoothing = dto.YouTurn?.Smoothing ?? 14,
+                UTurnCompensation = dto.Guidance?.UTurnCompensation ?? 1.0,
+            },
+            SectionPositions = sectionPositions,
+            NumSections = dto.Sections?.Count ?? 1,
+            IsMetric = dto.General?.IsMetric ?? false,
+            IsPurePursuit = dto.Guidance?.IsPurePursuit ?? true,
+            IsSimulatorOn = dto.General?.IsSimulatorOn ?? true,
+            SimLatitude = dto.General?.SimLatitude ?? 32.5904315166667,
+            SimLongitude = dto.General?.SimLongitude ?? -87.1804217333333,
+        };
+    }
+#pragma warning restore CS0612
+
+    // ---------------------------------------------------------------
+    // DTOs -- structured JSON representation
+    // ---------------------------------------------------------------
+
+    internal class ProfileDto
+    {
+        public int FormatVersion { get; set; }
+        public VehicleDto? Vehicle { get; set; }
+        public GuidanceDto? Guidance { get; set; }
+        public ToolDto? Tool { get; set; }
+        public SectionsDto? Sections { get; set; }
+        public YouTurnDto? YouTurn { get; set; }
+        public GeneralDto? General { get; set; }
+    }
+
+    internal class VehicleDto
+    {
+        public double AntennaHeight { get; set; }
+        public double AntennaPivot { get; set; }
+        public double AntennaOffset { get; set; }
+        public double Wheelbase { get; set; }
+        public double TrackWidth { get; set; }
+        public int Type { get; set; }
+        public double MaxSteerAngle { get; set; }
+        public double MaxAngularVelocity { get; set; }
+    }
+
+    internal class GuidanceDto
+    {
+        public double GoalPointLookAheadHold { get; set; }
+        public double GoalPointLookAheadMult { get; set; }
+        public double GoalPointAcquireFactor { get; set; }
+        public double StanleyDistanceErrorGain { get; set; }
+        public double StanleyHeadingErrorGain { get; set; }
+        public double StanleyIntegralGainAB { get; set; }
+        public double PurePursuitIntegralGain { get; set; }
+        public bool IsPurePursuit { get; set; }
+        public double UTurnCompensation { get; set; }
+    }
+
+    internal class ToolDto
+    {
+        public double Width { get; set; }
+        public double Overlap { get; set; }
+        public double Offset { get; set; }
+        public double HitchLength { get; set; }
+        public double TrailingHitchLength { get; set; }
+        public double TankTrailingHitchLength { get; set; }
+        public double TrailingToolToPivotLength { get; set; }
+        public bool IsToolTrailing { get; set; }
+        public bool IsToolTBT { get; set; }
+        public bool IsToolRearFixed { get; set; }
+        public bool IsToolFrontFixed { get; set; }
+        public int MinCoverage { get; set; }
+        public bool IsMultiColoredSections { get; set; }
+        public bool IsSectionsNotZones { get; set; }
+        public bool IsSectionOffWhenOut { get; set; }
+        public bool IsHeadlandSectionControl { get; set; }
+        public double LookAheadOn { get; set; }
+        public double LookAheadOff { get; set; }
+        public double TurnOffDelay { get; set; }
+    }
+
+    internal class SectionsDto
+    {
+        public int Count { get; set; }
+        public double[] Positions { get; set; } = Array.Empty<double>();
+    }
+
+    internal class YouTurnDto
+    {
+        public double TurnRadius { get; set; }
+        public double ExtensionLength { get; set; }
+        public double DistanceFromBoundary { get; set; }
+        public int SkipWidth { get; set; }
+        public int Style { get; set; }
+        public int Smoothing { get; set; }
+    }
+
+    internal class GeneralDto
+    {
+        public bool IsMetric { get; set; }
+        public bool IsSimulatorOn { get; set; }
+        public double SimLatitude { get; set; }
+        public double SimLongitude { get; set; }
+    }
+}

--- a/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
+++ b/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Tool;
 using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Profile;
 
 namespace AgValoniaGPS.Services;
 
@@ -55,20 +56,31 @@ public class VehicleProfileService : IVehicleProfileService
         if (!Directory.Exists(VehiclesDirectory))
             return new List<string>();
 
-        return Directory.GetFiles(VehiclesDirectory, "*.XML")
-            .Select(f => Path.GetFileNameWithoutExtension(f))
+        var xmlProfiles = Directory.GetFiles(VehiclesDirectory, "*.XML")
+            .Select(f => Path.GetFileNameWithoutExtension(f));
+        var jsonProfiles = Directory.GetFiles(VehiclesDirectory, "*.json")
+            .Select(f => Path.GetFileNameWithoutExtension(f));
+
+        return xmlProfiles.Concat(jsonProfiles)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(n => n)
             .ToList();
     }
 
     public VehicleProfile? Load(string profileName)
     {
-        var filePath = Path.Combine(VehiclesDirectory, $"{profileName}.XML");
-        if (!File.Exists(filePath))
-            return null;
-
         try
         {
+            // Prefer JSON format
+            var jsonProfile = ProfileJsonService.Load(VehiclesDirectory, profileName);
+            if (jsonProfile != null)
+                return jsonProfile;
+
+            // Fall back to legacy XML
+            var filePath = Path.Combine(VehiclesDirectory, $"{profileName}.XML");
+            if (!File.Exists(filePath))
+                return null;
+
             var doc = XDocument.Load(filePath);
             var settings = ParseSettings(doc);
 
@@ -99,6 +111,10 @@ public class VehicleProfileService : IVehicleProfileService
 
     public void Save(VehicleProfile profile)
     {
+        // Always save JSON (new canonical format)
+        ProfileJsonService.Save(VehiclesDirectory, profile);
+
+        // Also save legacy XML for backwards compatibility
         var filePath = string.IsNullOrEmpty(profile.FilePath)
             ? Path.Combine(VehiclesDirectory, $"{profile.Name}.XML")
             : profile.FilePath;

--- a/Tests/AgValoniaGPS.Services.Tests/FieldSaveLoadVerificationTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/FieldSaveLoadVerificationTests.cs
@@ -1,0 +1,293 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Services.GeoJson;
+
+using MTrack = AgValoniaGPS.Models.Track.Track;
+using MTrackType = AgValoniaGPS.Models.Track.TrackType;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// End-to-end verification of field save/load through FieldService.
+/// Simulates: create field -> add boundary -> add tracks -> save -> close -> reopen.
+/// </summary>
+[TestFixture]
+public class FieldSaveLoadVerificationTests
+{
+    private string _tempDir = null!;
+    private const double OriginLat = 32.5904;
+    private const double OriginLon = -87.1804;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"agvalonia_verify_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Test]
+    public void FullWorkflow_CreateField_SaveWithBoundary_Reopen()
+    {
+        var fieldService = new FieldService();
+
+        // 1. Create field
+        var field = fieldService.CreateField(_tempDir, "TestField", new Position
+        {
+            Latitude = OriginLat,
+            Longitude = OriginLon,
+        });
+
+        Assert.That(field.DirectoryPath, Does.Contain("TestField"));
+        var fieldDir = field.DirectoryPath;
+
+        // 2. Add outer boundary (100m square)
+        field.Boundary = new Boundary
+        {
+            OuterBoundary = CreateSquarePolygon(0, 0, 100),
+            InnerBoundaries = new List<BoundaryPolygon>
+            {
+                CreateSquarePolygon(30, 30, 20), // pond
+            },
+            HeadlandPolygon = CreateSquarePolygon(10, 10, 80), // headland inset
+        };
+
+        // 3. Save (writes legacy + GeoJSON)
+        fieldService.SaveField(field);
+
+        // 4. Verify files exist
+        Assert.That(File.Exists(Path.Combine(fieldDir, "Field.txt")), Is.True, "Legacy Field.txt");
+        Assert.That(File.Exists(Path.Combine(fieldDir, "Boundary.txt")), Is.True, "Legacy Boundary.txt");
+        Assert.That(File.Exists(Path.Combine(fieldDir, "field.geojson")), Is.True, "GeoJSON");
+
+        // 5. Reopen via FieldService (should prefer GeoJSON)
+        var loaded = fieldService.LoadField(fieldDir);
+
+        Assert.That(loaded.Name, Is.EqualTo("TestField"));
+        Assert.That(loaded.Origin.Latitude, Is.EqualTo(OriginLat).Within(1e-6));
+        Assert.That(loaded.Origin.Longitude, Is.EqualTo(OriginLon).Within(1e-6));
+
+        // 6. Verify boundary round-tripped
+        Assert.That(loaded.Boundary, Is.Not.Null);
+        Assert.That(loaded.Boundary!.OuterBoundary, Is.Not.Null);
+        Assert.That(loaded.Boundary.OuterBoundary!.Points, Has.Count.EqualTo(4));
+
+        // Corner accuracy within 1mm
+        Assert.That(loaded.Boundary.OuterBoundary.Points[0].Easting, Is.EqualTo(0).Within(0.001));
+        Assert.That(loaded.Boundary.OuterBoundary.Points[0].Northing, Is.EqualTo(0).Within(0.001));
+        Assert.That(loaded.Boundary.OuterBoundary.Points[2].Easting, Is.EqualTo(100).Within(0.001));
+        Assert.That(loaded.Boundary.OuterBoundary.Points[2].Northing, Is.EqualTo(100).Within(0.001));
+
+        // Inner boundary (pond)
+        Assert.That(loaded.Boundary.InnerBoundaries, Has.Count.EqualTo(1));
+        Assert.That(loaded.Boundary.InnerBoundaries[0].Points, Has.Count.EqualTo(4));
+
+        // Headland
+        Assert.That(loaded.Boundary.HeadlandPolygon, Is.Not.Null);
+        Assert.That(loaded.Boundary.HeadlandPolygon!.Points, Has.Count.EqualTo(4));
+        Assert.That(loaded.Boundary.HeadlandPolygon.Points[0].Easting, Is.EqualTo(10).Within(0.001));
+
+        // 7. Verify boundary is functional (point-in-polygon works after load)
+        Assert.That(loaded.Boundary.OuterBoundary.IsValid, Is.True);
+        Assert.That(loaded.Boundary.OuterBoundary.IsPointInside(50, 50), Is.True, "Center should be inside");
+        Assert.That(loaded.Boundary.OuterBoundary.IsPointInside(200, 200), Is.False, "Outside should be outside");
+    }
+
+    [Test]
+    public void FullWorkflow_GeoJsonWithTracks_RoundTrip()
+    {
+        // Save field + tracks via GeoJsonFieldService directly
+        var field = new Models.Field
+        {
+            Name = "TrackField",
+            DirectoryPath = _tempDir,
+            Origin = new Position { Latitude = OriginLat, Longitude = OriginLon },
+            Boundary = new Boundary
+            {
+                OuterBoundary = CreateSquarePolygon(0, 0, 500),
+            },
+        };
+
+        var tracks = new List<MTrack>
+        {
+            MTrack.FromABLine("North-South",
+                new Vec3(250, 0, 0),
+                new Vec3(250, 500, 0)),
+            MTrack.FromCurve("S-Curve", new List<Vec3>
+            {
+                new(100, 0, 0),
+                new(120, 100, 0.3),
+                new(100, 200, 0),
+                new(80, 300, -0.3),
+                new(100, 400, 0),
+            }),
+        };
+        tracks[0].NudgeDistance = 2.5;
+        tracks[0].IsVisible = true;
+        tracks[1].IsVisible = false;
+
+        GeoJsonFieldService.Save(field, tracks);
+
+        // Reload
+        var (loaded, loadedTracks) = GeoJsonFieldService.Load(_tempDir);
+
+        // Field
+        Assert.That(loaded.Name, Is.EqualTo("TrackField"));
+        Assert.That(loaded.Boundary!.OuterBoundary!.Points, Has.Count.EqualTo(4));
+
+        // Tracks
+        Assert.That(loadedTracks, Has.Count.EqualTo(2));
+
+        // AB Line
+        var ab = loadedTracks[0];
+        Assert.That(ab.Name, Is.EqualTo("North-South"));
+        Assert.That(ab.Type, Is.EqualTo(MTrackType.ABLine));
+        Assert.That(ab.Points, Has.Count.EqualTo(2));
+        Assert.That(ab.Points[0].Easting, Is.EqualTo(250).Within(0.001));
+        Assert.That(ab.Points[0].Northing, Is.EqualTo(0).Within(0.001));
+        Assert.That(ab.Points[1].Northing, Is.EqualTo(500).Within(0.001));
+        Assert.That(ab.NudgeDistance, Is.EqualTo(2.5).Within(0.001));
+        Assert.That(ab.IsVisible, Is.True);
+
+        // Curve
+        var curve = loadedTracks[1];
+        Assert.That(curve.Name, Is.EqualTo("S-Curve"));
+        Assert.That(curve.Type, Is.EqualTo(MTrackType.Curve));
+        Assert.That(curve.Points, Has.Count.EqualTo(5));
+        Assert.That(curve.IsVisible, Is.False);
+
+        // Curve point accuracy
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.That(curve.Points[i].Easting, Is.EqualTo(tracks[1].Points[i].Easting).Within(0.001),
+                $"Curve point {i} easting");
+            Assert.That(curve.Points[i].Northing, Is.EqualTo(tracks[1].Points[i].Northing).Within(0.001),
+                $"Curve point {i} northing");
+        }
+    }
+
+    [Test]
+    public void LegacyField_SaveReopen_MigratesGeoJson()
+    {
+        // Simulate a legacy field (Field.txt + Boundary.txt, no GeoJSON)
+        var fieldPlane = new FieldPlaneFileService();
+        var boundaryService = new BoundaryFileService();
+
+        var field = new Models.Field
+        {
+            Name = "LegacyField",
+            DirectoryPath = _tempDir,
+            Origin = new Position { Latitude = OriginLat, Longitude = OriginLon },
+        };
+        fieldPlane.SaveField(field, _tempDir);
+
+        var boundary = new Boundary { OuterBoundary = CreateSquarePolygon(0, 0, 200) };
+        boundaryService.SaveBoundary(boundary, _tempDir);
+
+        Assert.That(File.Exists(Path.Combine(_tempDir, "field.geojson")), Is.False, "No GeoJSON yet");
+
+        // Open via FieldService (legacy path since no GeoJSON)
+        var fieldService = new FieldService();
+        var loaded = fieldService.LoadField(_tempDir);
+        Assert.That(loaded.Boundary!.OuterBoundary!.Points, Has.Count.EqualTo(4));
+
+        // Save again -> should now create GeoJSON alongside legacy
+        fieldService.SaveField(loaded);
+        Assert.That(File.Exists(Path.Combine(_tempDir, "field.geojson")), Is.True, "GeoJSON created on save");
+
+        // Third open -> should now use GeoJSON path
+        var reopened = fieldService.LoadField(_tempDir);
+        Assert.That(reopened.Origin.Latitude, Is.EqualTo(OriginLat).Within(1e-6));
+        Assert.That(reopened.Boundary!.OuterBoundary!.Points, Has.Count.EqualTo(4));
+        Assert.That(reopened.Boundary.OuterBoundary.Points[2].Easting, Is.EqualTo(200).Within(0.001));
+    }
+
+    [Test]
+    public void HeadingValues_SurviveGeoJsonRoundTrip()
+    {
+        var field = new Models.Field
+        {
+            Name = "HeadingTest",
+            DirectoryPath = _tempDir,
+            Origin = new Position { Latitude = OriginLat, Longitude = OriginLon },
+            Boundary = new Boundary
+            {
+                OuterBoundary = CreateSquarePolygon(0, 0, 100),
+            },
+        };
+
+        // Boundary points have specific headings
+        var original = field.Boundary.OuterBoundary!.Points;
+        Assert.That(original[0].Heading, Is.EqualTo(0).Within(1e-10));
+        Assert.That(original[1].Heading, Is.EqualTo(Math.PI / 2).Within(1e-10));
+        Assert.That(original[2].Heading, Is.EqualTo(Math.PI).Within(1e-10));
+
+        GeoJsonFieldService.Save(field, tracks: null);
+        var (loaded, _) = GeoJsonFieldService.Load(_tempDir);
+
+        var loadedPts = loaded.Boundary!.OuterBoundary!.Points;
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.That(loadedPts[i].Heading, Is.EqualTo(original[i].Heading).Within(0.0001),
+                $"Point {i} heading");
+        }
+    }
+
+    [Test]
+    public void BoundaryPolygon_IsPointInside_WorksAfterGeoJsonLoad()
+    {
+        var field = new Models.Field
+        {
+            Name = "PointInPoly",
+            DirectoryPath = _tempDir,
+            Origin = new Position { Latitude = OriginLat, Longitude = OriginLon },
+            Boundary = new Boundary
+            {
+                OuterBoundary = CreateSquarePolygon(0, 0, 100),
+                InnerBoundaries = new List<BoundaryPolygon>
+                {
+                    CreateSquarePolygon(40, 40, 20), // hole in center
+                },
+            },
+        };
+
+        GeoJsonFieldService.Save(field, tracks: null);
+        var (loaded, _) = GeoJsonFieldService.Load(_tempDir);
+
+        var bnd = loaded.Boundary!;
+
+        // Outer boundary functional
+        Assert.That(bnd.OuterBoundary!.IsPointInside(50, 50), Is.True, "Center is inside outer");
+        Assert.That(bnd.OuterBoundary.IsPointInside(150, 150), Is.False, "Far away is outside");
+
+        // Inner boundary (hole) functional
+        Assert.That(bnd.InnerBoundaries[0].IsPointInside(50, 50), Is.True, "Center is inside hole");
+
+        // Composite check: point in hole should be outside usable area
+        Assert.That(bnd.IsPointInside(50, 50), Is.False, "Center of hole is not in usable area");
+        Assert.That(bnd.IsPointInside(10, 10), Is.True, "Corner is in usable area");
+    }
+
+    private static BoundaryPolygon CreateSquarePolygon(double originE, double originN, double size)
+    {
+        var polygon = new BoundaryPolygon
+        {
+            IsDriveThrough = false,
+            Points = new List<BoundaryPoint>
+            {
+                new(originE, originN, 0),
+                new(originE + size, originN, Math.PI / 2),
+                new(originE + size, originN + size, Math.PI),
+                new(originE, originN + size, 3 * Math.PI / 2),
+            }
+        };
+        polygon.UpdateBounds();
+        return polygon;
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/GeoJsonFieldServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/GeoJsonFieldServiceTests.cs
@@ -1,0 +1,302 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Services.Field;
+
+using MTrack = AgValoniaGPS.Models.Track.Track;
+using MTrackType = AgValoniaGPS.Models.Track.TrackType;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class GeoJsonFieldServiceTests
+{
+    private string _tempDir = null!;
+
+    // Origin near Tuscaloosa, AL (matches default sim position)
+    private const double OriginLat = 32.5904;
+    private const double OriginLon = -87.1804;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"agvalonia_geojson_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Test]
+    public void SaveAndLoad_EmptyField_RoundTrip()
+    {
+        var field = CreateTestField();
+
+        GeoJsonFieldService.Save(field, tracks: null);
+
+        Assert.That(File.Exists(Path.Combine(_tempDir, "field.geojson")), Is.True);
+
+        var (loaded, tracks) = GeoJsonFieldService.Load(_tempDir);
+
+        Assert.That(loaded.Name, Is.EqualTo(field.Name));
+        Assert.That(loaded.Origin.Latitude, Is.EqualTo(OriginLat).Within(1e-6));
+        Assert.That(loaded.Origin.Longitude, Is.EqualTo(OriginLon).Within(1e-6));
+        Assert.That(tracks, Is.Empty);
+    }
+
+    [Test]
+    public void SaveAndLoad_WithBoundary_CoordinateAccuracy()
+    {
+        var field = CreateTestField();
+        field.Boundary = new Boundary
+        {
+            OuterBoundary = CreateSquarePolygon(0, 0, 100)
+        };
+
+        GeoJsonFieldService.Save(field, tracks: null);
+        var (loaded, _) = GeoJsonFieldService.Load(_tempDir);
+
+        Assert.That(loaded.Boundary, Is.Not.Null);
+        Assert.That(loaded.Boundary!.OuterBoundary, Is.Not.Null);
+        Assert.That(loaded.Boundary.OuterBoundary!.Points, Has.Count.EqualTo(4));
+
+        // Verify coordinate round-trip accuracy within 1mm (local -> WGS84 -> local)
+        var originalPoints = field.Boundary.OuterBoundary!.Points;
+        var loadedPoints = loaded.Boundary.OuterBoundary.Points;
+        for (int i = 0; i < originalPoints.Count; i++)
+        {
+            Assert.That(loadedPoints[i].Easting, Is.EqualTo(originalPoints[i].Easting).Within(0.001),
+                $"Point {i} Easting accuracy");
+            Assert.That(loadedPoints[i].Northing, Is.EqualTo(originalPoints[i].Northing).Within(0.001),
+                $"Point {i} Northing accuracy");
+        }
+    }
+
+    [Test]
+    public void SaveAndLoad_WithInnerBoundaries_RoundTrip()
+    {
+        var field = CreateTestField();
+        field.Boundary = new Boundary
+        {
+            OuterBoundary = CreateSquarePolygon(0, 0, 200),
+            InnerBoundaries = new List<BoundaryPolygon>
+            {
+                CreateSquarePolygon(50, 50, 30),
+                CreateSquarePolygon(120, 120, 20),
+            }
+        };
+
+        GeoJsonFieldService.Save(field, tracks: null);
+        var (loaded, _) = GeoJsonFieldService.Load(_tempDir);
+
+        Assert.That(loaded.Boundary!.OuterBoundary, Is.Not.Null);
+        Assert.That(loaded.Boundary.InnerBoundaries, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void SaveAndLoad_WithHeadland_RoundTrip()
+    {
+        var field = CreateTestField();
+        field.Boundary = new Boundary
+        {
+            OuterBoundary = CreateSquarePolygon(0, 0, 200),
+            HeadlandPolygon = CreateSquarePolygon(20, 20, 160),
+        };
+
+        GeoJsonFieldService.Save(field, tracks: null);
+        var (loaded, _) = GeoJsonFieldService.Load(_tempDir);
+
+        Assert.That(loaded.Boundary!.HeadlandPolygon, Is.Not.Null);
+        Assert.That(loaded.Boundary.HeadlandPolygon!.Points, Has.Count.EqualTo(4));
+        Assert.That(loaded.Boundary.HeadlandPolygon.Points[0].Easting,
+            Is.EqualTo(20).Within(0.001));
+    }
+
+    [Test]
+    public void SaveAndLoad_WithTracks_RoundTrip()
+    {
+        var field = CreateTestField();
+        var tracks = new List<MTrack>
+        {
+            new()
+            {
+                Name = "AB Line 1",
+                Type = MTrackType.ABLine,
+                Points = new List<Vec3> { new(0, 0, 0), new(0, 100, 0) },
+                IsVisible = true,
+                NudgeDistance = 1.5,
+            },
+            new()
+            {
+                Name = "Curve 1",
+                Type = MTrackType.Curve,
+                Points = new List<Vec3> { new(10, 0, 0.1), new(15, 50, 0.2), new(20, 100, 0.3) },
+                IsVisible = false,
+                IsClosed = false,
+            },
+        };
+
+        GeoJsonFieldService.Save(field, tracks);
+        var (_, loadedTracks) = GeoJsonFieldService.Load(_tempDir);
+
+        Assert.That(loadedTracks, Has.Count.EqualTo(2));
+
+        Assert.That(loadedTracks[0].Name, Is.EqualTo("AB Line 1"));
+        Assert.That(loadedTracks[0].Type, Is.EqualTo(MTrackType.ABLine));
+        Assert.That(loadedTracks[0].Points, Has.Count.EqualTo(2));
+        Assert.That(loadedTracks[0].NudgeDistance, Is.EqualTo(1.5).Within(0.001));
+        Assert.That(loadedTracks[0].IsVisible, Is.True);
+
+        Assert.That(loadedTracks[1].Name, Is.EqualTo("Curve 1"));
+        Assert.That(loadedTracks[1].Type, Is.EqualTo(MTrackType.Curve));
+        Assert.That(loadedTracks[1].Points, Has.Count.EqualTo(3));
+        Assert.That(loadedTracks[1].IsVisible, Is.False);
+    }
+
+    [Test]
+    public void SaveAndLoad_TrackHeadings_Preserved()
+    {
+        var field = CreateTestField();
+        var tracks = new List<MTrack>
+        {
+            new()
+            {
+                Name = "Heading Test",
+                Type = MTrackType.Curve,
+                Points = new List<Vec3>
+                {
+                    new(0, 0, 0.7854),    // ~45 deg
+                    new(50, 50, 1.5708),   // ~90 deg
+                    new(100, 50, 3.1416),  // ~180 deg
+                },
+            }
+        };
+
+        GeoJsonFieldService.Save(field, tracks);
+        var (_, loadedTracks) = GeoJsonFieldService.Load(_tempDir);
+
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.That(loadedTracks[0].Points[i].Heading,
+                Is.EqualTo(tracks[0].Points[i].Heading).Within(0.0001),
+                $"Point {i} heading");
+        }
+    }
+
+    [Test]
+    public void SaveAndLoad_WithBackgroundImage_RoundTrip()
+    {
+        var field = CreateTestField();
+        field.BackgroundImage = new BackgroundImage
+        {
+            MinEasting = -200,
+            MaxEasting = 200,
+            MinNorthing = -150,
+            MaxNorthing = 150,
+            IsEnabled = true,
+        };
+
+        GeoJsonFieldService.Save(field, tracks: null);
+        var (loaded, _) = GeoJsonFieldService.Load(_tempDir);
+
+        Assert.That(loaded.BackgroundImage, Is.Not.Null);
+        Assert.That(loaded.BackgroundImage!.MinEasting, Is.EqualTo(-200).Within(0.01));
+        Assert.That(loaded.BackgroundImage.MaxEasting, Is.EqualTo(200).Within(0.01));
+        Assert.That(loaded.BackgroundImage.MinNorthing, Is.EqualTo(-150).Within(0.01));
+        Assert.That(loaded.BackgroundImage.MaxNorthing, Is.EqualTo(150).Within(0.01));
+    }
+
+    [Test]
+    public void SaveAndLoad_FieldMetadata_Preserved()
+    {
+        var field = CreateTestField();
+        field.Convergence = 1.23;
+        field.CreatedDate = new DateTime(2025, 6, 15, 10, 30, 0, DateTimeKind.Local);
+        field.LastModifiedDate = new DateTime(2025, 6, 16, 14, 0, 0, DateTimeKind.Local);
+
+        GeoJsonFieldService.Save(field, tracks: null);
+        var (loaded, _) = GeoJsonFieldService.Load(_tempDir);
+
+        Assert.That(loaded.Convergence, Is.EqualTo(1.23).Within(1e-6));
+        Assert.That(loaded.CreatedDate.Year, Is.EqualTo(2025));
+        Assert.That(loaded.CreatedDate.Month, Is.EqualTo(6));
+        Assert.That(loaded.CreatedDate.Day, Is.EqualTo(15));
+    }
+
+    [Test]
+    public void Exists_ReturnsFalse_WhenNoFile()
+    {
+        Assert.That(GeoJsonFieldService.Exists(_tempDir), Is.False);
+    }
+
+    [Test]
+    public void Exists_ReturnsTrue_AfterSave()
+    {
+        var field = CreateTestField();
+        GeoJsonFieldService.Save(field, tracks: null);
+
+        Assert.That(GeoJsonFieldService.Exists(_tempDir), Is.True);
+    }
+
+    [Test]
+    public void Load_ThrowsOnMissingFile()
+    {
+        Assert.Throws<FileNotFoundException>(() => GeoJsonFieldService.Load(_tempDir));
+    }
+
+    [Test]
+    public void GeoJsonOutput_IsValidJson()
+    {
+        var field = CreateTestField();
+        field.Boundary = new Boundary
+        {
+            OuterBoundary = CreateSquarePolygon(0, 0, 100)
+        };
+
+        GeoJsonFieldService.Save(field, tracks: null);
+
+        var json = File.ReadAllText(Path.Combine(_tempDir, "field.geojson"));
+        // Should not throw
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+
+        var root = doc.RootElement;
+        Assert.That(root.GetProperty("type").GetString(), Is.EqualTo("FeatureCollection"));
+        Assert.That(root.GetProperty("features").GetArrayLength(), Is.GreaterThan(0));
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private Models.Field CreateTestField()
+    {
+        return new Models.Field
+        {
+            Name = Path.GetFileName(_tempDir),
+            DirectoryPath = _tempDir,
+            Origin = new Position { Latitude = OriginLat, Longitude = OriginLon },
+            CreatedDate = DateTime.Now,
+            LastModifiedDate = DateTime.Now,
+        };
+    }
+
+    private static BoundaryPolygon CreateSquarePolygon(double originE, double originN, double size)
+    {
+        var polygon = new BoundaryPolygon
+        {
+            IsDriveThrough = false,
+            Points = new List<BoundaryPoint>
+            {
+                new(originE, originN, 0),
+                new(originE + size, originN, Math.PI / 2),
+                new(originE + size, originN + size, Math.PI),
+                new(originE, originN + size, 3 * Math.PI / 2),
+            }
+        };
+        polygon.UpdateBounds();
+        return polygon;
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/GeoJsonFieldServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/GeoJsonFieldServiceTests.cs
@@ -1,6 +1,6 @@
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Base;
-using AgValoniaGPS.Services.Field;
+using AgValoniaGPS.Services.GeoJson;
 
 using MTrack = AgValoniaGPS.Models.Track.Track;
 using MTrackType = AgValoniaGPS.Models.Track.TrackType;

--- a/Tests/AgValoniaGPS.Services.Tests/GeoJsonFieldServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/GeoJsonFieldServiceTests.cs
@@ -268,6 +268,67 @@ public class GeoJsonFieldServiceTests
     }
 
     // ---------------------------------------------------------------
+    // FieldService integration (auto-detect path)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void FieldService_SaveCreatesGeoJson_LoadPrefersIt()
+    {
+        // Save via FieldService (writes legacy + GeoJSON)
+        var fieldService = new FieldService();
+        var field = CreateTestField();
+        field.Boundary = new Boundary
+        {
+            OuterBoundary = CreateSquarePolygon(0, 0, 100)
+        };
+
+        // Create Field.txt so legacy path is valid
+        fieldService.SaveField(field);
+
+        // Verify both formats exist
+        Assert.That(File.Exists(Path.Combine(_tempDir, "Field.txt")), Is.True, "Legacy Field.txt");
+        Assert.That(File.Exists(Path.Combine(_tempDir, "field.geojson")), Is.True, "GeoJSON file");
+
+        // Load via FieldService -- should prefer GeoJSON
+        var loaded = fieldService.LoadField(_tempDir);
+        Assert.That(loaded.Origin.Latitude, Is.EqualTo(OriginLat).Within(1e-6));
+        Assert.That(loaded.Boundary, Is.Not.Null);
+        Assert.That(loaded.Boundary!.OuterBoundary, Is.Not.Null);
+        Assert.That(loaded.Boundary.OuterBoundary!.Points, Has.Count.EqualTo(4));
+    }
+
+    [Test]
+    public void FieldService_LoadsFallbackToLegacy_WhenNoGeoJson()
+    {
+        // Create legacy field only (no GeoJSON)
+        var fieldService = new FieldService();
+        var field = CreateTestField();
+        fieldService.SaveField(field);
+
+        // Delete the GeoJSON file to force legacy path
+        var geoJsonPath = Path.Combine(_tempDir, "field.geojson");
+        if (File.Exists(geoJsonPath))
+            File.Delete(geoJsonPath);
+
+        var loaded = fieldService.LoadField(_tempDir);
+        Assert.That(loaded.Origin.Latitude, Is.EqualTo(OriginLat).Within(1e-6));
+    }
+
+    [Test]
+    public void FieldService_FieldExists_DetectsGeoJson()
+    {
+        var fieldService = new FieldService();
+
+        Assert.That(fieldService.FieldExists(_tempDir), Is.False);
+
+        // Create only a GeoJSON file (no Field.txt)
+        var field = CreateTestField();
+        GeoJsonFieldService.Save(field, tracks: null);
+
+        Assert.That(fieldService.FieldExists(_tempDir), Is.True);
+    }
+
+    // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------
 

--- a/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
@@ -75,6 +75,7 @@ public class ProfileJsonServiceTests
         profile.Tool.IsToolTrailing = true;
         profile.Tool.IsToolTBT = false;
         profile.Tool.NumOfSections = 4;
+        profile.NumSections = 4;
         profile.Tool.MinCoverage = 80;
         profile.Tool.IsHeadlandSectionControl = true;
 

--- a/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
@@ -1,0 +1,237 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Tool;
+using AgValoniaGPS.Services.Profile;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class ProfileJsonServiceTests
+{
+    private string _tempDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"agvalonia_profile_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+#pragma warning disable CS0612 // Type or member is obsolete (VehicleProfile/VehicleConfiguration/ToolConfiguration/YouTurnConfiguration)
+
+    [Test]
+    public void SaveAndLoad_DefaultProfile_RoundTrip()
+    {
+        var profile = CreateTestProfile("TestTractor");
+
+        ProfileJsonService.Save(_tempDir, profile);
+
+        Assert.That(File.Exists(Path.Combine(_tempDir, "TestTractor.json")), Is.True);
+
+        var loaded = ProfileJsonService.Load(_tempDir, "TestTractor");
+
+        Assert.That(loaded, Is.Not.Null);
+        Assert.That(loaded!.Name, Is.EqualTo("TestTractor"));
+    }
+
+    [Test]
+    public void SaveAndLoad_VehicleConfig_AllProperties()
+    {
+        var profile = CreateTestProfile("VehicleTest");
+        profile.Vehicle.AntennaHeight = 4.2;
+        profile.Vehicle.AntennaPivot = 1.1;
+        profile.Vehicle.AntennaOffset = -0.3;
+        profile.Vehicle.Wheelbase = 3.5;
+        profile.Vehicle.TrackWidth = 2.1;
+        profile.Vehicle.MaxSteerAngle = 40.0;
+        profile.Vehicle.MaxAngularVelocity = 30.0;
+
+        ProfileJsonService.Save(_tempDir, profile);
+        var loaded = ProfileJsonService.Load(_tempDir, "VehicleTest")!;
+
+        Assert.That(loaded.Vehicle.AntennaHeight, Is.EqualTo(4.2).Within(1e-6));
+        Assert.That(loaded.Vehicle.AntennaPivot, Is.EqualTo(1.1).Within(1e-6));
+        Assert.That(loaded.Vehicle.AntennaOffset, Is.EqualTo(-0.3).Within(1e-6));
+        Assert.That(loaded.Vehicle.Wheelbase, Is.EqualTo(3.5).Within(1e-6));
+        Assert.That(loaded.Vehicle.TrackWidth, Is.EqualTo(2.1).Within(1e-6));
+        Assert.That(loaded.Vehicle.MaxSteerAngle, Is.EqualTo(40.0).Within(1e-6));
+        Assert.That(loaded.Vehicle.MaxAngularVelocity, Is.EqualTo(30.0).Within(1e-6));
+    }
+
+    [Test]
+    public void SaveAndLoad_ToolConfig_AllProperties()
+    {
+        var profile = CreateTestProfile("ToolTest");
+        profile.Tool.Width = 12.0;
+        profile.Tool.Overlap = 0.15;
+        profile.Tool.Offset = -0.5;
+        profile.Tool.HitchLength = -2.5;
+        profile.Tool.IsToolTrailing = true;
+        profile.Tool.IsToolTBT = false;
+        profile.Tool.NumOfSections = 4;
+        profile.Tool.MinCoverage = 80;
+        profile.Tool.IsHeadlandSectionControl = true;
+
+        ProfileJsonService.Save(_tempDir, profile);
+        var loaded = ProfileJsonService.Load(_tempDir, "ToolTest")!;
+
+        Assert.That(loaded.Tool.Width, Is.EqualTo(12.0).Within(1e-6));
+        Assert.That(loaded.Tool.Overlap, Is.EqualTo(0.15).Within(1e-6));
+        Assert.That(loaded.Tool.Offset, Is.EqualTo(-0.5).Within(1e-6));
+        Assert.That(loaded.Tool.HitchLength, Is.EqualTo(-2.5).Within(1e-6));
+        Assert.That(loaded.Tool.IsToolTrailing, Is.True);
+        Assert.That(loaded.Tool.IsToolTBT, Is.False);
+        Assert.That(loaded.Tool.NumOfSections, Is.EqualTo(4));
+        Assert.That(loaded.Tool.MinCoverage, Is.EqualTo(80));
+        Assert.That(loaded.Tool.IsHeadlandSectionControl, Is.True);
+    }
+
+    [Test]
+    public void SaveAndLoad_GuidanceConfig_RoundTrip()
+    {
+        var profile = CreateTestProfile("GuidanceTest");
+        profile.Vehicle.GoalPointLookAheadHold = 5.0;
+        profile.Vehicle.StanleyDistanceErrorGain = 1.2;
+        profile.Vehicle.StanleyHeadingErrorGain = 0.9;
+        profile.Vehicle.PurePursuitIntegralGain = 0.05;
+        profile.IsPurePursuit = false;
+
+        ProfileJsonService.Save(_tempDir, profile);
+        var loaded = ProfileJsonService.Load(_tempDir, "GuidanceTest")!;
+
+        Assert.That(loaded.Vehicle.GoalPointLookAheadHold, Is.EqualTo(5.0).Within(1e-6));
+        Assert.That(loaded.Vehicle.StanleyDistanceErrorGain, Is.EqualTo(1.2).Within(1e-6));
+        Assert.That(loaded.Vehicle.StanleyHeadingErrorGain, Is.EqualTo(0.9).Within(1e-6));
+        Assert.That(loaded.Vehicle.PurePursuitIntegralGain, Is.EqualTo(0.05).Within(1e-6));
+        Assert.That(loaded.IsPurePursuit, Is.False);
+    }
+
+    [Test]
+    public void SaveAndLoad_SectionPositions_DynamicArray()
+    {
+        var profile = CreateTestProfile("SectionTest");
+        profile.NumSections = 4;
+        profile.SectionPositions = new double[17];
+        profile.SectionPositions[0] = -6.0;
+        profile.SectionPositions[1] = -3.0;
+        profile.SectionPositions[2] = 0.0;
+        profile.SectionPositions[3] = 3.0;
+        profile.SectionPositions[4] = 6.0;
+
+        ProfileJsonService.Save(_tempDir, profile);
+        var loaded = ProfileJsonService.Load(_tempDir, "SectionTest")!;
+
+        Assert.That(loaded.NumSections, Is.EqualTo(4));
+        Assert.That(loaded.SectionPositions[0], Is.EqualTo(-6.0).Within(1e-6));
+        Assert.That(loaded.SectionPositions[1], Is.EqualTo(-3.0).Within(1e-6));
+        Assert.That(loaded.SectionPositions[2], Is.EqualTo(0.0).Within(1e-6));
+        Assert.That(loaded.SectionPositions[3], Is.EqualTo(3.0).Within(1e-6));
+        Assert.That(loaded.SectionPositions[4], Is.EqualTo(6.0).Within(1e-6));
+    }
+
+    [Test]
+    public void SaveAndLoad_YouTurnConfig_RoundTrip()
+    {
+        var profile = CreateTestProfile("UTurnTest");
+        profile.YouTurn.TurnRadius = 10.0;
+        profile.YouTurn.ExtensionLength = 25.0;
+        profile.YouTurn.DistanceFromBoundary = 3.0;
+        profile.YouTurn.SkipWidth = 2;
+        profile.YouTurn.Style = 1;
+        profile.YouTurn.Smoothing = 20;
+
+        ProfileJsonService.Save(_tempDir, profile);
+        var loaded = ProfileJsonService.Load(_tempDir, "UTurnTest")!;
+
+        Assert.That(loaded.YouTurn.TurnRadius, Is.EqualTo(10.0).Within(1e-6));
+        Assert.That(loaded.YouTurn.ExtensionLength, Is.EqualTo(25.0).Within(1e-6));
+        Assert.That(loaded.YouTurn.DistanceFromBoundary, Is.EqualTo(3.0).Within(1e-6));
+        Assert.That(loaded.YouTurn.SkipWidth, Is.EqualTo(2));
+        Assert.That(loaded.YouTurn.Style, Is.EqualTo(1));
+        Assert.That(loaded.YouTurn.Smoothing, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void SaveAndLoad_GeneralSettings_RoundTrip()
+    {
+        var profile = CreateTestProfile("GeneralTest");
+        profile.IsMetric = true;
+        profile.IsSimulatorOn = false;
+        profile.SimLatitude = 48.8566;
+        profile.SimLongitude = 2.3522;
+
+        ProfileJsonService.Save(_tempDir, profile);
+        var loaded = ProfileJsonService.Load(_tempDir, "GeneralTest")!;
+
+        Assert.That(loaded.IsMetric, Is.True);
+        Assert.That(loaded.IsSimulatorOn, Is.False);
+        Assert.That(loaded.SimLatitude, Is.EqualTo(48.8566).Within(1e-6));
+        Assert.That(loaded.SimLongitude, Is.EqualTo(2.3522).Within(1e-6));
+    }
+
+    [Test]
+    public void Load_MissingFile_ReturnsNull()
+    {
+        var loaded = ProfileJsonService.Load(_tempDir, "NonExistent");
+        Assert.That(loaded, Is.Null);
+    }
+
+    [Test]
+    public void Exists_ReturnsFalse_WhenNoFile()
+    {
+        Assert.That(ProfileJsonService.Exists(_tempDir, "Nope"), Is.False);
+    }
+
+    [Test]
+    public void Exists_ReturnsTrue_AfterSave()
+    {
+        ProfileJsonService.Save(_tempDir, CreateTestProfile("ExistsTest"));
+        Assert.That(ProfileJsonService.Exists(_tempDir, "ExistsTest"), Is.True);
+    }
+
+    [Test]
+    public void JsonOutput_IsValidAndReadable()
+    {
+        ProfileJsonService.Save(_tempDir, CreateTestProfile("JsonCheck"));
+        var json = File.ReadAllText(Path.Combine(_tempDir, "JsonCheck.json"));
+
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.That(root.GetProperty("formatVersion").GetInt32(), Is.EqualTo(1));
+        Assert.That(root.TryGetProperty("vehicle", out _), Is.True);
+        Assert.That(root.TryGetProperty("guidance", out _), Is.True);
+        Assert.That(root.TryGetProperty("tool", out _), Is.True);
+        Assert.That(root.TryGetProperty("sections", out _), Is.True);
+        Assert.That(root.TryGetProperty("youTurn", out _), Is.True);
+        Assert.That(root.TryGetProperty("general", out _), Is.True);
+    }
+
+#pragma warning restore CS0612
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static VehicleProfile CreateTestProfile(string name)
+    {
+        return new VehicleProfile
+        {
+            Name = name,
+            Vehicle = new VehicleConfiguration(),
+            Tool = new ToolConfiguration { Width = 6.0, NumOfSections = 1 },
+            YouTurn = new YouTurnConfiguration(),
+            SectionPositions = new double[17] { -3.0, 3.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            NumSections = 1,
+            IsMetric = false,
+            IsPurePursuit = true,
+            IsSimulatorOn = true,
+        };
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
@@ -214,6 +214,20 @@ public class ProfileJsonServiceTests
         Assert.That(root.TryGetProperty("general", out _), Is.True);
     }
 
+    [Test]
+    public void UTurnCompensation_RoundTrips_ToBothLocations()
+    {
+        var profile = CreateTestProfile("UTurnComp");
+        profile.Vehicle.UTurnCompensation = 1.75;
+        profile.YouTurn.UTurnCompensation = 1.75;
+
+        ProfileJsonService.Save(_tempDir, profile);
+        var loaded = ProfileJsonService.Load(_tempDir, "UTurnComp")!;
+
+        Assert.That(loaded.Vehicle.UTurnCompensation, Is.EqualTo(1.75).Within(1e-6));
+        Assert.That(loaded.YouTurn.UTurnCompensation, Is.EqualTo(1.75).Within(1e-6));
+    }
+
 #pragma warning restore CS0612
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## What changed

Adds modern file formats alongside the existing legacy text/XML services:

- **GeoJSON field format** (`field.geojson`) -- RFC 7946 FeatureCollection with boundaries, tracks, headland, background image bounds, and field metadata
- **JSON vehicle profiles** (`.json`) -- structured format with dynamic section array, removes the 17-section hard limit
- **Auto-detection** -- FieldService and VehicleProfileService prefer new formats on load, fall back to legacy, write both formats on save for backwards compatibility
- **32 new tests** -- round-trip accuracy within 1mm, FieldService integration, end-to-end save/load verification

Legacy file services are untouched and coexist.

## Related issue

Relates to #64, relates to #65, relates to #66

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes (185 tests: 72 model + 113 service)
- [x] Field save/load verified: create -> add boundary/tracks -> save -> reopen from GeoJSON
- [x] Legacy migration verified: legacy-only field auto-creates GeoJSON on save
- [x] IsPointInside works after GeoJSON round-trip (spatial index rebuilt)
- [x] Heading values survive GeoJSON round-trip