### PR TITLE
Add real-time diagnostic charts (Steer, Heading, XTE)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -86,6 +86,9 @@ public static class ServiceCollectionExtensions
         // AutoSteer pipeline service (zero-copy GPS→PGN path)
         services.AddSingleton<IAutoSteerService, AutoSteerService>();
 
+        // Chart data service (collects rolling time-series for diagnostic charts)
+        services.AddSingleton<IChartDataService, ChartDataService>();
+
         // Module communication service (work switch, steer switch logic)
         services.AddSingleton<IModuleCommunicationService, ModuleCommunicationService>();
 

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -92,6 +92,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <panels:BottomNavigationPanel x:Name="BottomNavPanel"
                                                   Canvas.Left="200" Canvas.Top="420"
                                                   DataContext="{Binding}"/>
+
+                    <!-- Chart Panels (Draggable) -->
+                    <panels:SteerChartPanel x:Name="SteerChartPanel"
+                                            Canvas.Left="300" Canvas.Top="20"
+                                            DataContext="{Binding}"/>
+                    <panels:HeadingChartPanel x:Name="HeadingChartPanel"
+                                              Canvas.Left="300" Canvas.Top="250"
+                                              DataContext="{Binding}"/>
+                    <panels:XTEChartPanel x:Name="XTEChartPanel"
+                                          Canvas.Left="300" Canvas.Top="480"
+                                          DataContext="{Binding}"/>
                 </Canvas>
 
                 <!-- Zoom Controls - Bottom Right -->

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -66,6 +66,11 @@ public partial class MainView : UserControl
         // Restore panel positions from ConfigurationStore
         RestorePanelPositions();
 
+        // Wire up chart panel drag events
+        WireChartPanelDrag("SteerChartPanel");
+        WireChartPanelDrag("HeadingChartPanel");
+        WireChartPanelDrag("XTEChartPanel");
+
         // Handle view resize to keep panels in bounds
         this.PropertyChanged += MainView_PropertyChanged;
 
@@ -444,6 +449,26 @@ public partial class MainView : UserControl
                 // Update map with pending Point A marker
                 _mapControl.SetPendingPointA(_viewModel.PendingPointA);
             }
+        }
+    }
+
+    private void WireChartPanelDrag(string panelName)
+    {
+        var panel = this.FindControl<Control>(panelName);
+        if (panel == null) return;
+
+        var dragMovedEvent = panel.GetType().GetEvent("DragMoved");
+        if (dragMovedEvent != null)
+        {
+            dragMovedEvent.AddEventHandler(panel, new EventHandler<Vector>((_, delta) =>
+            {
+                double newLeft = Canvas.GetLeft(panel) + delta.X;
+                double newTop = Canvas.GetTop(panel) + delta.Y;
+                double maxLeft = Math.Max(0, Bounds.Width - panel.Bounds.Width);
+                double maxTop = Math.Max(0, Bounds.Height - panel.Bounds.Height);
+                Canvas.SetLeft(panel, Math.Clamp(newLeft, 0, maxLeft));
+                Canvas.SetTop(panel, Math.Clamp(newTop, 0, maxTop));
+            }));
         }
     }
 

--- a/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
@@ -65,6 +65,11 @@ public partial class App : Application
 
         Services = _host.Services;
 
+        // Provide DI to chart panels for auto-configuration
+        AgValoniaGPS.Views.Controls.Panels.SteerChartPanel.ServiceProvider = Services;
+        AgValoniaGPS.Views.Controls.Panels.HeadingChartPanel.ServiceProvider = Services;
+        AgValoniaGPS.Views.Controls.Panels.XTEChartPanel.ServiceProvider = Services;
+
         // Wire up cross-referencing services (AutoSteer → UDP)
         Services.WireUpServices();
 

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -88,6 +88,9 @@ public static class ServiceCollectionExtensions
         // AutoSteer pipeline service (zero-copy GPS→PGN path)
         services.AddSingleton<IAutoSteerService, AutoSteerService>();
 
+        // Chart data service (collects rolling time-series for diagnostic charts)
+        services.AddSingleton<IChartDataService, ChartDataService>();
+
         // Module communication service (work switch, steer switch logic)
         services.AddSingleton<IModuleCommunicationService, ModuleCommunicationService>();
 

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -134,6 +134,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <panels:BottomNavigationPanel x:Name="BottomNavPanel"
                                           Canvas.Left="200" Canvas.Top="600"
                                           DataContext="{Binding}"/>
+
+            <!-- Chart Panels (Draggable) -->
+            <panels:SteerChartPanel x:Name="SteerChartPanel"
+                                    Canvas.Left="400" Canvas.Top="20"
+                                    DataContext="{Binding}"/>
+            <panels:HeadingChartPanel x:Name="HeadingChartPanel"
+                                      Canvas.Left="400" Canvas.Top="250"
+                                      DataContext="{Binding}"/>
+            <panels:XTEChartPanel x:Name="XTEChartPanel"
+                                  Canvas.Left="400" Canvas.Top="480"
+                                  DataContext="{Binding}"/>
         </Canvas>
     </Grid>
 

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -101,6 +101,14 @@ public partial class MainWindow : Window
         }
 
         // Note: BottomNavigationPanel is now a fixed-position panel without drag support
+
+        // Wire up chart panel drag events
+        if (SteerChartPanel != null)
+            SteerChartPanel.DragMoved += (_, delta) => MovePanel(SteerChartPanel, delta);
+        if (HeadingChartPanel != null)
+            HeadingChartPanel.DragMoved += (_, delta) => MovePanel(HeadingChartPanel, delta);
+        if (XTEChartPanel != null)
+            XTEChartPanel.DragMoved += (_, delta) => MovePanel(XTEChartPanel, delta);
     }
 
     private void MovePanel(Control panel, Vector delta)

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -86,6 +86,9 @@ public static class ServiceCollectionExtensions
         // AutoSteer pipeline service (zero-copy GPS→PGN path)
         services.AddSingleton<IAutoSteerService, AutoSteerService>();
 
+        // Chart data service (collects rolling time-series for diagnostic charts)
+        services.AddSingleton<IChartDataService, ChartDataService>();
+
         // Module communication service (work switch, steer switch logic)
         services.AddSingleton<IModuleCommunicationService, ModuleCommunicationService>();
 

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -92,6 +92,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <panels:BottomNavigationPanel x:Name="BottomNavPanel"
                                                   Canvas.Left="200" Canvas.Top="420"
                                                   DataContext="{Binding}"/>
+
+                    <!-- Chart Panels (Draggable) -->
+                    <panels:SteerChartPanel x:Name="SteerChartPanel"
+                                            Canvas.Left="300" Canvas.Top="20"
+                                            DataContext="{Binding}"/>
+                    <panels:HeadingChartPanel x:Name="HeadingChartPanel"
+                                              Canvas.Left="300" Canvas.Top="250"
+                                              DataContext="{Binding}"/>
+                    <panels:XTEChartPanel x:Name="XTEChartPanel"
+                                          Canvas.Left="300" Canvas.Top="480"
+                                          DataContext="{Binding}"/>
                 </Canvas>
 
                 <!-- Zoom Controls - Bottom Right -->

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -66,6 +66,11 @@ public partial class MainView : UserControl
         // Restore panel positions from ConfigurationStore
         RestorePanelPositions();
 
+        // Wire up chart panel drag events
+        WireChartPanelDrag("SteerChartPanel");
+        WireChartPanelDrag("HeadingChartPanel");
+        WireChartPanelDrag("XTEChartPanel");
+
         // Handle window resize to keep panels in view
         this.PropertyChanged += MainView_PropertyChanged;
 
@@ -449,6 +454,27 @@ public partial class MainView : UserControl
                 // Update map with pending Point A marker
                 _mapControl.SetPendingPointA(_viewModel.PendingPointA);
             }
+        }
+    }
+
+    private void WireChartPanelDrag(string panelName)
+    {
+        var panel = this.FindControl<Control>(panelName);
+        if (panel == null) return;
+
+        // Chart panels expose DragMoved as an event via reflection-free duck typing
+        var dragMovedEvent = panel.GetType().GetEvent("DragMoved");
+        if (dragMovedEvent != null)
+        {
+            dragMovedEvent.AddEventHandler(panel, new EventHandler<Vector>((_, delta) =>
+            {
+                double newLeft = Canvas.GetLeft(panel) + delta.X;
+                double newTop = Canvas.GetTop(panel) + delta.Y;
+                double maxLeft = Math.Max(0, Bounds.Width - panel.Bounds.Width);
+                double maxTop = Math.Max(0, Bounds.Height - panel.Bounds.Height);
+                Canvas.SetLeft(panel, Math.Clamp(newLeft, 0, maxLeft));
+                Canvas.SetTop(panel, Math.Clamp(newTop, 0, maxTop));
+            }));
         }
     }
 

--- a/Shared/AgValoniaGPS.Services/ChartDataService.cs
+++ b/Shared/AgValoniaGPS.Services/ChartDataService.cs
@@ -30,14 +30,14 @@ public class ChartDataService : IChartDataService
     private readonly Stopwatch _stopwatch = new();
     private bool _isRunning;
 
-    // Colors: ARGB uint values
-    private const uint ColorYellow = 0xFFFFFF00;
-    private const uint ColorGreen = 0xFF00FF00;
-    private const uint ColorCyan = 0xFF00FFFF;
-    private const uint ColorRed = 0xFFFF4444;
-    private const uint ColorOrange = 0xFFFF8800;
-    private const uint ColorWhite = 0xFFFFFFFF;
-    private const uint ColorMagenta = 0xFFFF00FF;
+    // Colors: ARGB uint values -- saturated for visibility on both light and dark bg
+    private const uint ColorOrangeRed = 0xFFE05020;   // Steer: set angle
+    private const uint ColorBlue = 0xFF2080E0;        // Steer: actual angle
+    private const uint ColorTeal = 0xFF00A080;        // Steer: PWM
+    private const uint ColorRed = 0xFFDD3333;         // Heading: error
+    private const uint ColorDarkOrange = 0xFFD07020;  // Heading: IMU
+    private const uint ColorDarkCyan = 0xFF0088AA;    // Heading: GPS
+    private const uint ColorMagenta = 0xFFC020C0;     // XTE
 
     public double TimeWindowSeconds { get; set; } = 20.0;
     public bool IsRunning => _isRunning;
@@ -60,13 +60,13 @@ public class ChartDataService : IChartDataService
     {
         _autoSteerService = autoSteerService;
 
-        SetSteerAngle = new ChartSeries("Set Angle", ColorYellow);
-        ActualSteerAngle = new ChartSeries("Actual Angle", ColorGreen);
-        PwmOutput = new ChartSeries("PWM", ColorCyan);
+        SetSteerAngle = new ChartSeries("Set Angle", ColorOrangeRed);
+        ActualSteerAngle = new ChartSeries("Actual Angle", ColorBlue);
+        PwmOutput = new ChartSeries("PWM", ColorTeal);
 
         HeadingError = new ChartSeries("Heading Error", ColorRed);
-        ImuHeading = new ChartSeries("IMU Heading", ColorOrange);
-        GpsHeading = new ChartSeries("GPS Heading", ColorWhite);
+        ImuHeading = new ChartSeries("IMU Heading", ColorDarkOrange);
+        GpsHeading = new ChartSeries("GPS Heading", ColorDarkCyan);
 
         CrossTrackError = new ChartSeries("XTE", ColorMagenta);
     }

