### PR TITLE
Fix track-up mode rotation and vehicle orientation

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -663,14 +663,15 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         // Center on screen
         matrix = matrix * Matrix.CreateTranslation(bounds.Width / 2, bounds.Height / 2);
 
-        // Apply rotation around center
+        // Scale from world to screen (includes Y-flip for screen coordinates)
+        matrix = Matrix.CreateScale(scaleX, scaleY) * matrix;
+
+        // Apply rotation in world space (before Y-flip so vehicle heading
+        // and camera rotation cancel correctly in track-up mode)
         if (Math.Abs(_rotation) > 0.001)
         {
             matrix = Matrix.CreateRotation(-_rotation) * matrix;
         }
-
-        // Scale from world to screen
-        matrix = Matrix.CreateScale(scaleX, scaleY) * matrix;
 
         // Translate camera position
         matrix = Matrix.CreateTranslation(-_cameraX, -_cameraY) * matrix;


### PR DESCRIPTION
## Summary
- Camera rotation in `GetCameraTransform` was applied after the Y-flip scale, causing it to operate in screen space while vehicle/tool rotations operate in world space
- In track-up mode the rotations stacked instead of canceling: the vehicle pointed sideways and the map rotated the wrong direction
- Fix: swap scale and rotation order so both are in world space and cancel correctly

Bug present since the control was created in 2632fd2.

## Test plan
- [x] Run `dotnet test Tests/` -- all 220 tests pass
- [x] Enable track-up mode in the app, verify vehicle points straight up
- [x] Verify map content (boundary, coverage, AB line) rotates correctly (CW for rightward headings)