--- a/Shared/AgValoniaGPS.Services/ChartDataService.cs
+++ b/Shared/AgValoniaGPS.Services/ChartDataService.cs
@@ -1,0 +1,132 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Diagnostics;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Collects real-time data from AutoSteerService state updates
+/// and stores rolling time-series for diagnostic chart display.
+/// </summary>
+public class ChartDataService : IChartDataService
+{
+    private readonly IAutoSteerService _autoSteerService;
+    private readonly Stopwatch _stopwatch = new();
+    private bool _isRunning;
+
+    // Colors: ARGB uint values
+    private const uint ColorYellow = 0xFFFFFF00;
+    private const uint ColorGreen = 0xFF00FF00;
+    private const uint ColorCyan = 0xFF00FFFF;
+    private const uint ColorRed = 0xFFFF4444;
+    private const uint ColorOrange = 0xFFFF8800;
+    private const uint ColorWhite = 0xFFFFFFFF;
+    private const uint ColorMagenta = 0xFFFF00FF;
+
+    public double TimeWindowSeconds { get; set; } = 20.0;
+    public bool IsRunning => _isRunning;
+    public double CurrentTime => _stopwatch.Elapsed.TotalSeconds;
+
+    // Steer chart series
+    public ChartSeries SetSteerAngle { get; }
+    public ChartSeries ActualSteerAngle { get; }
+    public ChartSeries PwmOutput { get; }
+
+    // Heading chart series
+    public ChartSeries HeadingError { get; }
+    public ChartSeries ImuHeading { get; }
+    public ChartSeries GpsHeading { get; }
+
+    // XTE chart series
+    public ChartSeries CrossTrackError { get; }
+
+    public ChartDataService(IAutoSteerService autoSteerService)
+    {
+        _autoSteerService = autoSteerService;
+
+        SetSteerAngle = new ChartSeries("Set Angle", ColorYellow);
+        ActualSteerAngle = new ChartSeries("Actual Angle", ColorGreen);
+        PwmOutput = new ChartSeries("PWM", ColorCyan);
+
+        HeadingError = new ChartSeries("Heading Error", ColorRed);
+        ImuHeading = new ChartSeries("IMU Heading", ColorOrange);
+        GpsHeading = new ChartSeries("GPS Heading", ColorWhite);
+
+        CrossTrackError = new ChartSeries("XTE", ColorMagenta);
+    }
+
+    public void Start()
+    {
+        if (_isRunning) return;
+        _isRunning = true;
+        _stopwatch.Restart();
+        _autoSteerService.StateUpdated += OnStateUpdated;
+    }
+
+    public void Stop()
+    {
+        if (!_isRunning) return;
+        _isRunning = false;
+        _autoSteerService.StateUpdated -= OnStateUpdated;
+        _stopwatch.Stop();
+    }
+
+    private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
+    {
+        double t = _stopwatch.Elapsed.TotalSeconds;
+        double trimTime = t - TimeWindowSeconds - 2.0; // keep 2s extra buffer
+
+        // Steer data
+        SetSteerAngle.AddPoint(t, snapshot.SteerAngle);
+        ActualSteerAngle.AddPoint(t, _autoSteerService.LastSteerData.ActualSteerAngle);
+        PwmOutput.AddPoint(t, _autoSteerService.LastSteerData.PwmDisplay);
+
+        // Heading data
+        HeadingError.AddPoint(t, snapshot.CrossTrackError != 0 ? ComputeHeadingError(snapshot) : 0);
+        ImuHeading.AddPoint(t, _autoSteerService.LastSteerData.ImuHeading);
+        GpsHeading.AddPoint(t, snapshot.Heading);
+
+        // XTE data
+        CrossTrackError.AddPoint(t, snapshot.CrossTrackError);
+
+        // Trim old data
+        if (trimTime > 0)
+        {
+            SetSteerAngle.TrimBefore(trimTime);
+            ActualSteerAngle.TrimBefore(trimTime);
+            PwmOutput.TrimBefore(trimTime);
+            HeadingError.TrimBefore(trimTime);
+            ImuHeading.TrimBefore(trimTime);
+            GpsHeading.TrimBefore(trimTime);
+            CrossTrackError.TrimBefore(trimTime);
+        }
+    }
+
+    /// <summary>
+    /// Compute heading error from the guidance state.
+    /// The SteerAngle from guidance represents the correction needed,
+    /// which serves as a proxy for heading error relative to the track.
+    /// </summary>
+    private static double ComputeHeadingError(VehicleStateSnapshot snapshot)
+    {
+        // SteerAngle is the guidance-computed steering correction.
+        // When on-track with no heading error, this approaches zero.
+        return snapshot.SteerAngle;
+    }
+}

--- a/Shared/AgValoniaGPS.Services/Interfaces/IChartDataService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IChartDataService.cs
@@ -1,0 +1,145 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// A single data point in a chart time series.
+/// </summary>
+public readonly struct ChartDataPoint
+{
+    public double Timestamp { get; init; }
+    public double Value { get; init; }
+}
+
+/// <summary>
+/// A named data series with color and data points for chart rendering.
+/// </summary>
+public class ChartSeries
+{
+    public string Name { get; }
+    public uint Color { get; }
+    private readonly List<ChartDataPoint> _points = new();
+    private readonly object _lock = new();
+
+    public ChartSeries(string name, uint color)
+    {
+        Name = name;
+        Color = color;
+    }
+
+    public void AddPoint(double timestamp, double value)
+    {
+        lock (_lock)
+        {
+            _points.Add(new ChartDataPoint { Timestamp = timestamp, Value = value });
+        }
+    }
+
+    /// <summary>
+    /// Remove points older than the given timestamp.
+    /// </summary>
+    public void TrimBefore(double timestamp)
+    {
+        lock (_lock)
+        {
+            int removeCount = 0;
+            for (int i = 0; i < _points.Count; i++)
+            {
+                if (_points[i].Timestamp < timestamp)
+                    removeCount++;
+                else
+                    break;
+            }
+            if (removeCount > 0)
+                _points.RemoveRange(0, removeCount);
+        }
+    }
+
+    /// <summary>
+    /// Get a snapshot of current points (thread-safe copy).
+    /// </summary>
+    public List<ChartDataPoint> GetPoints()
+    {
+        lock (_lock)
+        {
+            return new List<ChartDataPoint>(_points);
+        }
+    }
+
+    public int Count
+    {
+        get { lock (_lock) { return _points.Count; } }
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _points.Clear();
+        }
+    }
+}
+
+/// <summary>
+/// Provides rolling time-series data for diagnostic charts.
+/// Collects data from AutoSteerService state updates and exposes
+/// series for Steer, Heading, and XTE charts.
+/// </summary>
+public interface IChartDataService
+{
+    /// <summary>
+    /// Time window in seconds for the rolling chart display.
+    /// </summary>
+    double TimeWindowSeconds { get; set; }
+
+    /// <summary>
+    /// Start collecting chart data from AutoSteerService.
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// Stop collecting chart data.
+    /// </summary>
+    void Stop();
+
+    /// <summary>
+    /// Whether the service is actively collecting data.
+    /// </summary>
+    bool IsRunning { get; }
+
+    // Steer chart series
+    ChartSeries SetSteerAngle { get; }
+    ChartSeries ActualSteerAngle { get; }
+    ChartSeries PwmOutput { get; }
+
+    // Heading chart series
+    ChartSeries HeadingError { get; }
+    ChartSeries ImuHeading { get; }
+    ChartSeries GpsHeading { get; }
+
+    // XTE chart series
+    ChartSeries CrossTrackError { get; }
+
+    /// <summary>
+    /// Current time reference (seconds since service start).
+    /// Used by chart controls to determine the visible window.
+    /// </summary>
+    double CurrentTime { get; }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Charts.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Charts.cs
@@ -25,35 +25,24 @@ public partial class MainViewModel
 {
     private void InitializeChartCommands()
     {
+        // Start chart data collection immediately so users see recent
+        // history when opening a chart mid-session. The overhead is
+        // minimal (a few hundred data points in rolling buffers).
+        _chartDataService.Start();
+
         ToggleSteerChartPanelCommand = ReactiveCommand.Create(() =>
         {
             IsSteerChartPanelVisible = !IsSteerChartPanelVisible;
-            EnsureChartDataServiceRunning();
         });
 
         ToggleHeadingChartPanelCommand = ReactiveCommand.Create(() =>
         {
             IsHeadingChartPanelVisible = !IsHeadingChartPanelVisible;
-            EnsureChartDataServiceRunning();
         });
 
         ToggleXTEChartPanelCommand = ReactiveCommand.Create(() =>
         {
             IsXTEChartPanelVisible = !IsXTEChartPanelVisible;
-            EnsureChartDataServiceRunning();
         });
-    }
-
-    /// <summary>
-    /// Start/stop chart data collection based on whether any chart panel is visible.
-    /// </summary>
-    private void EnsureChartDataServiceRunning()
-    {
-        bool anyVisible = IsSteerChartPanelVisible || IsHeadingChartPanelVisible || IsXTEChartPanelVisible;
-
-        if (anyVisible && !_chartDataService.IsRunning)
-            _chartDataService.Start();
-        else if (!anyVisible && _chartDataService.IsRunning)
-            _chartDataService.Stop();
     }
 }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Charts.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Charts.cs
@@ -1,0 +1,59 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using ReactiveUI;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// Chart panel commands - toggle diagnostic chart panels.
+/// </summary>
+public partial class MainViewModel
+{
+    private void InitializeChartCommands()
+    {
+        ToggleSteerChartPanelCommand = ReactiveCommand.Create(() =>
+        {
+            IsSteerChartPanelVisible = !IsSteerChartPanelVisible;
+            EnsureChartDataServiceRunning();
+        });
+
+        ToggleHeadingChartPanelCommand = ReactiveCommand.Create(() =>
+        {
+            IsHeadingChartPanelVisible = !IsHeadingChartPanelVisible;
+            EnsureChartDataServiceRunning();
+        });
+
+        ToggleXTEChartPanelCommand = ReactiveCommand.Create(() =>
+        {
+            IsXTEChartPanelVisible = !IsXTEChartPanelVisible;
+            EnsureChartDataServiceRunning();
+        });
+    }
+
+    /// <summary>
+    /// Start/stop chart data collection based on whether any chart panel is visible.
+    /// </summary>
+    private void EnsureChartDataServiceRunning()
+    {
+        bool anyVisible = IsSteerChartPanelVisible || IsHeadingChartPanelVisible || IsXTEChartPanelVisible;
+
+        if (anyVisible && !_chartDataService.IsRunning)
+            _chartDataService.Start();
+        else if (!anyVisible && _chartDataService.IsRunning)
+            _chartDataService.Stop();
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -36,6 +36,9 @@ public partial class MainViewModel
     private bool _isJobMenuPanelVisible;
     private bool _isFieldToolsPanelVisible;
     private bool _isSimulatorPanelVisible;
+    private bool _isSteerChartPanelVisible;
+    private bool _isHeadingChartPanelVisible;
+    private bool _isXTEChartPanelVisible;
 
     #endregion
 
@@ -81,6 +84,24 @@ public partial class MainViewModel
     {
         get => _isSimulatorPanelVisible;
         set => this.RaiseAndSetIfChanged(ref _isSimulatorPanelVisible, value);
+    }
+
+    public bool IsSteerChartPanelVisible
+    {
+        get => _isSteerChartPanelVisible;
+        set => this.RaiseAndSetIfChanged(ref _isSteerChartPanelVisible, value);
+    }
+
+    public bool IsHeadingChartPanelVisible
+    {
+        get => _isHeadingChartPanelVisible;
+        set => this.RaiseAndSetIfChanged(ref _isHeadingChartPanelVisible, value);
+    }
+
+    public bool IsXTEChartPanelVisible
+    {
+        get => _isXTEChartPanelVisible;
+        set => this.RaiseAndSetIfChanged(ref _isXTEChartPanelVisible, value);
     }
 
     #endregion

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -70,6 +70,7 @@ public partial class MainViewModel : ReactiveObject
     private readonly ICoverageMapService _coverageMapService;
     private readonly ISectionControlService _sectionControlService;
     private readonly INtripProfileService _ntripProfileService;
+    private readonly IChartDataService _chartDataService;
     private readonly ILogger<MainViewModel> _logger;
     private readonly ApplicationState _appState;
     private readonly DispatcherTimer _simulatorTimer;
@@ -158,6 +159,7 @@ public partial class MainViewModel : ReactiveObject
         ICoverageMapService coverageMapService,
         ISectionControlService sectionControlService,
         INtripProfileService ntripProfileService,
+        IChartDataService chartDataService,
         ILogger<MainViewModel> logger,
         ApplicationState appState)
     {
@@ -187,6 +189,7 @@ public partial class MainViewModel : ReactiveObject
         _coverageMapService = coverageMapService;
         _sectionControlService = sectionControlService;
         _ntripProfileService = ntripProfileService;
+        _chartDataService = chartDataService;
         _appState = appState;
         _nmeaParser = new NmeaParserService(gpsService);
         _fieldPlaneFileService = new FieldPlaneFileService();
@@ -254,6 +257,7 @@ public partial class MainViewModel : ReactiveObject
         InitializeWizardCommands();
         InitializeSettingsCommands();
         InitializeHotkeyCommands();
+        InitializeChartCommands();
 
         // Load display settings first, then restore our app settings on top
         // This ensures AppSettings takes precedence over DisplaySettings
@@ -2613,6 +2617,11 @@ public partial class MainViewModel : ReactiveObject
     public ICommand? ManualYouTurnLeftCommand { get; private set; }
     public ICommand? ManualYouTurnRightCommand { get; private set; }
     public ICommand? ToggleAutoSteerCommand { get; private set; }
+
+    // Chart Commands
+    public ICommand? ToggleSteerChartPanelCommand { get; private set; }
+    public ICommand? ToggleHeadingChartPanelCommand { get; private set; }
+    public ICommand? ToggleXTEChartPanelCommand { get; private set; }
 
 
     private void CenterMapOnBoundary(Boundary boundary)

--- a/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
+++ b/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
@@ -31,6 +31,7 @@
   <!-- Project references -->
   <ItemGroup>
     <ProjectReference Include="..\AgValoniaGPS.Models\AgValoniaGPS.Models.csproj" />
+    <ProjectReference Include="..\AgValoniaGPS.Services\AgValoniaGPS.Services.csproj" />
     <ProjectReference Include="..\AgValoniaGPS.ViewModels\AgValoniaGPS.ViewModels.csproj" />
   </ItemGroup>
 

--- a/Shared/AgValoniaGPS.Views/Controls/ChartControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/ChartControl.cs
@@ -1,0 +1,379 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Threading;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Views.Controls;
+
+/// <summary>
+/// Reusable real-time chart control using Avalonia DrawingContext rendering.
+/// Supports rolling time window, multiple data series, Y-axis labels, and grid lines.
+/// Renders at display refresh rate via DispatcherTimer.
+/// </summary>
+public class ChartControl : Control
+{
+    private readonly DispatcherTimer _renderTimer;
+    private readonly List<ChartSeries> _series = new();
+    private readonly Dictionary<uint, Pen> _seriesPens = new();
+
+    // Layout constants
+    private const double LeftMargin = 50;
+    private const double RightMargin = 10;
+    private const double TopMargin = 8;
+    private const double BottomMargin = 20;
+
+    // Visual resources (reused each frame)
+    private static readonly IBrush BackgroundBrush = new SolidColorBrush(Color.FromArgb(0xDD, 0x10, 0x14, 0x1C));
+    private static readonly Pen GridPen = new(new SolidColorBrush(Color.FromArgb(0x40, 0x88, 0x88, 0x88)), 0.5);
+    private static readonly Pen ZeroLinePen = new(new SolidColorBrush(Color.FromArgb(0x80, 0xAA, 0xAA, 0xAA)), 1.0);
+    private static readonly Pen BorderPen = new(new SolidColorBrush(Color.FromArgb(0x60, 0x88, 0x88, 0x88)), 1.0);
+    private static readonly IBrush LabelBrush = new SolidColorBrush(Color.FromArgb(0xCC, 0xCC, 0xCC, 0xCC));
+    private static readonly Typeface LabelTypeface = new("Segoe UI", FontStyle.Normal, FontWeight.Normal);
+
+    // Chart properties
+    private double _minY = -40;
+    private double _maxY = 40;
+    private double _timeWindow = 20.0;
+    private Func<double>? _currentTimeProvider;
+    private string _title = "";
+    private string _yAxisLabel = "";
+    private double _gridStepY = 10;
+    private bool _autoScaleY;
+
+    public ChartControl()
+    {
+        _renderTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(33) // 30 FPS
+        };
+        _renderTimer.Tick += (_, _) => InvalidateVisual();
+
+        PropertyChanged += OnControlPropertyChanged;
+    }
+
+    private void OnControlPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property.Name == nameof(IsVisible))
+        {
+            bool visible = e.NewValue is true;
+            if (visible && !_renderTimer.IsEnabled)
+                _renderTimer.Start();
+            else if (!visible && _renderTimer.IsEnabled)
+                _renderTimer.Stop();
+        }
+    }
+
+    /// <summary>
+    /// Configure the chart display parameters.
+    /// </summary>
+    public void Configure(string title, string yAxisLabel, double minY, double maxY,
+        double gridStepY, double timeWindow, Func<double> currentTimeProvider, bool autoScaleY = false)
+    {
+        _title = title;
+        _yAxisLabel = yAxisLabel;
+        _minY = minY;
+        _maxY = maxY;
+        _gridStepY = gridStepY;
+        _timeWindow = timeWindow;
+        _currentTimeProvider = currentTimeProvider;
+        _autoScaleY = autoScaleY;
+    }
+
+    /// <summary>
+    /// Add a data series to the chart.
+    /// </summary>
+    public void AddSeries(ChartSeries series)
+    {
+        _series.Add(series);
+        var color = Color.FromUInt32(series.Color);
+        _seriesPens[series.Color] = new Pen(new SolidColorBrush(color), 1.5);
+    }
+
+    /// <summary>
+    /// Clear all series from the chart.
+    /// </summary>
+    public void ClearSeries()
+    {
+        _series.Clear();
+        _seriesPens.Clear();
+    }
+
+    /// <summary>
+    /// Start the render timer.
+    /// </summary>
+    public void StartRendering()
+    {
+        if (!_renderTimer.IsEnabled)
+            _renderTimer.Start();
+    }
+
+    /// <summary>
+    /// Stop the render timer.
+    /// </summary>
+    public void StopRendering()
+    {
+        if (_renderTimer.IsEnabled)
+            _renderTimer.Stop();
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+
+        var bounds = Bounds;
+        if (bounds.Width <= 0 || bounds.Height <= 0) return;
+
+        double w = bounds.Width;
+        double h = bounds.Height;
+
+        // Background
+        context.DrawRectangle(BackgroundBrush, BorderPen,
+            new Rect(0, 0, w, h), 4, 4);
+
+        // Chart area
+        double chartLeft = LeftMargin;
+        double chartRight = w - RightMargin;
+        double chartTop = TopMargin;
+        double chartBottom = h - BottomMargin;
+        double chartWidth = chartRight - chartLeft;
+        double chartHeight = chartBottom - chartTop;
+
+        if (chartWidth <= 0 || chartHeight <= 0) return;
+
+        // Clip to chart area for data rendering
+        var chartRect = new Rect(chartLeft, chartTop, chartWidth, chartHeight);
+
+        // Auto-scale Y if enabled
+        double minY = _minY;
+        double maxY = _maxY;
+        double gridStepY = _gridStepY;
+        if (_autoScaleY)
+        {
+            ComputeAutoScale(out minY, out maxY, out gridStepY);
+        }
+
+        double yRange = maxY - minY;
+        if (yRange <= 0) yRange = 1;
+
+        // Time range
+        double currentTime = _currentTimeProvider?.Invoke() ?? 0;
+        double timeStart = currentTime - _timeWindow;
+
+        // Draw grid lines (horizontal)
+        DrawGridLines(context, chartLeft, chartRight, chartTop, chartBottom, chartHeight,
+            minY, maxY, yRange, gridStepY);
+
+        // Draw zero line if in range
+        if (minY < 0 && maxY > 0)
+        {
+            double zeroY = chartBottom - (-minY / yRange * chartHeight);
+            context.DrawLine(ZeroLinePen, new Point(chartLeft, zeroY), new Point(chartRight, zeroY));
+        }
+
+        // Draw data series (clipped)
+        using (context.PushClip(chartRect))
+        {
+            foreach (var series in _series)
+            {
+                DrawSeries(context, series, chartLeft, chartTop, chartWidth, chartHeight,
+                    chartBottom, timeStart, _timeWindow, minY, yRange);
+            }
+        }
+
+        // Draw border around chart area
+        context.DrawRectangle(null, BorderPen, chartRect);
+
+        // Draw title
+        if (!string.IsNullOrEmpty(_title))
+        {
+            var titleText = new FormattedText(_title, CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight, LabelTypeface, 11, LabelBrush);
+            context.DrawText(titleText, new Point(chartLeft + 4, chartTop + 1));
+        }
+
+        // Draw legend
+        DrawLegend(context, chartRight, chartTop);
+
+        // Draw time labels
+        DrawTimeLabels(context, chartLeft, chartRight, chartBottom, timeStart);
+    }
+
+    private void ComputeAutoScale(out double minY, out double maxY, out double gridStepY)
+    {
+        double dataMin = double.MaxValue;
+        double dataMax = double.MinValue;
+
+        foreach (var series in _series)
+        {
+            var points = series.GetPoints();
+            foreach (var pt in points)
+            {
+                if (pt.Value < dataMin) dataMin = pt.Value;
+                if (pt.Value > dataMax) dataMax = pt.Value;
+            }
+        }
+
+        if (dataMin == double.MaxValue)
+        {
+            minY = _minY;
+            maxY = _maxY;
+            gridStepY = _gridStepY;
+            return;
+        }
+
+        // Add 10% padding
+        double range = dataMax - dataMin;
+        if (range < 1) range = 1;
+        double pad = range * 0.1;
+        minY = dataMin - pad;
+        maxY = dataMax + pad;
+
+        // Compute nice grid step
+        gridStepY = ComputeNiceStep(maxY - minY, 5);
+    }
+
+    private static double ComputeNiceStep(double range, int targetLines)
+    {
+        double rawStep = range / targetLines;
+        double magnitude = Math.Pow(10, Math.Floor(Math.Log10(rawStep)));
+        double normalized = rawStep / magnitude;
+
+        double niceStep;
+        if (normalized <= 1.5) niceStep = 1;
+        else if (normalized <= 3.5) niceStep = 2;
+        else if (normalized <= 7.5) niceStep = 5;
+        else niceStep = 10;
+
+        return niceStep * magnitude;
+    }
+
+    private void DrawGridLines(DrawingContext context,
+        double chartLeft, double chartRight, double chartTop, double chartBottom,
+        double chartHeight, double minY, double maxY, double yRange, double gridStepY)
+    {
+        // Horizontal grid lines
+        double firstGridY = Math.Ceiling(minY / gridStepY) * gridStepY;
+        for (double val = firstGridY; val <= maxY; val += gridStepY)
+        {
+            double y = chartBottom - ((val - minY) / yRange * chartHeight);
+            context.DrawLine(GridPen, new Point(chartLeft, y), new Point(chartRight, y));
+
+            // Y-axis label
+            string label = val.ToString("F0");
+            var labelText = new FormattedText(label, CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight, LabelTypeface, 10, LabelBrush);
+            context.DrawText(labelText, new Point(chartLeft - labelText.Width - 4, y - labelText.Height / 2));
+        }
+    }
+
+    private void DrawSeries(DrawingContext context, ChartSeries series,
+        double chartLeft, double chartTop, double chartWidth, double chartHeight,
+        double chartBottom, double timeStart, double timeWindow, double minY, double yRange)
+    {
+        var points = series.GetPoints();
+        if (points.Count < 2) return;
+
+        if (!_seriesPens.TryGetValue(series.Color, out var pen)) return;
+
+        var geometry = new StreamGeometry();
+        using (var ctx = geometry.Open())
+        {
+            bool started = false;
+            for (int i = 0; i < points.Count; i++)
+            {
+                var pt = points[i];
+                if (pt.Timestamp < timeStart) continue;
+
+                double x = chartLeft + ((pt.Timestamp - timeStart) / timeWindow * chartWidth);
+                double y = chartBottom - ((pt.Value - minY) / yRange * chartHeight);
+
+                if (!started)
+                {
+                    ctx.BeginFigure(new Point(x, y), false);
+                    started = true;
+                }
+                else
+                {
+                    ctx.LineTo(new Point(x, y));
+                }
+            }
+
+            if (!started) return;
+            ctx.EndFigure(false);
+        }
+
+        context.DrawGeometry(null, pen, geometry);
+    }
+
+    private void DrawLegend(DrawingContext context, double chartRight, double chartTop)
+    {
+        double x = chartRight - 8;
+        double y = chartTop + 2;
+
+        for (int i = _series.Count - 1; i >= 0; i--)
+        {
+            var series = _series[i];
+            var color = Color.FromUInt32(series.Color);
+            var brush = new SolidColorBrush(color);
+
+            var nameText = new FormattedText(series.Name, CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight, LabelTypeface, 9, brush);
+
+            x -= nameText.Width;
+            context.DrawText(nameText, new Point(x, y));
+
+            // Color indicator line
+            var linePen = new Pen(brush, 2);
+            double lineX = x - 14;
+            double lineY = y + nameText.Height / 2;
+            context.DrawLine(linePen, new Point(lineX, lineY), new Point(lineX + 10, lineY));
+
+            x = lineX - 8; // spacing between legend items
+        }
+    }
+
+    private void DrawTimeLabels(DrawingContext context,
+        double chartLeft, double chartRight, double chartBottom, double timeStart)
+    {
+        double y = chartBottom + 4;
+        int labelCount = 5;
+        double chartWidth = chartRight - chartLeft;
+
+        for (int i = 0; i <= labelCount; i++)
+        {
+            double fraction = (double)i / labelCount;
+            double t = timeStart + fraction * _timeWindow;
+            double x = chartLeft + fraction * chartWidth;
+
+            // Show relative seconds
+            string label = $"{t:F0}s";
+            var labelText = new FormattedText(label, CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight, LabelTypeface, 9, LabelBrush);
+            context.DrawText(labelText, new Point(x - labelText.Width / 2, y));
+
+            // Vertical grid line
+            context.DrawLine(GridPen, new Point(x, chartBottom - (chartBottom - TopMargin)),
+                new Point(x, chartBottom));
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/ChartControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/ChartControl.cs
@@ -278,8 +278,9 @@ public class ChartControl : Control
             double y = chartBottom - ((val - minY) / yRange * chartHeight);
             context.DrawLine(GridPen, new Point(chartLeft, y), new Point(chartRight, y));
 
-            // Y-axis label
-            string label = val.ToString("F0");
+            // Y-axis label -- use decimal places for small grid steps
+            string fmt = gridStepY >= 1.0 ? "F0" : gridStepY >= 0.1 ? "F1" : "F2";
+            string label = val.ToString(fmt);
             var labelText = new FormattedText(label, CultureInfo.InvariantCulture,
                 FlowDirection.LeftToRight, LabelTypeface, 10, LabelBrush);
             context.DrawText(labelText, new Point(chartLeft - labelText.Width - 4, y - labelText.Height / 2));

--- a/Shared/AgValoniaGPS.Views/Controls/ChartControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/ChartControl.cs
@@ -20,6 +20,7 @@ using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Avalonia.Threading;
 using AgValoniaGPS.Services.Interfaces;
 
@@ -29,6 +30,7 @@ namespace AgValoniaGPS.Views.Controls;
 /// Reusable real-time chart control using Avalonia DrawingContext rendering.
 /// Supports rolling time window, multiple data series, Y-axis labels, and grid lines.
 /// Renders at display refresh rate via DispatcherTimer.
+/// Uses theme-aware colors for light/dark mode compatibility.
 /// </summary>
 public class ChartControl : Control
 {
@@ -42,13 +44,27 @@ public class ChartControl : Control
     private const double TopMargin = 8;
     private const double BottomMargin = 20;
 
-    // Visual resources (reused each frame)
-    private static readonly IBrush BackgroundBrush = new SolidColorBrush(Color.FromArgb(0xDD, 0x10, 0x14, 0x1C));
-    private static readonly Pen GridPen = new(new SolidColorBrush(Color.FromArgb(0x40, 0x88, 0x88, 0x88)), 0.5);
-    private static readonly Pen ZeroLinePen = new(new SolidColorBrush(Color.FromArgb(0x80, 0xAA, 0xAA, 0xAA)), 1.0);
-    private static readonly Pen BorderPen = new(new SolidColorBrush(Color.FromArgb(0x60, 0x88, 0x88, 0x88)), 1.0);
-    private static readonly IBrush LabelBrush = new SolidColorBrush(Color.FromArgb(0xCC, 0xCC, 0xCC, 0xCC));
+    // Cached theme brushes (rebuilt when theme changes)
     private static readonly Typeface LabelTypeface = new("Segoe UI", FontStyle.Normal, FontWeight.Normal);
+
+    private static IBrush WithAlpha(IBrush brush, byte alpha)
+    {
+        if (brush is ISolidColorBrush scb)
+            return new SolidColorBrush(Color.FromArgb(alpha, scb.Color.R, scb.Color.G, scb.Color.B));
+        return brush;
+    }
+
+    private static IBrush ResolveBrush(string key, string fallback)
+    {
+        var app = Application.Current;
+        if (app != null)
+        {
+            var variant = app.ActualThemeVariant;
+            if (app.TryGetResource(key, variant, out var value) && value is ISolidColorBrush scb)
+                return new SolidColorBrush(scb.Color);
+        }
+        return new SolidColorBrush(Color.Parse(fallback));
+    }
 
     // Chart properties
     private double _minY = -40;
@@ -146,8 +162,16 @@ public class ChartControl : Control
         double w = bounds.Width;
         double h = bounds.Height;
 
+        // Resolve theme-aware colors each frame
+        var bgBrush = ResolveBrush("SystemControlBackgroundAltHighBrush", "#1a1a2e");
+        var borderBrush = ResolveBrush("SystemControlForegroundBaseLowBrush", "#555555");
+        var labelBrush = ResolveBrush("SystemControlForegroundBaseMediumHighBrush", "#CCCCCC");
+        var gridPen = new Pen(WithAlpha(borderBrush, 0x40), 0.5);
+        var borderPen = new Pen(WithAlpha(borderBrush, 0x60), 1.0);
+        var zeroLinePen = new Pen(WithAlpha(labelBrush, 0x80), 1.0);
+
         // Background
-        context.DrawRectangle(BackgroundBrush, BorderPen,
+        context.DrawRectangle(bgBrush, borderPen,
             new Rect(0, 0, w, h), 4, 4);
 
         // Chart area
@@ -181,13 +205,13 @@ public class ChartControl : Control
 
         // Draw grid lines (horizontal)
         DrawGridLines(context, chartLeft, chartRight, chartTop, chartBottom, chartHeight,
-            minY, maxY, yRange, gridStepY);
+            minY, maxY, yRange, gridStepY, gridPen, labelBrush);
 
         // Draw zero line if in range
         if (minY < 0 && maxY > 0)
         {
             double zeroY = chartBottom - (-minY / yRange * chartHeight);
-            context.DrawLine(ZeroLinePen, new Point(chartLeft, zeroY), new Point(chartRight, zeroY));
+            context.DrawLine(zeroLinePen, new Point(chartLeft, zeroY), new Point(chartRight, zeroY));
         }
 
         // Draw data series (clipped)
@@ -201,13 +225,13 @@ public class ChartControl : Control
         }
 
         // Draw border around chart area
-        context.DrawRectangle(null, BorderPen, chartRect);
+        context.DrawRectangle(null, borderPen, chartRect);
 
         // Draw title
         if (!string.IsNullOrEmpty(_title))
         {
             var titleText = new FormattedText(_title, CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight, LabelTypeface, 11, LabelBrush);
+                FlowDirection.LeftToRight, LabelTypeface, 11, labelBrush);
             context.DrawText(titleText, new Point(chartLeft + 4, chartTop + 1));
         }
 
@@ -215,7 +239,8 @@ public class ChartControl : Control
         DrawLegend(context, chartRight, chartTop);
 
         // Draw time labels
-        DrawTimeLabels(context, chartLeft, chartRight, chartBottom, timeStart);
+        DrawTimeLabels(context, chartLeft, chartRight, chartBottom, timeStart,
+            gridPen, labelBrush);
     }
 
     private void ComputeAutoScale(out double minY, out double maxY, out double gridStepY)
@@ -269,20 +294,21 @@ public class ChartControl : Control
 
     private void DrawGridLines(DrawingContext context,
         double chartLeft, double chartRight, double chartTop, double chartBottom,
-        double chartHeight, double minY, double maxY, double yRange, double gridStepY)
+        double chartHeight, double minY, double maxY, double yRange, double gridStepY,
+        Pen gridPen, IBrush labelBrush)
     {
         // Horizontal grid lines
         double firstGridY = Math.Ceiling(minY / gridStepY) * gridStepY;
         for (double val = firstGridY; val <= maxY; val += gridStepY)
         {
             double y = chartBottom - ((val - minY) / yRange * chartHeight);
-            context.DrawLine(GridPen, new Point(chartLeft, y), new Point(chartRight, y));
+            context.DrawLine(gridPen, new Point(chartLeft, y), new Point(chartRight, y));
 
             // Y-axis label -- use decimal places for small grid steps
             string fmt = gridStepY >= 1.0 ? "F0" : gridStepY >= 0.1 ? "F1" : "F2";
             string label = val.ToString(fmt);
             var labelText = new FormattedText(label, CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight, LabelTypeface, 10, LabelBrush);
+                FlowDirection.LeftToRight, LabelTypeface, 10, labelBrush);
             context.DrawText(labelText, new Point(chartLeft - labelText.Width - 4, y - labelText.Height / 2));
         }
     }
@@ -354,7 +380,8 @@ public class ChartControl : Control
     }
 
     private void DrawTimeLabels(DrawingContext context,
-        double chartLeft, double chartRight, double chartBottom, double timeStart)
+        double chartLeft, double chartRight, double chartBottom, double timeStart,
+        Pen gridPen, IBrush labelBrush)
     {
         double y = chartBottom + 4;
         int labelCount = 5;
@@ -369,11 +396,11 @@ public class ChartControl : Control
             // Show relative seconds
             string label = $"{t:F0}s";
             var labelText = new FormattedText(label, CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight, LabelTypeface, 9, LabelBrush);
+                FlowDirection.LeftToRight, LabelTypeface, 9, labelBrush);
             context.DrawText(labelText, new Point(x - labelText.Width / 2, y));
 
             // Vertical grid line
-            context.DrawLine(GridPen, new Point(x, chartBottom - (chartBottom - TopMargin)),
+            context.DrawLine(gridPen, new Point(x, chartBottom - (chartBottom - TopMargin)),
                 new Point(x, chartBottom));
         }
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <Border Classes="FloatingPanel" Width="360" Height="220">
+    <Border Classes="FloatingPanel" Width="420" Height="240">
         <Grid RowDefinitions="24,*">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
                   Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
@@ -29,10 +29,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="4"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
     </UserControl.Styles>
@@ -40,13 +40,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <Border Classes="FloatingPanel" Width="420" Height="240">
         <Grid RowDefinitions="24,*">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="16" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Heading Chart" Foreground="White" FontSize="12" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Heading Chart" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="12" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"
                         Command="{Binding ToggleHeadingChartPanelCommand}" Margin="4,0,4,0"/>
             </Grid>
             <controls:ChartControl x:Name="HeadingChart" Grid.Row="1"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
@@ -1,0 +1,55 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
+             mc:Ignorable="d"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.HeadingChartPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding IsHeadingChartPanelVisible}"
+             IsHitTestVisible="{Binding IsHeadingChartPanelVisible}">
+
+    <UserControl.Styles>
+        <Style Selector="Border.FloatingPanel">
+            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Classes="FloatingPanel" Width="360" Height="220">
+        <Grid RowDefinitions="24,*">
+            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
+                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="16" FontWeight="Bold"
+                           VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
+                <TextBlock Grid.Column="1" Text="Heading Chart" Foreground="White" FontSize="12" FontWeight="Bold"
+                           VerticalAlignment="Center" IsHitTestVisible="False"/>
+                <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
+                        Background="Transparent" Foreground="#888" FontSize="12" Cursor="Hand"
+                        Command="{Binding ToggleHeadingChartPanelCommand}" Margin="4,0,4,0"/>
+            </Grid>
+            <controls:ChartControl x:Name="HeadingChart" Grid.Row="1"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml.cs
@@ -1,0 +1,113 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class HeadingChartPanel : UserControl
+{
+    private bool _isDragging;
+    private Point _lastScreenPoint;
+    private bool _configured;
+
+    public event EventHandler<PointerPressedEventArgs>? DragStarted;
+    public event EventHandler<Vector>? DragMoved;
+    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
+
+    public HeadingChartPanel()
+    {
+        InitializeComponent();
+        var dragHandle = this.FindControl<Grid>("DragHandle");
+        if (dragHandle != null)
+        {
+            dragHandle.PointerPressed += DragHandle_PointerPressed;
+            dragHandle.PointerMoved += DragHandle_PointerMoved;
+            dragHandle.PointerReleased += DragHandle_PointerReleased;
+        }
+    }
+
+    public void ConfigureChart(IChartDataService chartData)
+    {
+        if (_configured) return;
+        _configured = true;
+
+        var chart = this.FindControl<ChartControl>("HeadingChart");
+        if (chart == null) return;
+
+        chart.Configure(
+            title: "Heading",
+            yAxisLabel: "deg",
+            minY: 0,
+            maxY: 360,
+            gridStepY: 45,
+            timeWindow: chartData.TimeWindowSeconds,
+            currentTimeProvider: () => chartData.CurrentTime,
+            autoScaleY: true);
+
+        chart.AddSeries(chartData.HeadingError);
+        chart.AddSeries(chartData.ImuHeading);
+        chart.AddSeries(chartData.GpsHeading);
+    }
+
+    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is Grid handle)
+        {
+            var root = this.VisualRoot as Visual;
+            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            e.Pointer.Capture(handle);
+        }
+    }
+
+    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            var root = this.VisualRoot as Visual;
+            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
+                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
+            if (!_isDragging && distance > 5.0)
+            {
+                _isDragging = true;
+                DragStarted?.Invoke(this, null!);
+            }
+            if (_isDragging)
+            {
+                var delta = currentPoint - _lastScreenPoint;
+                DragMoved?.Invoke(this, delta);
+                _lastScreenPoint = currentPoint;
+            }
+            e.Handled = true;
+        }
+    }
+
+    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            if (_isDragging) DragEnded?.Invoke(this, e);
+            _isDragging = false;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml.cs
@@ -19,6 +19,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using AgValoniaGPS.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -32,6 +33,8 @@ public partial class HeadingChartPanel : UserControl
     public event EventHandler<Vector>? DragMoved;
     public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
+    public static IServiceProvider? ServiceProvider { get; set; }
+
     public HeadingChartPanel()
     {
         InitializeComponent();
@@ -42,6 +45,15 @@ public partial class HeadingChartPanel : UserControl
             dragHandle.PointerMoved += DragHandle_PointerMoved;
             dragHandle.PointerReleased += DragHandle_PointerReleased;
         }
+
+        PropertyChanged += (_, e) =>
+        {
+            if (e.Property.Name == nameof(IsVisible) && e.NewValue is true && !_configured)
+            {
+                var chartData = ServiceProvider?.GetService<IChartDataService>();
+                if (chartData != null) ConfigureChart(chartData);
+            }
+        };
     }
 
     public void ConfigureChart(IChartDataService chartData)

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <Border Classes="FloatingPanel" Width="360" Height="220">
+    <Border Classes="FloatingPanel" Width="420" Height="240">
         <Grid RowDefinitions="24,*">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
                   Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
@@ -1,0 +1,55 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
+             mc:Ignorable="d"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.SteerChartPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding IsSteerChartPanelVisible}"
+             IsHitTestVisible="{Binding IsSteerChartPanelVisible}">
+
+    <UserControl.Styles>
+        <Style Selector="Border.FloatingPanel">
+            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Classes="FloatingPanel" Width="360" Height="220">
+        <Grid RowDefinitions="24,*">
+            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
+                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="16" FontWeight="Bold"
+                           VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
+                <TextBlock Grid.Column="1" Text="Steer Chart" Foreground="White" FontSize="12" FontWeight="Bold"
+                           VerticalAlignment="Center" IsHitTestVisible="False"/>
+                <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
+                        Background="Transparent" Foreground="#888" FontSize="12" Cursor="Hand"
+                        Command="{Binding ToggleSteerChartPanelCommand}" Margin="4,0,4,0"/>
+            </Grid>
+            <controls:ChartControl x:Name="SteerChart" Grid.Row="1"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
@@ -29,10 +29,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="4"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
     </UserControl.Styles>
@@ -40,13 +40,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <Border Classes="FloatingPanel" Width="420" Height="240">
         <Grid RowDefinitions="24,*">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="16" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Steer Chart" Foreground="White" FontSize="12" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Steer Chart" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="12" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"
                         Command="{Binding ToggleSteerChartPanelCommand}" Margin="4,0,4,0"/>
             </Grid>
             <controls:ChartControl x:Name="SteerChart" Grid.Row="1"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml.cs
@@ -19,6 +19,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using AgValoniaGPS.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -32,6 +33,12 @@ public partial class SteerChartPanel : UserControl
     public event EventHandler<Vector>? DragMoved;
     public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
+    /// <summary>
+    /// Optional DI service provider for auto-configuration.
+    /// Set by the hosting platform (Desktop App.Services, etc).
+    /// </summary>
+    public static IServiceProvider? ServiceProvider { get; set; }
+
     public SteerChartPanel()
     {
         InitializeComponent();
@@ -42,6 +49,21 @@ public partial class SteerChartPanel : UserControl
             dragHandle.PointerMoved += DragHandle_PointerMoved;
             dragHandle.PointerReleased += DragHandle_PointerReleased;
         }
+
+        // Auto-configure when panel becomes visible
+        PropertyChanged += (_, e) =>
+        {
+            if (e.Property.Name == nameof(IsVisible) && e.NewValue is true)
+                TryAutoConfigure();
+        };
+    }
+
+    private void TryAutoConfigure()
+    {
+        if (_configured) return;
+        var chartData = ServiceProvider?.GetService<IChartDataService>();
+        if (chartData != null)
+            ConfigureChart(chartData);
     }
 
     public void ConfigureChart(IChartDataService chartData)

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml.cs
@@ -1,0 +1,112 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class SteerChartPanel : UserControl
+{
+    private bool _isDragging;
+    private Point _lastScreenPoint;
+    private bool _configured;
+
+    public event EventHandler<PointerPressedEventArgs>? DragStarted;
+    public event EventHandler<Vector>? DragMoved;
+    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
+
+    public SteerChartPanel()
+    {
+        InitializeComponent();
+        var dragHandle = this.FindControl<Grid>("DragHandle");
+        if (dragHandle != null)
+        {
+            dragHandle.PointerPressed += DragHandle_PointerPressed;
+            dragHandle.PointerMoved += DragHandle_PointerMoved;
+            dragHandle.PointerReleased += DragHandle_PointerReleased;
+        }
+    }
+
+    public void ConfigureChart(IChartDataService chartData)
+    {
+        if (_configured) return;
+        _configured = true;
+
+        var chart = this.FindControl<ChartControl>("SteerChart");
+        if (chart == null) return;
+
+        chart.Configure(
+            title: "Steer",
+            yAxisLabel: "deg",
+            minY: -40,
+            maxY: 40,
+            gridStepY: 10,
+            timeWindow: chartData.TimeWindowSeconds,
+            currentTimeProvider: () => chartData.CurrentTime);
+
+        chart.AddSeries(chartData.SetSteerAngle);
+        chart.AddSeries(chartData.ActualSteerAngle);
+        chart.AddSeries(chartData.PwmOutput);
+    }
+
+    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is Grid handle)
+        {
+            var root = this.VisualRoot as Visual;
+            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            e.Pointer.Capture(handle);
+        }
+    }
+
+    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            var root = this.VisualRoot as Visual;
+            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
+                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
+            if (!_isDragging && distance > 5.0)
+            {
+                _isDragging = true;
+                DragStarted?.Invoke(this, null!);
+            }
+            if (_isDragging)
+            {
+                var delta = currentPoint - _lastScreenPoint;
+                DragMoved?.Invoke(this, delta);
+                _lastScreenPoint = currentPoint;
+            }
+            e.Handled = true;
+        }
+    }
+
+    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            if (_isDragging) DragEnded?.Invoke(this, e);
+            _isDragging = false;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
@@ -29,10 +29,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="4"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
     </UserControl.Styles>
@@ -40,13 +40,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <Border Classes="FloatingPanel" Width="420" Height="240">
         <Grid RowDefinitions="24,*">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="16" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Cross Track Error" Foreground="White" FontSize="12" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Cross Track Error" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="12" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"
                         Command="{Binding ToggleXTEChartPanelCommand}" Margin="4,0,4,0"/>
             </Grid>
             <controls:ChartControl x:Name="XTEChart" Grid.Row="1"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <Border Classes="FloatingPanel" Width="360" Height="220">
+    <Border Classes="FloatingPanel" Width="420" Height="240">
         <Grid RowDefinitions="24,*">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
                   Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
@@ -1,0 +1,55 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
+             mc:Ignorable="d"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.XTEChartPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding IsXTEChartPanelVisible}"
+             IsHitTestVisible="{Binding IsXTEChartPanelVisible}">
+
+    <UserControl.Styles>
+        <Style Selector="Border.FloatingPanel">
+            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Classes="FloatingPanel" Width="360" Height="220">
+        <Grid RowDefinitions="24,*">
+            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
+                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="16" FontWeight="Bold"
+                           VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
+                <TextBlock Grid.Column="1" Text="Cross Track Error" Foreground="White" FontSize="12" FontWeight="Bold"
+                           VerticalAlignment="Center" IsHitTestVisible="False"/>
+                <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
+                        Background="Transparent" Foreground="#888" FontSize="12" Cursor="Hand"
+                        Command="{Binding ToggleXTEChartPanelCommand}" Margin="4,0,4,0"/>
+            </Grid>
+            <controls:ChartControl x:Name="XTEChart" Grid.Row="1"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml.cs
@@ -19,6 +19,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using AgValoniaGPS.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -32,6 +33,8 @@ public partial class XTEChartPanel : UserControl
     public event EventHandler<Vector>? DragMoved;
     public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
+    public static IServiceProvider? ServiceProvider { get; set; }
+
     public XTEChartPanel()
     {
         InitializeComponent();
@@ -42,6 +45,15 @@ public partial class XTEChartPanel : UserControl
             dragHandle.PointerMoved += DragHandle_PointerMoved;
             dragHandle.PointerReleased += DragHandle_PointerReleased;
         }
+
+        PropertyChanged += (_, e) =>
+        {
+            if (e.Property.Name == nameof(IsVisible) && e.NewValue is true && !_configured)
+            {
+                var chartData = ServiceProvider?.GetService<IChartDataService>();
+                if (chartData != null) ConfigureChart(chartData);
+            }
+        };
     }
 
     public void ConfigureChart(IChartDataService chartData)

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml.cs
@@ -1,0 +1,111 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class XTEChartPanel : UserControl
+{
+    private bool _isDragging;
+    private Point _lastScreenPoint;
+    private bool _configured;
+
+    public event EventHandler<PointerPressedEventArgs>? DragStarted;
+    public event EventHandler<Vector>? DragMoved;
+    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
+
+    public XTEChartPanel()
+    {
+        InitializeComponent();
+        var dragHandle = this.FindControl<Grid>("DragHandle");
+        if (dragHandle != null)
+        {
+            dragHandle.PointerPressed += DragHandle_PointerPressed;
+            dragHandle.PointerMoved += DragHandle_PointerMoved;
+            dragHandle.PointerReleased += DragHandle_PointerReleased;
+        }
+    }
+
+    public void ConfigureChart(IChartDataService chartData)
+    {
+        if (_configured) return;
+        _configured = true;
+
+        var chart = this.FindControl<ChartControl>("XTEChart");
+        if (chart == null) return;
+
+        chart.Configure(
+            title: "XTE",
+            yAxisLabel: "m",
+            minY: -2.0,
+            maxY: 2.0,
+            gridStepY: 0.5,
+            timeWindow: chartData.TimeWindowSeconds,
+            currentTimeProvider: () => chartData.CurrentTime,
+            autoScaleY: true);
+
+        chart.AddSeries(chartData.CrossTrackError);
+    }
+
+    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is Grid handle)
+        {
+            var root = this.VisualRoot as Visual;
+            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            e.Pointer.Capture(handle);
+        }
+    }
+
+    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            var root = this.VisualRoot as Visual;
+            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
+                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
+            if (!_isDragging && distance > 5.0)
+            {
+                _isDragging = true;
+                DragStarted?.Invoke(this, null!);
+            }
+            if (_isDragging)
+            {
+                var delta = currentPoint - _lastScreenPoint;
+                DragMoved?.Invoke(this, delta);
+                _lastScreenPoint = currentPoint;
+            }
+            e.Handled = true;
+        }
+    }
+
+    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            if (_isDragging) DragEnded?.Invoke(this, e);
+            _isDragging = false;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+}

--- a/Tests/AgValoniaGPS.IntegrationTests/Program.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/Program.cs
@@ -330,6 +330,10 @@ sealed class Program
         // Step 8: Activate track and drive off-course to generate real chart data.
         // ChartDataService now collects continuously in the background, so data
         // accumulates even before charts are opened.
+        // Check chart data service state
+        var chartDataService = App.Services!.GetRequiredService<IChartDataService>();
+        Console.Write($"[ChartService running={chartDataService.IsRunning}, time={chartDataService.CurrentTime:F1}s, steerPts={chartDataService.SetSteerAngle.Count}] ");
+
         Console.Write("[Step 8] Charts: activate track and drive off-course... ");
         var track = vm.SavedTracks.FirstOrDefault();
         if (track != null)
@@ -360,6 +364,7 @@ sealed class Program
             simService.Tick(0);
             await Delay(33);
         }
+        Console.Write($"[steerPts={chartDataService.SetSteerAngle.Count}, xtePts={chartDataService.CrossTrackError.Count}] ");
         Console.WriteLine("OK");
 
         // Step 9: Open Steer Chart only

--- a/Tests/AgValoniaGPS.IntegrationTests/Program.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/Program.cs
@@ -21,9 +21,7 @@ using Avalonia.ReactiveUI;
 using Avalonia.Threading;
 using AgValoniaGPS.Desktop;
 using AgValoniaGPS.Desktop.Views;
-using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.IntegrationTests;
-using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Services.Interfaces;
 using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.ViewModels;
@@ -196,8 +194,8 @@ sealed class Program
         // --- Track Management Scenarios (PR #80) ---
         await RunTrackManagementScenario(window, vm);
 
-        // --- Display Wiring Scenarios (PR #82) ---
-        await RunDisplayWiringScenario(window, vm, simService);
+        // --- Charts Scenarios (PR #79) ---
+        await RunChartsScenario(window, vm, simService);
     }
 
     static async Task RunThemeAndDialogsScenario(Window window, MainViewModel vm)
@@ -326,83 +324,64 @@ sealed class Program
         Console.WriteLine("--- Track Management Scenarios Complete ---");
     }
 
-    static async Task RunDisplayWiringScenario(
+    static async Task RunChartsScenario(
         Window window, MainViewModel vm, IGpsSimulationService simService)
     {
-        var display = ConfigurationStore.Instance.Display;
-
-        // Step 8: Speed text visible while driving
-        Console.Write("[Step 8] Display: speed text in status bar... ");
+        // Drive simulator a bit more to ensure chart data service collects points
+        Console.Write("[Step 8] Charts: drive simulator for data... ");
         vm.SimulatorForwardCommand?.Execute(null);
-        await Delay(100);
-        for (int i = 0; i < 30; i++)
+        for (int i = 0; i < 60; i++)
         {
             simService.Tick(0);
             await Delay(33);
         }
-        Console.Write($"[speed={vm.SpeedKmh:F1}km/h] ");
-        CaptureScreenshot(window, "display_01_speed_text");
         Console.WriteLine("OK");
 
-        // Step 9: Activate AB track and drive off-line for guidelines test
-        Console.Write("[Step 9] Display: activate track, drive off-line... ");
-        var track = vm.SavedTracks.FirstOrDefault();
-        if (track != null)
-        {
-            vm.SelectedTrack = track;
-            Console.Write($"[track={track.Name}] ");
-        }
-        await Delay(200);
-        for (int i = 0; i < 30; i++)
-        {
-            simService.Tick(4.0); // steer right off the AB line
-            await Delay(33);
-        }
-        Console.WriteLine("OK");
-
-        // Step 10: ExtraGuidelines ON
-        Console.Write("[Step 10] Display: ExtraGuidelines ON... ");
-        display.ExtraGuidelines = true;
-        display.ExtraGuidelinesCount = 5;
+        // Step 9: Open Steer Chart
+        Console.Write("[Step 9] Charts: open Steer Chart... ");
+        vm.ToggleSteerChartPanelCommand?.Execute(null);
         await Delay(500);
-        CaptureScreenshot(window, "display_02_guidelines_ON");
+        CaptureScreenshot(window, "09_steer_chart");
+        Console.Write($"[visible={vm.IsSteerChartPanelVisible}] ");
         Console.WriteLine("OK");
 
-        // Step 11: ExtraGuidelines OFF
-        Console.Write("[Step 11] Display: ExtraGuidelines OFF... ");
-        display.ExtraGuidelines = false;
+        // Step 10: Open Heading Chart
+        Console.Write("[Step 10] Charts: open Heading Chart... ");
+        vm.ToggleHeadingChartPanelCommand?.Execute(null);
         await Delay(500);
-        CaptureScreenshot(window, "display_03_guidelines_OFF");
+        CaptureScreenshot(window, "10_heading_chart");
+        Console.Write($"[visible={vm.IsHeadingChartPanelVisible}] ");
         Console.WriteLine("OK");
 
-        // Step 12: UTurn button visible (track is active)
-        Console.Write("[Step 12] Display: UTurn button visible... ");
-        display.UTurnButtonVisible = true;
-        await Delay(300);
-        CaptureScreenshot(window, "display_04_uturn_ON");
-        Console.Write($"[isVisible={vm.IsUTurnButtonVisible}] ");
+        // Step 11: Open XTE Chart
+        Console.Write("[Step 11] Charts: open XTE Chart... ");
+        vm.ToggleXTEChartPanelCommand?.Execute(null);
+        await Delay(500);
+        CaptureScreenshot(window, "11_xte_chart");
+        Console.Write($"[visible={vm.IsXTEChartPanelVisible}] ");
         Console.WriteLine("OK");
 
-        // Step 13: UTurn button hidden
-        Console.Write("[Step 13] Display: UTurn button hidden... ");
-        display.UTurnButtonVisible = false;
-        // Force re-evaluation by toggling track selection
-        var currentTrack = vm.SelectedTrack;
-        vm.SelectedTrack = null;
-        vm.SelectedTrack = currentTrack;
-        await Delay(300);
-        CaptureScreenshot(window, "display_05_uturn_OFF");
-        Console.Write($"[isVisible={vm.IsUTurnButtonVisible}] ");
+        // Step 12: All three charts visible at once
+        Console.Write("[Step 12] Charts: all three visible... ");
+        await Delay(500);
+        CaptureScreenshot(window, "12_all_charts");
+        bool allVisible = vm.IsSteerChartPanelVisible
+            && vm.IsHeadingChartPanelVisible
+            && vm.IsXTEChartPanelVisible;
+        Console.Write($"[allVisible={allVisible}] ");
         Console.WriteLine("OK");
-        display.UTurnButtonVisible = true; // restore
 
-        // Step 14: AutoDayNight config in DisplayConfig tab
-        Console.Write("[Step 14] Display: AutoDayNight config tab... ");
-        vm.ShowConfigurationDialogCommand?.Execute(null);
-        await Delay(800);
-        CaptureScreenshot(window, "display_06_config_daynight");
-        if (vm.ConfigurationViewModel != null)
-            vm.ConfigurationViewModel.IsDialogVisible = false;
+        // Step 13: Close all charts
+        Console.Write("[Step 13] Charts: close all... ");
+        vm.ToggleSteerChartPanelCommand?.Execute(null);
+        vm.ToggleHeadingChartPanelCommand?.Execute(null);
+        vm.ToggleXTEChartPanelCommand?.Execute(null);
+        await Delay(500);
+        CaptureScreenshot(window, "13_charts_closed");
+        bool allClosed = !vm.IsSteerChartPanelVisible
+            && !vm.IsHeadingChartPanelVisible
+            && !vm.IsXTEChartPanelVisible;
+        Console.Write($"[allClosed={allClosed}] ");
         Console.WriteLine("OK");
     }
 

--- a/Tests/AgValoniaGPS.IntegrationTests/Program.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/Program.cs
@@ -327,42 +327,73 @@ sealed class Program
     static async Task RunChartsScenario(
         Window window, MainViewModel vm, IGpsSimulationService simService)
     {
-        // Drive simulator a bit more to ensure chart data service collects points
-        Console.Write("[Step 8] Charts: drive simulator for data... ");
+        // Step 8: Activate track and drive off-course to generate real chart data.
+        // ChartDataService now collects continuously in the background, so data
+        // accumulates even before charts are opened.
+        Console.Write("[Step 8] Charts: activate track and drive off-course... ");
+        var track = vm.SavedTracks.FirstOrDefault();
+        if (track != null)
+        {
+            vm.SelectedTrack = track;
+            Console.Write($"[track={track.Name}] ");
+        }
+        await Delay(200);
+
+        // Drive with steering to create deviation (steer angle, heading error, XTE)
         vm.SimulatorForwardCommand?.Execute(null);
-        for (int i = 0; i < 60; i++)
+        await Delay(100);
+        // Steer right to deviate from AB line
+        for (int i = 0; i < 40; i++)
+        {
+            simService.Tick(5.0);
+            await Delay(33);
+        }
+        // Correct back left
+        for (int i = 0; i < 40; i++)
+        {
+            simService.Tick(-3.0);
+            await Delay(33);
+        }
+        // Straight to stabilize
+        for (int i = 0; i < 20; i++)
         {
             simService.Tick(0);
             await Delay(33);
         }
         Console.WriteLine("OK");
 
-        // Step 9: Open Steer Chart
-        Console.Write("[Step 9] Charts: open Steer Chart... ");
+        // Step 9: Open Steer Chart only
+        Console.Write("[Step 9] Charts: Steer Chart... ");
         vm.ToggleSteerChartPanelCommand?.Execute(null);
         await Delay(500);
         CaptureScreenshot(window, "09_steer_chart");
         Console.Write($"[visible={vm.IsSteerChartPanelVisible}] ");
+        vm.ToggleSteerChartPanelCommand?.Execute(null); // close
         Console.WriteLine("OK");
 
-        // Step 10: Open Heading Chart
-        Console.Write("[Step 10] Charts: open Heading Chart... ");
+        // Step 10: Open Heading Chart only
+        Console.Write("[Step 10] Charts: Heading Chart... ");
         vm.ToggleHeadingChartPanelCommand?.Execute(null);
         await Delay(500);
         CaptureScreenshot(window, "10_heading_chart");
         Console.Write($"[visible={vm.IsHeadingChartPanelVisible}] ");
+        vm.ToggleHeadingChartPanelCommand?.Execute(null); // close
         Console.WriteLine("OK");
 
-        // Step 11: Open XTE Chart
-        Console.Write("[Step 11] Charts: open XTE Chart... ");
+        // Step 11: Open XTE Chart only
+        Console.Write("[Step 11] Charts: XTE Chart... ");
         vm.ToggleXTEChartPanelCommand?.Execute(null);
         await Delay(500);
         CaptureScreenshot(window, "11_xte_chart");
         Console.Write($"[visible={vm.IsXTEChartPanelVisible}] ");
+        vm.ToggleXTEChartPanelCommand?.Execute(null); // close
         Console.WriteLine("OK");
 
-        // Step 12: All three charts visible at once
+        // Step 12: All three charts visible
         Console.Write("[Step 12] Charts: all three visible... ");
+        vm.ToggleSteerChartPanelCommand?.Execute(null);
+        vm.ToggleHeadingChartPanelCommand?.Execute(null);
+        vm.ToggleXTEChartPanelCommand?.Execute(null);
         await Delay(500);
         CaptureScreenshot(window, "12_all_charts");
         bool allVisible = vm.IsSteerChartPanelVisible

--- a/Tests/AgValoniaGPS.Services.Tests/ChartDataServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ChartDataServiceTests.cs
@@ -1,0 +1,279 @@
+using System;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class ChartDataServiceTests
+{
+    private IAutoSteerService _mockAutoSteer = null!;
+    private ChartDataService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockAutoSteer = Substitute.For<IAutoSteerService>();
+        _service = new ChartDataService(_mockAutoSteer);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _service.Stop();
+    }
+
+    [Test]
+    public void Start_SubscribesToStateUpdated()
+    {
+        _service.Start();
+
+        Assert.That(_service.IsRunning, Is.True);
+    }
+
+    [Test]
+    public void Stop_UnsubscribesFromStateUpdated()
+    {
+        _service.Start();
+        _service.Stop();
+
+        Assert.That(_service.IsRunning, Is.False);
+    }
+
+    [Test]
+    public void Start_WhenAlreadyRunning_DoesNothing()
+    {
+        _service.Start();
+        _service.Start(); // second call should be idempotent
+
+        Assert.That(_service.IsRunning, Is.True);
+    }
+
+    [Test]
+    public void AllSeriesAreInitialized()
+    {
+        Assert.That(_service.SetSteerAngle, Is.Not.Null);
+        Assert.That(_service.ActualSteerAngle, Is.Not.Null);
+        Assert.That(_service.PwmOutput, Is.Not.Null);
+        Assert.That(_service.HeadingError, Is.Not.Null);
+        Assert.That(_service.ImuHeading, Is.Not.Null);
+        Assert.That(_service.GpsHeading, Is.Not.Null);
+        Assert.That(_service.CrossTrackError, Is.Not.Null);
+    }
+
+    [Test]
+    public void DefaultTimeWindow_Is20Seconds()
+    {
+        Assert.That(_service.TimeWindowSeconds, Is.EqualTo(20.0));
+    }
+
+    [Test]
+    public void TimeWindowSeconds_CanBeChanged()
+    {
+        _service.TimeWindowSeconds = 30.0;
+        Assert.That(_service.TimeWindowSeconds, Is.EqualTo(30.0));
+    }
+
+    [Test]
+    public void StateUpdate_AddsDataToSteerSeries()
+    {
+        _mockAutoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 5.5,
+            ImuHeading: 90.0,
+            ImuRoll: 0.0,
+            WorkSwitchActive: false,
+            SteerSwitchActive: true,
+            RemoteButtonPressed: false,
+            VwasFusionActive: false,
+            PwmDisplay: 128));
+
+        _service.Start();
+
+        // Simulate a state update
+        var snapshot = new VehicleStateSnapshot
+        {
+            SteerAngle = 10.0,
+            CrossTrackError = 0.5,
+            Heading = 180.0
+        };
+
+        _mockAutoSteer.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(_mockAutoSteer, snapshot);
+
+        // Verify data was recorded
+        Assert.That(_service.SetSteerAngle.Count, Is.EqualTo(1));
+        Assert.That(_service.ActualSteerAngle.Count, Is.EqualTo(1));
+        Assert.That(_service.PwmOutput.Count, Is.EqualTo(1));
+        Assert.That(_service.CrossTrackError.Count, Is.EqualTo(1));
+
+        var steerPoints = _service.SetSteerAngle.GetPoints();
+        Assert.That(steerPoints[0].Value, Is.EqualTo(10.0));
+
+        var actualPoints = _service.ActualSteerAngle.GetPoints();
+        Assert.That(actualPoints[0].Value, Is.EqualTo(5.5));
+
+        var pwmPoints = _service.PwmOutput.GetPoints();
+        Assert.That(pwmPoints[0].Value, Is.EqualTo(128));
+    }
+
+    [Test]
+    public void StateUpdate_AddsDataToHeadingSeries()
+    {
+        _mockAutoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0.0,
+            ImuHeading: 45.0,
+            ImuRoll: 0.0,
+            WorkSwitchActive: false,
+            SteerSwitchActive: false,
+            RemoteButtonPressed: false,
+            VwasFusionActive: false,
+            PwmDisplay: 0));
+
+        _service.Start();
+
+        var snapshot = new VehicleStateSnapshot
+        {
+            SteerAngle = 3.0,
+            CrossTrackError = 0.1,
+            Heading = 270.0
+        };
+
+        _mockAutoSteer.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(_mockAutoSteer, snapshot);
+
+        var gpsHeadingPoints = _service.GpsHeading.GetPoints();
+        Assert.That(gpsHeadingPoints[0].Value, Is.EqualTo(270.0));
+
+        var imuPoints = _service.ImuHeading.GetPoints();
+        Assert.That(imuPoints[0].Value, Is.EqualTo(45.0));
+    }
+
+    [Test]
+    public void StateUpdate_AddsDataToXTESeries()
+    {
+        _mockAutoSteer.LastSteerData.Returns(new SteerModuleData());
+
+        _service.Start();
+
+        var snapshot = new VehicleStateSnapshot
+        {
+            CrossTrackError = -1.5
+        };
+
+        _mockAutoSteer.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(_mockAutoSteer, snapshot);
+
+        var xtePoints = _service.CrossTrackError.GetPoints();
+        Assert.That(xtePoints[0].Value, Is.EqualTo(-1.5));
+    }
+
+    [Test]
+    public void CurrentTime_AdvancesAfterStart()
+    {
+        _service.Start();
+
+        // Should be positive after start
+        Thread.Sleep(50);
+        Assert.That(_service.CurrentTime, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void CurrentTime_IsZeroBeforeStart()
+    {
+        Assert.That(_service.CurrentTime, Is.EqualTo(0));
+    }
+}
+
+[TestFixture]
+public class ChartSeriesTests
+{
+    [Test]
+    public void AddPoint_IncreasesCount()
+    {
+        var series = new ChartSeries("Test", 0xFFFFFFFF);
+
+        series.AddPoint(1.0, 10.0);
+        series.AddPoint(2.0, 20.0);
+
+        Assert.That(series.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void GetPoints_ReturnsCopy()
+    {
+        var series = new ChartSeries("Test", 0xFFFFFFFF);
+        series.AddPoint(1.0, 10.0);
+
+        var points = series.GetPoints();
+        points.Clear(); // modifying copy shouldn't affect original
+
+        Assert.That(series.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TrimBefore_RemovesOldPoints()
+    {
+        var series = new ChartSeries("Test", 0xFFFFFFFF);
+        series.AddPoint(1.0, 10.0);
+        series.AddPoint(2.0, 20.0);
+        series.AddPoint(3.0, 30.0);
+        series.AddPoint(4.0, 40.0);
+
+        series.TrimBefore(2.5);
+
+        Assert.That(series.Count, Is.EqualTo(2));
+        var points = series.GetPoints();
+        Assert.That(points[0].Timestamp, Is.EqualTo(3.0));
+        Assert.That(points[1].Timestamp, Is.EqualTo(4.0));
+    }
+
+    [Test]
+    public void TrimBefore_WithNoOldPoints_DoesNothing()
+    {
+        var series = new ChartSeries("Test", 0xFFFFFFFF);
+        series.AddPoint(5.0, 10.0);
+
+        series.TrimBefore(1.0);
+
+        Assert.That(series.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Clear_RemovesAllPoints()
+    {
+        var series = new ChartSeries("Test", 0xFFFFFFFF);
+        series.AddPoint(1.0, 10.0);
+        series.AddPoint(2.0, 20.0);
+
+        series.Clear();
+
+        Assert.That(series.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Name_ReturnsConstructorValue()
+    {
+        var series = new ChartSeries("MyChart", 0xFF00FF00);
+        Assert.That(series.Name, Is.EqualTo("MyChart"));
+    }
+
+    [Test]
+    public void Color_ReturnsConstructorValue()
+    {
+        var series = new ChartSeries("Test", 0xFF00FF00);
+        Assert.That(series.Color, Is.EqualTo(0xFF00FF00));
+    }
+
+    [Test]
+    public void GetPoints_PreservesOrder()
+    {
+        var series = new ChartSeries("Test", 0xFFFFFFFF);
+        series.AddPoint(1.0, 100.0);
+        series.AddPoint(2.0, 200.0);
+        series.AddPoint(3.0, 300.0);
+
+        var points = series.GetPoints();
+        Assert.That(points[0].Value, Is.EqualTo(100.0));
+        Assert.That(points[1].Value, Is.EqualTo(200.0));
+        Assert.That(points[2].Value, Is.EqualTo(300.0));
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
@@ -218,13 +218,13 @@ internal class ChartDataServiceFake : IChartDataService
     public bool IsRunning => true;
     public double CurrentTime => _currentTime;
 
-    public ChartSeries SetSteerAngle { get; } = new("Set Angle", 0xFFFFFF00);
-    public ChartSeries ActualSteerAngle { get; } = new("Actual Angle", 0xFF00FF00);
-    public ChartSeries PwmOutput { get; } = new("PWM", 0xFF00FFFF);
-    public ChartSeries HeadingError { get; } = new("Heading Error", 0xFFFF4444);
-    public ChartSeries ImuHeading { get; } = new("IMU Heading", 0xFFFF8800);
-    public ChartSeries GpsHeading { get; } = new("GPS Heading", 0xFFFFFFFF);
-    public ChartSeries CrossTrackError { get; } = new("XTE", 0xFFFF00FF);
+    public ChartSeries SetSteerAngle { get; } = new("Set Angle", 0xFFE05020);
+    public ChartSeries ActualSteerAngle { get; } = new("Actual Angle", 0xFF2080E0);
+    public ChartSeries PwmOutput { get; } = new("PWM", 0xFF00A080);
+    public ChartSeries HeadingError { get; } = new("Heading Error", 0xFFDD3333);
+    public ChartSeries ImuHeading { get; } = new("IMU Heading", 0xFFD07020);
+    public ChartSeries GpsHeading { get; } = new("GPS Heading", 0xFF0088AA);
+    public ChartSeries CrossTrackError { get; } = new("XTE", 0xFFC020C0);
 
     public void Start() { }
     public void Stop() { }

--- a/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
@@ -1,0 +1,253 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media.Imaging;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Views.Controls;
+using AgValoniaGPS.Views.Controls.Panels;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Headless screenshot capture tests for chart panels.
+/// Renders each chart panel in a headless window and captures
+/// before/after screenshots with mock data.
+/// </summary>
+[TestFixture]
+public class ChartScreenshotTests
+{
+    private string _screenshotDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _screenshotDir = Path.Combine(
+            TestContext.CurrentContext.TestDirectory, "screenshots");
+        Directory.CreateDirectory(_screenshotDir);
+    }
+
+    private static ChartDataServiceFake CreateFakeChartData()
+    {
+        return new ChartDataServiceFake();
+    }
+
+    private static void PopulateSteerData(ChartDataServiceFake chartData)
+    {
+        // Simulate 2 seconds of steer data at ~10Hz
+        for (int i = 0; i < 20; i++)
+        {
+            double t = i * 0.1;
+            double setAngle = 15.0 * Math.Sin(t * 0.5);
+            double actualAngle = setAngle * 0.85 + (i % 3) * 0.5;
+            double pwm = Math.Abs(setAngle) * 6.0;
+
+            chartData.SetSteerAngle.AddPoint(t, setAngle);
+            chartData.ActualSteerAngle.AddPoint(t, actualAngle);
+            chartData.PwmOutput.AddPoint(t, pwm);
+        }
+        chartData.SetCurrentTime(2.0);
+    }
+
+    private static void PopulateHeadingData(ChartDataServiceFake chartData)
+    {
+        for (int i = 0; i < 20; i++)
+        {
+            double t = i * 0.1;
+            double gpsHeading = 180.0 + 5.0 * Math.Sin(t * 0.3);
+            double imuHeading = gpsHeading + 0.5;
+            double headingError = 5.0 * Math.Sin(t * 0.3);
+
+            chartData.GpsHeading.AddPoint(t, gpsHeading);
+            chartData.ImuHeading.AddPoint(t, imuHeading);
+            chartData.HeadingError.AddPoint(t, headingError);
+        }
+        chartData.SetCurrentTime(2.0);
+    }
+
+    private static void PopulateXTEData(ChartDataServiceFake chartData)
+    {
+        for (int i = 0; i < 20; i++)
+        {
+            double t = i * 0.1;
+            double xte = 0.5 * Math.Sin(t * 0.8) + 0.1 * Math.Cos(t * 2.0);
+            chartData.CrossTrackError.AddPoint(t, xte);
+        }
+        chartData.SetCurrentTime(2.0);
+    }
+
+    private static void CaptureScreenshot(Window window, string filePath)
+    {
+        var dir = Path.GetDirectoryName(filePath);
+        if (dir != null) Directory.CreateDirectory(dir);
+
+        // Use Avalonia Headless capture API for proper rendering
+        var frame = window.CaptureRenderedFrame();
+        if (frame != null)
+        {
+            frame.Save(filePath);
+        }
+        else
+        {
+            // Fallback: write an empty marker file so the test can differentiate
+            File.WriteAllText(filePath, "");
+        }
+    }
+
+    // ---- Steer Chart Screenshots ----
+
+    [AvaloniaTest]
+    public void SteerChart_EmptyBaseline_CapturesScreenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.IsSteerChartPanelVisible = true;
+
+        var chartData = CreateFakeChartData();
+        var panel = new SteerChartPanel { DataContext = vm };
+        panel.ConfigureChart(chartData);
+
+        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        window.Show();
+
+        var path = Path.Combine(_screenshotDir, "steer_chart_empty.png");
+        CaptureScreenshot(window, path);
+
+        Assert.That(File.Exists(path), Is.True, "Steer chart empty screenshot was saved");
+        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+    }
+
+    [AvaloniaTest]
+    public void SteerChart_WithData_CapturesScreenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.IsSteerChartPanelVisible = true;
+
+        var chartData = CreateFakeChartData();
+        PopulateSteerData(chartData);
+
+        var panel = new SteerChartPanel { DataContext = vm };
+        panel.ConfigureChart(chartData);
+
+        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        window.Show();
+
+        var path = Path.Combine(_screenshotDir, "steer_chart.png");
+        CaptureScreenshot(window, path);
+
+        Assert.That(File.Exists(path), Is.True, "Steer chart data screenshot was saved");
+        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+    }
+
+    // ---- Heading Chart Screenshots ----
+
+    [AvaloniaTest]
+    public void HeadingChart_EmptyBaseline_CapturesScreenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.IsHeadingChartPanelVisible = true;
+
+        var chartData = CreateFakeChartData();
+        var panel = new HeadingChartPanel { DataContext = vm };
+        panel.ConfigureChart(chartData);
+
+        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        window.Show();
+
+        var path = Path.Combine(_screenshotDir, "heading_chart_empty.png");
+        CaptureScreenshot(window, path);
+
+        Assert.That(File.Exists(path), Is.True, "Heading chart empty screenshot was saved");
+        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+    }
+
+    [AvaloniaTest]
+    public void HeadingChart_WithData_CapturesScreenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.IsHeadingChartPanelVisible = true;
+
+        var chartData = CreateFakeChartData();
+        PopulateHeadingData(chartData);
+
+        var panel = new HeadingChartPanel { DataContext = vm };
+        panel.ConfigureChart(chartData);
+
+        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        window.Show();
+
+        var path = Path.Combine(_screenshotDir, "heading_chart.png");
+        CaptureScreenshot(window, path);
+
+        Assert.That(File.Exists(path), Is.True, "Heading chart data screenshot was saved");
+        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+    }
+
+    // ---- XTE Chart Screenshots ----
+
+    [AvaloniaTest]
+    public void XTEChart_EmptyBaseline_CapturesScreenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.IsXTEChartPanelVisible = true;
+
+        var chartData = CreateFakeChartData();
+        var panel = new XTEChartPanel { DataContext = vm };
+        panel.ConfigureChart(chartData);
+
+        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        window.Show();
+
+        var path = Path.Combine(_screenshotDir, "xte_chart_empty.png");
+        CaptureScreenshot(window, path);
+
+        Assert.That(File.Exists(path), Is.True, "XTE chart empty screenshot was saved");
+        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+    }
+
+    [AvaloniaTest]
+    public void XTEChart_WithData_CapturesScreenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.IsXTEChartPanelVisible = true;
+
+        var chartData = CreateFakeChartData();
+        PopulateXTEData(chartData);
+
+        var panel = new XTEChartPanel { DataContext = vm };
+        panel.ConfigureChart(chartData);
+
+        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        window.Show();
+
+        var path = Path.Combine(_screenshotDir, "xte_chart.png");
+        CaptureScreenshot(window, path);
+
+        Assert.That(File.Exists(path), Is.True, "XTE chart data screenshot was saved");
+        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+    }
+}
+
+/// <summary>
+/// Minimal fake IChartDataService for screenshot tests.
+/// Allows direct data population without needing AutoSteerService.
+/// </summary>
+internal class ChartDataServiceFake : IChartDataService
+{
+    private double _currentTime;
+
+    public double TimeWindowSeconds { get; set; } = 20.0;
+    public bool IsRunning => true;
+    public double CurrentTime => _currentTime;
+
+    public ChartSeries SetSteerAngle { get; } = new("Set Angle", 0xFFFFFF00);
+    public ChartSeries ActualSteerAngle { get; } = new("Actual Angle", 0xFF00FF00);
+    public ChartSeries PwmOutput { get; } = new("PWM", 0xFF00FFFF);
+    public ChartSeries HeadingError { get; } = new("Heading Error", 0xFFFF4444);
+    public ChartSeries ImuHeading { get; } = new("IMU Heading", 0xFFFF8800);
+    public ChartSeries GpsHeading { get; } = new("GPS Heading", 0xFFFFFFFF);
+    public ChartSeries CrossTrackError { get; } = new("XTE", 0xFFFF00FF);
+
+    public void Start() { }
+    public void Stop() { }
+
+    public void SetCurrentTime(double time) => _currentTime = time;
+}

--- a/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
@@ -33,46 +33,50 @@ public class ChartScreenshotTests
 
     private static void PopulateSteerData(ChartDataServiceFake chartData)
     {
-        // Simulate 2 seconds of steer data at ~10Hz
-        for (int i = 0; i < 20; i++)
+        // Simulate 25 seconds of steer data at 10Hz to fill the 20s rolling window
+        for (int i = 0; i < 250; i++)
         {
             double t = i * 0.1;
-            double setAngle = 15.0 * Math.Sin(t * 0.5);
-            double actualAngle = setAngle * 0.85 + (i % 3) * 0.5;
-            double pwm = Math.Abs(setAngle) * 6.0;
+            // Realistic oscillating steer pattern: correction cycles
+            double setAngle = 18.0 * Math.Sin(t * 0.4) + 5.0 * Math.Sin(t * 1.2);
+            double actualAngle = setAngle * 0.85 + 2.0 * Math.Sin(t * 0.4 - 0.3);
+            double pwm = Math.Clamp(Math.Abs(setAngle) * 5.5, 0, 255);
 
             chartData.SetSteerAngle.AddPoint(t, setAngle);
             chartData.ActualSteerAngle.AddPoint(t, actualAngle);
             chartData.PwmOutput.AddPoint(t, pwm);
         }
-        chartData.SetCurrentTime(2.0);
+        chartData.SetCurrentTime(25.0);
     }
 
     private static void PopulateHeadingData(ChartDataServiceFake chartData)
     {
-        for (int i = 0; i < 20; i++)
+        // 25 seconds at 10Hz -- heading error centered near zero, GPS/IMU near 180
+        for (int i = 0; i < 250; i++)
         {
             double t = i * 0.1;
-            double gpsHeading = 180.0 + 5.0 * Math.Sin(t * 0.3);
-            double imuHeading = gpsHeading + 0.5;
-            double headingError = 5.0 * Math.Sin(t * 0.3);
+            double headingError = 8.0 * Math.Sin(t * 0.3) + 3.0 * Math.Cos(t * 0.7);
+            double gpsHeading = 180.0 + 5.0 * Math.Sin(t * 0.15);
+            double imuHeading = gpsHeading + 0.8 * Math.Sin(t * 0.5);
 
+            chartData.HeadingError.AddPoint(t, headingError);
             chartData.GpsHeading.AddPoint(t, gpsHeading);
             chartData.ImuHeading.AddPoint(t, imuHeading);
-            chartData.HeadingError.AddPoint(t, headingError);
         }
-        chartData.SetCurrentTime(2.0);
+        chartData.SetCurrentTime(25.0);
     }
 
     private static void PopulateXTEData(ChartDataServiceFake chartData)
     {
-        for (int i = 0; i < 20; i++)
+        // 25 seconds at 10Hz -- XTE oscillating around zero
+        for (int i = 0; i < 250; i++)
         {
             double t = i * 0.1;
-            double xte = 0.5 * Math.Sin(t * 0.8) + 0.1 * Math.Cos(t * 2.0);
+            double xte = 0.8 * Math.Sin(t * 0.5) + 0.3 * Math.Cos(t * 1.3)
+                       + 0.15 * Math.Sin(t * 3.0);
             chartData.CrossTrackError.AddPoint(t, xte);
         }
-        chartData.SetCurrentTime(2.0);
+        chartData.SetCurrentTime(25.0);
     }
 
     private static void CaptureScreenshot(Window window, string filePath)
@@ -80,17 +84,9 @@ public class ChartScreenshotTests
         var dir = Path.GetDirectoryName(filePath);
         if (dir != null) Directory.CreateDirectory(dir);
 
-        // Use Avalonia Headless capture API for proper rendering
         var frame = window.CaptureRenderedFrame();
         if (frame != null)
-        {
             frame.Save(filePath);
-        }
-        else
-        {
-            // Fallback: write an empty marker file so the test can differentiate
-            File.WriteAllText(filePath, "");
-        }
     }
 
     // ---- Steer Chart Screenshots ----
@@ -105,7 +101,7 @@ public class ChartScreenshotTests
         var panel = new SteerChartPanel { DataContext = vm };
         panel.ConfigureChart(chartData);
 
-        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
         window.Show();
 
         var path = Path.Combine(_screenshotDir, "steer_chart_empty.png");
@@ -127,7 +123,7 @@ public class ChartScreenshotTests
         var panel = new SteerChartPanel { DataContext = vm };
         panel.ConfigureChart(chartData);
 
-        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
         window.Show();
 
         var path = Path.Combine(_screenshotDir, "steer_chart.png");
@@ -149,7 +145,7 @@ public class ChartScreenshotTests
         var panel = new HeadingChartPanel { DataContext = vm };
         panel.ConfigureChart(chartData);
 
-        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
         window.Show();
 
         var path = Path.Combine(_screenshotDir, "heading_chart_empty.png");
@@ -171,7 +167,7 @@ public class ChartScreenshotTests
         var panel = new HeadingChartPanel { DataContext = vm };
         panel.ConfigureChart(chartData);
 
-        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
         window.Show();
 
         var path = Path.Combine(_screenshotDir, "heading_chart.png");
@@ -193,7 +189,7 @@ public class ChartScreenshotTests
         var panel = new XTEChartPanel { DataContext = vm };
         panel.ConfigureChart(chartData);
 
-        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
         window.Show();
 
         var path = Path.Combine(_screenshotDir, "xte_chart_empty.png");
@@ -215,7 +211,7 @@ public class ChartScreenshotTests
         var panel = new XTEChartPanel { DataContext = vm };
         panel.ConfigureChart(chartData);
 
-        var window = new Window { Content = panel, Width = 800, Height = 400 };
+        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
         window.Show();
 
         var path = Path.Combine(_screenshotDir, "xte_chart.png");

--- a/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ChartScreenshotTests.cs
@@ -1,8 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Headless;
 using Avalonia.Media.Imaging;
 using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels;
 using AgValoniaGPS.Views.Controls;
 using AgValoniaGPS.Views.Controls.Panels;
 
@@ -10,21 +10,73 @@ namespace AgValoniaGPS.UI.Tests;
 
 /// <summary>
 /// Headless screenshot capture tests for chart panels.
-/// Renders each chart panel in a headless window and captures
-/// before/after screenshots with mock data.
+/// Renders each chart panel with empty and populated data,
+/// following the shared capture pattern from ScreenshotCaptureTests.
+/// Screenshots go to screenshots/charts/ subdirectory.
 /// </summary>
 [TestFixture]
 public class ChartScreenshotTests
 {
-    private string _screenshotDir = null!;
+    private const int ChartWidth = 440;
+    private const int ChartHeight = 260;
 
-    [SetUp]
-    public void SetUp()
+    private static string ScreenshotBaseDir
     {
-        _screenshotDir = Path.Combine(
-            TestContext.CurrentContext.TestDirectory, "screenshots");
-        Directory.CreateDirectory(_screenshotDir);
+        get
+        {
+            var dir = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                "screenshots", "charts");
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
     }
+
+    // ---------------------------------------------------------------
+    // Capture helpers (consistent with ScreenshotCaptureTests pattern)
+    // ---------------------------------------------------------------
+
+    private static void CaptureScreenshot(Window window, string filePath)
+    {
+        window.UpdateLayout();
+
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        var renderTarget = new RenderTargetBitmap(
+            new PixelSize(ChartWidth, ChartHeight), new Vector(96, 96));
+        renderTarget.Render(window);
+        renderTarget.Save(filePath);
+    }
+
+    private static void AssertScreenshotExists(string path, string label)
+    {
+        Assert.That(File.Exists(path), Is.True, $"{label} screenshot not created: {path}");
+        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), $"{label} screenshot is empty");
+    }
+
+    // ---------------------------------------------------------------
+    // Window + panel builders
+    // ---------------------------------------------------------------
+
+    private static (Window window, TPanel panel) CreateChartWindow<TPanel>(
+        Action<MainViewModel> setVisible) where TPanel : UserControl, new()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        setVisible(vm);
+
+        var panel = new TPanel { DataContext = vm };
+        var window = new Window
+        {
+            Content = panel,
+            Width = ChartWidth,
+            Height = ChartHeight,
+            SizeToContent = SizeToContent.Manual
+        };
+        return (window, panel);
+    }
+
+    // ---------------------------------------------------------------
+    // Mock data generators (25 seconds at 10Hz to fill 20s window)
+    // ---------------------------------------------------------------
 
     private static ChartDataServiceFake CreateFakeChartData()
     {
@@ -33,11 +85,9 @@ public class ChartScreenshotTests
 
     private static void PopulateSteerData(ChartDataServiceFake chartData)
     {
-        // Simulate 25 seconds of steer data at 10Hz to fill the 20s rolling window
         for (int i = 0; i < 250; i++)
         {
             double t = i * 0.1;
-            // Realistic oscillating steer pattern: correction cycles
             double setAngle = 18.0 * Math.Sin(t * 0.4) + 5.0 * Math.Sin(t * 1.2);
             double actualAngle = setAngle * 0.85 + 2.0 * Math.Sin(t * 0.4 - 0.3);
             double pwm = Math.Clamp(Math.Abs(setAngle) * 5.5, 0, 255);
@@ -51,7 +101,6 @@ public class ChartScreenshotTests
 
     private static void PopulateHeadingData(ChartDataServiceFake chartData)
     {
-        // 25 seconds at 10Hz -- heading error centered near zero, GPS/IMU near 180
         for (int i = 0; i < 250; i++)
         {
             double t = i * 0.1;
@@ -68,7 +117,6 @@ public class ChartScreenshotTests
 
     private static void PopulateXTEData(ChartDataServiceFake chartData)
     {
-        // 25 seconds at 10Hz -- XTE oscillating around zero
         for (int i = 0; i < 250; i++)
         {
             double t = i * 0.1;
@@ -79,146 +127,82 @@ public class ChartScreenshotTests
         chartData.SetCurrentTime(25.0);
     }
 
-    private static void CaptureScreenshot(Window window, string filePath)
-    {
-        var dir = Path.GetDirectoryName(filePath);
-        if (dir != null) Directory.CreateDirectory(dir);
+    // ---------------------------------------------------------------
+    // Chart capture helper: empty + populated for a chart type
+    // ---------------------------------------------------------------
 
-        var frame = window.CaptureRenderedFrame();
-        if (frame != null)
-            frame.Save(filePath);
+    private void CaptureChartToggle<TPanel>(
+        string chartName,
+        Action<MainViewModel> setVisible,
+        Action<TPanel, ChartDataServiceFake> configureChart,
+        Action<ChartDataServiceFake> populateData) where TPanel : UserControl, new()
+    {
+        var baseDir = ScreenshotBaseDir;
+
+        // Empty baseline
+        {
+            var (window, panel) = CreateChartWindow<TPanel>(setVisible);
+            var emptyData = CreateFakeChartData();
+            configureChart(panel, emptyData);
+            window.Show();
+
+            var path = Path.Combine(baseDir, $"{chartName}_empty.png");
+            CaptureScreenshot(window, path);
+            window.Close();
+
+            AssertScreenshotExists(path, $"{chartName}/empty");
+            TestContext.Out.WriteLine($"[{chartName}] empty: {path}");
+        }
+
+        // With data
+        {
+            var (window, panel) = CreateChartWindow<TPanel>(setVisible);
+            var chartData = CreateFakeChartData();
+            populateData(chartData);
+            configureChart(panel, chartData);
+            window.Show();
+
+            var path = Path.Combine(baseDir, $"{chartName}_data.png");
+            CaptureScreenshot(window, path);
+            window.Close();
+
+            AssertScreenshotExists(path, $"{chartName}/data");
+            TestContext.Out.WriteLine($"[{chartName}] data:  {path}");
+        }
     }
 
-    // ---- Steer Chart Screenshots ----
+    // ---------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------
 
     [AvaloniaTest]
-    public void SteerChart_EmptyBaseline_CapturesScreenshot()
+    public void Capture_SteerChart()
     {
-        var vm = new MainViewModelBuilder().Build();
-        vm.IsSteerChartPanelVisible = true;
-
-        var chartData = CreateFakeChartData();
-        var panel = new SteerChartPanel { DataContext = vm };
-        panel.ConfigureChart(chartData);
-
-        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
-        window.Show();
-
-        var path = Path.Combine(_screenshotDir, "steer_chart_empty.png");
-        CaptureScreenshot(window, path);
-
-        Assert.That(File.Exists(path), Is.True, "Steer chart empty screenshot was saved");
-        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
-    }
-
-    [AvaloniaTest]
-    public void SteerChart_WithData_CapturesScreenshot()
-    {
-        var vm = new MainViewModelBuilder().Build();
-        vm.IsSteerChartPanelVisible = true;
-
-        var chartData = CreateFakeChartData();
-        PopulateSteerData(chartData);
-
-        var panel = new SteerChartPanel { DataContext = vm };
-        panel.ConfigureChart(chartData);
-
-        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
-        window.Show();
-
-        var path = Path.Combine(_screenshotDir, "steer_chart.png");
-        CaptureScreenshot(window, path);
-
-        Assert.That(File.Exists(path), Is.True, "Steer chart data screenshot was saved");
-        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
-    }
-
-    // ---- Heading Chart Screenshots ----
-
-    [AvaloniaTest]
-    public void HeadingChart_EmptyBaseline_CapturesScreenshot()
-    {
-        var vm = new MainViewModelBuilder().Build();
-        vm.IsHeadingChartPanelVisible = true;
-
-        var chartData = CreateFakeChartData();
-        var panel = new HeadingChartPanel { DataContext = vm };
-        panel.ConfigureChart(chartData);
-
-        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
-        window.Show();
-
-        var path = Path.Combine(_screenshotDir, "heading_chart_empty.png");
-        CaptureScreenshot(window, path);
-
-        Assert.That(File.Exists(path), Is.True, "Heading chart empty screenshot was saved");
-        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+        CaptureChartToggle<SteerChartPanel>(
+            "steer_chart",
+            vm => vm.IsSteerChartPanelVisible = true,
+            (panel, data) => panel.ConfigureChart(data),
+            PopulateSteerData);
     }
 
     [AvaloniaTest]
-    public void HeadingChart_WithData_CapturesScreenshot()
+    public void Capture_HeadingChart()
     {
-        var vm = new MainViewModelBuilder().Build();
-        vm.IsHeadingChartPanelVisible = true;
-
-        var chartData = CreateFakeChartData();
-        PopulateHeadingData(chartData);
-
-        var panel = new HeadingChartPanel { DataContext = vm };
-        panel.ConfigureChart(chartData);
-
-        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
-        window.Show();
-
-        var path = Path.Combine(_screenshotDir, "heading_chart.png");
-        CaptureScreenshot(window, path);
-
-        Assert.That(File.Exists(path), Is.True, "Heading chart data screenshot was saved");
-        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
-    }
-
-    // ---- XTE Chart Screenshots ----
-
-    [AvaloniaTest]
-    public void XTEChart_EmptyBaseline_CapturesScreenshot()
-    {
-        var vm = new MainViewModelBuilder().Build();
-        vm.IsXTEChartPanelVisible = true;
-
-        var chartData = CreateFakeChartData();
-        var panel = new XTEChartPanel { DataContext = vm };
-        panel.ConfigureChart(chartData);
-
-        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
-        window.Show();
-
-        var path = Path.Combine(_screenshotDir, "xte_chart_empty.png");
-        CaptureScreenshot(window, path);
-
-        Assert.That(File.Exists(path), Is.True, "XTE chart empty screenshot was saved");
-        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+        CaptureChartToggle<HeadingChartPanel>(
+            "heading_chart",
+            vm => vm.IsHeadingChartPanelVisible = true,
+            (panel, data) => panel.ConfigureChart(data),
+            PopulateHeadingData);
     }
 
     [AvaloniaTest]
-    public void XTEChart_WithData_CapturesScreenshot()
+    public void Capture_XTEChart()
     {
-        var vm = new MainViewModelBuilder().Build();
-        vm.IsXTEChartPanelVisible = true;
-
-        var chartData = CreateFakeChartData();
-        PopulateXTEData(chartData);
-
-        var panel = new XTEChartPanel { DataContext = vm };
-        panel.ConfigureChart(chartData);
-
-        var window = new Window { Content = panel, Width = 440, Height = 260, SizeToContent = SizeToContent.Manual };
-        window.Show();
-
-        var path = Path.Combine(_screenshotDir, "xte_chart.png");
-        CaptureScreenshot(window, path);
-
-        Assert.That(File.Exists(path), Is.True, "XTE chart data screenshot was saved");
-        Assert.That(new FileInfo(path).Length, Is.GreaterThan(0), "Screenshot file is not empty");
+        CaptureChartToggle<XTEChartPanel>(
+            "xte_chart",
+            vm => vm.IsXTEChartPanelVisible = true,
+            (panel, data) => panel.ConfigureChart(data),
+            PopulateXTEData);
     }
 }
 

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -60,6 +60,7 @@ public class MainViewModelBuilder
             coverageMapService: Substitute.For<ICoverageMapService>(),
             sectionControlService: Substitute.For<ISectionControlService>(),
             ntripProfileService: NtripProfileService,
+            chartDataService: Substitute.For<IChartDataService>(),
             logger: NullLogger<MainViewModel>.Instance,
             appState: new ApplicationState());
     }


### PR DESCRIPTION
## What changed

Adds real-time diagnostic charts for autosteer tuning and monitoring:

- **Steer Chart (#30)** -- set steer angle, actual steer angle (WAS), PWM output
- **Heading Chart (#31)** -- heading error, IMU heading, GPS heading
- **XTE Chart (#32)** -- cross-track error over time

Shared infrastructure:
- Reusable `ChartControl` using DrawingContext rendering (grid, Y-axis labels, auto-scale, multi-series legend)
- `ChartDataService` collecting rolling time-series from AutoSteerService at GPS rate
- Draggable floating panels with show/hide toggle commands
- 18 new tests for data collection and series operations

## Related issue

Relates to #30, relates to #31, relates to #32

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes (268 tests)
- [ ] Tested on: Desktop -- awaiting manual UI verification