### PR TITLE
Add theme switching, log viewer, flag by lat/lon, view settings

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -40,7 +40,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="15">
                         <TextBlock Text="{Binding StatusMessage}" Foreground="#2ECC71" FontSize="14"
                                    TextTrimming="CharacterEllipsis" Width="180"/>
-                        <TextBlock Text="{Binding State.Vehicle.FixQualityText}" Foreground="#3498DB" FontSize="12"
+                        <TextBlock Text="{Binding State.Vehicle.FixQualityText}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12"
                                    MinWidth="70"/>
                         <TextBlock Text="{Binding CurrentFps, StringFormat='FPS: {0:F0}'}" Foreground="#F1C40F" FontSize="12"
                                    MinWidth="55"/>
@@ -51,13 +51,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Right: Field Statistics (when field is active) -->
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="10"
                                 IsVisible="{Binding HasActiveField}">
-                        <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="White" FontSize="12" MinWidth="60"/>
-                        <TextBlock Text="|" Foreground="#555" FontSize="12"/>
+                        <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" MinWidth="60"/>
+                        <TextBlock Text="|" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                         <TextBlock Text="{Binding WorkedAreaDisplay}" Foreground="#2ECC71" FontSize="12" FontWeight="Bold" MinWidth="60"/>
-                        <TextBlock Text="|" Foreground="#555" FontSize="12"/>
+                        <TextBlock Text="|" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                         <TextBlock Text="{Binding RemainingPercent, StringFormat='{}{0:F0}%'}" Foreground="#F39C12" FontSize="12" MinWidth="35"/>
-                        <TextBlock Text="|" Foreground="#555" FontSize="12"/>
-                        <TextBlock Text="{Binding WorkRateDisplay}" Foreground="#3498DB" FontSize="12" MinWidth="65"/>
+                        <TextBlock Text="|" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                        <TextBlock Text="{Binding WorkRateDisplay}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12" MinWidth="65"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -100,11 +100,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Button Content="+" Command="{Binding ZoomInCommand}"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="White" CornerRadius="8"/>
+                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
                     <Button Content="-" Command="{Binding ZoomOutCommand}"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="White" CornerRadius="8"/>
+                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
                 </StackPanel>
             </Grid>
         </Grid>
@@ -115,28 +115,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 IsVisible="{Binding IsCreatingABLine}">
             <StackPanel Orientation="Horizontal" Spacing="16">
                 <TextBlock Text="{Binding ABCreationInstructions}"
-                           Foreground="White" FontSize="16" VerticalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" VerticalAlignment="Center"/>
                 <!-- Finish button for drive-recording Curve mode -->
                 <Button Content="Finish"
                         Command="{Binding FinishCurveRecordingCommand}"
-                        Background="#27AE60" Foreground="White"
+                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"
                         IsVisible="{Binding IsRecordingCurve}"/>
                 <!-- Finish button for DrawCurve mode -->
                 <Button Content="Finish"
                         Command="{Binding FinishDrawCurveCommand}"
-                        Background="#27AE60" Foreground="White"
+                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"
                         IsVisible="{Binding IsDrawingCurve}"/>
                 <!-- Undo button for DrawCurve mode -->
                 <Button Content="Undo"
                         Command="{Binding UndoLastDrawnPointCommand}"
-                        Background="#E67E22" Foreground="White"
+                        Background="#E67E22" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"
                         IsVisible="{Binding IsDrawingCurve}"/>
                 <Button Content="Cancel"
                         Command="{Binding CancelABCreationCommand}"
-                        Background="#DD3333" Foreground="White"
+                        Background="#DD3333" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"/>
             </StackPanel>
         </Border>

--- a/Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
+++ b/Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
@@ -11,6 +11,16 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <!-- Embed git short hash into AssemblyInformationalVersion -->
+  <Target Name="SetGitHash" BeforeTargets="GetAssemblyVersion">
+    <Exec Command="git rev-parse --short HEAD" ConsoleToMsBuild="true" StandardOutputImportance="low" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitHash" />
+    </Exec>
+    <PropertyGroup>
+      <InformationalVersion>26.2.0+$(GitHash)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
+
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>

--- a/Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
+++ b/Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
@@ -11,15 +11,17 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <!-- Embed git short hash into AssemblyInformationalVersion -->
-  <Target Name="SetGitHash" BeforeTargets="GetAssemblyVersion">
-    <Exec Command="git rev-parse --short HEAD" ConsoleToMsBuild="true" StandardOutputImportance="low" IgnoreExitCode="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitHash" />
+  <!-- Embed git hash + dirty flag into AssemblyInformationalVersion (e.g. "26.2.0+9e92e46" or "26.2.0+9e92e46-dirty") -->
+  <Target Name="SetGitHash" BeforeTargets="InitializeSourceControlInformation">
+    <Exec Command="git describe --always --dirty" ConsoleToMsBuild="true" StandardOutputImportance="low" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="SourceRevisionId" />
     </Exec>
-    <PropertyGroup>
-      <InformationalVersion>26.2.0+$(GitHash)</InformationalVersion>
-    </PropertyGroup>
   </Target>
+
+  <PropertyGroup>
+    <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
+    <Version>26.2.0</Version>
+  </PropertyGroup>
 
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />

--- a/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
@@ -16,11 +16,13 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 using AgValoniaGPS.Desktop.Views;
 using AgValoniaGPS.Desktop.DependencyInjection;
 using AgValoniaGPS.Services.Interfaces;
@@ -35,6 +37,10 @@ public partial class App : Application
 
     public static IServiceProvider? Services { get; set; }
 
+    // Hooks for integration test harness
+    public static Action<IServiceCollection>? ConfigureTestServices { get; set; }
+    public static Func<IClassicDesktopStyleApplicationLifetime, Task>? OnAppReady { get; set; }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -47,6 +53,7 @@ public partial class App : Application
             .ConfigureServices((context, services) =>
             {
                 services.AddAgValoniaServices();
+                ConfigureTestServices?.Invoke(services);
             })
             .Build();
 
@@ -69,6 +76,18 @@ public partial class App : Application
 
             var mainWindow = new MainWindow();
             desktop.MainWindow = mainWindow;
+
+            // Fire integration test scenario after window is shown
+            if (OnAppReady != null)
+            {
+                var callback = OnAppReady;
+                Dispatcher.UIThread.Post(async () =>
+                {
+                    await Task.Delay(500);
+                    await callback(desktop);
+                    desktop.Shutdown();
+                });
+            }
 
             desktop.Exit += (sender, args) =>
             {

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ using AgValoniaGPS.Services.Track;
 using AgValoniaGPS.Services.YouTurn;
 using AgValoniaGPS.Services.Tool;
 using AgValoniaGPS.Services.Coverage;
+using AgValoniaGPS.Services.Logging;
 using AgValoniaGPS.Services.Section;
 using AgValoniaGPS.Services.Tram;
 using AgValoniaGPS.ViewModels;
@@ -44,6 +45,7 @@ public static class ServiceCollectionExtensions
         {
             builder.AddConsole();
             builder.AddDebug();
+            builder.AddProvider(new InMemoryLoggerProvider());
             builder.SetMinimumLevel(LogLevel.Debug);
         });
 

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -28,7 +28,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         x:DataType="vm:MainViewModel"
         Icon="/Assets/avalonia-logo.ico"
         Title="AgValoniaGPS"
-        Background="#1a1a1a">
+        Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
 
     <!-- Styles are now in shared SharedStyles.axaml -->
 
@@ -136,7 +136,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </Grid>
 
     <!-- AB Creation Instruction Banner -->
-    <Border Background="#CC000000" CornerRadius="8" Padding="16,8"
+    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Padding="16,8"
             HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,80,0,0"
             IsVisible="{Binding IsCreatingABLine}">
         <StackPanel Orientation="Horizontal" Spacing="16">

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -52,13 +52,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 VerticalAlignment="Top"
                 IsHitTestVisible="True">
             <StackPanel Orientation="Horizontal" Spacing="10">
-                <TextBlock Text="RTK Status" Foreground="#3498DB" FontSize="14" FontWeight="Bold"/>
+                <TextBlock Text="RTK Status" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="Bold"/>
                 <Ellipse Width="12" Height="12"
                          Fill="{Binding State.Vehicle.FixQualityText, Converter={StaticResource FixQualityToColorConverter}}"/>
-                <TextBlock Text="{Binding State.Vehicle.FixQualityText}" Foreground="White" FontSize="14" FontWeight="Bold"/>
-                <Rectangle Width="1" Height="16" Fill="#555" Margin="5,0"/>
+                <TextBlock Text="{Binding State.Vehicle.FixQualityText}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" FontWeight="Bold"/>
+                <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="5,0"/>
                 <TextBlock Text="{Binding CurrentFps, StringFormat='FPS: {0:F0}'}" Foreground="#2ECC71" FontSize="14" FontWeight="Bold"/>
-                <Rectangle Width="1" Height="16" Fill="#555" Margin="5,0"/>
+                <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="5,0"/>
                 <TextBlock Text="{Binding GpsToPgnLatencyMs, StringFormat='Lat: {0:F2}ms'}" Foreground="#F39C12" FontSize="14" FontWeight="Bold"/>
             </StackPanel>
         </Border>
@@ -73,23 +73,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 IsVisible="{Binding HasActiveField}">
             <StackPanel Orientation="Horizontal" Spacing="12">
                 <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock Text="Field:" Foreground="#888" FontSize="13"/>
-                    <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="White" FontSize="13" FontWeight="Bold"/>
+                    <TextBlock Text="Field:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
+                    <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13" FontWeight="Bold"/>
                 </StackPanel>
-                <Rectangle Width="1" Height="16" Fill="#555"/>
+                <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
                 <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock Text="Done:" Foreground="#888" FontSize="13"/>
+                    <TextBlock Text="Done:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
                     <TextBlock Text="{Binding WorkedAreaDisplay}" Foreground="#2ECC71" FontSize="13" FontWeight="Bold"/>
                 </StackPanel>
-                <Rectangle Width="1" Height="16" Fill="#555"/>
+                <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
                 <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock Text="Left:" Foreground="#888" FontSize="13"/>
+                    <TextBlock Text="Left:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
                     <TextBlock Text="{Binding RemainingPercent, StringFormat='{}{0:F1}%'}" Foreground="#F39C12" FontSize="13" FontWeight="Bold"/>
                 </StackPanel>
-                <Rectangle Width="1" Height="16" Fill="#555"/>
+                <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
                 <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock Text="Rate:" Foreground="#888" FontSize="13"/>
-                    <TextBlock Text="{Binding WorkRateDisplay}" Foreground="#3498DB" FontSize="13" FontWeight="Bold"/>
+                    <TextBlock Text="Rate:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
+                    <TextBlock Text="{Binding WorkRateDisplay}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="13" FontWeight="Bold"/>
                 </StackPanel>
             </StackPanel>
         </Border>
@@ -100,11 +100,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Button Content="+" Command="{Binding ZoomInCommand}"
                     Width="50" Height="50" FontSize="28" FontWeight="Bold"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    Background="#4A5568" Foreground="White" CornerRadius="8"/>
+                    Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
             <Button Content="-" Command="{Binding ZoomOutCommand}"
                     Width="50" Height="50" FontSize="28" FontWeight="Bold"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    Background="#4A5568" Foreground="White" CornerRadius="8"/>
+                    Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
         </StackPanel>
 
         <!-- All Draggable Panels in single Canvas (must be in same Canvas for consistent drag bounds) -->
@@ -141,28 +141,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             IsVisible="{Binding IsCreatingABLine}">
         <StackPanel Orientation="Horizontal" Spacing="16">
             <TextBlock Text="{Binding ABCreationInstructions}"
-                       Foreground="White" FontSize="16" VerticalAlignment="Center"/>
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" VerticalAlignment="Center"/>
             <!-- Finish button for drive-recording Curve mode -->
             <Button Content="Finish"
                     Command="{Binding FinishCurveRecordingCommand}"
-                    Background="#27AE60" Foreground="White"
+                    Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                     Padding="12,4"
                     IsVisible="{Binding IsRecordingCurve}"/>
             <!-- Finish button for DrawCurve mode -->
             <Button Content="Finish"
                     Command="{Binding FinishDrawCurveCommand}"
-                    Background="#27AE60" Foreground="White"
+                    Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                     Padding="12,4"
                     IsVisible="{Binding IsDrawingCurve}"/>
             <!-- Undo button for DrawCurve mode -->
             <Button Content="Undo"
                     Command="{Binding UndoLastDrawnPointCommand}"
-                    Background="#E67E22" Foreground="White"
+                    Background="#E67E22" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                     Padding="12,4"
                     IsVisible="{Binding IsDrawingCurve}"/>
             <Button Content="Cancel"
                     Command="{Binding CancelABCreationCommand}"
-                    Background="#DD3333" Foreground="White"
+                    Background="#DD3333" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                     Padding="12,4"/>
         </StackPanel>
     </Border>

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -40,7 +40,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="15">
                         <TextBlock Text="{Binding StatusMessage}" Foreground="#2ECC71" FontSize="14"
                                    TextTrimming="CharacterEllipsis" Width="180"/>
-                        <TextBlock Text="{Binding State.Vehicle.FixQualityText}" Foreground="#3498DB" FontSize="12"
+                        <TextBlock Text="{Binding State.Vehicle.FixQualityText}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12"
                                    MinWidth="70"/>
                         <TextBlock Text="{Binding CurrentFps, StringFormat='FPS: {0:F0}'}" Foreground="#F1C40F" FontSize="12"
                                    MinWidth="55"/>
@@ -51,13 +51,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Right: Field Statistics (when field is active) -->
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="10"
                                 IsVisible="{Binding HasActiveField}">
-                        <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="White" FontSize="12" MinWidth="60"/>
-                        <TextBlock Text="|" Foreground="#555" FontSize="12"/>
+                        <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" MinWidth="60"/>
+                        <TextBlock Text="|" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                         <TextBlock Text="{Binding WorkedAreaDisplay}" Foreground="#2ECC71" FontSize="12" FontWeight="Bold" MinWidth="60"/>
-                        <TextBlock Text="|" Foreground="#555" FontSize="12"/>
+                        <TextBlock Text="|" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                         <TextBlock Text="{Binding RemainingPercent, StringFormat='{}{0:F0}%'}" Foreground="#F39C12" FontSize="12" MinWidth="35"/>
-                        <TextBlock Text="|" Foreground="#555" FontSize="12"/>
-                        <TextBlock Text="{Binding WorkRateDisplay}" Foreground="#3498DB" FontSize="12" MinWidth="65"/>
+                        <TextBlock Text="|" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                        <TextBlock Text="{Binding WorkRateDisplay}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12" MinWidth="65"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -100,11 +100,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Button Content="+" Command="{Binding ZoomInCommand}"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="White" CornerRadius="8"/>
+                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
                     <Button Content="-" Command="{Binding ZoomOutCommand}"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="White" CornerRadius="8"/>
+                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
                 </StackPanel>
             </Grid>
         </Grid>
@@ -115,28 +115,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 IsVisible="{Binding IsCreatingABLine}">
             <StackPanel Orientation="Horizontal" Spacing="16">
                 <TextBlock Text="{Binding ABCreationInstructions}"
-                           Foreground="White" FontSize="16" VerticalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" VerticalAlignment="Center"/>
                 <!-- Finish button for drive-recording Curve mode -->
                 <Button Content="Finish"
                         Command="{Binding FinishCurveRecordingCommand}"
-                        Background="#27AE60" Foreground="White"
+                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"
                         IsVisible="{Binding IsRecordingCurve}"/>
                 <!-- Finish button for DrawCurve mode -->
                 <Button Content="Finish"
                         Command="{Binding FinishDrawCurveCommand}"
-                        Background="#27AE60" Foreground="White"
+                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"
                         IsVisible="{Binding IsDrawingCurve}"/>
                 <!-- Undo button for DrawCurve mode -->
                 <Button Content="Undo"
                         Command="{Binding UndoLastDrawnPointCommand}"
-                        Background="#E67E22" Foreground="White"
+                        Background="#E67E22" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"
                         IsVisible="{Binding IsDrawingCurve}"/>
                 <Button Content="Cancel"
                         Command="{Binding CancelABCreationCommand}"
-                        Background="#DD3333" Foreground="White"
+                        Background="#DD3333" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         Padding="12,4"/>
             </StackPanel>
         </Border>

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -64,6 +64,9 @@ public class UIState : ReactiveObject
                 this.RaisePropertyChanged(nameof(IsAppDirectoriesDialogVisible));
                 this.RaisePropertyChanged(nameof(IsHotkeyConfigDialogVisible));
                 this.RaisePropertyChanged(nameof(IsAboutDialogVisible));
+                this.RaisePropertyChanged(nameof(IsLogViewerDialogVisible));
+                this.RaisePropertyChanged(nameof(IsFlagByLatLonDialogVisible));
+                this.RaisePropertyChanged(nameof(IsViewSettingsDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -98,6 +101,9 @@ public class UIState : ReactiveObject
     public bool IsAppDirectoriesDialogVisible => ActiveDialog == DialogType.AppDirectories;
     public bool IsHotkeyConfigDialogVisible => ActiveDialog == DialogType.HotkeyConfig;
     public bool IsAboutDialogVisible => ActiveDialog == DialogType.About;
+    public bool IsLogViewerDialogVisible => ActiveDialog == DialogType.LogViewer;
+    public bool IsFlagByLatLonDialogVisible => ActiveDialog == DialogType.FlagByLatLon;
+    public bool IsViewSettingsDialogVisible => ActiveDialog == DialogType.ViewSettings;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -211,7 +217,10 @@ public enum DialogType
     Error,
     AppDirectories,
     HotkeyConfig,
-    About
+    About,
+    LogViewer,
+    FlagByLatLon,
+    ViewSettings
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Services/Logging/InMemoryLoggerProvider.cs
+++ b/Shared/AgValoniaGPS.Services/Logging/InMemoryLoggerProvider.cs
@@ -1,0 +1,107 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace AgValoniaGPS.Services.Logging;
+
+/// <summary>
+/// A log entry captured by the in-memory logger.
+/// </summary>
+public sealed class LogEntry
+{
+    public DateTime Timestamp { get; init; }
+    public LogLevel Level { get; init; }
+    public string Category { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Stores log entries in memory for the log viewer dialog.
+/// Thread-safe; capped at MaxEntries to prevent unbounded growth.
+/// </summary>
+public sealed class LogStore
+{
+    public const int MaxEntries = 2000;
+
+    private static readonly Lazy<LogStore> _instance = new(() => new LogStore());
+    public static LogStore Instance => _instance.Value;
+
+    private readonly object _lock = new();
+    private readonly List<LogEntry> _entries = new(MaxEntries);
+
+    public event Action? LogAdded;
+
+    public void Add(LogEntry entry)
+    {
+        lock (_lock)
+        {
+            if (_entries.Count >= MaxEntries)
+                _entries.RemoveAt(0);
+            _entries.Add(entry);
+        }
+        LogAdded?.Invoke();
+    }
+
+    public List<LogEntry> GetSnapshot()
+    {
+        lock (_lock)
+            return new List<LogEntry>(_entries);
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+            _entries.Clear();
+        LogAdded?.Invoke();
+    }
+}
+
+/// <summary>
+/// Logger that writes to the shared LogStore for display in the log viewer.
+/// </summary>
+internal sealed class InMemoryLogger : ILogger
+{
+    private readonly string _category;
+
+    public InMemoryLogger(string category) => _category = category;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+        Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel)) return;
+
+        var message = formatter(state, exception);
+        if (exception != null)
+            message += Environment.NewLine + exception;
+
+        LogStore.Instance.Add(new LogEntry
+        {
+            Timestamp = DateTime.Now,
+            Level = logLevel,
+            Category = _category,
+            Message = message
+        });
+    }
+}
+
+/// <summary>
+/// Logger provider that creates InMemoryLogger instances.
+/// Register in DI to capture all log output for the log viewer.
+/// </summary>
+public sealed class InMemoryLoggerProvider : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName) => new InMemoryLogger(categoryName);
+    public void Dispose() { }
+}

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -934,6 +934,7 @@ public partial class ConfigurationViewModel : ReactiveObject
     public ICommand ToggleLineSmoothCommand { get; private set; } = null!;
     public ICommand ToggleDirectionMarkersCommand { get; private set; } = null!;
     public ICommand ToggleSectionLinesCommand { get; private set; } = null!;
+    public ICommand ToggleDayNightThemeCommand { get; private set; } = null!;
     public ICommand SetMetricUnitsCommand { get; private set; } = null!;
     public ICommand SetImperialUnitsCommand { get; private set; } = null!;
 
@@ -1602,6 +1603,13 @@ public partial class ConfigurationViewModel : ReactiveObject
         ToggleSectionLinesCommand = ReactiveCommand.Create(() =>
         {
             Display.SectionLinesVisible = !Display.SectionLinesVisible;
+            Config.MarkChanged();
+        });
+
+        ToggleDayNightThemeCommand = ReactiveCommand.Create(() =>
+        {
+            Display.IsDayMode = !Display.IsDayMode;
+            MainViewModel.ApplyThemeVariant(Display.IsDayMode);
             Config.MarkChanged();
         });
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
@@ -15,6 +15,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System.Reactive;
+using Avalonia;
+using Avalonia.Styling;
 using ReactiveUI;
 
 namespace AgValoniaGPS.ViewModels;
@@ -67,6 +69,7 @@ public partial class MainViewModel
         {
             IsDayMode = !IsDayMode;
             _mapService.SetDayMode(IsDayMode);
+            ApplyThemeVariant(IsDayMode);
         });
 
         Toggle2D3DCommand = ReactiveCommand.Create(() =>
@@ -120,5 +123,19 @@ public partial class MainViewModel
         {
             IsSettingsVisible = !IsSettingsVisible;
         });
+    }
+
+    /// <summary>
+    /// Applies the Avalonia theme variant based on day/night mode.
+    /// Day mode = Light theme, Night mode = Dark theme.
+    /// </summary>
+    internal static void ApplyThemeVariant(bool isDayMode)
+    {
+        if (Application.Current != null)
+        {
+            Application.Current.RequestedThemeVariant = isDayMode
+                ? ThemeVariant.Light
+                : ThemeVariant.Dark;
+        }
     }
 }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -14,9 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Input;
 using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Logging;
+using Avalonia.Threading;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 
 namespace AgValoniaGPS.ViewModels;
@@ -59,6 +67,68 @@ public partial class MainViewModel
                     StatusMessage = "All settings reset to defaults. Restart recommended.";
                 });
         });
+
+        // Log Viewer (#22)
+        ShowLogViewerDialogCommand = ReactiveCommand.Create(() =>
+        {
+            RefreshLogEntries();
+            _logStoreSubscribed = true;
+            LogStore.Instance.LogAdded += OnLogStoreUpdated;
+            State.UI.ShowDialog(Models.State.DialogType.LogViewer);
+        });
+
+        CloseLogViewerDialogCommand = ReactiveCommand.Create(() =>
+        {
+            if (_logStoreSubscribed)
+            {
+                LogStore.Instance.LogAdded -= OnLogStoreUpdated;
+                _logStoreSubscribed = false;
+            }
+            State.UI.CloseDialog();
+        });
+
+        ClearLogEntriesCommand = ReactiveCommand.Create(() =>
+        {
+            LogStore.Instance.Clear();
+            FilteredLogEntries.Clear();
+        });
+
+        SetLogFilterCommand = ReactiveCommand.Create<string>(level =>
+        {
+            LogFilterLevel = Enum.TryParse<LogLevel>(level, out var parsed) ? parsed : LogLevel.Debug;
+            RefreshLogEntries();
+        });
+
+        // Flag By Lat/Lon (#23)
+        ShowFlagByLatLonDialogCommand = ReactiveCommand.Create(() =>
+        {
+            FlagLatitudeInput = "";
+            FlagLongitudeInput = "";
+            FlagByLatLonError = "";
+            State.UI.ShowDialog(Models.State.DialogType.FlagByLatLon);
+        });
+
+        CloseFlagByLatLonDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.CloseDialog();
+        });
+
+        PlaceFlagByLatLonCommand = ReactiveCommand.Create(() =>
+        {
+            PlaceFlagAtLatLon();
+        });
+
+        // View All Settings (#29)
+        ShowViewSettingsDialogCommand = ReactiveCommand.Create(() =>
+        {
+            RefreshSettingsTree();
+            State.UI.ShowDialog(Models.State.DialogType.ViewSettings);
+        });
+
+        CloseViewSettingsDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.CloseDialog();
+        });
     }
 
     private void RefreshAppDirectories()
@@ -72,6 +142,190 @@ public partial class MainViewModel
         dirs.Add(new AppDirectoryInfo("NTRIP Profiles", _ntripProfileService.ProfilesDirectory));
 
         AppDirectories = dirs;
+    }
+}
+
+// --- Log Viewer (#22) ---
+public partial class MainViewModel
+{
+    private bool _logStoreSubscribed;
+
+    private LogLevel _logFilterLevel = LogLevel.Debug;
+    public LogLevel LogFilterLevel
+    {
+        get => _logFilterLevel;
+        set => this.RaiseAndSetIfChanged(ref _logFilterLevel, value);
+    }
+
+    public ObservableCollection<LogEntry> FilteredLogEntries { get; } = new();
+
+    private void OnLogStoreUpdated()
+    {
+        Dispatcher.UIThread.Post(RefreshLogEntries);
+    }
+
+    private void RefreshLogEntries()
+    {
+        var entries = LogStore.Instance.GetSnapshot()
+            .Where(e => e.Level >= _logFilterLevel)
+            .TakeLast(500)
+            .ToList();
+        FilteredLogEntries.Clear();
+        foreach (var entry in entries)
+            FilteredLogEntries.Add(entry);
+    }
+
+    public ICommand? ShowLogViewerDialogCommand { get; private set; }
+    public ICommand? CloseLogViewerDialogCommand { get; private set; }
+    public ICommand? ClearLogEntriesCommand { get; private set; }
+    public ICommand? SetLogFilterCommand { get; private set; }
+}
+
+// --- Flag By Lat/Lon (#23) ---
+public partial class MainViewModel
+{
+    private string _flagLatitudeInput = "";
+    public string FlagLatitudeInput
+    {
+        get => _flagLatitudeInput;
+        set => this.RaiseAndSetIfChanged(ref _flagLatitudeInput, value);
+    }
+
+    private string _flagLongitudeInput = "";
+    public string FlagLongitudeInput
+    {
+        get => _flagLongitudeInput;
+        set => this.RaiseAndSetIfChanged(ref _flagLongitudeInput, value);
+    }
+
+    private string _flagByLatLonError = "";
+    public string FlagByLatLonError
+    {
+        get => _flagByLatLonError;
+        set => this.RaiseAndSetIfChanged(ref _flagByLatLonError, value);
+    }
+
+    private void PlaceFlagAtLatLon()
+    {
+        if (!double.TryParse(FlagLatitudeInput, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out double lat) ||
+            lat < -90 || lat > 90)
+        {
+            FlagByLatLonError = "Invalid latitude (must be -90 to 90)";
+            return;
+        }
+
+        if (!double.TryParse(FlagLongitudeInput, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out double lon) ||
+            lon < -180 || lon > 180)
+        {
+            FlagByLatLonError = "Invalid longitude (must be -180 to 180)";
+            return;
+        }
+
+        if (_fieldOriginLatitude == 0 && _fieldOriginLongitude == 0 &&
+            Latitude == 0 && Longitude == 0)
+        {
+            FlagByLatLonError = "No field or GPS origin available";
+            return;
+        }
+
+        // Use field origin if available, else current GPS position as origin
+        double originLat = _fieldOriginLatitude != 0 ? _fieldOriginLatitude : Latitude;
+        double originLon = _fieldOriginLongitude != 0 ? _fieldOriginLongitude : Longitude;
+
+        var converter = new Models.Base.GeoConversion(originLat, originLon);
+        var local = converter.ToLocal(lat, lon);
+
+        var point = new Models.Base.Vec3(local.Easting, local.Northing, 0);
+        _flagPoints.Add((point, "Red"));
+        StatusMessage = $"Flag #{_flagPoints.Count} placed at {lat:F6}, {lon:F6}";
+        FlagByLatLonError = "";
+
+        State.UI.CloseDialog();
+    }
+
+    public ICommand? ShowFlagByLatLonDialogCommand { get; private set; }
+    public ICommand? CloseFlagByLatLonDialogCommand { get; private set; }
+    public ICommand? PlaceFlagByLatLonCommand { get; private set; }
+}
+
+// --- View All Settings (#29) ---
+public partial class MainViewModel
+{
+    public ObservableCollection<SettingsGroupItem> SettingsTree { get; } = new();
+
+    private void RefreshSettingsTree()
+    {
+        SettingsTree.Clear();
+        var store = ConfigurationStore.Instance;
+
+        AddConfigGroup("Vehicle", store.Vehicle);
+        AddConfigGroup("Tool", store.Tool);
+        AddConfigGroup("Guidance", store.Guidance);
+        AddConfigGroup("Display", store.Display);
+        AddConfigGroup("Simulator", store.Simulator);
+        AddConfigGroup("Connections", store.Connections);
+        AddConfigGroup("AHRS", store.Ahrs);
+        AddConfigGroup("Machine", store.Machine);
+        AddConfigGroup("Tram", store.Tram);
+        AddConfigGroup("AutoSteer", store.AutoSteer);
+
+        // Global settings
+        var global = new SettingsGroupItem("Global");
+        global.Items.Add(new SettingsValueItem("Active Profile", store.ActiveProfileName));
+        global.Items.Add(new SettingsValueItem("Is Metric", store.IsMetric.ToString()));
+        global.Items.Add(new SettingsValueItem("Num Sections", store.NumSections.ToString()));
+        global.Items.Add(new SettingsValueItem("Actual Tool Width", $"{store.ActualToolWidth:F2} m"));
+        SettingsTree.Add(global);
+    }
+
+    private void AddConfigGroup(string name, object config)
+    {
+        var group = new SettingsGroupItem(name);
+        var props = config.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && !p.GetIndexParameters().Any())
+            .OrderBy(p => p.Name);
+
+        foreach (var prop in props)
+        {
+            try
+            {
+                var value = prop.GetValue(config);
+                var display = value?.ToString() ?? "(null)";
+                group.Items.Add(new SettingsValueItem(prop.Name, display));
+            }
+            catch
+            {
+                // Skip properties that throw
+            }
+        }
+
+        SettingsTree.Add(group);
+    }
+
+    public ICommand? ShowViewSettingsDialogCommand { get; private set; }
+    public ICommand? CloseViewSettingsDialogCommand { get; private set; }
+}
+
+public class SettingsGroupItem
+{
+    public string Name { get; }
+    public ObservableCollection<SettingsValueItem> Items { get; } = new();
+
+    public SettingsGroupItem(string name) => Name = name;
+}
+
+public class SettingsValueItem
+{
+    public string Name { get; }
+    public string Value { get; }
+
+    public SettingsValueItem(string name, string value)
+    {
+        Name = name;
+        Value = value;
     }
 }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -260,6 +260,9 @@ public partial class MainViewModel : ReactiveObject
         _displaySettings.LoadSettings();
         RestoreSettings();
 
+        // Apply theme variant based on saved day/night mode
+        ApplyThemeVariant(IsDayMode);
+
         // Start UDP communication (fire-and-forget but explicit)
         _ = InitializeAsync();
     }

--- a/Shared/AgValoniaGPS.Views/Controls/AlphanumericKeyboardPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/AlphanumericKeyboardPanel.axaml
@@ -24,7 +24,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontSize" Value="16"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Margin" Value="2"/>
             <Setter Property="MinWidth" Value="32"/>
@@ -33,7 +33,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.KeyButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.KeyButton:pressed">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -51,19 +51,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.ShiftButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.ShiftButton:pointerover">
             <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
         </Style>
         <Style Selector="Button.ShiftActive">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
 
         <Style Selector="Button.BackButton">
             <Setter Property="Background" Value="#E67E22"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.BackButton:pointerover">
             <Setter Property="Background" Value="#F39C12"/>
@@ -71,7 +71,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.ClearButton">
             <Setter Property="Background" Value="#E67E22"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.ClearButton:pointerover">
             <Setter Property="Background" Value="#F39C12"/>
@@ -79,18 +79,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.SpaceButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.SpaceButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
 
         <Style Selector="Button.PasteButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.PasteButton:pointerover">
-            <Setter Property="Background" Value="#5DADE2"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/AlphanumericKeyboardPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/AlphanumericKeyboardPanel.axaml
@@ -23,7 +23,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Button.KeyButton">
             <Setter Property="FontSize" Value="16"/>
             <Setter Property="FontWeight" Value="Bold"/>
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Margin" Value="2"/>
@@ -50,14 +50,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
 
         <Style Selector="Button.ShiftButton">
-            <Setter Property="Background" Value="#7F8C8D"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="Button.ShiftButton:pointerover">
-            <Setter Property="Background" Value="#95A5A6"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
         </Style>
         <Style Selector="Button.ShiftActive">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
 
@@ -78,7 +78,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
 
         <Style Selector="Button.SpaceButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="Button.SpaceButton:pointerover">
@@ -86,7 +86,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
 
         <Style Selector="Button.PasteButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="Button.PasteButton:pointerover">
@@ -94,7 +94,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <StackPanel Spacing="2" Background="#2C3E50">
+    <StackPanel Spacing="2" Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
         <!-- Number row -->
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
             <Button Content="1" Classes="KeyButton" Click="OnKeyClick"/>

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -70,14 +70,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Background="#80000000"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-            <Border Background="#FF333333"
+            <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                     CornerRadius="8"
                     Padding="30,20"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     BoxShadow="0 4 12 #80000000">
                 <TextBlock Text="{Binding State.UI.BusyMessage}"
-                           Foreground="White"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            FontSize="18"
                            FontWeight="SemiBold"
                            HorizontalAlignment="Center"/>

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -56,6 +56,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:AppDirectoriesDialogPanel/>
         <dialogs:HotkeyConfigDialogPanel/>
         <dialogs:AboutDialogPanel/>
+        <dialogs:LogViewerDialogPanel/>
+        <dialogs:FlagByLatLonDialogPanel/>
+        <dialogs:ViewSettingsDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
@@ -28,7 +28,7 @@ the Free Software Foundation, either version 3 of the License, or
                 <TextBlock Text="AgValoniaGPS" FontSize="22" FontWeight="Bold"
                            Foreground="#3498DB" HorizontalAlignment="Center"/>
 
-                <TextBlock Text="Version 26.2.0" FontSize="16" FontWeight="SemiBold"
+                <TextBlock x:Name="VersionText" FontSize="16" FontWeight="SemiBold"
                            Foreground="White" HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Cross-platform agricultural GPS guidance"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
@@ -21,43 +21,43 @@ the Free Software Foundation, either version 3 of the License, or
     <Grid>
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="#2C3E50" CornerRadius="12" Padding="24"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="24"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="420" MaxWidth="550">
             <StackPanel Spacing="12">
                 <TextBlock Text="AgValoniaGPS" FontSize="22" FontWeight="Bold"
-                           Foreground="#3498DB" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
 
                 <TextBlock x:Name="VersionText" FontSize="16" FontWeight="SemiBold"
-                           Foreground="White" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"/>
 
                 <TextBlock x:Name="GitHashText" FontSize="11"
-                           Foreground="#7F8C8D" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Cross-platform agricultural GPS guidance"
-                           FontSize="12" Foreground="#95A5A6" HorizontalAlignment="Center"/>
+                           FontSize="12" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" HorizontalAlignment="Center"/>
 
-                <Separator Height="1" Background="#444" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <StackPanel Spacing="4">
                     <TextBlock Text="Based on AgOpenGPS by Brian Tee"
-                               Foreground="#BDC3C7" FontSize="12"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                     <TextBlock Text="Built with Avalonia UI 11.3.9 and .NET 10.0"
-                               Foreground="#BDC3C7" FontSize="12"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                 </StackPanel>
 
-                <Separator Height="1" Background="#444" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <StackPanel Spacing="4">
                     <TextBlock Text="License: GNU General Public License v3.0"
-                               Foreground="#BDC3C7" FontSize="12"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                     <TextBlock Text="github.com/chriskinal/AgValoniaGPS3"
-                               Foreground="#3498DB" FontSize="12"/>
+                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12"/>
                 </StackPanel>
 
                 <Button Content="Close" Margin="0,8,0,0"
                         Command="{Binding CloseAboutDialogCommand}"
-                        Background="#3498DB" Foreground="White"
+                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="44" FontSize="16" FontWeight="Bold"
                         HorizontalContentAlignment="Center" CornerRadius="6"/>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
@@ -31,6 +31,9 @@ the Free Software Foundation, either version 3 of the License, or
                 <TextBlock x:Name="VersionText" FontSize="16" FontWeight="SemiBold"
                            Foreground="White" HorizontalAlignment="Center"/>
 
+                <TextBlock x:Name="GitHashText" FontSize="11"
+                           Foreground="#7F8C8D" HorizontalAlignment="Center"/>
+
                 <TextBlock Text="Cross-platform agricultural GPS guidance"
                            FontSize="12" Foreground="#95A5A6" HorizontalAlignment="Center"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
@@ -22,7 +22,11 @@ public partial class AboutDialogPanel : UserControl
         var infoVersion = Assembly.GetEntryAssembly()?
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
             .InformationalVersion ?? "26.2.0";
-        VersionText.Text = $"Version {infoVersion}";
+
+        // Split "26.2.0+9e92e46-dirty" into version and hash
+        var parts = infoVersion.Split('+', 2);
+        VersionText.Text = $"Version {parts[0]}";
+        GitHashText.Text = parts.Length > 1 ? parts[1] : "";
     }
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
@@ -6,6 +6,7 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
+using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Input;
 
@@ -16,6 +17,12 @@ public partial class AboutDialogPanel : UserControl
     public AboutDialogPanel()
     {
         InitializeComponent();
+
+        // Read version + git hash from AssemblyInformationalVersion (set by MSBuild)
+        var infoVersion = Assembly.GetEntryAssembly()?
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion ?? "26.2.0";
+        VersionText.Text = $"Version {infoVersion}";
     }
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
@@ -31,7 +31,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="6"/>
         </Style>
         <Style Selector="CheckBox">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -50,7 +50,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
                 <!-- Field List -->
-                <Border Grid.Row="1" Background="#1a1a1a" CornerRadius="6"
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6"
                         Padding="5" MinHeight="200" MaxHeight="350">
                     <ScrollViewer>
                         <ListBox x:Name="FieldListBox"
@@ -91,7 +91,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="3" Margin="0,5">
                     <ProgressBar x:Name="ProgressBar" IsVisible="False"
                                  Height="8" Minimum="0" Maximum="100"
-                                 Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="#1a1a1a"/>
+                                 Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
                     <TextBlock x:Name="StatusLabel" Text="Loading fields..."
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                HorizontalAlignment="Center" Margin="0,5"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
@@ -40,13 +40,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog Content -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="20"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="400" MaxWidth="500" MaxHeight="600">
             <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
                 <!-- Header -->
                 <TextBlock Grid.Row="0" Text="Download from AgShare"
-                           FontSize="20" FontWeight="Bold" Foreground="White"
+                           FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
                 <!-- Field List -->
@@ -58,15 +58,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                  SelectionChanged="FieldListBox_SelectionChanged">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="#34495E" CornerRadius="4" Padding="10" Margin="2">
+                                    <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4" Padding="10" Margin="2">
                                         <Grid ColumnDefinitions="*,Auto">
                                             <StackPanel Grid.Column="0">
                                                 <TextBlock Text="{Binding Name}"
-                                                           Foreground="White" FontWeight="SemiBold"/>
+                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                                             </StackPanel>
                                             <TextBlock Grid.Column="1"
                                                        Text="{Binding AreaDisplay}"
-                                                       Foreground="#3498DB"
+                                                       Foreground="{DynamicResource SystemControlHighlightAccentBrush}"
                                                        VerticalAlignment="Center" FontSize="12"/>
                                         </Grid>
                                     </Border>
@@ -80,9 +80,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="2" Margin="0,10" Spacing="10">
                     <StackPanel Orientation="Horizontal" Spacing="10">
                         <Button Content="Refresh" Click="Refresh_Click"
-                                Background="#3498DB" Foreground="White" Padding="10,5" CornerRadius="4"/>
+                                Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
                         <Button x:Name="BtnDownloadAll" Content="Download All" Click="DownloadAll_Click"
-                                Background="#9B59B6" Foreground="White" Padding="10,5" CornerRadius="4"/>
+                                Background="#9B59B6" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
                     </StackPanel>
                     <CheckBox x:Name="ForceOverwriteCheckBox" Content="Force overwrite existing fields"/>
                 </StackPanel>
@@ -91,9 +91,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="3" Margin="0,5">
                     <ProgressBar x:Name="ProgressBar" IsVisible="False"
                                  Height="8" Minimum="0" Maximum="100"
-                                 Foreground="#3498DB" Background="#1a1a1a"/>
+                                 Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="#1a1a1a"/>
                     <TextBlock x:Name="StatusLabel" Text="Loading fields..."
-                               Foreground="#BDC3C7" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                HorizontalAlignment="Center" Margin="0,5"/>
                 </StackPanel>
 
@@ -101,10 +101,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid Grid.Row="4" ColumnDefinitions="*,Auto,Auto" Margin="0,10,0,0">
                     <Button Grid.Column="1" x:Name="BtnDownload" Content="Download Selected"
                             Classes="DialogButton" IsEnabled="False"
-                            Background="#27AE60" Foreground="White"
+                            Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Download_Click" Margin="0,0,10,0"/>
                     <Button Grid.Column="2" Content="Cancel" Classes="DialogButton"
-                            Background="#7F8C8D" Foreground="White"
+                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Cancel_Click"/>
                 </Grid>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
@@ -34,13 +34,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,0,0,4"/>
         </Style>
         <Style Selector="TextBlock.Hint">
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="FontSize" Value="11"/>
             <Setter Property="Margin" Value="0,4,0,0"/>
         </Style>
         <Style Selector="Border.InputField">
             <Setter Property="Background" Value="#2D2D2D"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -64,13 +64,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#1084D8"/>
         </Style>
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
             <Setter Property="Background" Value="#666"/>
         </Style>
         <Style Selector="Button.TestButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,8"/>
@@ -92,7 +92,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Dialog panel positioned near top for mobile -->
         <Border Background="#1E1E1E"
                 CornerRadius="12"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
@@ -118,7 +118,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             PointerPressed="ServerUrl_PointerPressed">
                         <TextBlock x:Name="ServerUrlDisplay"
                                    FontSize="14"
-                                   Foreground="White"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"
                                    TextTrimming="CharacterEllipsis"
                                    Text="https://agshare.agopengps.com"/>
@@ -132,7 +132,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             PointerPressed="ApiKey_PointerPressed">
                         <TextBlock x:Name="ApiKeyDisplay"
                                    FontSize="14"
-                                   Foreground="White"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"
                                    Text="(not set)"/>
                     </Border>
@@ -145,12 +145,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Test Connection"/>
                     </Button>
                     <TextBlock x:Name="ConnectionStatusLabel" Grid.Column="1"
-                               Foreground="#BDC3C7" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                VerticalAlignment="Center" HorizontalAlignment="Center"
                                TextWrapping="Wrap"
                                Text=""/>
                     <CheckBox x:Name="EnabledCheckBox" Grid.Column="2"
-                              Content="Enabled" Foreground="White"
+                              Content="Enabled" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                               VerticalAlignment="Center"/>
                 </Grid>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Label">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Margin" Value="0,0,0,4"/>
         </Style>
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,4,0,0"/>
         </Style>
         <Style Selector="Border.InputField">
-            <Setter Property="Background" Value="#2D2D2D"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
@@ -51,8 +51,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderThickness" Value="2"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#0078D4"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="24,12"/>
             <Setter Property="FontSize" Value="14"/>
@@ -61,17 +61,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="6"/>
         </Style>
         <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#1084D8"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#666"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.TestButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,8"/>
             <Setter Property="FontSize" Value="12"/>
@@ -79,7 +79,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="Button.TestButton:pointerover">
-            <Setter Property="Background" Value="#5DADE2"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -90,7 +90,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel positioned near top for mobile -->
-        <Border Background="#1E1E1E"
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 CornerRadius="12"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
@@ -40,13 +40,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog Content -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="20"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="400" MaxWidth="500" MaxHeight="600">
             <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
                 <!-- Header -->
                 <TextBlock Grid.Row="0" Text="Upload to AgShare"
-                           FontSize="20" FontWeight="Bold" Foreground="White"
+                           FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
                 <!-- Field List -->
@@ -56,16 +56,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <ItemsControl x:Name="FieldList">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="#34495E" CornerRadius="4" Padding="10" Margin="2">
+                                    <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4" Padding="10" Margin="2">
                                         <Grid ColumnDefinitions="Auto,*,Auto">
                                             <CheckBox Grid.Column="0"
                                                       IsChecked="{Binding IsSelected}"
                                                       VerticalAlignment="Center"/>
                                             <StackPanel Grid.Column="1" Margin="10,0">
                                                 <TextBlock Text="{Binding Name}"
-                                                           Foreground="White" FontWeight="SemiBold"/>
+                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                                                 <TextBlock Text="{Binding HasBoundaryDisplay}"
-                                                           Foreground="#BDC3C7" FontSize="12"/>
+                                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                                             </StackPanel>
                                             <TextBlock Grid.Column="2"
                                                        Text="{Binding HasBoundaryDisplay}"
@@ -83,9 +83,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="2" Margin="0,10">
                     <StackPanel Orientation="Horizontal" Spacing="10">
                         <Button Content="Select All" Click="SelectAll_Click"
-                                Background="#3498DB" Foreground="White" Padding="10,5" CornerRadius="4"/>
+                                Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
                         <Button Content="Deselect All" Click="DeselectAll_Click"
-                                Background="#7F8C8D" Foreground="White" Padding="10,5" CornerRadius="4"/>
+                                Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
                     </StackPanel>
                     <CheckBox x:Name="PublicCheckBox" Content="Make fields public" Margin="0,10,0,0"/>
                 </StackPanel>
@@ -94,9 +94,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="3" Margin="0,5">
                     <ProgressBar x:Name="ProgressBar" IsVisible="False"
                                  Height="8" Minimum="0" Maximum="100"
-                                 Foreground="#3498DB" Background="#1a1a1a"/>
+                                 Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="#1a1a1a"/>
                     <TextBlock x:Name="StatusLabel" Text="Select fields to upload"
-                               Foreground="#BDC3C7" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                HorizontalAlignment="Center" Margin="0,5"/>
                 </StackPanel>
 
@@ -104,10 +104,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid Grid.Row="4" ColumnDefinitions="*,Auto,Auto" Margin="0,10,0,0">
                     <Button Grid.Column="1" x:Name="BtnUpload" Content="Upload"
                             Classes="DialogButton" IsEnabled="False"
-                            Background="#27AE60" Foreground="White"
+                            Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Upload_Click" Margin="0,0,10,0"/>
                     <Button Grid.Column="2" Content="Cancel" Classes="DialogButton"
-                            Background="#7F8C8D" Foreground="White"
+                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Cancel_Click"/>
                 </Grid>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
@@ -31,7 +31,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="6"/>
         </Style>
         <Style Selector="CheckBox">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -50,7 +50,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
                 <!-- Field List -->
-                <Border Grid.Row="1" Background="#1a1a1a" CornerRadius="6"
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6"
                         Padding="5" MinHeight="200" MaxHeight="350">
                     <ScrollViewer>
                         <ItemsControl x:Name="FieldList">
@@ -94,7 +94,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="3" Margin="0,5">
                     <ProgressBar x:Name="ProgressBar" IsVisible="False"
                                  Height="8" Minimum="0" Maximum="100"
-                                 Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="#1a1a1a"/>
+                                 Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
                     <TextBlock x:Name="StatusLabel" Text="Select fields to upload"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                HorizontalAlignment="Center" Margin="0,5"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml
@@ -32,24 +32,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="20"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="420" MaxWidth="600">
             <StackPanel Spacing="16">
                 <!-- Title -->
                 <TextBlock Text="App Directories" FontSize="20" FontWeight="Bold"
-                           Foreground="#3498DB" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
 
                 <!-- Directory list -->
                 <ItemsControl ItemsSource="{Binding AppDirectories}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="vm:AppDirectoryInfo">
-                            <Border Background="#34495E" CornerRadius="6" Padding="12,8" Margin="0,4">
+                            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="12,8" Margin="0,4">
                                 <StackPanel Spacing="2">
                                     <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="SemiBold"
-                                               Foreground="#3498DB"/>
+                                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
                                     <TextBlock Text="{Binding Path}" FontSize="12"
-                                               Foreground="#BDC3C7" TextWrapping="Wrap"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" TextWrapping="Wrap"
                                                TextTrimming="CharacterEllipsis" MaxLines="2"/>
                                 </StackPanel>
                             </Border>
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Close button -->
                 <Button Content="Close" Margin="0,8,0,0"
                         Command="{Binding CloseAppDirectoriesDialogCommand}"
-                        Background="#3498DB" Foreground="White"
+                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="44" FontSize="16" FontWeight="Bold"
                         HorizontalContentAlignment="Center" CornerRadius="6"/>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
@@ -29,23 +29,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Tab styling for compact mode (top tabs) -->
         <Style Selector="TabControl.SteerTabs > TabItem">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="Margin" Value="2,0"/>
             <Setter Property="MinWidth" Value="56"/>
             <Setter Property="MinHeight" Value="56"/>
         </Style>
         <Style Selector="TabControl.SteerTabs > TabItem:selected">
-            <Setter Property="Background" Value="#DD4A9A7E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TabControl.SteerTabs > TabItem:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
 
         <!-- Tappable Value Button -->
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,6"/>
@@ -59,20 +59,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Toggle Button -->
         <Style Selector="Button.ToggleButton">
-            <Setter Property="Background" Value="#DD34495E"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ToggleButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
 
         <!-- Icon Toggle Button - preserves background binding on hover -->
         <Style Selector="Button.IconToggle">
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="4"/>
@@ -84,7 +84,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Parameter Card -->
         <Style Selector="Border.ParamCard">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12"/>
         </Style>
@@ -97,7 +97,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Status label -->
         <Style Selector="TextBlock.StatusLabel">
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="FontSize" Value="11"/>
         </Style>
         <Style Selector="TextBlock.StatusValue">
@@ -110,22 +110,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Full screen modal overlay -->
     <Grid Background="#80000000">
         <!-- Main dialog container -->
-        <Border Background="#DD1E2A38"
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 CornerRadius="8"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 BoxShadow="0 8 32 #80000000">
 
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Header -->
-                <Border Grid.Row="0" Background="#DD2C3E50" Padding="12,8">
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="12,8">
                     <Grid ColumnDefinitions="*,Auto">
-                        <TextBlock Text="Auto Steer Configuration" FontSize="16" FontWeight="Bold" Foreground="White"/>
+                        <TextBlock Text="Auto Steer Configuration" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <Button Grid.Column="1" Command="{Binding ClosePanelCommand}"
                                 Background="Transparent" BorderThickness="0" Padding="8,4" Cursor="Hand">
-                            <TextBlock Text="X" FontSize="16" Foreground="#AAA"/>
+                            <TextBlock Text="X" FontSize="16" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
                         </Button>
                     </Grid>
                 </Border>
@@ -140,7 +140,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Grid.ColumnDefinitions>
 
                     <!-- LEFT SIDE: Compact Mode Tabs -->
-                    <Border Grid.Column="0" Background="#DD253545" Padding="8">
+                    <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundListLowBrush}" Padding="8">
                         <Grid RowDefinitions="*,Auto">
                             <!-- Tab Headers -->
                             <TabControl Grid.Row="0" Classes="SteerTabs"
@@ -173,7 +173,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Spacing="8">
                                                         <Grid ColumnDefinitions="Auto,*,Auto">
                                                             <TextBlock Text="Fast" Foreground="#4A9A7E" FontSize="12"/>
-                                                            <TextBlock Grid.Column="1" Text="Steer Response" Foreground="White"
+                                                            <TextBlock Grid.Column="1" Text="Steer Response" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                        HorizontalAlignment="Center" FontWeight="SemiBold"/>
                                                             <TextBlock Grid.Column="2" Text="Slow" Foreground="#E74C3C" FontSize="12"/>
                                                         </Grid>
@@ -181,7 +181,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                             <Button Classes="TappableValue" Command="{Binding EditSteerResponseCommand}"
                                                                     Margin="0,0,8,0">
                                                                 <TextBlock Text="{Binding AutoSteer.SteerResponseHold, StringFormat='{}{0:F1}'}"
-                                                                           Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                             </Button>
                                                             <Slider Grid.Column="1" Minimum="1" Maximum="10"
                                                                     Value="{Binding AutoSteer.SteerResponseHold}"
@@ -193,13 +193,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <!-- Integral (Pure Pursuit) -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Integral" Foreground="White" FontWeight="SemiBold"
+                                                        <TextBlock Text="Integral" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditIntegralGainCommand}"
                                                                     Margin="0,0,8,0">
                                                                 <TextBlock Text="{Binding AutoSteer.IntegralGain, StringFormat='{}{0:P0}'}"
-                                                                           Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                             </Button>
                                                             <Slider Grid.Column="1" Minimum="0" Maximum="1"
                                                                     Value="{Binding AutoSteer.IntegralGain}"
@@ -221,13 +221,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <!-- Aggressiveness -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Aggressiveness" Foreground="White" FontWeight="SemiBold"
+                                                        <TextBlock Text="Aggressiveness" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditStanleyAggressivenessCommand}"
                                                                     Margin="0,0,8,0">
                                                                 <TextBlock Text="{Binding AutoSteer.StanleyAggressiveness, StringFormat='{}{0:F1}'}"
-                                                                           Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                             </Button>
                                                             <Slider Grid.Column="1" Minimum="0" Maximum="10"
                                                                     Value="{Binding AutoSteer.StanleyAggressiveness}"
@@ -239,13 +239,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <!-- Overshoot Reduction -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Overshoot Reduction" Foreground="White" FontWeight="SemiBold"
+                                                        <TextBlock Text="Overshoot Reduction" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditStanleyOvershootCommand}"
                                                                     Margin="0,0,8,0">
                                                                 <TextBlock Text="{Binding AutoSteer.StanleyOvershootReduction, StringFormat='{}{0:F1}'}"
-                                                                           Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                             </Button>
                                                             <Slider Grid.Column="1" Minimum="0" Maximum="10"
                                                                     Value="{Binding AutoSteer.StanleyOvershootReduction}"
@@ -257,13 +257,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <!-- Integral (Stanley) -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Integral" Foreground="White" FontWeight="SemiBold"
+                                                        <TextBlock Text="Integral" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditStanleyIntegralCommand}"
                                                                     Margin="0,0,8,0">
                                                                 <TextBlock Text="{Binding AutoSteer.IntegralGain, StringFormat='{}{0:F1}'}"
-                                                                           Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                             </Button>
                                                             <Slider Grid.Column="1" Minimum="0" Maximum="1"
                                                                     Value="{Binding AutoSteer.IntegralGain}"
@@ -290,11 +290,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <StackPanel Spacing="8" HorizontalAlignment="Center">
                                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
                                                         <TextBlock Text="-->" Foreground="#4A9A7E"/>
-                                                        <TextBlock Text="{Binding AutoSteer.WasOffset}" Foreground="White"
+                                                        <TextBlock Text="{Binding AutoSteer.WasOffset}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                    FontWeight="Bold" FontSize="18"/>
                                                         <TextBlock Text="&lt;--" Foreground="#4A9A7E"/>
                                                     </StackPanel>
-                                                    <TextBlock Text="Was Zero" Foreground="#AAA" HorizontalAlignment="Center"/>
+                                                    <TextBlock Text="Was Zero" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
                                                     <Button Content="Zero WAS" Command="{Binding ZeroWasCommand}"
                                                             HorizontalAlignment="Center" Padding="16,6"/>
                                                 </StackPanel>
@@ -306,13 +306,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditCountsPerDegreeCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.CountsPerDegree, StringFormat='{}{0:F0}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="1" Maximum="255"
                                                                 Value="{Binding AutoSteer.CountsPerDegree}"
                                                                 VerticalAlignment="Center" Margin="8,0,0,0"/>
                                                     </Grid>
-                                                    <TextBlock Text="Counts Per Degree" Foreground="#AAA" FontSize="11"/>
+                                                    <TextBlock Text="Counts Per Degree" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                                                 </StackPanel>
                                             </Border>
 
@@ -322,13 +322,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditAckermannCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.Ackermann}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="0" Maximum="200"
                                                                 Value="{Binding AutoSteer.Ackermann}"
                                                                 VerticalAlignment="Center" Margin="8,0,0,0"/>
                                                     </Grid>
-                                                    <TextBlock Text="Ackermann" Foreground="#AAA" FontSize="11"/>
+                                                    <TextBlock Text="Ackermann" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                                                 </StackPanel>
                                             </Border>
 
@@ -338,13 +338,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditMaxSteerAngleCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.MaxSteerAngle, StringFormat='{}{0}°'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="10" Maximum="90"
                                                                 Value="{Binding AutoSteer.MaxSteerAngle}"
                                                                 VerticalAlignment="Center" Margin="8,0,0,0"/>
                                                     </Grid>
-                                                    <TextBlock Text="Max Steer Angle" Foreground="#AAA" FontSize="11"/>
+                                                    <TextBlock Text="Max Steer Angle" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                                                 </StackPanel>
                                             </Border>
                                         </StackPanel>
@@ -361,7 +361,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
                                             <!-- Deadzone Header -->
-                                            <TextBlock Text="---Deadzone---" FontSize="14" FontWeight="Bold" Foreground="White"
+                                            <TextBlock Text="---Deadzone---" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Deadzone values in a row -->
@@ -371,9 +371,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <Button Classes="TappableValue" Command="{Binding EditDeadzoneHeadingCommand}"
                                                                 HorizontalAlignment="Center">
                                                             <TextBlock Text="{Binding AutoSteer.DeadzoneHeading, StringFormat='{}{0:F1}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
-                                                        <TextBlock Text="Heading" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Heading" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Border>
@@ -382,9 +382,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <Button Classes="TappableValue" Command="{Binding EditDeadzoneDelayCommand}"
                                                                 HorizontalAlignment="Center">
                                                             <TextBlock Text="{Binding AutoSteer.DeadzoneDelay}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
-                                                        <TextBlock Text="On-Delay" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="On-Delay" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Border>
@@ -393,12 +393,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Speed Factor -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Speed Factor" Foreground="White" FontWeight="SemiBold"
+                                                    <TextBlock Text="Speed Factor" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditSpeedFactorCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.SpeedFactor, StringFormat='{}{0:F1}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="0.5" Maximum="3"
                                                                 Value="{Binding AutoSteer.SpeedFactor}"
@@ -410,12 +410,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Acquire Factor -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Acquire Factor" Foreground="White" FontWeight="SemiBold"
+                                                    <TextBlock Text="Acquire Factor" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditAcquireFactorCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.AcquireFactor, StringFormat='{}{0:F1}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="0.5" Maximum="1"
                                                                 Value="{Binding AutoSteer.AcquireFactor}"
@@ -444,12 +444,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Proportional Gain -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Proportional Gain" Foreground="White" FontWeight="SemiBold"
+                                                    <TextBlock Text="Proportional Gain" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditProportionalGainCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.ProportionalGain}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="1" Maximum="100"
                                                                 Value="{Binding AutoSteer.ProportionalGain}"
@@ -461,12 +461,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Max PWM -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Max Limit" Foreground="White" FontWeight="SemiBold"
+                                                    <TextBlock Text="Max Limit" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditMaxPwmCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.MaxPwm}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="50" Maximum="255"
                                                                 Value="{Binding AutoSteer.MaxPwm}"
@@ -478,12 +478,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Min PWM -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Minimum to Move" Foreground="White" FontWeight="SemiBold"
+                                                    <TextBlock Text="Minimum to Move" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditMinPwmCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.MinPwm}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="1" Maximum="50"
                                                                 Value="{Binding AutoSteer.MinPwm}"
@@ -497,7 +497,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             </TabControl>
 
                             <!-- TEST MODE PANEL (Full Mode Only) -->
-                            <Border Grid.Row="1" Background="#DD1E2A38" CornerRadius="6" Padding="8" Margin="0,8,0,0"
+                            <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Margin="0,8,0,0"
                                     IsVisible="{Binding IsFullMode}">
                                 <StackPanel Spacing="8">
                                     <TextBlock Text="Test Mode" FontSize="14" FontWeight="Bold" Foreground="#F39C12"
@@ -515,7 +515,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                        Width="32" Height="32" Stretch="Uniform"
                                                        IsVisible="{Binding !IsFreeDriveMode}"/>
                                             </Grid>
-                                            <TextBlock Grid.Column="1" Text="Free Drive" Foreground="White" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" Text="Free Drive" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                         </Grid>
                                     </Button>
 
@@ -534,18 +534,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </StackPanel>
 
                                     <!-- Commanded Angle & PWM Display -->
-                                    <Border Background="#DD2C3E50" CornerRadius="4" Padding="12,6"
+                                    <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="4" Padding="12,6"
                                             HorizontalAlignment="Center" IsVisible="{Binding IsFreeDriveMode}">
                                         <StackPanel Orientation="Horizontal" Spacing="16">
                                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                                <TextBlock Text="Set:" Foreground="#AAA" VerticalAlignment="Center"/>
+                                                <TextBlock Text="Set:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                                                 <TextBlock Text="{Binding FreeDriveSteerAngle, StringFormat='{}{0:F0}°'}"
                                                            Foreground="#F39C12" FontWeight="Bold"
                                                            FontSize="16" VerticalAlignment="Center" Width="40" TextAlignment="Right"/>
                                             </StackPanel>
                                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                                <TextBlock Text="PWM:" Foreground="#AAA" VerticalAlignment="Center"/>
-                                                <TextBlock Text="{Binding PwmDisplay}" Foreground="White" FontWeight="Bold"
+                                                <TextBlock Text="PWM:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{Binding PwmDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"
                                                            FontSize="16" VerticalAlignment="Center" Width="30" TextAlignment="Right"/>
                                             </StackPanel>
                                         </StackPanel>
@@ -555,9 +555,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Border Classes="ParamCard" IsEnabled="{Binding IsFreeDriveMode}">
                                         <StackPanel HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ActualSteerAngle, StringFormat='{}{0:F1}°'}"
-                                                       Foreground="White" FontWeight="Bold" FontSize="18"
+                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18"
                                                        HorizontalAlignment="Center"/>
-                                            <TextBlock Text="Actual Steer Angle" Foreground="#AAA" FontSize="10"
+                                            <TextBlock Text="Actual Steer Angle" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
                                     </Border>
@@ -567,7 +567,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
 
                     <!-- RIGHT SIDE: Full Mode Additional Content (5 tabs) -->
-                    <Border Grid.Column="1" Background="#DD2C3E50" Padding="8"
+                    <Border Grid.Column="1" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="8"
                             IsVisible="{Binding IsFullMode}" Width="420">
                         <Grid RowDefinitions="*,Auto">
                             <!-- Right Side Tabs -->
@@ -588,7 +588,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <StackPanel Spacing="8">
                                                     <TextBlock Text="Turn Sensor" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
                                                     <Grid ColumnDefinitions="Auto,*">
-                                                        <Border Grid.Column="0" CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
                                                                 Background="{Binding AutoSteer.TurnSensorEnabled, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleTurnSensorCommand}"
@@ -600,11 +600,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <!-- Counts field - visible when Turn Sensor enabled -->
                                                         <StackPanel Grid.Column="1" IsVisible="{Binding AutoSteer.TurnSensorEnabled}"
                                                                     Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                                                            <TextBlock Text="Counts" Foreground="#AAA" VerticalAlignment="Center"/>
+                                                            <TextBlock Text="Counts" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                                                             <Button Classes="TappableValue" Command="{Binding EditTurnSensorCountsCommand}"
                                                                     Padding="16,8">
                                                                 <TextBlock Text="{Binding AutoSteer.TurnSensorCounts}"
-                                                                           Foreground="White" FontWeight="Bold" FontSize="18"/>
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18"/>
                                                             </Button>
                                                         </StackPanel>
                                                     </Grid>
@@ -616,7 +616,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <StackPanel Spacing="8">
                                                     <TextBlock Text="Pressure Turn" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
                                                     <Grid ColumnDefinitions="Auto,*">
-                                                        <Border Grid.Column="0" CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
                                                                 Background="{Binding AutoSteer.PressureSensorEnabled, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding TogglePressureSensorCommand}"
@@ -628,17 +628,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <!-- Pressure fields - visible when Pressure Sensor enabled -->
                                                         <StackPanel Grid.Column="1" IsVisible="{Binding AutoSteer.PressureSensorEnabled}"
                                                                     Spacing="4">
-                                                            <TextBlock Text="Off at %" Foreground="#AAA" HorizontalAlignment="Center" FontSize="12"/>
+                                                            <TextBlock Text="Off at %" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center" FontSize="12"/>
                                                             <!-- Actual pressure reading from PGN -->
                                                             <ProgressBar Minimum="0" Maximum="100" Value="{Binding ActualPressurePercent}"
-                                                                         Height="16" Foreground="#3498DB"/>
+                                                                         Height="16" Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
                                                             <!-- Trip point slider -->
                                                             <Grid ColumnDefinitions="*,Auto">
                                                                 <Slider Grid.Column="0" Minimum="0" Maximum="99"
                                                                         Value="{Binding AutoSteer.PressureTripPoint}"
                                                                         VerticalAlignment="Center"/>
                                                                 <TextBlock Grid.Column="1" Text="{Binding AutoSteer.PressureTripPoint, StringFormat='{}{0}%'}"
-                                                                           Foreground="White" FontWeight="Bold" MinWidth="40" Margin="8,0,0,0"
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" MinWidth="40" Margin="8,0,0,0"
                                                                            VerticalAlignment="Center"/>
                                                             </Grid>
                                                         </StackPanel>
@@ -651,7 +651,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <StackPanel Spacing="8">
                                                     <TextBlock Text="Current Turn" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
                                                     <Grid ColumnDefinitions="Auto,*">
-                                                        <Border Grid.Column="0" CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
                                                                 Background="{Binding AutoSteer.CurrentSensorEnabled, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleCurrentSensorCommand}"
@@ -663,17 +663,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <!-- Current fields - visible when Current Sensor enabled -->
                                                         <StackPanel Grid.Column="1" IsVisible="{Binding AutoSteer.CurrentSensorEnabled}"
                                                                     Spacing="4">
-                                                            <TextBlock Text="Off at %" Foreground="#AAA" HorizontalAlignment="Center" FontSize="12"/>
+                                                            <TextBlock Text="Off at %" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center" FontSize="12"/>
                                                             <!-- Actual current reading from PGN -->
                                                             <ProgressBar Minimum="0" Maximum="100" Value="{Binding ActualCurrentPercent}"
-                                                                         Height="16" Foreground="#3498DB"/>
+                                                                         Height="16" Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
                                                             <!-- Trip point slider -->
                                                             <Grid ColumnDefinitions="*,Auto">
                                                                 <Slider Grid.Column="0" Minimum="0" Maximum="99"
                                                                         Value="{Binding AutoSteer.CurrentTripPoint}"
                                                                         VerticalAlignment="Center"/>
                                                                 <TextBlock Grid.Column="1" Text="{Binding AutoSteer.CurrentTripPoint, StringFormat='{}{0}%'}"
-                                                                           Foreground="White" FontWeight="Bold" MinWidth="40" Margin="8,0,0,0"
+                                                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" MinWidth="40" Margin="8,0,0,0"
                                                                            VerticalAlignment="Center"/>
                                                             </Grid>
                                                         </StackPanel>
@@ -700,7 +700,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                                     <!-- Danfoss -->
                                                     <StackPanel Margin="4">
-                                                        <Border CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Background="{Binding AutoSteer.DanfossEnabled, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleDanfossCommand}"
                                                                     Background="Transparent" BorderThickness="0" Padding="4" Cursor="Hand">
@@ -708,12 +708,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Danfoss" Foreground="#AAA" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="Danfoss" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
 
                                                     <!-- Invert WAS -->
                                                     <StackPanel Margin="4">
-                                                        <Border CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Background="{Binding AutoSteer.InvertWas, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleInvertWasCommand}"
                                                                     Background="Transparent" BorderThickness="0" Padding="4" Cursor="Hand">
@@ -721,12 +721,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Invert WAS" Foreground="#AAA" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="Invert WAS" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
 
                                                     <!-- Invert Motor -->
                                                     <StackPanel Margin="4">
-                                                        <Border CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Background="{Binding AutoSteer.InvertMotor, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleInvertMotorCommand}"
                                                                     Background="Transparent" BorderThickness="0" Padding="4" Cursor="Hand">
@@ -734,12 +734,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Invert Motor" Foreground="#AAA" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="Invert Motor" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
 
                                                     <!-- Invert Relays -->
                                                     <StackPanel Margin="4">
-                                                        <Border CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Background="{Binding AutoSteer.InvertRelays, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleInvertRelaysCommand}"
                                                                     Background="Transparent" BorderThickness="0" Padding="4" Cursor="Hand">
@@ -747,7 +747,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Invert Relays" Foreground="#AAA" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="Invert Relays" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </WrapPanel>
                                             </Border>
@@ -756,7 +756,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="Motor Driver" Foreground="White" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="Motor Driver" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.MotorDriver}"
                                                                   Width="120">
                                                             <ComboBoxItem Content="IBT2"/>
@@ -765,7 +765,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     </Grid>
 
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="AD Converter" Foreground="White" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="AD Converter" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.AdConverter}"
                                                                   Width="120">
                                                             <ComboBoxItem Content="Differential"/>
@@ -774,7 +774,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     </Grid>
 
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="External Enable" Foreground="White" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="External Enable" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.ExternalEnable}"
                                                                   Width="120">
                                                             <ComboBoxItem Content="None"/>
@@ -784,7 +784,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     </Grid>
 
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="IMU Axis Swap" Foreground="White" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="IMU Axis Swap" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.ImuAxisSwap}"
                                                                   Width="120">
                                                             <ComboBoxItem Content="X"/>
@@ -813,11 +813,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <Button Classes="ToggleButton" Command="{Binding ToggleStanleyModeCommand}"
                                                         HorizontalAlignment="Stretch">
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="Algorithm" Foreground="White"/>
+                                                        <TextBlock Text="Algorithm" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                                         <Grid Grid.Column="1">
                                                             <TextBlock Text="Stanley" Foreground="#4A9A7E" FontWeight="Bold"
                                                                        IsVisible="{Binding AutoSteer.IsStanleyMode}"/>
-                                                            <TextBlock Text="Pure Pursuit" Foreground="#3498DB" FontWeight="Bold"
+                                                            <TextBlock Text="Pure Pursuit" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontWeight="Bold"
                                                                        IsVisible="{Binding !AutoSteer.IsStanleyMode}"/>
                                                         </Grid>
                                                     </Grid>
@@ -829,14 +829,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <StackPanel Spacing="4">
                                                     <Grid ColumnDefinitions="Auto,*,Auto">
                                                         <TextBlock Text="Out" Foreground="#E74C3C" FontSize="11"/>
-                                                        <TextBlock Grid.Column="1" Text="U-Turn Compensation" Foreground="White"
+                                                        <TextBlock Grid.Column="1" Text="U-Turn Compensation" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                    HorizontalAlignment="Center" FontWeight="SemiBold"/>
                                                         <TextBlock Grid.Column="2" Text="In" Foreground="#4A9A7E" FontSize="11"/>
                                                     </Grid>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditUTurnCompensationCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.UTurnCompensation, StringFormat='{}{0:F0}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="-100" Maximum="100"
                                                                 Value="{Binding AutoSteer.UTurnCompensation}"
@@ -848,12 +848,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Sidehill Compensation -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Sidehill / Degree" Foreground="White" FontWeight="SemiBold"
+                                                    <TextBlock Text="Sidehill / Degree" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditSidehillCompensationCommand}">
                                                             <TextBlock Text="{Binding AutoSteer.SideHillCompensation, StringFormat='{}{0:F2}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
                                                         <Slider Grid.Column="1" Minimum="0" Maximum="1"
                                                                 Value="{Binding AutoSteer.SideHillCompensation}"
@@ -867,7 +867,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <Button Classes="ToggleButton" Command="{Binding ToggleSteerInReverseCommand}"
                                                         HorizontalAlignment="Stretch">
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="Steer in Reverse" Foreground="White"/>
+                                                        <TextBlock Text="Steer in Reverse" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                                         <Grid Grid.Column="1">
                                                             <TextBlock Text="ON" Foreground="#4A9A7E" FontWeight="Bold"
                                                                        IsVisible="{Binding AutoSteer.SteerInReverse}"/>
@@ -899,12 +899,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/con_VehicleFunctionSpeedLimit.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Manual Turns" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Manual Turns" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditManualTurnsSpeedCommand}"
                                                                 HorizontalAlignment="Stretch">
                                                             <TextBlock Text="{Binding AutoSteer.ManualTurnsSpeed, StringFormat='{}{0:F1}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
                                                         <TextBlock Text="km/h" Foreground="#777" FontSize="10"
@@ -914,12 +914,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="1" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_MinAutoSteer.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Min Speed" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Min Speed" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditMinSteerSpeedCommand}"
                                                                 HorizontalAlignment="Stretch">
                                                             <TextBlock Text="{Binding AutoSteer.MinSteerSpeed, StringFormat='{}{0:F1}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
                                                         <TextBlock Text="km/h" Foreground="#777" FontSize="10"
@@ -929,12 +929,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_MaxAutoSteer.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Max Speed" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Max Speed" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditMaxSteerSpeedCommand}"
                                                                 HorizontalAlignment="Stretch">
                                                             <TextBlock Text="{Binding AutoSteer.MaxSteerSpeed, StringFormat='{}{0:F1}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
                                                         <TextBlock Text="km/h" Foreground="#777" FontSize="10"
@@ -964,12 +964,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="0" Margin="0,0,4,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_LineWith.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Line Width" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Line Width" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditLineWidthCommand}"
                                                                 HorizontalAlignment="Stretch">
                                                             <TextBlock Text="{Binding AutoSteer.LineWidth}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
                                                         <TextBlock Text="pixels" Foreground="#777" FontSize="10"
@@ -979,12 +979,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="1" Margin="4,0,0,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_SnapDistance.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Nudge Distance" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Nudge Distance" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditNudgeDistanceCommand}"
                                                                 HorizontalAlignment="Stretch">
                                                             <TextBlock Text="{Binding AutoSteer.NudgeDistance}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
                                                         <TextBlock Text="cm" Foreground="#777" FontSize="10"
@@ -1000,12 +1000,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="0" Margin="0,0,4,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_GuidanceLookAhead.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Next Guidance" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Next Guidance" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditNextGuidanceTimeCommand}"
                                                                 HorizontalAlignment="Stretch">
                                                             <TextBlock Text="{Binding AutoSteer.NextGuidanceTime, StringFormat='{}{0:F1}'}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
                                                         <TextBlock Text="sec" Foreground="#777" FontSize="10"
@@ -1015,12 +1015,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="1" Margin="4,0,0,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_CmPixel.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Cm -> Pixel" Foreground="#AAA" FontSize="11"
+                                                        <TextBlock Text="Cm -> Pixel" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditCmPerPixelCommand}"
                                                                 HorizontalAlignment="Stretch">
                                                             <TextBlock Text="{Binding AutoSteer.CmPerPixel}"
-                                                                       Foreground="White" FontWeight="Bold" FontSize="16"
+                                                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
                                                         <TextBlock Text="cm/px" Foreground="#777" FontSize="10"
@@ -1034,7 +1034,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <Grid ColumnDefinitions="*,*,*" HorizontalAlignment="Stretch">
                                                     <!-- Lightbar -->
                                                     <StackPanel Grid.Column="0" HorizontalAlignment="Center">
-                                                        <Border CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Background="{Binding AutoSteer.LightbarEnabled, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleLightbarCommand}"
                                                                     Background="Transparent" BorderThickness="0" Padding="4" Cursor="Hand">
@@ -1042,11 +1042,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Lightbar" Foreground="#AAA" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="Lightbar" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- Steering Bar -->
                                                     <StackPanel Grid.Column="1" HorizontalAlignment="Center">
-                                                        <Border CornerRadius="4" BorderBrush="#555" BorderThickness="1"
+                                                        <Border CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Background="{Binding AutoSteer.SteerBarEnabled, Converter={x:Static converters:BoolToToggleBackgroundConverter.Instance}}">
                                                             <Button Command="{Binding ToggleSteerBarCommand}"
                                                                     Background="Transparent" BorderThickness="0" Padding="4" Cursor="Hand">
@@ -1054,7 +1054,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Steer Bar" Foreground="#AAA" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="Steer Bar" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- On/Off (Guidance Bar) -->
                                                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
@@ -1069,7 +1069,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        IsVisible="{Binding !AutoSteer.GuidanceBarOn}"/>
                                                             </Grid>
                                                         </Button>
-                                                        <TextBlock Text="On/Off" Foreground="#AAA" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="On/Off" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Grid>
                                             </Border>
@@ -1086,7 +1086,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png"
                                                Width="32" Height="32" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                        <TextBlock Text="Wizard" Foreground="White" FontSize="10" HorizontalAlignment="Center"/>
+                                        <TextBlock Text="Wizard" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <!-- Reset -->
@@ -1095,12 +1095,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Reset_Default.png"
                                                Width="32" Height="32" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                        <TextBlock Text="Defaults" Foreground="White" FontSize="10" HorizontalAlignment="Center"/>
+                                        <TextBlock Text="Defaults" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <!-- Send+Save with unsaved changes warning -->
                                 <Button Grid.Column="2" Margin="2" Padding="4"
-                                        Background="#DD4A9A7E" Command="{Binding SendAndSaveCommand}">
+                                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Command="{Binding SendAndSaveCommand}">
                                     <StackPanel HorizontalAlignment="Center">
                                         <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center">
                                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ToolAcceptChange.png"
@@ -1110,7 +1110,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                    Width="24" Height="24" Stretch="Uniform" VerticalAlignment="Center"
                                                    IsVisible="{Binding HasUnsavedRightSideChanges}"/>
                                         </StackPanel>
-                                        <TextBlock Text="Send+Save" Foreground="White" FontSize="10" HorizontalAlignment="Center"/>
+                                        <TextBlock Text="Send+Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <!-- Close -->
@@ -1125,7 +1125,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Grid>
 
                 <!-- Footer: Status Bar -->
-                <Border Grid.Row="2" Background="#DD2C3E50" Padding="12,8">
+                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="12,8">
                     <Grid ColumnDefinitions="*,Auto">
                         <!-- Status Values - Fixed width columns to prevent layout shift -->
                         <StackPanel Orientation="Horizontal" Spacing="16">
@@ -1149,13 +1149,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Expand/Collapse Button -->
                         <Button Grid.Column="1" Command="{Binding ToggleFullModeCommand}"
-                                Background="#DD4A9A7E" Padding="12,6" CornerRadius="4">
+                                Background="{DynamicResource SystemControlHighlightAccentBrush}" Padding="12,6" CornerRadius="4">
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="|||" Foreground="White" FontWeight="Bold"/>
+                                <TextBlock Text="|||" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                                 <Grid>
-                                    <TextBlock Text="◀" Foreground="White" FontWeight="Bold"
+                                    <TextBlock Text="◀" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"
                                                IsVisible="{Binding IsFullMode}"/>
-                                    <TextBlock Text="▶" Foreground="White" FontWeight="Bold"
+                                    <TextBlock Text="▶" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"
                                                IsVisible="{Binding !IsFullMode}"/>
                                 </Grid>
                             </StackPanel>
@@ -1169,24 +1169,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#CC000000"
                 IsVisible="{Binding IsNumericInputVisible}"
                 ZIndex="100">
-            <Border Background="#DD1E2A38" CornerRadius="12" Padding="20"
+            <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"
                     Width="320" Height="400"
                     HorizontalAlignment="Center" VerticalAlignment="Center"
-                    BorderBrush="#555" BorderThickness="1">
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
                 <Grid RowDefinitions="Auto,Auto,*,Auto">
                     <!-- Title -->
                     <TextBlock Grid.Row="0" Text="{Binding NumericInputTitle}"
-                               FontSize="18" FontWeight="Bold" Foreground="White"
+                               FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                HorizontalAlignment="Center" Margin="0,0,0,12"/>
 
                     <!-- Value Display -->
-                    <Border Grid.Row="1" Background="#DD2C3E50" CornerRadius="6"
+                    <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="6"
                             Padding="16,12" Margin="0,0,0,12">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
                             <TextBlock Text="{Binding NumericInputDisplayText}"
-                                       FontSize="28" FontWeight="Bold" Foreground="White"/>
+                                       FontSize="28" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                             <TextBlock Text="{Binding NumericInputUnit}"
-                                       FontSize="16" Foreground="#AAA" VerticalAlignment="Bottom" Margin="0,0,0,4"/>
+                                       FontSize="16" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Bottom" Margin="0,0,0,4"/>
                         </StackPanel>
                     </Border>
 
@@ -1209,9 +1209,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Confirm/Cancel -->
                     <Grid Grid.Row="3" ColumnDefinitions="*,*" Margin="0,12,0,0">
                         <Button Grid.Column="0" Content="Cancel" Command="{Binding CancelNumericInputCommand}"
-                                Margin="0,0,4,0" Background="#DD34495E"/>
+                                Margin="0,0,4,0" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                         <Button Grid.Column="1" Content="OK" Command="{Binding ConfirmNumericInputCommand}"
-                                Margin="4,0,0,0" Background="#DD4A9A7E"/>
+                                Margin="4,0,0,0" Background="{DynamicResource SystemControlHighlightAccentBrush}"/>
                     </Grid>
                 </Grid>
             </Border>
@@ -1221,7 +1221,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#CC000000"
                 IsVisible="{Binding IsResetConfirmVisible}"
                 ZIndex="100">
-            <Border Background="#DD1E2A38" CornerRadius="12" Padding="24"
+            <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="24"
                     Width="320"
                     HorizontalAlignment="Center" VerticalAlignment="Center"
                     BorderBrush="#E74C3C" BorderThickness="2">
@@ -1230,18 +1230,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Reset_Default.png"
                                Width="40" Height="40" Stretch="Uniform"/>
-                        <TextBlock Text="Reset to Defaults?" FontSize="18" FontWeight="Bold" Foreground="White"
+                        <TextBlock Text="Reset to Defaults?" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
 
                     <!-- Warning Message -->
                     <TextBlock Text="This will reset ALL AutoSteer settings to factory defaults and send them to the module."
-                               TextWrapping="Wrap" Foreground="#AAA" TextAlignment="Center"/>
+                               TextWrapping="Wrap" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" TextAlignment="Center"/>
 
                     <!-- Buttons -->
                     <Grid ColumnDefinitions="*,*" Margin="0,8,0,0">
                         <Button Grid.Column="0" Content="Cancel" Command="{Binding CancelResetCommand}"
-                                Margin="0,0,4,0" Padding="16,10" Background="#DD34495E"/>
+                                Margin="0,0,4,0" Padding="16,10" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                         <Button Grid.Column="1" Content="Reset" Command="{Binding ConfirmResetCommand}"
                                 Margin="4,0,0,0" Padding="16,10" Background="#DDE74C3C"/>
                     </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
@@ -53,7 +53,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
 
@@ -101,7 +101,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontSize" Value="11"/>
         </Style>
         <Style Selector="TextBlock.StatusValue">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="FontSize" Value="14"/>
         </Style>
@@ -1166,7 +1166,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Border>
 
         <!-- Numeric Input Overlay -->
-        <Border Background="#CC000000"
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 IsVisible="{Binding IsNumericInputVisible}"
                 ZIndex="100">
             <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"
@@ -1218,7 +1218,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Border>
 
         <!-- Reset Confirmation Dialog -->
-        <Border Background="#CC000000"
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 IsVisible="{Binding IsResetConfirmVisible}"
                 ZIndex="100">
             <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="24"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="MinWidth" Value="70"/>
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ToolButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ToolButton:pressed">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -50,7 +50,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.CancelButton">
             <Setter Property="Background" Value="#C0392B"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="MinWidth" Value="80"/>
             <Setter Property="MinHeight" Value="44"/>
@@ -63,7 +63,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.OkButton">
             <Setter Property="Background" Value="#27AE60"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="MinWidth" Value="80"/>
             <Setter Property="MinHeight" Value="44"/>
@@ -78,7 +78,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
 
         <Style Selector="CheckBox">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.ToolButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -87,13 +87,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel - full screen with margin for touch targets -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
                 Margin="20"
                 BoxShadow="0 8 32 #40000000">
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Header with instructions -->
-                <Border Grid.Row="0" Background="#34495E" Padding="15" CornerRadius="12,12,0,0">
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Padding="15" CornerRadius="12,12,0,0">
                     <Grid ColumnDefinitions="*,Auto">
                         <StackPanel Grid.Column="0">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -101,14 +101,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <TextBlock Text="Draw Field Boundary" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18"/>
                             </StackPanel>
                             <TextBlock Text="Tap on the map to add boundary points. Pan with drag, pinch to zoom."
-                                       Foreground="#BDC3C7" FontSize="13" Margin="0,5,0,0"/>
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,5,0,0"/>
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
                             <TextBlock x:Name="PointCountLabel" Text="{Binding BoundaryMapPointCount, StringFormat='Points: {0}'}"
                                        Foreground="#1ABC9C" FontSize="14"
                                        FontWeight="Bold" VerticalAlignment="Center"/>
                             <TextBlock x:Name="CoordinateLabel" Text="{Binding BoundaryMapCoordinateText}"
-                                       Foreground="#BDC3C7" FontSize="12"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                        VerticalAlignment="Center" MinWidth="150"/>
                         </StackPanel>
                     </Grid>
@@ -126,7 +126,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 Click="BtnDraw_Click" ToolTip.Tip="Toggle drawing mode">
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="20" Height="20"/>
-                                <TextBlock x:Name="BtnDrawText" Text="Draw" Foreground="White" VerticalAlignment="Center"/>
+                                <TextBlock x:Name="BtnDrawText" Text="Draw" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
 
@@ -134,19 +134,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 Click="BtnUndo_Click" ToolTip.Tip="Remove last point" IsEnabled="False">
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BackSpace.png" Width="20" Height="20"/>
-                                <TextBlock Text="Undo" Foreground="White" VerticalAlignment="Center"/>
+                                <TextBlock Text="Undo" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
 
                         <Button x:Name="BtnClear" Classes="ToolButton"
                                 Click="BtnClear_Click" ToolTip.Tip="Clear all points" IsEnabled="False">
-                            <TextBlock Text="Clear" Foreground="White"/>
+                            <TextBlock Text="Clear" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         </Button>
                     </StackPanel>
                 </Border>
 
                 <!-- Bottom action bar -->
-                <Border Grid.Row="2" Background="#34495E" Padding="15" CornerRadius="0,0,12,12">
+                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Padding="15" CornerRadius="0,0,12,12">
                     <Grid ColumnDefinitions="Auto,*,Auto,Auto">
                         <CheckBox x:Name="ChkSaveBackground" Grid.Column="0" Content="Include Background Image"
                                   IsChecked="{Binding BoundaryMapIncludeBackground}"
@@ -156,13 +156,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <Button Grid.Column="2" Classes="CancelButton" Margin="0,0,10,0"
                                 Command="{Binding CancelBoundaryMapDialogCommand}" ToolTip.Tip="Cancel">
-                            <TextBlock Text="Cancel" Foreground="White"/>
+                            <TextBlock Text="Cancel" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         </Button>
 
                         <Button x:Name="BtnSave" Grid.Column="3" Classes="OkButton"
                                 Click="BtnSave_Click" ToolTip.Tip="Save boundary"
                                 IsEnabled="{Binding BoundaryMapCanSave}">
-                            <TextBlock Text="Save" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                         </Button>
                     </Grid>
                 </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/AdditionalOptionsConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/AdditionalOptionsConfigTab.axaml
@@ -49,7 +49,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Section Panel -->
         <Style Selector="Border.SectionPanel">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="16"/>
         </Style>
@@ -65,7 +65,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,*">
         <!-- Header -->
-        <TextBlock Text="Additional Options" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="16,12,16,8"/>
+        <TextBlock Text="Additional Options" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <ScrollViewer Grid.Row="1">
             <StackPanel Spacing="16" Margin="16,8,16,16">
@@ -84,7 +84,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Con_UTurnMenu.png"
                                            Width="60" Height="60" Stretch="Uniform"/>
                                 </Button>
-                                <TextBlock Text="U-Turn" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                <TextBlock Text="U-Turn" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             </StackPanel>
 
                             <!-- Lateral Button -->
@@ -96,7 +96,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABSnapNudgeMenu.png"
                                            Width="60" Height="60" Stretch="Uniform"/>
                                 </Button>
-                                <TextBlock Text="Lateral" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Lateral" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </StackPanel>
                     </StackPanel>
@@ -116,7 +116,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConF_SteerSound.png"
                                            Width="60" Height="60" Stretch="Uniform"/>
                                 </Button>
-                                <TextBlock Text="Auto Steer" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Auto Steer" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             </StackPanel>
 
                             <!-- U-Turn Sound -->
@@ -128,7 +128,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConF_TurnSound.png"
                                            Width="60" Height="60" Stretch="Uniform"/>
                                 </Button>
-                                <TextBlock Text="U-Turn" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                <TextBlock Text="U-Turn" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             </StackPanel>
 
                             <!-- Hydraulic Sound -->
@@ -140,7 +140,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConF_HydLiftSound.png"
                                            Width="60" Height="60" Stretch="Uniform"/>
                                 </Button>
-                                <TextBlock Text="Hydraulic" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Hydraulic" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             </StackPanel>
 
                             <!-- Sections Sound -->
@@ -152,7 +152,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConF_SoundSections.png"
                                            Width="60" Height="60" Stretch="Uniform"/>
                                 </Button>
-                                <TextBlock Text="Sections" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Sections" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Grid>
                     </StackPanel>
@@ -172,7 +172,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConS_ModulesMachine.png"
                                            Width="60" Height="60" Stretch="Uniform"/>
                                 </Button>
-                                <TextBlock Text="Messages" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Messages" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </StackPanel>
                     </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -72,8 +72,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Tappable Value Button -->
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Width" Value="90"/>
@@ -89,12 +89,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,*">
         <!-- Header -->
-        <TextBlock Text="Display Options" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="16,12,16,8"/>
+        <TextBlock Text="Display Options" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <ScrollViewer Grid.Row="1">
             <StackPanel Spacing="16" Margin="16,8,16,16">
                 <!-- Main Toggle Grid: 4 columns x 5 rows -->
-                <Border Background="#DD253545" CornerRadius="8" Padding="20">
+                <Border Background="{DynamicResource SystemControlBackgroundListLowBrush}" CornerRadius="8" Padding="20">
                     <Grid ColumnDefinitions="*,*,*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto"
                           RowSpacing="12" ColumnSpacing="12" HorizontalAlignment="Center">
 
@@ -107,7 +107,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_Poligons.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Polygons" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Polygons" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="0" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
@@ -118,7 +118,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_Speedometer.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Speedo" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Speedo" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="0" Grid.Column="2" Spacing="4" HorizontalAlignment="Center">
@@ -129,7 +129,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_KeyBoard.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Keyboard" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Keyboard" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="0" Grid.Column="3" Spacing="4" HorizontalAlignment="Center">
@@ -140,7 +140,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_LightBar.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Headland Dist" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Headland Dist" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Row 1: Brightness, Svenn Arrow, Start Fullscreen, Elevation Log -->
@@ -152,7 +152,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_AutoDayNight.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Brightness" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Brightness" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="1" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
@@ -163,7 +163,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_RollHelper.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Svenn Arrow" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Svenn Arrow" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="1" Grid.Column="2" Spacing="4" HorizontalAlignment="Center">
@@ -174,7 +174,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_FullScreenBegin.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Fullscreen" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Fullscreen" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="1" Grid.Column="3" Spacing="4" HorizontalAlignment="Center">
@@ -185,7 +185,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_LogElevation.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Elevation Log" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Elevation Log" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Row 2: Field Texture, Grid, Extra Guidelines, Guidelines Count -->
@@ -197,7 +197,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_FloorTexture.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Field Texture" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Field Texture" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="2" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
@@ -208,7 +208,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_Grid.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Grid" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Grid" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="2" Grid.Column="2" Spacing="4" HorizontalAlignment="Center">
@@ -219,16 +219,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_ExtraGuides.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Extra Guides" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Extra Guides" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="2" Grid.Column="3" Spacing="4" HorizontalAlignment="Center">
                             <Button Classes="TappableValue" Command="{Binding EditExtraGuidelinesCountCommand}">
                                 <TextBlock Text="{Binding Display.ExtraGuidelinesCount}"
-                                           Foreground="White" FontWeight="Bold" FontSize="32"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="32"
                                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
-                            <TextBlock Text="Guide Count" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Guide Count" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Row 3: Line Smooth, Direction Markers, Section Lines -->
@@ -240,7 +240,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_LineSmooth.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Line Smooth" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Line Smooth" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
@@ -251,7 +251,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_DirectionMarker.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Direction" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Direction" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="3" Grid.Column="2" Spacing="4" HorizontalAlignment="Center">
@@ -262,12 +262,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_SectionHighlights.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Section Lines" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Section Lines" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Units Section (Row 3, Column 3) -->
                         <StackPanel Grid.Row="3" Grid.Column="3" Spacing="4" HorizontalAlignment="Center">
-                            <TextBlock Text="Units" Foreground="White" FontSize="12" FontWeight="SemiBold"
+                            <TextBlock Text="Units" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="SemiBold"
                                        HorizontalAlignment="Center" Margin="0,0,0,4"/>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <Button Classes="UnitsToggle" Width="40" Height="40"
@@ -293,10 +293,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Background="{Binding Display.IsDayMode, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
                                     BorderBrush="{Binding Display.IsDayMode, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
                                     Command="{Binding ToggleDayNightThemeCommand}">
-                                <TextBlock Text="Light" Foreground="White" FontSize="14" FontWeight="Bold"
+                                <TextBlock Text="Light" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" FontWeight="Bold"
                                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
-                            <TextBlock Text="Light Theme" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Light Theme" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <StackPanel Grid.Row="4" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
@@ -304,10 +304,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Background="{Binding !Display.IsDayMode, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
                                     BorderBrush="{Binding !Display.IsDayMode, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
                                     Command="{Binding ToggleDayNightThemeCommand}">
-                                <TextBlock Text="Dark" Foreground="White" FontSize="14" FontWeight="Bold"
+                                <TextBlock Text="Dark" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" FontWeight="Bold"
                                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
-                            <TextBlock Text="Dark Theme" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Dark Theme" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -93,9 +93,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <ScrollViewer Grid.Row="1">
             <StackPanel Spacing="16" Margin="16,8,16,16">
-                <!-- Main Toggle Grid: 4 columns x 4 rows -->
+                <!-- Main Toggle Grid: 4 columns x 5 rows -->
                 <Border Background="#DD253545" CornerRadius="8" Padding="20">
-                    <Grid ColumnDefinitions="*,*,*,*" RowDefinitions="Auto,Auto,Auto,Auto"
+                    <Grid ColumnDefinitions="*,*,*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto"
                           RowSpacing="12" ColumnSpacing="12" HorizontalAlignment="Center">
 
                         <!-- Row 0: Polygons, Speedo, Keyboard, Headland Dist -->
@@ -285,6 +285,29 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                            Width="28" Height="28" Stretch="Uniform"/>
                                 </Button>
                             </StackPanel>
+                        </StackPanel>
+
+                        <!-- Row 4: App Theme -->
+                        <StackPanel Grid.Row="4" Grid.Column="0" Spacing="4" HorizontalAlignment="Center">
+                            <Button Classes="DisplayToggle"
+                                    Background="{Binding Display.IsDayMode, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
+                                    BorderBrush="{Binding Display.IsDayMode, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
+                                    Command="{Binding ToggleDayNightThemeCommand}">
+                                <TextBlock Text="Light" Foreground="White" FontSize="14" FontWeight="Bold"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Button>
+                            <TextBlock Text="Light Theme" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="4" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
+                            <Button Classes="DisplayToggle"
+                                    Background="{Binding !Display.IsDayMode, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
+                                    BorderBrush="{Binding !Display.IsDayMode, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
+                                    Command="{Binding ToggleDayNightThemeCommand}">
+                                <TextBlock Text="Dark" Foreground="White" FontSize="14" FontWeight="Bold"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Button>
+                            <TextBlock Text="Dark Theme" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -82,7 +82,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Padding" Value="8"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/HardwareConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/HardwareConfigTab.axaml
@@ -26,8 +26,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <ScrollViewer>
         <StackPanel Margin="16">
-            <TextBlock Text="Hardware / Modules" FontSize="16" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,12"/>
-            <TextBlock Text="Hardware configuration coming soon..." Foreground="#AAA"/>
+            <TextBlock Text="Hardware / Modules" FontSize="16" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,0,0,12"/>
+            <TextBlock Text="Hardware configuration coming soon..." Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineControlConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineControlConfigTab.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Sub-tab styling -->
         <Style Selector="TabControl.SubTabs">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem">
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,0,2,0"/>
-            <Setter Property="Background" Value="#DD2C3E50"/>
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:selected">
             <Setter Property="Background" Value="#DD1E8449"/>
@@ -48,7 +48,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,*">
         <!-- Header -->
-        <TextBlock Text="Machine Control" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="16,12,16,8"/>
+        <TextBlock Text="Machine Control" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <!-- Sub-Tab Control -->
         <TabControl Grid.Row="1" Classes="SubTabs" Margin="8,0,8,8">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineControlConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineControlConfigTab.axaml
@@ -38,11 +38,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:selected">
-            <Setter Property="Background" Value="#DD1E8449"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:pointerover">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
@@ -28,8 +28,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Tappable Value Button -->
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -64,8 +64,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Action Button (non-toggle) -->
         <Style Selector="Button.ActionButton">
-            <Setter Property="Background" Value="#DD2C3E50"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -77,7 +77,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Settings Panel -->
         <Style Selector="Border.SettingsPanel">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12"/>
         </Style>
@@ -101,23 +101,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="16">
                     <!-- Enable Button -->
                     <StackPanel Grid.Column="0" Spacing="4">
-                        <TextBlock Text="Enable" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Enable" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="ToggleButton"
                                 Background="{Binding Machine.HydraulicLiftEnabled, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
                                 BorderBrush="{Binding Machine.HydraulicLiftEnabled, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
                                 Command="{Binding ToggleHydraulicLiftCommand}"
                                 Width="70" Height="70">
-                            <TextBlock Text="&#x23FB;" FontSize="28" Foreground="White" HorizontalAlignment="Center"/>
+                            <TextBlock Text="&#x23FB;" FontSize="28" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"/>
                         </Button>
                     </StackPanel>
 
                     <!-- Raise Time -->
                     <StackPanel Grid.Column="1" Spacing="4">
-                        <TextBlock Text="Raise Time" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Raise Time" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="TappableValue" Command="{Binding EditRaiseTimeCommand}" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Machine.RaiseTime}" Foreground="White" FontWeight="Bold" FontSize="24"/>
+                            <TextBlock Text="{Binding Machine.RaiseTime}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
                         </Button>
-                        <TextBlock Text="Plant Pop" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Plant Pop" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                     </StackPanel>
 
                     <!-- Raise Time Graphic -->
@@ -130,18 +130,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,Auto,*" ColumnSpacing="16">
                     <!-- Look Ahead -->
                     <StackPanel Grid.Column="0" Spacing="4">
-                        <TextBlock Text="Look Ahead" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Look Ahead" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="TappableValue" Command="{Binding EditLookAheadCommand}" HorizontalAlignment="Center"
                                 Width="70" Height="70">
-                            <TextBlock Text="{Binding Machine.LookAhead, StringFormat='{}{0:F1}'}" Foreground="White" FontWeight="Bold" FontSize="20"/>
+                            <TextBlock Text="{Binding Machine.LookAhead, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20"/>
                         </Button>
                     </StackPanel>
 
                     <!-- Lower Time -->
                     <StackPanel Grid.Column="1" Spacing="4">
-                        <TextBlock Text="Lower Time" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Lower Time" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="TappableValue" Command="{Binding EditLowerTimeCommand}" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Machine.LowerTime}" Foreground="White" FontWeight="Bold" FontSize="24"/>
+                            <TextBlock Text="{Binding Machine.LowerTime}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
                         </Button>
                     </StackPanel>
 
@@ -153,7 +153,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Invert Relay -->
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Invert Relay" Foreground="#AAA" FontSize="11"/>
+                    <TextBlock Text="Invert Relay" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                     <Button Classes="ToggleButton"
                             Background="{Binding Machine.InvertRelay, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
                             BorderBrush="{Binding Machine.InvertRelay, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
@@ -168,8 +168,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Button Classes="ActionButton" Command="{Binding SendAndSaveMachineConfigCommand}"
                         HorizontalAlignment="Right" Margin="0,12,0,0">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="Send + Save" Foreground="White" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                        <TextBlock Text="&#x2699;" FontSize="18" Foreground="#AAA" VerticalAlignment="Center"/>
+                        <TextBlock Text="Send + Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        <TextBlock Text="&#x2699;" FontSize="18" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                         <TextBlock Text="&#x2192;" FontSize="18" Foreground="#4A9A7E" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
@@ -180,33 +180,33 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Spacing="8" Width="100">
                     <!-- User 1 -->
                     <StackPanel Spacing="2">
-                        <TextBlock Text="User 1" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="User 1" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="TappableValue" Command="{Binding EditUser1Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User1Value}" Foreground="White" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding Machine.User1Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
                         </Button>
                     </StackPanel>
 
                     <!-- User 2 -->
                     <StackPanel Spacing="2">
-                        <TextBlock Text="User 2" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="User 2" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="TappableValue" Command="{Binding EditUser2Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User2Value}" Foreground="White" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding Machine.User2Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
                         </Button>
                     </StackPanel>
 
                     <!-- User 3 -->
                     <StackPanel Spacing="2">
-                        <TextBlock Text="User 3" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="User 3" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="TappableValue" Command="{Binding EditUser3Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User3Value}" Foreground="White" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding Machine.User3Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
                         </Button>
                     </StackPanel>
 
                     <!-- User 4 -->
                     <StackPanel Spacing="2">
-                        <TextBlock Text="User 4" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="User 4" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         <Button Classes="TappableValue" Command="{Binding EditUser4Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User4Value}" Foreground="White" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding Machine.User4Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
                         </Button>
                     </StackPanel>
                 </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
 
@@ -72,7 +72,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ActionButton:pointerover">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
 
         <!-- Settings Panel -->
@@ -121,7 +121,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <!-- Raise Time Graphic -->
-                    <Border Grid.Column="2" Background="#1A1A2E" CornerRadius="6" Padding="8" Height="100">
+                    <Border Grid.Column="2" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Height="100">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConMa_LiftRaiseTime.png" Stretch="Uniform"/>
                     </Border>
                 </Grid>
@@ -146,7 +146,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <!-- Lower Time Graphic -->
-                    <Border Grid.Column="2" Background="#1A1A2E" CornerRadius="6" Padding="8" Height="100">
+                    <Border Grid.Column="2" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Height="100">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConMa_LiftLowerTime.png" Stretch="Uniform"/>
                     </Border>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/PinConfigSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/PinConfigSubTab.axaml
@@ -36,8 +36,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Pin ComboBox -->
         <Style Selector="ComboBox.PinCombo">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="MinWidth" Value="100"/>
             <Setter Property="FontSize" Value="11"/>
@@ -45,8 +45,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Action Button -->
         <Style Selector="Button.ActionButton">
-            <Setter Property="Background" Value="#DD2C3E50"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -205,11 +205,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </ScrollViewer>
 
         <!-- Bottom Action Buttons -->
-        <Border Grid.Row="1" Background="#DD253545" Padding="16,12">
+        <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundListLowBrush}" Padding="16,12">
             <Grid ColumnDefinitions="Auto,Auto,*,Auto">
                 <!-- Reset Button -->
                 <Button Grid.Column="0" Classes="ActionButton" Command="{Binding ResetPinConfigCommand}">
-                    <TextBlock Text="&#x21BA;" FontSize="20" Foreground="#AAA"/>
+                    <TextBlock Text="&#x21BA;" FontSize="20" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
                 </Button>
 
                 <!-- Upload Button -->
@@ -220,8 +220,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Send + Save -->
                 <Button Grid.Column="3" Classes="ActionButton" Command="{Binding SendAndSaveMachineConfigCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="Send + Save" Foreground="White" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                        <TextBlock Text="&#x2699;" FontSize="18" Foreground="#AAA" VerticalAlignment="Center"/>
+                        <TextBlock Text="Send + Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        <TextBlock Text="&#x2699;" FontSize="18" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                         <TextBlock Text="&#x2192;" FontSize="18" Foreground="#4A9A7E" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/PinConfigSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/PinConfigSubTab.axaml
@@ -53,7 +53,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ActionButton:pointerover">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SectionsConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SectionsConfigTab.axaml
@@ -49,7 +49,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SectionsConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SectionsConfigTab.axaml
@@ -26,22 +26,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
         </Style>
         <Style Selector="Border.ValueBox">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="MinWidth" Value="80"/>
         </Style>
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -56,39 +56,39 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <ScrollViewer>
         <StackPanel Spacing="8" Margin="16">
-            <TextBlock Text="Section Configuration" FontSize="16" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,12"/>
+            <TextBlock Text="Section Configuration" FontSize="16" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,0,0,12"/>
 
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Text="Number of Sections" Foreground="White" VerticalAlignment="Center"/>
+                    <TextBlock Text="Number of Sections" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditNumSectionsCommand}">
-                        <TextBlock Text="{Binding Config.NumSections}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Config.NumSections}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
 
-            <TextBlock Text="Section Timing" FontWeight="SemiBold" Foreground="White" Margin="0,16,0,8"/>
+            <TextBlock Text="Section Timing" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,16,0,8"/>
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Text="Look Ahead On" Foreground="White" VerticalAlignment="Center"/>
+                    <TextBlock Text="Look Ahead On" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditLookAheadOnCommand}">
-                        <TextBlock Text="{Binding Tool.LookAheadOnSetting, StringFormat='{}{0:F1} s'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.LookAheadOnSetting, StringFormat='{}{0:F1} s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Text="Look Ahead Off" Foreground="White" VerticalAlignment="Center"/>
+                    <TextBlock Text="Look Ahead Off" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditLookAheadOffCommand}">
-                        <TextBlock Text="{Binding Tool.LookAheadOffSetting, StringFormat='{}{0:F1} s'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.LookAheadOffSetting, StringFormat='{}{0:F1} s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Text="Turn Off Delay" Foreground="White" VerticalAlignment="Center"/>
+                    <TextBlock Text="Turn Off Delay" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTurnOffDelayCommand}">
-                        <TextBlock Text="{Binding Tool.TurnOffDelay, StringFormat='{}{0:F1} s'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.TurnOffDelay, StringFormat='{}{0:F1} s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesConfigTab.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Sub-tab styling -->
         <Style Selector="TabControl.SubTabs">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem">
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,0,2,0"/>
-            <Setter Property="Background" Value="#DD2C3E50"/>
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:selected">
             <Setter Property="Background" Value="#DD1E8449"/>
@@ -48,7 +48,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,*">
         <!-- Header -->
-        <TextBlock Text="GPS / Data Sources" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="16,12,16,8"/>
+        <TextBlock Text="GPS / Data Sources" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <!-- Sub-Tab Control -->
         <TabControl Grid.Row="1" Classes="SubTabs" Margin="8,0,8,8">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesConfigTab.axaml
@@ -38,11 +38,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:selected">
-            <Setter Property="Background" Value="#DD1E8449"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:pointerover">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
@@ -28,7 +28,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Antenna Type Card Style -->
         <Style Selector="Border.AntennaCard">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Cursor" Value="Hand"/>
@@ -61,15 +61,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Settings Panel -->
         <Style Selector="Border.SettingsPanel">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12"/>
         </Style>
 
         <!-- Tappable Value Button Style -->
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="8,4"/>
@@ -82,7 +82,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.TappableValue:disabled">
             <Setter Property="Background" Value="#DD1A1A1A"/>
-            <Setter Property="Foreground" Value="#555"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderBrush" Value="#333"/>
         </Style>
 
@@ -109,8 +109,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Action Button Style (non-toggle) -->
         <Style Selector="Button.ActionButton">
-            <Setter Property="Background" Value="#DD2C3E50"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -121,7 +121,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ActionButton:disabled">
             <Setter Property="Background" Value="#DD1A1A1A"/>
-            <Setter Property="Foreground" Value="#555"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
 
         <!-- Toggle Switch Style -->
@@ -135,7 +135,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel Spacing="12" Margin="16,8,16,16">
 
             <!-- ANTENNA TYPE -->
-            <TextBlock Text="Antenna Type" FontSize="14" FontWeight="SemiBold" Foreground="White"/>
+            <TextBlock Text="Antenna Type" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
 
             <Grid ColumnDefinitions="*,16,*">
                 <!-- Dual Antenna Card -->
@@ -145,7 +145,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Spacing="4" HorizontalAlignment="Center">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Con_SourcesGPSDual.png"
                                Width="80" Height="50" Stretch="Uniform"/>
-                        <TextBlock Text="Dual" Foreground="White" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Dual" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </Border>
 
@@ -156,7 +156,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Spacing="4" HorizontalAlignment="Center">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Con_SourcesGPSSingle.png"
                                Width="80" Height="50" Stretch="Uniform"/>
-                        <TextBlock Text="Fix" Foreground="White" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Fix" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </Border>
             </Grid>
@@ -181,7 +181,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Heading Offset (Degree)" Foreground="{Binding Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
                             <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDualHeadingOffsetCommand}" IsEnabled="{Binding Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.DualHeadingOffset, StringFormat='{}{0:F1}'}" Foreground="White" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding Connections.DualHeadingOffset, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                             </Button>
                         </Grid>
 
@@ -189,7 +189,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Reverse Distance" Foreground="{Binding Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
                             <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDualReverseDistanceCommand}" IsEnabled="{Binding Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.DualReverseDistance, StringFormat='{}{0:F2}'}" Foreground="White" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding Connections.DualReverseDistance, StringFormat='{}{0:F2}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                             </Button>
                         </Grid>
 
@@ -199,14 +199,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 BorderBrush="{Binding Connections.AutoDualFix, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
                                 Command="{Binding ToggleAutoDualFixCommand}" IsEnabled="{Binding Connections.IsDualGps}"
                                 HorizontalAlignment="Stretch">
-                            <TextBlock Text="Auto Dual &lt;&gt; Fix" Foreground="White" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Auto Dual &lt;&gt; Fix" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"/>
                         </Button>
 
                         <!-- Switch Speed -->
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Switch Speed" Foreground="{Binding Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
                             <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDualSwitchSpeedCommand}" IsEnabled="{Binding Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.DualSwitchSpeed, StringFormat='{}{0:F1}'}" Foreground="White" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding Connections.DualSwitchSpeed, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                             </Button>
                         </Grid>
                     </StackPanel>
@@ -223,7 +223,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Minimum GPS Step" Foreground="{Binding !Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
                             <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditMinGpsStepCommand}" IsEnabled="{Binding !Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.MinGpsStep, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding Connections.MinGpsStep, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                             </Button>
                         </Grid>
 
@@ -231,7 +231,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Fix to Fix Distance" Foreground="{Binding !Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
                             <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditFixToFixDistanceCommand}" IsEnabled="{Binding !Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.FixToFixDistance, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding Connections.FixToFixDistance, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                             </Button>
                         </Grid>
 
@@ -254,7 +254,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TextBlock.Text>
                                 </TextBlock>
                             </Grid>
-                            <TextBlock Text="Default: 70%" Foreground="#555" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Default: 70%" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Reverse Detection -->
@@ -263,7 +263,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 BorderBrush="{Binding Connections.ReverseDetection, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
                                 Command="{Binding ToggleReverseDetectionCommand}" IsEnabled="{Binding !Connections.IsDualGps}"
                                 HorizontalAlignment="Stretch">
-                            <TextBlock Text="Reverse Detection" Foreground="White" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Reverse Detection" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"/>
                         </Button>
                     </StackPanel>
                 </Border>
@@ -278,7 +278,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ToggleRtkAlarmCommand}" HorizontalAlignment="Stretch" Height="70">
                     <StackPanel Spacing="4" HorizontalAlignment="Center">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Con_SourcesRTKAlarm.png" Width="32" Height="32"/>
-                        <TextBlock Text="RTK Fix Alarm" Foreground="White" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="RTK Fix Alarm" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 
@@ -289,7 +289,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ToggleAlarmStopsAutosteerCommand}" HorizontalAlignment="Stretch" Height="70">
                     <StackPanel Spacing="4" HorizontalAlignment="Center">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoSteerOff.png" Width="32" Height="32"/>
-                        <TextBlock Text="Alarm Stops Autosteer" Foreground="White" FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Alarm Stops Autosteer" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
@@ -36,11 +36,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderBrush" Value="Transparent"/>
         </Style>
         <Style Selector="Border.AntennaCard:pointerover">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Border.AntennaCard.Selected">
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
-            <Setter Property="Background" Value="#DD2A4A3A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
 
         <!-- Section Header Style -->
@@ -55,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="TextBlock.SectionHeaderDisabled">
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#666"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
         </Style>
 
@@ -77,13 +77,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.TappableValue:disabled">
-            <Setter Property="Background" Value="#DD1A1A1A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#333"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
         </Style>
 
         <!-- Toggle Button with custom template for instant feedback -->
@@ -117,10 +117,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ActionButton:pointerover">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ActionButton:disabled">
-            <Setter Property="Background" Value="#DD1A1A1A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
 
@@ -171,7 +171,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Classes.SectionHeaderDisabled="{Binding !Connections.IsDualGps}"/>
 
                         <!-- Dual Antenna Graphic -->
-                        <Border Background="#1A1A2E" CornerRadius="4" Padding="4" Height="80" HorizontalAlignment="Center"
+                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="4" Padding="4" Height="80" HorizontalAlignment="Center"
                                 IsEnabled="{Binding Connections.IsDualGps}">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Con_SourcesHead.png" Stretch="Uniform"
                                    Opacity="{Binding Connections.IsDualGps, Converter={x:Static conv:BoolToOpacityConverter.Instance}, ConverterParameter=1|0.3}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
@@ -52,13 +52,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
 
         <!-- Action Button Style -->
         <Style Selector="Button.ActionButton">
-            <Setter Property="Background" Value="#DD1E8449"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
@@ -66,7 +66,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ActionButton:pointerover">
-            <Setter Property="Background" Value="#DD2A9A5A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
 
         <!-- Toggle Switch Style -->
@@ -84,7 +84,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- Roll Helper Graphic with explanation -->
             <Grid ColumnDefinitions="Auto,*">
-                <Border Background="#1A1A2E" CornerRadius="6" Padding="8" Width="160" Height="120" Margin="0,0,12,0">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Width="160" Height="120" Margin="0,0,12,0">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_RollHelper.png" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
@@ -103,12 +103,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Roll Zero Offset -->
             <Border Classes="SettingRow" Margin="0,12,0,0">
                 <Grid ColumnDefinitions="Auto,*,Auto">
-                    <Border Background="#1A1A2E" CornerRadius="4" Padding="4" Width="48" Height="48" Margin="0,0,12,0">
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="4" Padding="4" Width="48" Height="48" Margin="0,0,12,0">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConDa_RollSetZero.png" Stretch="Uniform"/>
                     </Border>
                     <StackPanel Grid.Column="1" VerticalAlignment="Center">
                         <TextBlock Text="Roll Zero Offset" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                        <TextBlock Text="Manual offset adjustment" Foreground="#666" FontSize="10"/>
+                        <TextBlock Text="Manual offset adjustment" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                     </StackPanel>
                     <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditRollZeroCommand}">
                         <TextBlock Text="{Binding Ahrs.RollZero, StringFormat='{}{0:F1}°'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
@@ -123,7 +123,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
                         <TextBlock Text="Roll Filter" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                        <TextBlock Text="0 = no filtering, 1 = max filtering" Foreground="#666" FontSize="10"/>
+                        <TextBlock Text="0 = no filtering, 1 = max filtering" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditRollFilterCommand}">
                         <TextBlock Text="{Binding Ahrs.RollFilter, StringFormat='{}{0:F2}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
@@ -135,14 +135,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <TextBlock Text="ROLL DIRECTION" Classes="SectionHeader"/>
 
             <Grid ColumnDefinitions="Auto,*">
-                <Border Background="#1A1A2E" CornerRadius="6" Padding="8" Width="100" Height="70" Margin="0,0,12,0">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Width="100" Height="70" Margin="0,0,12,0">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConDa_InvertRoll.png" Stretch="Uniform"/>
                 </Border>
                 <Border Grid.Column="1" Classes="SettingRow" VerticalAlignment="Center">
                     <Grid ColumnDefinitions="*,Auto">
                         <StackPanel>
                             <TextBlock Text="Invert Roll" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                            <TextBlock Text="Flip roll direction if mounted upside-down" Foreground="#666" FontSize="10"/>
+                            <TextBlock Text="Flip roll direction if mounted upside-down" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" IsChecked="{Binding Ahrs.IsRollInvert}" VerticalAlignment="Center"/>
                     </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
@@ -35,7 +35,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Setting Row Style -->
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
@@ -43,8 +43,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Tappable Value Button Style -->
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -88,13 +88,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_RollHelper.png" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
-                    <TextBlock Text="Roll Correction" Foreground="White" FontWeight="SemiBold"/>
+                    <TextBlock Text="Roll Correction" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                     <TextBlock Text="Adjust roll offset to compensate for IMU mounting angle. Park on level ground and use 'Set Zero' to calibrate."
-                               Foreground="#888" FontSize="11" TextWrapping="Wrap"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" TextWrapping="Wrap"/>
                     <Button Classes="ActionButton" Command="{Binding SetRollZeroCommand}" HorizontalAlignment="Left">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConDa_RollSetZero.png" Width="24" Height="24"/>
-                            <TextBlock Text="Set Zero" Foreground="White" VerticalAlignment="Center"/>
+                            <TextBlock Text="Set Zero" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
                 </StackPanel>
@@ -107,11 +107,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConDa_RollSetZero.png" Stretch="Uniform"/>
                     </Border>
                     <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                        <TextBlock Text="Roll Zero Offset" Foreground="White"/>
+                        <TextBlock Text="Roll Zero Offset" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Manual offset adjustment" Foreground="#666" FontSize="10"/>
                     </StackPanel>
                     <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditRollZeroCommand}">
-                        <TextBlock Text="{Binding Ahrs.RollZero, StringFormat='{}{0:F1}°'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Ahrs.RollZero, StringFormat='{}{0:F1}°'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -122,11 +122,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Roll Filter" Foreground="White"/>
+                        <TextBlock Text="Roll Filter" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="0 = no filtering, 1 = max filtering" Foreground="#666" FontSize="10"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditRollFilterCommand}">
-                        <TextBlock Text="{Binding Ahrs.RollFilter, StringFormat='{}{0:F2}'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Ahrs.RollFilter, StringFormat='{}{0:F2}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -141,7 +141,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Column="1" Classes="SettingRow" VerticalAlignment="Center">
                     <Grid ColumnDefinitions="*,Auto">
                         <StackPanel>
-                            <TextBlock Text="Invert Roll" Foreground="White"/>
+                            <TextBlock Text="Invert Roll" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                             <TextBlock Text="Flip roll direction if mounted upside-down" Foreground="#666" FontSize="10"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" IsChecked="{Binding Ahrs.IsRollInvert}" VerticalAlignment="Center"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolConfigTab.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Sub-tab styling - give TabControl a solid background -->
         <Style Selector="TabControl.SubTabs">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem">
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,0,2,0"/>
-            <Setter Property="Background" Value="#DD2C3E50"/>
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:selected">
             <Setter Property="Background" Value="#DD1E8449"/>
@@ -48,7 +48,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,*">
         <!-- Header -->
-        <TextBlock Text="Tool/Implement Configuration" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="16,12,16,8"/>
+        <TextBlock Text="Tool/Implement Configuration" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <!-- Sub-Tab Control with solid background -->
         <TabControl Grid.Row="1" Classes="SubTabs" Margin="8,0,8,8">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolConfigTab.axaml
@@ -38,11 +38,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:selected">
-            <Setter Property="Background" Value="#DD1E8449"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TabControl.SubTabs > TabItem:pointerover">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
@@ -41,7 +41,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>
@@ -49,7 +49,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <ScrollViewer>
         <StackPanel Spacing="12" Margin="16,8,16,16">
             <!-- Dynamic Hitch Diagram based on tool type -->
-            <Border Background="#1A1A2E" CornerRadius="8" Height="150" Margin="0,0,0,16" Padding="8">
+            <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Height="150" Margin="0,0,0,16" Padding="8">
                 <Panel>
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ToolHitchPageFront.png"
                            Stretch="Uniform" IsVisible="{Binding Tool.IsToolFrontFixed}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
@@ -26,14 +26,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
         </Style>
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -66,11 +66,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow" IsVisible="{Binding !Tool.IsToolTrailing}">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Hitch Length" Foreground="White" FontWeight="SemiBold"/>
-                        <TextBlock Text="Distance from rear axle to hitch point" Foreground="#888" FontSize="12"/>
+                        <TextBlock Text="Hitch Length" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="Distance from rear axle to hitch point" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditToolHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.HitchLength, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.HitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -79,11 +79,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow" IsVisible="{Binding Tool.IsToolTrailing}">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Trailing Hitch Length" Foreground="White" FontWeight="SemiBold"/>
-                        <TextBlock Text="Distance from hitch to trailing tool" Foreground="#888" FontSize="12"/>
+                        <TextBlock Text="Trailing Hitch Length" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="Distance from hitch to trailing tool" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTrailingHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.TrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.TrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -92,11 +92,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow" IsVisible="{Binding Tool.IsToolTBT}">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Trailing Hitch Length" Foreground="White" FontWeight="SemiBold"/>
-                        <TextBlock Text="Distance from hitch to implement" Foreground="#888" FontSize="12"/>
+                        <TextBlock Text="Trailing Hitch Length" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="Distance from hitch to implement" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTrailingHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.TrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.TrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -105,11 +105,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow" IsVisible="{Binding Tool.IsToolTBT}">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Tank Trailing Hitch" Foreground="White" FontWeight="SemiBold"/>
-                        <TextBlock Text="Distance from implement to tank trailer" Foreground="#888" FontSize="12"/>
+                        <TextBlock Text="Tank Trailing Hitch" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="Distance from implement to tank trailer" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTankHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.TankTrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.TankTrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -119,7 +119,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Spacing="4">
                     <TextBlock Text="Note:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
                     <TextBlock Text="Values are entered as positive numbers. The system automatically applies the correct sign based on tool type (negative for rear, positive for front)."
-                               Foreground="#AAA" FontSize="12" TextWrapping="Wrap"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
@@ -26,14 +26,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
         </Style>
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -45,8 +45,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.DirectionBtn">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -62,15 +62,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ToolOffsetPositiveRight.png" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                    <TextBlock Text="Tool Offset" FontWeight="SemiBold" Foreground="White"/>
-                    <TextBlock Text="Lateral offset from centerline" Foreground="#888" FontSize="11" Margin="0,2,0,6"/>
+                    <TextBlock Text="Tool Offset" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                    <TextBlock Text="Lateral offset from centerline" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,2,0,6"/>
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Classes="DirectionBtn" Content="Left"/>
                         <Button Classes="DirectionBtn" Content="Right"/>
                         <Button Classes="TappableValue" Command="{Binding EditToolOffsetCommand}">
-                            <TextBlock Text="{Binding Tool.Offset, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Tool.Offset, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                         </Button>
-                        <Button Content="Zero" Background="#DD4A3A3A" Foreground="White" Padding="8,6"/>
+                        <Button Content="Zero" Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </StackPanel>
             </Grid>
@@ -81,15 +81,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ToolOverlap.png" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                    <TextBlock Text="Overlap / Gap" FontWeight="SemiBold" Foreground="White"/>
-                    <TextBlock Text="Pass overlap (positive) or gap (negative)" Foreground="#888" FontSize="11" Margin="0,2,0,6"/>
+                    <TextBlock Text="Overlap / Gap" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                    <TextBlock Text="Pass overlap (positive) or gap (negative)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,2,0,6"/>
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Classes="DirectionBtn" Content="Overlap"/>
                         <Button Classes="DirectionBtn" Content="Gap"/>
                         <Button Classes="TappableValue" Command="{Binding EditToolOverlapCommand}">
-                            <TextBlock Text="{Binding Tool.Overlap, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Tool.Overlap, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                         </Button>
-                        <Button Content="Zero" Background="#DD4A3A3A" Foreground="White" Padding="8,6"/>
+                        <Button Content="Zero" Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </StackPanel>
             </Grid>
@@ -98,15 +98,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,16,0,0">
                 <StackPanel Spacing="4">
                     <TextBlock Text="Usage:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Offset"/>
                         <Run Text=" - Use when tool is not centered on tractor (side-mounted sprayer)"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Overlap"/>
                         <Run Text=" - Ensure complete coverage with slight overlap between passes"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Gap"/>
                         <Run Text=" - Leave intentional gap (skip rows, tramlines)"/>
                     </TextBlock>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
@@ -41,7 +41,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.DirectionBtn">
@@ -58,7 +58,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel Spacing="8" Margin="16,8,16,16">
             <!-- Tool Offset Section -->
             <Grid ColumnDefinitions="Auto,*">
-                <Border Background="#1A1A2E" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ToolOffsetPositiveRight.png" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
@@ -77,7 +77,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- Overlap/Gap Section -->
             <Grid ColumnDefinitions="Auto,*" Margin="0,8,0,0">
-                <Border Background="#1A1A2E" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ToolOverlap.png" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
@@ -26,14 +26,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
         </Style>
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -45,8 +45,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.DirectionBtn">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -62,7 +62,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <TextBlock Text="Note:" Foreground="#DAA520" FontWeight="SemiBold"/>
                     <TextBlock Text="Pivot settings are only used for Trailing and TBT tool types."
-                               Foreground="#AAA" TextWrapping="Wrap"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" TextWrapping="Wrap"/>
                 </StackPanel>
             </Border>
 
@@ -76,9 +76,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Pivot Distance -->
-            <TextBlock Text="Tool Pivot Distance" FontWeight="SemiBold" Foreground="White" Margin="0,8,0,4"/>
+            <TextBlock Text="Tool Pivot Distance" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,8,0,4"/>
             <TextBlock Text="Distance from hitch pivot point to the tool working point"
-                       Foreground="#888" FontSize="12" Margin="0,0,0,8"/>
+                       Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Margin="0,0,0,8"/>
 
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="Auto,*,Auto">
@@ -96,10 +96,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Value -->
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
                         <Button Classes="TappableValue" Command="{Binding EditToolPivotCommand}">
-                            <TextBlock Text="{Binding Tool.TrailingToolToPivotLength, StringFormat='{}{0:F2} m'}" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Tool.TrailingToolToPivotLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                         </Button>
                         <Button Content="Zero" Command="{Binding ZeroToolPivotCommand}"
-                                Background="#DD4A3A3A" Foreground="White" Padding="8,6"/>
+                                Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -108,11 +108,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,16,0,0">
                 <StackPanel Spacing="4">
                     <TextBlock Text="Pivot Explanation:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Behind Pivot (positive)"/>
                         <Run Text=" - Tool working point is behind the hitch pivot (most common)"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Ahead of Pivot (negative)"/>
                         <Run Text=" - Tool working point is ahead of the hitch pivot (rare)"/>
                     </TextBlock>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
@@ -41,7 +41,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.DirectionBtn">
@@ -67,7 +67,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Dynamic Pivot Diagram -->
-            <Border Background="#1A1A2E" CornerRadius="8" Height="150" Margin="0,0,0,16" Padding="8">
+            <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Height="150" Margin="0,0,0,16" Padding="8">
                 <Panel>
                     <!-- Show positive pivot (behind) when value >= 0 -->
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ToolHitchPivotOffsetPos.png"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
@@ -47,7 +47,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.SectionWidthBtn">
@@ -62,7 +62,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="HorizontalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.SectionWidthBtn:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>
@@ -241,7 +241,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         </StackPanel>
                     </StackPanel>
 
-                    <TextBlock Text="All widths in cm" Foreground="#666" FontSize="10" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                    <TextBlock Text="All widths in cm" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center" Margin="0,8,0,0"/>
                 </StackPanel>
             </Border>
 
@@ -338,7 +338,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </WrapPanel>
 
                     <TextBlock Text="Example: Zone 1 → 4 means Zone 1 controls sections 1-4"
-                               Foreground="#666" FontSize="10" FontStyle="Italic" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" FontStyle="Italic" HorizontalAlignment="Center" Margin="0,8,0,0"/>
                 </StackPanel>
             </Border>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
@@ -32,14 +32,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
         </Style>
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -51,8 +51,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.SectionWidthBtn">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="4,6"/>
@@ -72,16 +72,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Mode Toggle -->
             <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,0,0,8">
                 <StackPanel>
-                    <TextBlock Text="Section Mode" Foreground="White" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Section Mode" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                     <StackPanel Orientation="Horizontal" Spacing="16">
                         <RadioButton Content="Individual Sections" GroupName="SectionMode"
                                      IsChecked="{Binding Tool.IsSectionsNotZones}"
-                                     Foreground="White"/>
+                                     Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <RadioButton Content="Symmetric Zones" GroupName="SectionMode"
-                                     Foreground="White"/>
+                                     Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                     </StackPanel>
                     <TextBlock Text="Individual: Each section has its own width. Zones: All sections same width, grouped into zones."
-                               Foreground="#888" FontSize="11" TextWrapping="Wrap" Margin="0,8,0,0"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,8,0,0"/>
                 </StackPanel>
             </Border>
 
@@ -89,11 +89,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Number of Sections" Foreground="White" FontWeight="SemiBold"/>
-                        <TextBlock Text="Total implement sections (1-16)" Foreground="#888" FontSize="12"/>
+                        <TextBlock Text="Number of Sections" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="Total implement sections (1-16)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditNumSectionsCommand}">
-                        <TextBlock Text="{Binding Config.NumSections}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Config.NumSections}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -102,11 +102,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Default Section Width" Foreground="White" FontWeight="SemiBold"/>
-                        <TextBlock Text="Width applied to new sections (or all sections in zone mode)" Foreground="#888" FontSize="12"/>
+                        <TextBlock Text="Default Section Width" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="Width applied to new sections (or all sections in zone mode)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDefaultSectionWidthCommand}">
-                        <TextBlock Text="{Binding Tool.DefaultSectionWidth, StringFormat='{}{0:F0} cm'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.DefaultSectionWidth, StringFormat='{}{0:F0} cm'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -115,9 +115,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,8,0,0"
                     IsVisible="{Binding Tool.IsSectionsNotZones}">
                 <StackPanel>
-                    <TextBlock Text="Section Widths" Foreground="White" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Section Widths" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                     <TextBlock Text="Tap a section to edit its width. Sections shown based on count above."
-                               Foreground="#888" FontSize="11" Margin="0,0,0,12"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,0,0,12"/>
 
                     <StackPanel Spacing="4">
                         <!-- Row 1: Sections 1-8 -->
@@ -125,57 +125,57 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection1WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="1" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section1Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="1" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section1Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection2WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="2" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section2Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="2" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section2Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection3WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=2}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="3" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section3Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="3" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section3Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection4WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=3}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="4" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section4Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="4" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section4Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection5WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=4}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="5" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section5Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="5" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section5Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection6WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=5}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="6" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section6Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="6" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section6Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection7WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=6}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="7" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section7Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="7" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section7Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection8WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=7}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="8" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section8Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="8" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section8Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
@@ -185,57 +185,57 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection9WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=8}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="9" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section9Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="9" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section9Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection10WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=9}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="10" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section10Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="10" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section10Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection11WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=10}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="11" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section11Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="11" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section11Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection12WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=11}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="12" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section12Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="12" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section12Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection13WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=12}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="13" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section13Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="13" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section13Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection14WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=13}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="14" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section14Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="14" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section14Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection15WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=14}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="15" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section15Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="15" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section15Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection16WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=15}">
                                 <StackPanel HorizontalAlignment="Center">
-                                    <TextBlock Text="16" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section16Width, StringFormat='{}{0:F0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="16" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section16Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
@@ -249,25 +249,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,8,0,0"
                     IsVisible="{Binding !Tool.IsSectionsNotZones}">
                 <StackPanel>
-                    <TextBlock Text="Zone Configuration" Foreground="White" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Zone Configuration" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                     <TextBlock Text="In zone mode, all sections have the same width. Sections are grouped into zones for control. Each zone ends at the specified section number."
-                               Foreground="#888" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,12"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,12"/>
 
                     <!-- Number of Zones -->
-                    <Border Background="#DD2C3E50" CornerRadius="4" Padding="12,8" Margin="0,4">
+                    <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="4" Padding="12,8" Margin="0,4">
                         <Grid ColumnDefinitions="*,Auto">
                             <StackPanel>
-                                <TextBlock Text="Number of Zones" Foreground="White" FontWeight="SemiBold"/>
-                                <TextBlock Text="How many control zones (2-8)" Foreground="#888" FontSize="12"/>
+                                <TextBlock Text="Number of Zones" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                                <TextBlock Text="How many control zones (2-8)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             </StackPanel>
                             <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditNumZonesCommand}">
-                                <TextBlock Text="{Binding Tool.Zones}" Foreground="White" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding Tool.Zones}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                             </Button>
                         </Grid>
                     </Border>
 
-                    <TextBlock Text="Zone End Sections" Foreground="White" FontWeight="SemiBold" Margin="0,12,0,4"/>
-                    <TextBlock Text="Tap to set which section each zone ends at" Foreground="#888" FontSize="11" Margin="0,0,0,8"/>
+                    <TextBlock Text="Zone End Sections" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,12,0,4"/>
+                    <TextBlock Text="Tap to set which section each zone ends at" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,0,0,8"/>
 
                     <!-- Zone End Buttons -->
                     <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center">
@@ -275,64 +275,64 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone1EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 1" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone1EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 1" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone1EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <!-- Zone 2 -->
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone2EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 2" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone2EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 2" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone2EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <!-- Zone 3 -->
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone3EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=2}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 3" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone3EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 3" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone3EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <!-- Zone 4 -->
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone4EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=3}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 4" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone4EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 4" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone4EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <!-- Zone 5 -->
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone5EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=4}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 5" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone5EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 5" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone5EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <!-- Zone 6 -->
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone6EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=5}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 6" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone6EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 6" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone6EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <!-- Zone 7 -->
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone7EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=6}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 7" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone7EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 7" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone7EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <!-- Zone 8 -->
                         <Button Classes="SectionWidthBtn" Command="{Binding EditZone8EndCommand}"
                                 Margin="4" IsVisible="{Binding Tool.Zones, Converter={StaticResource GreaterThanConverter}, ConverterParameter=7}">
                             <StackPanel HorizontalAlignment="Center">
-                                <TextBlock Text="Zone 8" Foreground="#888" FontSize="10" HorizontalAlignment="Center"/>
-                                <TextBlock Text="{Binding Zone8EndSection, StringFormat='→ {0}'}" Foreground="White" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Zone 8" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Zone8EndSection, StringFormat='→ {0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                     </WrapPanel>
@@ -346,23 +346,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD1E8449" CornerRadius="6" Padding="12" Margin="0,8,0,0">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel VerticalAlignment="Center">
-                        <TextBlock Text="Calculated Total Width" Foreground="White" FontWeight="SemiBold"/>
-                        <TextBlock Text="(sum of active section widths)" Foreground="#AAA" FontSize="11"/>
+                        <TextBlock Text="Calculated Total Width" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="(sum of active section widths)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                     </StackPanel>
                     <TextBlock Grid.Column="1" Text="{Binding CalculatedSectionTotal, StringFormat='{}{0:F2} m'}"
-                               Foreground="White" FontWeight="Bold" FontSize="16" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" VerticalAlignment="Center"/>
                 </Grid>
             </Border>
 
             <!-- Coverage Color Settings -->
-            <TextBlock Text="Coverage Colors" FontWeight="SemiBold" Foreground="White" Margin="0,16,0,8"/>
+            <TextBlock Text="Coverage Colors" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,16,0,8"/>
 
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Multi-Colored Sections" Foreground="White"/>
+                        <TextBlock Text="Multi-Colored Sections" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Each section paints a different color on the map"
-                                   Foreground="#888" FontSize="12"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <ToggleSwitch Grid.Column="1" IsChecked="{Binding Tool.IsMultiColoredSections}"
                                   OnContent="On" OffContent="Off"/>
@@ -373,9 +373,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,4,0,0"
                     IsVisible="{Binding Tool.IsMultiColoredSections}">
                 <StackPanel>
-                    <TextBlock Text="Section Colors" Foreground="White" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Section Colors" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                     <TextBlock Text="Tap a color to change it"
-                               Foreground="#888" FontSize="11" Margin="0,0,0,8"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,0,0,8"/>
                     <StackPanel Spacing="4">
                         <!-- Row 1: Sections 1-8 -->
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
@@ -383,49 +383,49 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Background="{Binding SectionColor1, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="0"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}">
-                                <TextBlock Text="1" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="1" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor2, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="1"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}">
-                                <TextBlock Text="2" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="2" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor3, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="2"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=2}">
-                                <TextBlock Text="3" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="3" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor4, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="3"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=3}">
-                                <TextBlock Text="4" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="4" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor5, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="4"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=4}">
-                                <TextBlock Text="5" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="5" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor6, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="5"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=5}">
-                                <TextBlock Text="6" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="6" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor7, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="6"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=6}">
-                                <TextBlock Text="7" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="7" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor8, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="7"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=7}">
-                                <TextBlock Text="8" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="8" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                         </StackPanel>
                         <!-- Row 2: Sections 9-16 (only visible when NumSections > 8) -->
@@ -435,49 +435,49 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Background="{Binding SectionColor9, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="8"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=8}">
-                                <TextBlock Text="9" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="9" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor10, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="9"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=9}">
-                                <TextBlock Text="10" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="10" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor11, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="10"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=10}">
-                                <TextBlock Text="11" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="11" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor12, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="11"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=11}">
-                                <TextBlock Text="12" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="12" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor13, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="12"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=12}">
-                                <TextBlock Text="13" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="13" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor14, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="13"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=13}">
-                                <TextBlock Text="14" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="14" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor15, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="14"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=14}">
-                                <TextBlock Text="15" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="15" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                             <Button Width="40" Height="40" CornerRadius="4" Margin="3" Cursor="Hand"
                                     Background="{Binding SectionColor16, Converter={StaticResource UintToBrush}}"
                                     Command="{Binding EditSectionColorCommand}" CommandParameter="15"
                                     IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=15}">
-                                <TextBlock Text="16" Foreground="White" FontWeight="Bold" FontSize="14"/>
+                                <TextBlock Text="16" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="14"/>
                             </Button>
                         </StackPanel>
                     </StackPanel>
@@ -488,25 +488,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow" IsVisible="{Binding !Tool.IsMultiColoredSections}">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel VerticalAlignment="Center">
-                        <TextBlock Text="Coverage Color" Foreground="White"/>
-                        <TextBlock Text="Tap to change the color used for all sections" Foreground="#888" FontSize="12"/>
+                        <TextBlock Text="Coverage Color" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                        <TextBlock Text="Tap to change the color used for all sections" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Width="60" Height="32" CornerRadius="4" Cursor="Hand"
                             Background="{Binding SingleCoverageColor, Converter={StaticResource UintToBrush}}"
-                            BorderBrush="#555" BorderThickness="1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                             Command="{Binding EditSingleCoverageColorCommand}"/>
                 </Grid>
             </Border>
 
             <!-- Additional Settings -->
-            <TextBlock Text="Section Control Options" FontWeight="SemiBold" Foreground="White" Margin="0,16,0,8"/>
+            <TextBlock Text="Section Control Options" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,16,0,8"/>
 
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Section Off When Outside Boundary" Foreground="White"/>
+                        <TextBlock Text="Section Off When Outside Boundary" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Automatically turn off sections outside field boundary"
-                                   Foreground="#888" FontSize="12"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <ToggleSwitch Grid.Column="1" IsChecked="{Binding Tool.IsSectionOffWhenOut}"
                                   OnContent="On" OffContent="Off"/>
@@ -516,9 +516,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Section Off In Headland" Foreground="White"/>
+                        <TextBlock Text="Section Off In Headland" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Automatically turn off sections when entering headland zone"
-                                   Foreground="#888" FontSize="12"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <ToggleSwitch Grid.Column="1" IsChecked="{Binding Tool.IsHeadlandSectionControl}"
                                   OnContent="On" OffContent="Off"/>
@@ -528,12 +528,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Minimum Coverage" Foreground="White"/>
+                        <TextBlock Text="Minimum Coverage" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Minimum % of section in uncovered area to turn on"
-                                   Foreground="#888" FontSize="12"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditMinCoverageCommand}">
-                        <TextBlock Text="{Binding Tool.MinCoverage, StringFormat='{}{0} %'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.MinCoverage, StringFormat='{}{0} %'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -541,12 +541,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Slow Speed Cutoff" Foreground="White"/>
+                        <TextBlock Text="Slow Speed Cutoff" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Speed below which sections turn off"
-                                   Foreground="#888" FontSize="12"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditCutoffSpeedCommand}">
-                        <TextBlock Text="{Binding Tool.SlowSpeedCutoff, StringFormat='{}{0:F1} km/h'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.SlowSpeedCutoff, StringFormat='{}{0:F1} km/h'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>
@@ -554,12 +554,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel>
-                        <TextBlock Text="Coverage Margin" Foreground="White"/>
+                        <TextBlock Text="Coverage Margin" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Expand recorded coverage to prevent gaps between passes"
-                                   Foreground="#888" FontSize="12"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
                     <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditCoverageMarginCommand}">
-                        <TextBlock Text="{Binding Tool.CoverageMargin, StringFormat='{}{0:F0} cm'}" Foreground="White" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding Tool.CoverageMargin, StringFormat='{}{0:F0} cm'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                     </Button>
                 </Grid>
             </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSwitchesSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSwitchesSubTab.axaml
@@ -26,7 +26,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
@@ -45,26 +45,26 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SwitchGroup">
                 <StackPanel Spacing="12">
                     <Grid ColumnDefinitions="*,Auto">
-                        <TextBlock Text="Work Switch" Foreground="White" FontWeight="SemiBold" FontSize="14"/>
+                        <TextBlock Text="Work Switch" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" FontSize="14"/>
                         <ToggleSwitch Grid.Column="1" IsChecked="{Binding Tool.IsWorkSwitchEnabled}"
                                       OnContent="Enabled" OffContent="Disabled"/>
                     </Grid>
                     <TextBlock Text="Physical switch input to control sections"
-                               Foreground="#888" FontSize="12"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
 
                     <!-- Work switch options (visible when enabled) -->
                     <StackPanel Spacing="8" IsVisible="{Binding Tool.IsWorkSwitchEnabled}">
-                        <Border Background="#DD2C3E50" CornerRadius="4" Padding="12">
+                        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="4" Padding="12">
                             <Grid ColumnDefinitions="*,Auto">
                                 <StackPanel>
-                                    <TextBlock Text="Active State" Foreground="White" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                    <TextBlock Text="Active State" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                                     <StackPanel Orientation="Horizontal" Spacing="16">
                                         <RadioButton Content="Active Low (Closed)" GroupName="WorkSwitchActive"
                                                      IsChecked="{Binding Tool.IsWorkSwitchActiveLow}"
-                                                     Foreground="White"/>
+                                                     Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                         <RadioButton Content="Active High (Open)" GroupName="WorkSwitchActive"
                                                      IsChecked="{Binding !Tool.IsWorkSwitchActiveLow}"
-                                                     Foreground="White"/>
+                                                     Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                     </StackPanel>
                                 </StackPanel>
                                 <Panel Grid.Column="1" Width="60" Height="60">
@@ -76,16 +76,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             </Grid>
                         </Border>
 
-                        <Border Background="#DD2C3E50" CornerRadius="4" Padding="12">
+                        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="4" Padding="12">
                             <StackPanel>
-                                <TextBlock Text="Controls" Foreground="White" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                <TextBlock Text="Controls" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                                 <StackPanel Orientation="Horizontal" Spacing="16">
                                     <RadioButton Content="Auto Sections" GroupName="WorkSwitchControl"
                                                  IsChecked="{Binding !Tool.IsWorkSwitchManualSections}"
-                                                 Foreground="White"/>
+                                                 Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                     <RadioButton Content="Manual Sections" GroupName="WorkSwitchControl"
                                                  IsChecked="{Binding Tool.IsWorkSwitchManualSections}"
-                                                 Foreground="White"/>
+                                                 Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                 </StackPanel>
                             </StackPanel>
                         </Border>
@@ -97,25 +97,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SwitchGroup">
                 <StackPanel Spacing="12">
                     <Grid ColumnDefinitions="*,Auto">
-                        <TextBlock Text="Steer Switch" Foreground="White" FontWeight="SemiBold" FontSize="14"/>
+                        <TextBlock Text="Steer Switch" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" FontSize="14"/>
                         <ToggleSwitch Grid.Column="1" IsChecked="{Binding Tool.IsSteerSwitchEnabled}"
                                       OnContent="Enabled" OffContent="Disabled"/>
                     </Grid>
                     <TextBlock Text="Secondary switch input (often linked to autosteer)"
-                               Foreground="#888" FontSize="12"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
 
                     <!-- Steer switch options (visible when enabled) -->
                     <StackPanel Spacing="8" IsVisible="{Binding Tool.IsSteerSwitchEnabled}">
-                        <Border Background="#DD2C3E50" CornerRadius="4" Padding="12">
+                        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="4" Padding="12">
                             <StackPanel>
-                                <TextBlock Text="Controls" Foreground="White" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                <TextBlock Text="Controls" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                                 <StackPanel Orientation="Horizontal" Spacing="16">
                                     <RadioButton Content="Auto Sections" GroupName="SteerSwitchControl"
                                                  IsChecked="{Binding !Tool.IsSteerSwitchManualSections}"
-                                                 Foreground="White"/>
+                                                 Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                     <RadioButton Content="Manual Sections" GroupName="SteerSwitchControl"
                                                  IsChecked="{Binding Tool.IsSteerSwitchManualSections}"
-                                                 Foreground="White"/>
+                                                 Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                 </StackPanel>
                             </StackPanel>
                         </Border>
@@ -127,19 +127,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,8,0,0">
                 <StackPanel Spacing="4">
                     <TextBlock Text="Switch Usage:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Work Switch"/>
                         <Run Text=" - Typically connected to implement hydraulic raise/lower sensor"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Steer Switch"/>
                         <Run Text=" - Secondary input, often tied to autosteer engagement"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Active Low"/>
                         <Run Text=" - Switch is ON when circuit is closed (grounded)"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Active High"/>
                         <Run Text=" - Switch is ON when circuit is open"/>
                     </TextBlock>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSwitchesSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSwitchesSubTab.axaml
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,4"/>
         </Style>
         <Style Selector="Border.SwitchGroup">
-            <Setter Property="Background" Value="#DD1A1A2E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="16"/>
             <Setter Property="Margin" Value="0,8"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
@@ -27,14 +27,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.SettingRow">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
         </Style>
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -55,11 +55,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <gif:GifImage Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/SectionOnLookAhead.gif" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                    <TextBlock Text="Look Ahead On" Foreground="White" FontWeight="SemiBold"/>
-                    <TextBlock Text="Time before entering coverage to turn ON" Foreground="#888" FontSize="11"/>
+                    <TextBlock Text="Look Ahead On" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                    <TextBlock Text="Time before entering coverage to turn ON" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                 </StackPanel>
                 <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditLookAheadOnCommand}" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Tool.LookAheadOnSetting, StringFormat='{}{0:F1} sec'}" Foreground="White" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding Tool.LookAheadOnSetting, StringFormat='{}{0:F1} sec'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                 </Button>
             </Grid>
 
@@ -69,11 +69,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <gif:GifImage Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/SectionLookAheadOff.gif" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                    <TextBlock Text="Look Ahead Off" Foreground="White" FontWeight="SemiBold"/>
-                    <TextBlock Text="Time before leaving coverage to turn OFF" Foreground="#888" FontSize="11"/>
+                    <TextBlock Text="Look Ahead Off" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                    <TextBlock Text="Time before leaving coverage to turn OFF" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                 </StackPanel>
                 <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditLookAheadOffCommand}" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Tool.LookAheadOffSetting, StringFormat='{}{0:F1} sec'}" Foreground="White" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding Tool.LookAheadOffSetting, StringFormat='{}{0:F1} sec'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                 </Button>
             </Grid>
 
@@ -83,11 +83,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <gif:GifImage Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/SectionLookAheadDelay.gif" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                    <TextBlock Text="Turn Off Delay" Foreground="White" FontWeight="SemiBold"/>
-                    <TextBlock Text="Delay before turning OFF (alt to Look Ahead Off)" Foreground="#888" FontSize="11"/>
+                    <TextBlock Text="Turn Off Delay" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                    <TextBlock Text="Delay before turning OFF (alt to Look Ahead Off)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                 </StackPanel>
                 <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditTurnOffDelayCommand}" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Tool.TurnOffDelay, StringFormat='{}{0:F1} sec'}" Foreground="White" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding Tool.TurnOffDelay, StringFormat='{}{0:F1} sec'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                 </Button>
             </Grid>
 
@@ -95,15 +95,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,16,0,0">
                 <StackPanel Spacing="4">
                     <TextBlock Text="Timing Tips:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Look Ahead On"/>
                         <Run Text=" - Increase for slow-responding equipment (spray valves)"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Look Ahead Off"/>
                         <Run Text=" - Cannot exceed 80% of Look Ahead On value"/>
                     </TextBlock>
-                    <TextBlock Foreground="#AAA" FontSize="12" TextWrapping="Wrap">
+                    <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Turn Off Delay"/>
                         <Run Text=" - Alternative to Look Ahead Off (one or the other, not both)"/>
                     </TextBlock>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
@@ -42,7 +42,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>
@@ -51,7 +51,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel Spacing="8" Margin="16,8,16,16">
             <!-- Look Ahead On -->
             <Grid ColumnDefinitions="Auto,*,Auto">
-                <Border Background="#1A1A2E" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
                     <gif:GifImage Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/SectionOnLookAhead.gif" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
@@ -65,7 +65,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- Look Ahead Off -->
             <Grid ColumnDefinitions="Auto,*,Auto">
-                <Border Background="#1A1A2E" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
                     <gif:GifImage Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/SectionLookAheadOff.gif" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">
@@ -79,7 +79,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- Turn Off Delay -->
             <Grid ColumnDefinitions="Auto,*,Auto">
-                <Border Background="#1A1A2E" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4" Width="160" Height="120" Margin="0,0,12,0">
                     <gif:GifImage Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/SectionLookAheadDelay.gif" Stretch="Uniform"/>
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTypeSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTypeSubTab.axaml
@@ -26,7 +26,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="RadioButton.TypeCard">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="16"/>
             <Setter Property="Margin" Value="4"/>
@@ -62,9 +62,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Front Fixed -->
                 <RadioButton Classes="TypeCard" GroupName="ToolType" IsChecked="{Binding Tool.IsToolFrontFixed}">
                     <StackPanel>
-                        <TextBlock Text="Front Fixed" FontWeight="SemiBold" FontSize="14" Foreground="White"/>
+                        <TextBlock Text="Front Fixed" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Front-mounted implement (harvester header, front loader)"
-                                   Foreground="#AAA" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ToolChkFront.png"
                                Height="60" Stretch="Uniform" Margin="0,8,0,0"/>
                     </StackPanel>
@@ -73,9 +73,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Rear Fixed -->
                 <RadioButton Classes="TypeCard" GroupName="ToolType" IsChecked="{Binding Tool.IsToolRearFixed}">
                     <StackPanel>
-                        <TextBlock Text="Rear Fixed" FontWeight="SemiBold" FontSize="14" Foreground="White"/>
+                        <TextBlock Text="Rear Fixed" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="3-point hitch mounted implement (cultivator, planter)"
-                                   Foreground="#AAA" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ToolChkRear.png"
                                Height="60" Stretch="Uniform" Margin="0,8,0,0"/>
                     </StackPanel>
@@ -84,9 +84,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- TBT (Tow Between Tanks) -->
                 <RadioButton Classes="TypeCard" GroupName="ToolType" IsChecked="{Binding Tool.IsToolTBT}">
                     <StackPanel>
-                        <TextBlock Text="TBT (Tow Between)" FontWeight="SemiBold" FontSize="14" Foreground="White"/>
+                        <TextBlock Text="TBT (Tow Between)" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Tool between tractor and tank trailer (sprayer setup)"
-                                   Foreground="#AAA" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ToolChkTBT.png"
                                Height="60" Stretch="Uniform" Margin="0,8,0,0"/>
                     </StackPanel>
@@ -95,9 +95,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Trailing -->
                 <RadioButton Classes="TypeCard" GroupName="ToolType" IsChecked="{Binding Tool.IsToolTrailing}">
                     <StackPanel>
-                        <TextBlock Text="Trailing" FontWeight="SemiBold" FontSize="14" Foreground="White"/>
+                        <TextBlock Text="Trailing" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Towed implement on drawbar (grain drill, air seeder)"
-                                   Foreground="#AAA" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" TextWrapping="Wrap" Margin="0,4,0,0"/>
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ToolChkTrailing.png"
                                Height="60" Stretch="Uniform" Margin="0,8,0,0"/>
                     </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTypeSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTypeSubTab.axaml
@@ -47,10 +47,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Setter>
         </Style>
         <Style Selector="RadioButton.TypeCard:pointerover /template/ Border#PART_Border">
-            <Setter Property="Background" Value="#DD3C4E60"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="RadioButton.TypeCard:checked /template/ Border#PART_Border">
-            <Setter Property="Background" Value="#DD1E8449"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/TramConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/TramConfigTab.axaml
@@ -28,8 +28,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Tappable Value Button -->
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="16,8"/>
@@ -64,7 +64,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Parameter Card -->
         <Style Selector="Border.ParamCard">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="16"/>
         </Style>
@@ -72,7 +72,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,*">
         <!-- Header -->
-        <TextBlock Text="Tram Lines" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="16,12,16,8"/>
+        <TextBlock Text="Tram Lines" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <ScrollViewer Grid.Row="1">
             <!-- Two-column layout -->
@@ -88,15 +88,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Passes Value -->
                         <StackPanel Spacing="4" HorizontalAlignment="Center">
-                            <TextBlock Text="Passes" Foreground="#AAA" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Passes" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" HorizontalAlignment="Center"/>
                             <Button Classes="TappableValue" Command="{Binding EditTramPassesCommand}" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding Guidance.TramPasses}" Foreground="White" FontWeight="Bold" FontSize="24"/>
+                                <TextBlock Text="{Binding Guidance.TramPasses}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
                             </Button>
                         </StackPanel>
 
                         <!-- Display Toggle -->
                         <StackPanel Spacing="4" HorizontalAlignment="Center">
-                            <TextBlock Text="Display" Foreground="#AAA" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Display" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" HorizontalAlignment="Center"/>
                             <Button Classes="ToggleButton"
                                     Background="{Binding Guidance.TramDisplay, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
                                     BorderBrush="{Binding Guidance.TramDisplay, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
@@ -119,9 +119,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Tram Line Value -->
                         <StackPanel Spacing="4" HorizontalAlignment="Center">
-                            <TextBlock Text="Tram Line" Foreground="#AAA" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Tram Line" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" HorizontalAlignment="Center"/>
                             <Button Classes="TappableValue" Command="{Binding EditTramLineCommand}" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding Guidance.TramLine}" Foreground="White" FontWeight="Bold" FontSize="24"/>
+                                <TextBlock Text="{Binding Guidance.TramLine}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
                             </Button>
                         </StackPanel>
                     </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/TramConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/TramConfigTab.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
 
@@ -82,7 +82,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Column="0" Classes="ParamCard" Margin="0,0,8,0">
                     <StackPanel Spacing="16" HorizontalAlignment="Center">
                         <!-- Graphic -->
-                        <Border Background="#1A1A2E" CornerRadius="6" Padding="12" Height="120">
+                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="12" Height="120">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConT_TramOverride.png" Stretch="Uniform"/>
                         </Border>
 
@@ -113,7 +113,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Column="1" Classes="ParamCard" Margin="8,0,0,0">
                     <StackPanel Spacing="16" HorizontalAlignment="Center">
                         <!-- Graphic -->
-                        <Border Background="#1A1A2E" CornerRadius="6" Padding="12" Height="120">
+                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="12" Height="120">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConT_TramSpacing.png" Stretch="Uniform"/>
                         </Border>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
@@ -27,8 +27,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Tappable Value Button -->
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="16,8"/>
@@ -42,7 +42,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Parameter Card -->
         <Style Selector="Border.ParamCard">
-            <Setter Property="Background" Value="#DD253545"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
         </Style>
@@ -50,7 +50,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,*">
         <!-- Header -->
-        <TextBlock Text="U-Turn Settings" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="16,12,16,8"/>
+        <TextBlock Text="U-Turn Settings" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <ScrollViewer Grid.Row="1">
             <!-- 3-Column Layout matching AgOpenGPS -->
@@ -67,12 +67,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Value Display -->
                         <Button Classes="TappableValue" Command="{Binding EditUTurnExtensionCommand}" HorizontalAlignment="Center">
                             <TextBlock Text="{Binding Guidance.UTurnExtension, StringFormat='{}{0:F1} m'}"
-                                       Foreground="White" FontWeight="Bold" FontSize="18"/>
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18"/>
                         </Button>
 
                         <!-- Tip Text -->
                         <TextBlock Text="Set extension length to 2 or 3x Radius"
-                                   Foreground="#AAA" FontSize="11" TextWrapping="Wrap"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" TextWrapping="Wrap"
                                    HorizontalAlignment="Center" TextAlignment="Center"/>
                     </StackPanel>
                 </Border>
@@ -88,12 +88,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Value Display -->
                         <Button Classes="TappableValue" Command="{Binding EditUTurnSmoothingCommand}" HorizontalAlignment="Center">
                             <TextBlock Text="{Binding Guidance.UTurnSmoothing}"
-                                       Foreground="White" FontWeight="Bold" FontSize="18"/>
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18"/>
                         </Button>
 
                         <!-- Tip Text -->
                         <TextBlock Text="Set Smoothing 3-4x Radius"
-                                   Foreground="#AAA" FontSize="11" TextWrapping="Wrap"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" TextWrapping="Wrap"
                                    HorizontalAlignment="Center" TextAlignment="Center"/>
                     </StackPanel>
                 </Border>
@@ -112,8 +112,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Button Classes="TappableValue" Command="{Binding EditUTurnRadiusCommand}" HorizontalAlignment="Center">
                                 <StackPanel>
                                     <TextBlock Text="{Binding Guidance.UTurnRadius, StringFormat='{}{0:F2}'}"
-                                               Foreground="White" FontWeight="Bold" FontSize="18" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="m" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="m" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
@@ -131,8 +131,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Button Classes="TappableValue" Command="{Binding EditUTurnDistanceCommand}" HorizontalAlignment="Center">
                                 <StackPanel>
                                     <TextBlock Text="{Binding Guidance.UTurnDistanceFromBoundary, StringFormat='{}{0:F2}'}"
-                                               Foreground="White" FontWeight="Bold" FontSize="18" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="m" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center"/>
+                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="m" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
 
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Column="0" Classes="ParamCard" Margin="4">
                     <StackPanel Spacing="8" HorizontalAlignment="Center">
                         <!-- Graphic -->
-                        <Border Background="#1A1A2E" CornerRadius="6" Padding="8" Height="120">
+                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Height="120">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConU_UturnLength.png" Stretch="Uniform"/>
                         </Border>
 
@@ -81,7 +81,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Column="1" Classes="ParamCard" Margin="4">
                     <StackPanel Spacing="8" HorizontalAlignment="Center">
                         <!-- Graphic -->
-                        <Border Background="#1A1A2E" CornerRadius="6" Padding="8" Height="120">
+                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Height="120">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConU_UturnSmooth.png" Stretch="Uniform"/>
                         </Border>
 
@@ -104,7 +104,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Border Classes="ParamCard" Margin="4">
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <!-- Graphic -->
-                            <Border Background="#1A1A2E" CornerRadius="6" Padding="8" Height="80">
+                            <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Height="80">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConU_UturnRadius.png" Stretch="Uniform"/>
                             </Border>
 
@@ -123,7 +123,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Border Classes="ParamCard" Margin="4">
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <!-- Graphic -->
-                            <Border Background="#1A1A2E" CornerRadius="6" Padding="8" Height="80">
+                            <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Height="80">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConU_UturnDistance.png" Stretch="Uniform"/>
                             </Border>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
@@ -63,13 +63,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="#DD2A3A4A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
             <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="TextBlock.LargeValue">
             <Setter Property="FontSize" Value="32"/>
             <Setter Property="FontWeight" Value="Bold"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="HorizontalAlignment" Value="Center"/>
         </Style>
         <Style Selector="TextBlock.UnitLabel">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
@@ -38,24 +38,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="MinHeight" Value="56"/>
         </Style>
         <Style Selector="TabControl.VehicleSubTabs > TabItem:selected">
-            <Setter Property="Background" Value="#DD4A9A7E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TabControl.VehicleSubTabs > TabItem:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
 
         <!-- Value boxes -->
         <Style Selector="Border.ValueBox">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="MinWidth" Value="80"/>
         </Style>
         <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="#DD1E2A38"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -74,18 +74,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="TextBlock.UnitLabel">
             <Setter Property="FontSize" Value="14"/>
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
         <Style Selector="TextBlock.SectionLabel">
             <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="HorizontalAlignment" Value="Center"/>
         </Style>
     </UserControl.Styles>
 
     <!-- Nested TabControl for vehicle sub-sections -->
-    <TabControl Classes="VehicleSubTabs" TabStripPlacement="Left" Background="#DD2C3E50">
+    <TabControl Classes="VehicleSubTabs" TabStripPlacement="Left" Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
         <!-- Summary Tab -->
         <TabItem ToolTip.Tip="Vehicle Summary">
             <TabItem.Header>
@@ -95,55 +95,55 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <ScrollViewer>
                 <StackPanel Spacing="8" Margin="16">
                     <TextBlock Text="{Binding SelectedProfileName, StringFormat='Current: {0}'}"
-                               FontSize="24" FontWeight="Bold" Foreground="White"
+                               FontSize="24" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                HorizontalAlignment="Center" Margin="0,0,0,20"/>
 
                     <!-- Summary grid -->
                     <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                           HorizontalAlignment="Center" Width="400">
-                        <TextBlock Grid.Row="0" Text="Units:" Foreground="#AAA" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Row="0" Text="Units:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                         <TextBlock Grid.Row="0" Grid.Column="1"
                                    Text="{Binding Config.IsMetric, Converter={x:Static conv:BoolToStringConverter.Instance}, ConverterParameter='Metric|Imperial'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
 
-                        <TextBlock Grid.Row="1" Text="Width:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="1" Text="Width:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Tool.Width, StringFormat='{}{0:F2} m'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
 
-                        <TextBlock Grid.Row="2" Text="Sections:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="2" Text="Sections:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Config.NumSections}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
 
-                        <TextBlock Grid.Row="3" Text="Offset:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="3" Text="Offset:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Offset, StringFormat='{}{0:F2} m'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
 
-                        <TextBlock Grid.Row="4" Text="Overlap:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="4" Text="Overlap:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Tool.Overlap, StringFormat='{}{0:F2} m'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
 
-                        <TextBlock Grid.Row="5" Text="Look Ahead:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="5" Text="Look Ahead:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Tool.LookAheadOnSetting, StringFormat='{}{0:F1} s'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
 
-                        <TextBlock Grid.Row="6" Text="Nudge:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="6" Text="Nudge:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="6" Grid.Column="1" Text="7.9 in"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
 
-                        <TextBlock Grid.Row="7" Text="Tram Width:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="7" Text="Tram Width:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding Vehicle.TrackWidth, StringFormat='{}{0:F2} m'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
 
-                        <TextBlock Grid.Row="8" Text="Wheelbase:" Foreground="#AAA" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                        <TextBlock Grid.Row="8" Text="Wheelbase:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                         <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding Vehicle.Wheelbase, StringFormat='{}{0:F2} m'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" Margin="0,8,0,0"/>
                     </Grid>
 
                     <!-- Info banner -->
-                    <Border Background="#3498DB" CornerRadius="8" Padding="16,12" Margin="0,24,0,0"
+                    <Border Background="{DynamicResource SystemControlHighlightAccentBrush}" CornerRadius="8" Padding="16,12" Margin="0,24,0,0"
                             HorizontalAlignment="Center">
                         <TextBlock Text="Vehicle settings are now called &quot;profiles&quot; and can be&#x0a;created/loaded in the main menu (top left)."
-                                   Foreground="White" TextAlignment="Center" FontSize="14"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" TextAlignment="Center" FontSize="14"/>
                     </Border>
                 </StackPanel>
             </ScrollViewer>
@@ -157,7 +157,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </TabItem.Header>
             <ScrollViewer>
                 <StackPanel Spacing="16" Margin="16">
-                    <TextBlock Text="Select Vehicle Type" FontSize="18" FontWeight="SemiBold" Foreground="White"
+                    <TextBlock Text="Select Vehicle Type" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                HorizontalAlignment="Center" Margin="0,0,0,8"/>
 
                     <!-- Vehicle type selector -->
@@ -169,17 +169,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 BorderBrush="{Binding Vehicle.Type, Converter={x:Static conv:EnumToSelectionBrushConverter.Instance}, ConverterParameter=Harvester}">
                             <Button.Styles>
                                 <Style Selector="Button">
-                                    <Setter Property="Background" Value="#DD34495E"/>
+                                    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                 </Style>
                                 <Style Selector="Button:pointerover">
-                                    <Setter Property="Background" Value="#DD475A6E"/>
+                                    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                 </Style>
                             </Button.Styles>
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/vehiclePageHarvester.png"
                                        Width="80" Height="60" Stretch="Uniform"/>
                                 <TextBlock Text="Harvester" FontSize="14" FontWeight="SemiBold"
-                                           Foreground="White" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center" Margin="0,8,0,0"/>
                             </StackPanel>
                         </Button>
 
@@ -190,17 +190,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 BorderBrush="{Binding Vehicle.Type, Converter={x:Static conv:EnumToSelectionBrushConverter.Instance}, ConverterParameter=Tractor}">
                             <Button.Styles>
                                 <Style Selector="Button">
-                                    <Setter Property="Background" Value="#DD34495E"/>
+                                    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                 </Style>
                                 <Style Selector="Button:pointerover">
-                                    <Setter Property="Background" Value="#DD475A6E"/>
+                                    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                 </Style>
                             </Button.Styles>
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/vehiclePageTractor.png"
                                        Width="80" Height="60" Stretch="Uniform"/>
                                 <TextBlock Text="Tractor" FontSize="14" FontWeight="SemiBold"
-                                           Foreground="White" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center" Margin="0,8,0,0"/>
                             </StackPanel>
                         </Button>
 
@@ -211,17 +211,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 BorderBrush="{Binding Vehicle.Type, Converter={x:Static conv:EnumToSelectionBrushConverter.Instance}, ConverterParameter=FourWD}">
                             <Button.Styles>
                                 <Style Selector="Button">
-                                    <Setter Property="Background" Value="#DD34495E"/>
+                                    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                 </Style>
                                 <Style Selector="Button:pointerover">
-                                    <Setter Property="Background" Value="#DD475A6E"/>
+                                    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                 </Style>
                             </Button.Styles>
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/vehiclePageArticulated.png"
                                        Width="80" Height="60" Stretch="Uniform"/>
                                 <TextBlock Text="Articulated" FontSize="14" FontWeight="SemiBold"
-                                           Foreground="White" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center" Margin="0,8,0,0"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>
@@ -230,11 +230,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Border Background="#4A9A7E" CornerRadius="8" Padding="16,12"
                             HorizontalAlignment="Center" Margin="0,24,0,0">
                         <TextBlock Text="{Binding Vehicle.VehicleTypeDisplayName, StringFormat='Selected: {0}'}"
-                                   Foreground="White" FontWeight="Bold" FontSize="16"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                     </Border>
 
                     <TextBlock Text="Select your vehicle type to configure appropriate steering geometry and dimensions."
-                               Foreground="#AAA" FontSize="13" TextWrapping="Wrap"
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13" TextWrapping="Wrap"
                                HorizontalAlignment="Center" MaxWidth="500" TextAlignment="Center"
                                Margin="0,16,0,0"/>
                 </StackPanel>
@@ -337,7 +337,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                     <!-- Offset selector buttons: Left = antenna left of center (negative), Right = antenna right of center (positive) -->
                     <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Left" Margin="0,8,0,0">
-                        <Button Width="50" Height="36" Padding="4" Background="#DD34495E" ToolTip.Tip="Antenna Left of Center"
+                        <Button Width="50" Height="36" Padding="4" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" ToolTip.Tip="Antenna Left of Center"
                                 Command="{Binding SetAntennaOffsetLeftCommand}">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AntennaLeftOffset.png" Stretch="Uniform"/>
                         </Button>
@@ -345,7 +345,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 Command="{Binding SetAntennaOffsetCenterCommand}">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AntennaNoOffset.png" Stretch="Uniform"/>
                         </Button>
-                        <Button Width="50" Height="36" Padding="4" Background="#DD34495E" ToolTip.Tip="Antenna Right of Center"
+                        <Button Width="50" Height="36" Padding="4" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" ToolTip.Tip="Antenna Right of Center"
                                 Command="{Binding SetAntennaOffsetRightCommand}">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AntennaRightOffset.png" Stretch="Uniform"/>
                         </Button>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -147,7 +147,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </TabControl>
 
                 <!-- Numeric Input Overlay -->
-                <Border Grid.Row="1" Background="#CC000000"
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                         IsVisible="{Binding IsNumericInputVisible}"
                         ZIndex="100">
                     <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"
@@ -177,7 +177,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Grid.Styles>
                                     <Style Selector="Button.KeypadButton">
                                         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-                                        <Setter Property="Foreground" Value="White"/>
+                                        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                         <Setter Property="FontSize" Value="24"/>
                                         <Setter Property="FontWeight" Value="Bold"/>
                                         <Setter Property="CornerRadius" Value="8"/>
@@ -188,10 +188,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                     </Style>
                                     <Style Selector="Button.ClearButton">
-                                        <Setter Property="Background" Value="#DD8E5526"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                     </Style>
                                     <Style Selector="Button.ClearButton:pointerover">
-                                        <Setter Property="Background" Value="#DDA96B30"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
                                     </Style>
                                 </Grid.Styles>
 
@@ -254,7 +254,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Border>
 
                 <!-- Text Input Overlay -->
-                <Border Grid.Row="1" Background="#CC000000"
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                         IsVisible="{Binding IsTextInputVisible}"
                         ZIndex="100">
                     <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"
@@ -281,7 +281,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <Grid.Styles>
                                     <Style Selector="Button.KeyButton">
                                         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-                                        <Setter Property="Foreground" Value="White"/>
+                                        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                         <Setter Property="FontSize" Value="18"/>
                                         <Setter Property="FontWeight" Value="Bold"/>
                                         <Setter Property="CornerRadius" Value="6"/>
@@ -294,10 +294,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                     </Style>
                                     <Style Selector="Button.SpecialKey">
-                                        <Setter Property="Background" Value="#DD8E5526"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                     </Style>
                                     <Style Selector="Button.SpecialKey:pointerover">
-                                        <Setter Property="Background" Value="#DDA96B30"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
                                     </Style>
                                 </Grid.Styles>
 
@@ -390,7 +390,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Border>
 
                 <!-- Color Picker Overlay -->
-                <Border Grid.Row="1" Background="#CC000000"
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                         IsVisible="{Binding IsColorPickerVisible}"
                         ZIndex="100">
                     <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -33,17 +33,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="Transparent"/>
         </Style>
         <Style Selector="TabControl.MainConfigTabs > TabItem">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Padding" Value="12"/>
             <Setter Property="Margin" Value="0,2"/>
             <Setter Property="MinWidth" Value="64"/>
             <Setter Property="MinHeight" Value="64"/>
         </Style>
         <Style Selector="TabControl.MainConfigTabs > TabItem:selected">
-            <Setter Property="Background" Value="#DD4A9A7E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TabControl.MainConfigTabs > TabItem:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -54,24 +54,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Full screen modal overlay -->
     <Grid Background="#80000000">
         <!-- Main dialog container - fixed size to prevent resizing on tab switch -->
-        <Border Background="#DD1E2A38"
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 CornerRadius="8"
                 Margin="20"
                 Width="900"
                 Height="720"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 BoxShadow="0 8 32 #80000000">
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Header with title -->
-                <Border Grid.Row="0" Background="#DD2C3E50" Padding="16,8">
-                    <TextBlock Text="Configuration" FontSize="18" FontWeight="Bold" Foreground="White"/>
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,8">
+                    <TextBlock Text="Configuration" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                 </Border>
 
                 <!-- Main content area with TabControl -->
-                <TabControl Grid.Row="1" Classes="MainConfigTabs" TabStripPlacement="Left" Background="#DD253545"
+                <TabControl Grid.Row="1" Classes="MainConfigTabs" TabStripPlacement="Left" Background="{DynamicResource SystemControlBackgroundListLowBrush}"
                             HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <!-- Vehicle Tab -->
                     <TabItem ToolTip.Tip="Vehicle">
@@ -150,25 +150,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Row="1" Background="#CC000000"
                         IsVisible="{Binding IsNumericInputVisible}"
                         ZIndex="100">
-                    <Border Background="#DD1E2A38" CornerRadius="12" Padding="20"
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"
                             Width="360" Height="440"
                             HorizontalAlignment="Center" VerticalAlignment="Center"
-                            BorderBrush="#555" BorderThickness="1">
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
                         <Grid RowDefinitions="Auto,Auto,*,Auto">
                             <!-- Title -->
                             <TextBlock Grid.Row="0" Text="{Binding NumericInputTitle}"
-                                       FontSize="20" FontWeight="Bold" Foreground="White"
+                                       FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                        HorizontalAlignment="Center" Margin="0,0,0,12"/>
 
                             <!-- Value Display -->
-                            <Border Grid.Row="1" Background="#DD2C3E50" CornerRadius="6"
+                            <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="6"
                                     Padding="20,16" Margin="0,0,0,16" MinWidth="280">
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
                                     <TextBlock Text="{Binding NumericInputDisplayText}"
-                                               FontSize="42" FontWeight="Bold" Foreground="White"
+                                               FontSize="42" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                MinWidth="120" TextAlignment="Right"/>
                                     <TextBlock Text="{Binding NumericInputUnit}"
-                                               FontSize="24" Foreground="#AAA" VerticalAlignment="Bottom" Margin="0,0,0,6"/>
+                                               FontSize="24" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Bottom" Margin="0,0,0,6"/>
                                 </StackPanel>
                             </Border>
 
@@ -176,7 +176,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Grid Grid.Row="2" ColumnDefinitions="*,*,*,*" RowDefinitions="*,*,*,*" Margin="0,0,0,16">
                                 <Grid.Styles>
                                     <Style Selector="Button.KeypadButton">
-                                        <Setter Property="Background" Value="#DD34495E"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         <Setter Property="Foreground" Value="White"/>
                                         <Setter Property="FontSize" Value="24"/>
                                         <Setter Property="FontWeight" Value="Bold"/>
@@ -185,7 +185,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         <Setter Property="Cursor" Value="Hand"/>
                                     </Style>
                                     <Style Selector="Button.KeypadButton:pointerover">
-                                        <Setter Property="Background" Value="#DD475A6E"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                     </Style>
                                     <Style Selector="Button.ClearButton">
                                         <Setter Property="Background" Value="#DD8E5526"/>
@@ -236,13 +236,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                             <!-- Action Buttons -->
                             <Grid Grid.Row="3" ColumnDefinitions="*,*" ColumnSpacing="8">
-                                <Button Grid.Column="0" Background="#E74C3C" Foreground="White"
+                                <Button Grid.Column="0" Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding CancelNumericInputCommand}"
                                         HorizontalContentAlignment="Center">
                                     <TextBlock Text="Cancel"/>
                                 </Button>
-                                <Button Grid.Column="1" Background="#4A9A7E" Foreground="White"
+                                <Button Grid.Column="1" Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding ConfirmNumericInputCommand}"
                                         HorizontalContentAlignment="Center">
@@ -257,21 +257,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Row="1" Background="#CC000000"
                         IsVisible="{Binding IsTextInputVisible}"
                         ZIndex="100">
-                    <Border Background="#DD1E2A38" CornerRadius="12" Padding="20"
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"
                             Width="500" Height="520"
                             HorizontalAlignment="Center" VerticalAlignment="Center"
-                            BorderBrush="#555" BorderThickness="1">
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
                         <Grid RowDefinitions="Auto,Auto,*,Auto">
                             <!-- Title -->
                             <TextBlock Grid.Row="0" Text="{Binding TextInputTitle}"
-                                       FontSize="20" FontWeight="Bold" Foreground="White"
+                                       FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                        HorizontalAlignment="Center" Margin="0,0,0,12"/>
 
                             <!-- Value Display -->
-                            <Border Grid.Row="1" Background="#DD2C3E50" CornerRadius="6"
+                            <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="6"
                                     Padding="16,12" Margin="0,0,0,16" MinWidth="400">
                                 <TextBlock Text="{Binding TextInputValue}"
-                                           FontSize="24" FontWeight="Bold" Foreground="White"
+                                           FontSize="24" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                            TextAlignment="Left" TextWrapping="NoWrap"
                                            MinHeight="32"/>
                             </Border>
@@ -280,7 +280,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Grid Grid.Row="2" RowDefinitions="*,*,*,*,Auto" Margin="0,0,0,16">
                                 <Grid.Styles>
                                     <Style Selector="Button.KeyButton">
-                                        <Setter Property="Background" Value="#DD34495E"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         <Setter Property="Foreground" Value="White"/>
                                         <Setter Property="FontSize" Value="18"/>
                                         <Setter Property="FontWeight" Value="Bold"/>
@@ -291,7 +291,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         <Setter Property="MinHeight" Value="44"/>
                                     </Style>
                                     <Style Selector="Button.KeyButton:pointerover">
-                                        <Setter Property="Background" Value="#DD475A6E"/>
+                                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
                                     </Style>
                                     <Style Selector="Button.SpecialKey">
                                         <Setter Property="Background" Value="#DD8E5526"/>
@@ -372,13 +372,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                             <!-- Action Buttons -->
                             <Grid Grid.Row="3" ColumnDefinitions="*,*" ColumnSpacing="8">
-                                <Button Grid.Column="0" Background="#E74C3C" Foreground="White"
+                                <Button Grid.Column="0" Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding CancelTextInputCommand}"
                                         HorizontalContentAlignment="Center">
                                     <TextBlock Text="Cancel"/>
                                 </Button>
-                                <Button Grid.Column="1" Background="#4A9A7E" Foreground="White"
+                                <Button Grid.Column="1" Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding ConfirmTextInputCommand}"
                                         HorizontalContentAlignment="Center">
@@ -393,14 +393,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Row="1" Background="#CC000000"
                         IsVisible="{Binding IsColorPickerVisible}"
                         ZIndex="100">
-                    <Border Background="#DD1E2A38" CornerRadius="12" Padding="20"
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="20"
                             Width="340" Height="360"
                             HorizontalAlignment="Center" VerticalAlignment="Center"
-                            BorderBrush="#555" BorderThickness="1">
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
                         <Grid RowDefinitions="Auto,*,Auto">
                             <!-- Title -->
                             <TextBlock Grid.Row="0" Text="{Binding ColorPickerTitle}"
-                                       FontSize="20" FontWeight="Bold" Foreground="White"
+                                       FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                        HorizontalAlignment="Center" Margin="0,0,0,16"/>
 
                             <!-- Color Grid (4x4) -->
@@ -456,7 +456,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             </UniformGrid>
 
                             <!-- Cancel Button -->
-                            <Button Grid.Row="2" Background="#E74C3C" Foreground="White"
+                            <Button Grid.Row="2" Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                     FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                     Command="{Binding CancelColorPickerCommand}"
                                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center">
@@ -467,24 +467,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Border>
 
                 <!-- Footer with profile info and action buttons -->
-                <Border Grid.Row="2" Background="#DD2C3E50" Padding="16,12">
+                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,12">
                     <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto">
                         <!-- Current profile -->
                         <TextBlock Text="{Binding Config.ActiveProfileName, StringFormat='Profile: {0}'}"
-                                   Foreground="White" FontWeight="Bold" VerticalAlignment="Center"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" VerticalAlignment="Center"/>
 
                         <!-- Units display -->
                         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" Margin="0,0,24,0">
-                            <TextBlock Text="Units:" Foreground="#AAA" VerticalAlignment="Center"/>
+                            <TextBlock Text="Units:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                             <TextBlock Text="{Binding Display.IsMetric, Converter={x:Static conv:BoolToStringConverter.Instance}, ConverterParameter='Metric|Imperial'}"
                                        Foreground="#4A9" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Width display -->
                         <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8" Margin="0,0,24,0">
-                            <TextBlock Text="Width:" Foreground="#AAA" VerticalAlignment="Center"/>
+                            <TextBlock Text="Width:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                             <TextBlock Text="{Binding Tool.Width, StringFormat='{}{0:F2} m'}"
-                                       Foreground="White" FontWeight="Bold" VerticalAlignment="Center"/>
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Apply button (checkmark) -->
@@ -492,7 +492,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 Background="#4A9A7E" CornerRadius="24"
                                 Command="{Binding ApplyCommand}"
                                 ToolTip.Tip="Apply and Close">
-                            <TextBlock Text="✓" FontSize="24" Foreground="White" FontWeight="Bold"
+                            <TextBlock Text="✓" FontSize="24" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"
                                        HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Button>
                     </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="20"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="320" MaxWidth="400">
             <StackPanel Spacing="16">
@@ -42,7 +42,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Message -->
                 <TextBlock Text="{Binding ConfirmationDialogMessage}" FontSize="14"
-                           Foreground="White" TextWrapping="Wrap"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" TextWrapping="Wrap"
                            HorizontalAlignment="Center" TextAlignment="Center"
                            Margin="0,8"/>
 
@@ -50,12 +50,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="*,*" Margin="0,12,0,0">
                     <Button Grid.Column="0" Content="No" Margin="0,0,8,0"
                             Command="{Binding CancelConfirmationDialogCommand}"
-                            Background="#7F8C8D" Foreground="White"
+                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="50" FontSize="18" FontWeight="Bold"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="1" Content="Yes" Margin="8,0,0,0"
                             Command="{Binding ConfirmConfirmationDialogCommand}"
-                            Background="#E74C3C" Foreground="White"
+                            Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="50" FontSize="18" FontWeight="Bold"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/DataIODialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/DataIODialogPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Modern Panel Style -->
         <Style Selector="Border.Panel">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="15"/>
             <Setter Property="Margin" Value="0,0,0,15"/>
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Modern Button Style -->
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,6"/>
@@ -73,13 +73,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Label Style -->
         <Style Selector="TextBlock.Label">
-            <Setter Property="Foreground" Value="#BDC3C7"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
             <Setter Property="FontSize" Value="14"/>
         </Style>
 
         <!-- Header Style -->
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#3498DB"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="16"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,10"/>
@@ -94,7 +94,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 BorderThickness="0" CornerRadius="0"/>
 
         <!-- Dialog Content -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="0"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="0"
                 MinWidth="500" MaxWidth="800"
                 Margin="20,40,20,40"
                 HorizontalAlignment="Center" VerticalAlignment="Stretch"
@@ -102,15 +102,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Header -->
-                <Border Grid.Row="0" Background="#34495E" CornerRadius="12,12,0,0" Padding="20,15">
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="12,12,0,0" Padding="20,15">
                     <Grid ColumnDefinitions="*,Auto">
                         <StackPanel>
-                            <TextBlock Text="Data I/O Configuration" Foreground="White" FontSize="20" FontWeight="Bold"/>
-                            <TextBlock Text="Network and GPS settings" Foreground="#BDC3C7" FontSize="13" Margin="0,5,0,0"/>
+                            <TextBlock Text="Data I/O Configuration" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="20" FontWeight="Bold"/>
+                            <TextBlock Text="Network and GPS settings" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,5,0,0"/>
                         </StackPanel>
                         <Button Grid.Column="1" Background="Transparent" BorderThickness="0"
                                 Command="{Binding CloseDataIODialogCommand}" Cursor="Hand" VerticalAlignment="Top">
-                            <TextBlock Text="✕" Foreground="#BDC3C7" FontSize="20"/>
+                            <TextBlock Text="✕" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="20"/>
                         </Button>
                     </Grid>
                 </Border>
@@ -126,7 +126,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                                 <Grid ColumnDefinitions="140,*">
                                     <TextBlock Classes="Label" Text="Network Status:" VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1" Text="{Binding NetworkStatus}" Foreground="White" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding NetworkStatus}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                 </Grid>
                             </StackPanel>
                         </Border>
@@ -143,7 +143,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                              Fill="{Binding State.Connections.IsAutoSteerDataOk, Converter={StaticResource BoolToColorConverter}}"/>
                                     <TextBlock Grid.Column="2"
                                                Text="{Binding State.Connections.IsAutoSteerDataOk, Converter={StaticResource BoolToStatusConverter}}"
-                                               Foreground="White" VerticalAlignment="Center"/>
+                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
 
                                     <!-- Machine -->
                                     <TextBlock Grid.Row="1" Classes="Label" Text="Machine:" VerticalAlignment="Center" Margin="0,8,0,0"/>
@@ -151,7 +151,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                              Fill="{Binding State.Connections.IsMachineDataOk, Converter={StaticResource BoolToColorConverter}}"/>
                                     <TextBlock Grid.Row="1" Grid.Column="2" Margin="0,8,0,0"
                                                Text="{Binding State.Connections.IsMachineDataOk, Converter={StaticResource BoolToStatusConverter}}"
-                                               Foreground="White" VerticalAlignment="Center"/>
+                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
 
                                     <!-- IMU -->
                                     <TextBlock Grid.Row="2" Classes="Label" Text="IMU:" VerticalAlignment="Center" Margin="0,8,0,0"/>
@@ -159,7 +159,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                              Fill="{Binding State.Connections.IsImuDataOk, Converter={StaticResource BoolToColorConverter}}"/>
                                     <TextBlock Grid.Row="2" Grid.Column="2" Margin="0,8,0,0"
                                                Text="{Binding State.Connections.IsImuDataOk, Converter={StaticResource BoolToStatusConverter}}"
-                                               Foreground="White" VerticalAlignment="Center"/>
+                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                 </Grid>
                             </StackPanel>
                         </Border>
@@ -171,22 +171,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                                 <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
                                     <TextBlock Classes="Label" Text="Status:"/>
-                                    <TextBlock Grid.Column="1" Text="{Binding StatusMessage}" Foreground="White"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding StatusMessage}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
 
                                     <TextBlock Grid.Row="1" Classes="Label" Text="Fix Quality:" Margin="0,6,0,0"/>
-                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding State.Vehicle.FixQualityText}" Foreground="White" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding State.Vehicle.FixQualityText}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
                                     <TextBlock Grid.Row="2" Classes="Label" Text="Satellites:" Margin="0,6,0,0"/>
-                                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding State.Vehicle.SatelliteCount}" Foreground="White" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding State.Vehicle.SatelliteCount}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
                                     <TextBlock Grid.Row="3" Classes="Label" Text="Latitude:" Margin="0,6,0,0"/>
-                                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding State.Vehicle.Latitude, StringFormat='{}{0:F6}°'}" Foreground="White" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding State.Vehicle.Latitude, StringFormat='{}{0:F6}°'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
                                     <TextBlock Grid.Row="4" Classes="Label" Text="Longitude:" Margin="0,6,0,0"/>
-                                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding State.Vehicle.Longitude, StringFormat='{}{0:F6}°'}" Foreground="White" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding State.Vehicle.Longitude, StringFormat='{}{0:F6}°'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
                                     <TextBlock Grid.Row="5" Classes="Label" Text="Speed:" Margin="0,6,0,0"/>
-                                    <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding State.Vehicle.Speed, StringFormat='{}{0:F2} m/s'}" Foreground="White" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding State.Vehicle.Speed, StringFormat='{}{0:F2} m/s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
                                 </Grid>
                             </StackPanel>
                         </Border>
@@ -194,7 +194,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </ScrollViewer>
 
                 <!-- Footer -->
-                <Border Grid.Row="2" Background="#34495E" CornerRadius="0,0,12,12" Padding="15">
+                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="0,0,12,12" Padding="15">
                     <Button Classes="ModernButton" Content="Close"
                             Command="{Binding CloseDataIODialogCommand}"
                             HorizontalAlignment="Stretch" Background="#27AE60"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/DataIODialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/DataIODialogPanel.axaml
@@ -38,7 +38,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Modern Button Style -->
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,6"/>
             <Setter Property="BorderThickness" Value="0"/>
@@ -49,14 +49,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2980B9"/>
         </Style>
         <Style Selector="Button.ModernButton:pressed">
-            <Setter Property="Background" Value="#21618C"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
 
         <!-- Input Field Button Style (tappable fields that show keyboard) -->
         <Style Selector="Button.DataIOInput">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -65,10 +65,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.DataIOInput:pointerover">
-            <Setter Property="Background" Value="#2A3940"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.DataIOInput:pressed">
-            <Setter Property="Background" Value="#3A4950"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
         </Style>
 
         <!-- Label Style -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <Style Selector="Button.ModeButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
             <Setter Property="MinWidth" Value="100"/>
@@ -38,7 +38,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModeButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ModeButton:pressed">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -46,7 +46,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.CancelButton">
             <Setter Property="Background" Value="#C0392B"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
             <Setter Property="MinWidth" Value="100"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
@@ -28,7 +28,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.ModeButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
@@ -64,17 +64,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Draw AB panel - centered -->
-        <Border Background="#2C3E50" CornerRadius="12"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 Padding="20" BoxShadow="0 8 32 #40000000">
             <StackPanel Spacing="16">
                 <!-- Title -->
                 <TextBlock Text="Draw Track on Map"
-                           Foreground="White" FontSize="18" FontWeight="Bold"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" FontWeight="Bold"
                            HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Tap on the map to place points"
-                           Foreground="#BDC3C7" FontSize="14"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14"
                            HorizontalAlignment="Center"/>
 
                 <!-- Mode selection buttons -->
@@ -86,7 +86,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
                             <TextBlock Text="Straight" FontSize="12" HorizontalAlignment="Center"/>
-                            <TextBlock Text="(2 pts)" FontSize="10" Foreground="#BDC3C7" HorizontalAlignment="Center"/>
+                            <TextBlock Text="(2 pts)" FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -97,7 +97,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackCurve.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
                             <TextBlock Text="Curve" FontSize="12" HorizontalAlignment="Center"/>
-                            <TextBlock Text="(3+ pts)" FontSize="10" Foreground="#BDC3C7" HorizontalAlignment="Center"/>
+                            <TextBlock Text="(3+ pts)" FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -113,14 +113,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </StackPanel>
 
                 <!-- Instructions for straight line -->
-                <Border Background="#34495E" CornerRadius="8" Padding="12">
+                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="8" Padding="12">
                     <StackPanel Spacing="4">
-                        <TextBlock Text="Straight Line:" Foreground="White" FontWeight="Bold" FontSize="13"/>
+                        <TextBlock Text="Straight Line:" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="13"/>
                         <TextBlock Text="Tap 2 points to create a straight AB line"
-                                   Foreground="#BDC3C7" FontSize="12"/>
-                        <TextBlock Text="Curve:" Foreground="White" FontWeight="Bold" FontSize="13" Margin="0,8,0,0"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
+                        <TextBlock Text="Curve:" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="13" Margin="0,8,0,0"/>
                         <TextBlock Text="Tap 3+ points, then tap Finish in the status bar"
-                                   Foreground="#BDC3C7" FontSize="12"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                     </StackPanel>
                 </Border>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ErrorDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ErrorDialogPanel.axaml
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="20"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="320" MaxWidth="450">
             <StackPanel Spacing="16">
@@ -42,14 +42,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Message -->
                 <TextBlock Text="{Binding ErrorDialogMessage}" FontSize="14"
-                           Foreground="White" TextWrapping="Wrap"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" TextWrapping="Wrap"
                            HorizontalAlignment="Center" TextAlignment="Center"
                            Margin="0,8"/>
 
                 <!-- OK Button -->
                 <Button Content="OK" Margin="0,12,0,0"
                         Command="{Binding DismissErrorDialogCommand}"
-                        Background="#3498DB" Foreground="White"
+                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Center" Width="120" Height="50"
                         FontSize="18" FontWeight="Bold"
                         HorizontalContentAlignment="Center" CornerRadius="6"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
@@ -28,13 +28,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#3498DB"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -70,10 +70,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="ListBoxItem:pointerover">
-            <Setter Property="Background" Value="#2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -84,9 +84,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
@@ -99,12 +99,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Grid.Row="0" Classes="Header" Text="Select Field to Open"/>
 
                 <!-- Column Headers -->
-                <Border Grid.Row="1" Background="#34495E" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
                     <Grid ColumnDefinitions="*,120,80,80">
-                        <TextBlock Grid.Column="0" Text="Field Name" Foreground="#BDC3C7" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="1" Text="NTRIP Profile" Foreground="#BDC3C7" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="2" Text="Distance" Foreground="#BDC3C7" FontWeight="SemiBold" TextAlignment="Right"/>
-                        <TextBlock Grid.Column="3" Text="Area (ha)" Foreground="#BDC3C7" FontWeight="SemiBold" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="0" Text="Field Name" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="1" Text="NTRIP Profile" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="2" Text="Distance" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="3" Text="Area (ha)" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Right"/>
                     </Grid>
                 </Border>
 
@@ -119,11 +119,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Grid ColumnDefinitions="*,120,80,80">
-                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="White" FontSize="14"/>
-                                <TextBlock Grid.Column="1" Text="{Binding NtripProfileName}" Foreground="#7F8C8D" FontSize="13"
+                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"/>
+                                <TextBlock Grid.Column="1" Text="{Binding NtripProfileName}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"
                                            TextTrimming="CharacterEllipsis"/>
-                                <TextBlock Grid.Column="2" Text="{Binding Distance, StringFormat='{}{0:F1}'}" Foreground="#BDC3C7" TextAlignment="Right" FontSize="14"/>
-                                <TextBlock Grid.Column="3" Text="{Binding Area, StringFormat='{}{0:F1}'}" Foreground="#BDC3C7" TextAlignment="Right" FontSize="14"/>
+                                <TextBlock Grid.Column="2" Text="{Binding Distance, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" TextAlignment="Right" FontSize="14"/>
+                                <TextBlock Grid.Column="3" Text="{Binding Area, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" TextAlignment="Right" FontSize="14"/>
                             </Grid>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
@@ -35,7 +35,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="FontSize" Value="14"/>
@@ -47,10 +47,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2980B9"/>
         </Style>
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#5D6D7E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#4A5A6A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.DangerButton">
             <Setter Property="Background" Value="#E74C3C"/>
@@ -59,8 +59,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#C0392B"/>
         </Style>
         <Style Selector="ListBox">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
@@ -1,0 +1,80 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.FlagByLatLonDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsFlagByLatLonDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsFlagByLatLonDialogVisible}">
+
+    <Grid>
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <Border Background="#2C3E50" CornerRadius="12" Padding="24"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                MinWidth="400" MaxWidth="500">
+            <StackPanel Spacing="16">
+                <TextBlock Text="Place Flag by Lat/Lon" FontSize="20" FontWeight="Bold"
+                           Foreground="#3498DB" HorizontalAlignment="Center"/>
+
+                <TextBlock Text="Enter WGS84 coordinates in decimal degrees"
+                           FontSize="12" Foreground="#95A5A6" HorizontalAlignment="Center"/>
+
+                <Separator Height="1" Background="#444"/>
+
+                <!-- Latitude -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Latitude (-90 to 90)" Foreground="#BDC3C7" FontSize="13"/>
+                    <TextBox Text="{Binding FlagLatitudeInput, Mode=TwoWay}"
+                             Watermark="e.g. 43.123456"
+                             FontSize="16" Padding="8,6"
+                             Background="#1A252F" Foreground="White"
+                             BorderBrush="#555" CornerRadius="4"/>
+                </StackPanel>
+
+                <!-- Longitude -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Longitude (-180 to 180)" Foreground="#BDC3C7" FontSize="13"/>
+                    <TextBox Text="{Binding FlagLongitudeInput, Mode=TwoWay}"
+                             Watermark="e.g. -80.654321"
+                             FontSize="16" Padding="8,6"
+                             Background="#1A252F" Foreground="White"
+                             BorderBrush="#555" CornerRadius="4"/>
+                </StackPanel>
+
+                <!-- Error message -->
+                <TextBlock Text="{Binding FlagByLatLonError}"
+                           Foreground="#E74C3C" FontSize="12"
+                           IsVisible="{Binding FlagByLatLonError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                           HorizontalAlignment="Center"/>
+
+                <Separator Height="1" Background="#444"/>
+
+                <!-- Buttons -->
+                <Grid ColumnDefinitions="*,12,*">
+                    <Button Grid.Column="0" Content="Cancel"
+                            Command="{Binding CloseFlagByLatLonDialogCommand}"
+                            Background="#7F8C8D" Foreground="White"
+                            HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
+                            HorizontalContentAlignment="Center" CornerRadius="6"/>
+                    <Button Grid.Column="2" Content="Place Flag"
+                            Command="{Binding PlaceFlagByLatLonCommand}"
+                            Background="#27AE60" Foreground="White"
+                            HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
+                            HorizontalContentAlignment="Center" CornerRadius="6"/>
+                </Grid>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
@@ -27,7 +27,7 @@ the Free Software Foundation, either version 3 of the License, or
                 MinWidth="400" MaxWidth="500">
             <StackPanel Spacing="16">
                 <TextBlock Text="Place Flag by Lat/Lon" FontSize="20" FontWeight="Bold"
-                           Foreground="#3498DB" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Enter WGS84 coordinates in decimal degrees"
                            FontSize="12"
@@ -62,18 +62,18 @@ the Free Software Foundation, either version 3 of the License, or
                            IsVisible="{Binding FlagByLatLonError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                            HorizontalAlignment="Center"/>
 
-                <Separator Height="1" Background="#444"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
 
                 <!-- Buttons -->
                 <Grid ColumnDefinitions="*,12,*">
                     <Button Grid.Column="0" Content="Cancel"
                             Command="{Binding CloseFlagByLatLonDialogCommand}"
-                            Background="#7F8C8D" Foreground="White"
+                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="2" Content="Place Flag"
                             Command="{Binding PlaceFlagByLatLonCommand}"
-                            Background="#27AE60" Foreground="White"
+                            Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
@@ -21,7 +21,8 @@ the Free Software Foundation, either version 3 of the License, or
     <Grid>
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="#2C3E50" CornerRadius="12" Padding="24"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                CornerRadius="12" Padding="24"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="400" MaxWidth="500">
             <StackPanel Spacing="16">
@@ -29,28 +30,30 @@ the Free Software Foundation, either version 3 of the License, or
                            Foreground="#3498DB" HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Enter WGS84 coordinates in decimal degrees"
-                           FontSize="12" Foreground="#95A5A6" HorizontalAlignment="Center"/>
+                           FontSize="12"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                           HorizontalAlignment="Center"/>
 
-                <Separator Height="1" Background="#444"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
 
                 <!-- Latitude -->
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Latitude (-90 to 90)" Foreground="#BDC3C7" FontSize="13"/>
+                    <TextBlock Text="Latitude (-90 to 90)"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                               FontSize="13"/>
                     <TextBox Text="{Binding FlagLatitudeInput, Mode=TwoWay}"
                              Watermark="e.g. 43.123456"
-                             FontSize="16" Padding="8,6"
-                             Background="#1A252F" Foreground="White"
-                             BorderBrush="#555" CornerRadius="4"/>
+                             FontSize="16" Padding="8,6"/>
                 </StackPanel>
 
                 <!-- Longitude -->
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Longitude (-180 to 180)" Foreground="#BDC3C7" FontSize="13"/>
+                    <TextBlock Text="Longitude (-180 to 180)"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                               FontSize="13"/>
                     <TextBox Text="{Binding FlagLongitudeInput, Mode=TwoWay}"
                              Watermark="e.g. -80.654321"
-                             FontSize="16" Padding="8,6"
-                             Background="#1A252F" Foreground="White"
-                             BorderBrush="#555" CornerRadius="4"/>
+                             FontSize="16" Padding="8,6"/>
                 </StackPanel>
 
                 <!-- Error message -->
@@ -67,12 +70,12 @@ the Free Software Foundation, either version 3 of the License, or
                             Command="{Binding CloseFlagByLatLonDialogCommand}"
                             Background="#7F8C8D" Foreground="White"
                             HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
-                            HorizontalContentAlignment="Center" CornerRadius="6"/>
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="2" Content="Place Flag"
                             Command="{Binding PlaceFlagByLatLonCommand}"
                             Background="#27AE60" Foreground="White"
                             HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
-                            HorizontalContentAlignment="Center" CornerRadius="6"/>
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>
             </StackPanel>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml.cs
@@ -1,0 +1,28 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class FlagByLatLonDialogPanel : UserControl
+{
+    public FlagByLatLonDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CloseFlagByLatLonDialogCommand?.Execute(null);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
@@ -28,13 +28,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#3498DB"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="20"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -59,7 +59,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2ECC71"/>
         </Style>
         <Style Selector="Button.ToolButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
@@ -91,35 +91,35 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="ListBoxItem:pointerover">
-            <Setter Property="Background" Value="#2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
 
         <Style Selector="TextBox.DialogInput">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#7F8C8D"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="FontSize" Value="16"/>
             <Setter Property="CaretBrush" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#3498DB"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput /template/ TextBlock">
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -128,7 +128,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
                 MaxWidth="650"
                 MaxHeight="550"
@@ -141,7 +141,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Grid.Row="0" Classes="Header" Text="Create Field From Existing"/>
 
                 <!-- Column Headers -->
-                <Border Grid.Row="1" Background="#34495E" CornerRadius="4,4,0,0" Padding="12,8">
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8">
                     <Grid ColumnDefinitions="*,80,80">
                         <TextBlock Grid.Column="0" Text="Field Name" Foreground="#E74C3C" FontWeight="Bold" FontSize="14"/>
                         <TextBlock Grid.Column="1" Text="Distance" Foreground="#E74C3C" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
@@ -159,9 +159,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Grid ColumnDefinitions="*,80,80">
-                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="White" FontSize="14"/>
-                                <TextBlock Grid.Column="1" Text="{Binding Distance, StringFormat='{}{0:F1}'}" Foreground="#BDC3C7" TextAlignment="Right" FontSize="14"/>
-                                <TextBlock Grid.Column="2" Text="{Binding Area, StringFormat='{}{0:F1}'}" Foreground="#BDC3C7" TextAlignment="Right" FontSize="14"/>
+                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"/>
+                                <TextBlock Grid.Column="1" Text="{Binding Distance, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" TextAlignment="Right" FontSize="14"/>
+                                <TextBlock Grid.Column="2" Text="{Binding Area, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" TextAlignment="Right" FontSize="14"/>
                             </Grid>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
@@ -169,7 +169,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Name input row -->
                 <StackPanel Grid.Row="3" Margin="0,12,0,0" Spacing="6">
-                    <TextBlock Text="New Field Name:" Foreground="#BDC3C7" FontSize="13"/>
+                    <TextBlock Text="New Field Name:" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBox Grid.Column="0"
                                  Classes="DialogInput"
@@ -186,7 +186,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid Grid.Row="4" ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto,Auto,Auto" Margin="0,12,0,0">
                     <!-- Name append buttons -->
                     <StackPanel Grid.Column="0" Orientation="Horizontal">
-                        <TextBlock Text="+" Foreground="White" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="+" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button Classes="ToolButton" Width="48" Height="48"
                                 Command="{Binding AppendVehicleNameCommand}" ToolTip.Tip="Append vehicle name">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/vehiclePageTractor.png" Width="32" Height="32"/>
@@ -194,7 +194,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="4,0,0,0">
-                        <TextBlock Text="+" Foreground="White" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="+" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button Classes="ToolButton" Width="48" Height="48"
                                 Command="{Binding AppendDateCommand}" ToolTip.Tip="Append date">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/JobNameCalendar.png" Width="32" Height="32"/>
@@ -202,7 +202,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="4,0,0,0">
-                        <TextBlock Text="+" Foreground="White" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="+" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button Classes="ToolButton" Width="48" Height="48"
                                 Command="{Binding AppendTimeCommand}" ToolTip.Tip="Append time">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/JobNameTime.png" Width="32" Height="32"/>
@@ -218,7 +218,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyFlagsCommand}" ToolTip.Tip="Include Flags">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FlagRed.png" Width="24" Height="24"/>
-                            <TextBlock Text="Flags" Foreground="White" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Flags" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -227,7 +227,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyMappingCommand}" ToolTip.Tip="Include Mapping">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/MappingOn.png" Width="24" Height="24"/>
-                            <TextBlock Text="Map" Foreground="White" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Map" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -236,7 +236,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyHeadlandCommand}" ToolTip.Tip="Include Headland">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandOn.png" Width="24" Height="24"/>
-                            <TextBlock Text="Head" Foreground="White" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Head" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -245,7 +245,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyLinesCommand}" ToolTip.Tip="Include AB Lines">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png" Width="24" Height="24"/>
-                            <TextBlock Text="Lines" Foreground="White" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Lines" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
@@ -35,7 +35,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="FontSize" Value="14"/>
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="MinWidth" Value="50"/>
@@ -68,7 +68,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderThickness" Value="0"/>
         </Style>
         <Style Selector="Button.ToolButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ToolButton:pressed">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -80,8 +80,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2ECC71"/>
         </Style>
         <Style Selector="ListBox">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
@@ -99,7 +99,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="TextBox.DialogInput">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
@@ -108,15 +108,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput /template/ TextBlock">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandBuilderDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandBuilderDialogPanel.axaml
@@ -50,11 +50,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Spacing="12" IsVisible="{Binding HasBoundary}">
 
                     <!-- Distance Setting -->
-                    <Border Background="#1a1a1a" CornerRadius="8" Padding="12">
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Padding="12">
                         <StackPanel Spacing="8">
                             <TextBlock Text="Headland Distance (meters)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto,Auto">
-                                <Border Grid.Column="0" Background="#333" CornerRadius="6" Padding="12,8">
+                                <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundListLowBrush}" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandDistance, StringFormat={}{0:F1}}"
                                                FontSize="24" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                HorizontalAlignment="Center"/>
@@ -77,11 +77,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
 
                     <!-- Passes Setting -->
-                    <Border Background="#1a1a1a" CornerRadius="8" Padding="12">
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Padding="12">
                         <StackPanel Spacing="8">
                             <TextBlock Text="Number of Passes" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto">
-                                <Border Grid.Column="0" Background="#333" CornerRadius="6" Padding="12,8">
+                                <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundListLowBrush}" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandPasses}"
                                                FontSize="24" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                HorizontalAlignment="Center"/>
@@ -99,7 +99,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
 
                     <!-- Preview indicator -->
-                    <Border Background="#1a1a1a" CornerRadius="8" Padding="12"
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Padding="12"
                             IsVisible="{Binding HeadlandPreviewLine, Converter={x:Static ObjectConverters.IsNotNull}}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
                             <Ellipse Width="12" Height="12" Fill="#F39C12"/>
@@ -108,7 +108,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
 
                     <!-- Current headland status -->
-                    <Border Background="#1a1a1a" CornerRadius="8" Padding="12"
+                    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Padding="12"
                             IsVisible="{Binding HasHeadland}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
                             <Ellipse Width="12" Height="12" Fill="#1ABC9C"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandBuilderDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandBuilderDialogPanel.axaml
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="16"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="16"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="320" MaxWidth="400">
             <StackPanel Spacing="12">
@@ -52,23 +52,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Distance Setting -->
                     <Border Background="#1a1a1a" CornerRadius="8" Padding="12">
                         <StackPanel Spacing="8">
-                            <TextBlock Text="Headland Distance (meters)" Foreground="#AAA" FontSize="12"/>
+                            <TextBlock Text="Headland Distance (meters)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto,Auto">
                                 <Border Grid.Column="0" Background="#333" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandDistance, StringFormat={}{0:F1}}"
-                                               FontSize="24" FontWeight="Bold" Foreground="White"
+                                               FontSize="24" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                HorizontalAlignment="Center"/>
                                 </Border>
                                 <StackPanel Grid.Column="1" Margin="8,0,0,0" Spacing="2">
                                     <Button Content="▲" Width="36" Height="28" FontSize="12"
-                                            Background="#34495E" Foreground="White" CornerRadius="4"
+                                            Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="4"
                                             Command="{Binding IncrementHeadlandDistanceCommand}"/>
                                     <Button Content="▼" Width="36" Height="28" FontSize="12"
-                                            Background="#34495E" Foreground="White" CornerRadius="4"
+                                            Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="4"
                                             Command="{Binding DecrementHeadlandDistanceCommand}"/>
                                 </StackPanel>
                                 <Button Grid.Column="2" Content="Tool Width" Width="80" Height="58"
-                                        FontSize="11" Background="#2980B9" Foreground="White"
+                                        FontSize="11" Background="#2980B9" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         CornerRadius="6" Margin="8,0,0,0"
                                         Command="{Binding SetHeadlandToToolWidthCommand}"
                                         ToolTip.Tip="Set distance to implement width"/>
@@ -79,19 +79,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Passes Setting -->
                     <Border Background="#1a1a1a" CornerRadius="8" Padding="12">
                         <StackPanel Spacing="8">
-                            <TextBlock Text="Number of Passes" Foreground="#AAA" FontSize="12"/>
+                            <TextBlock Text="Number of Passes" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto">
                                 <Border Grid.Column="0" Background="#333" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandPasses}"
-                                               FontSize="24" FontWeight="Bold" Foreground="White"
+                                               FontSize="24" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                HorizontalAlignment="Center"/>
                                 </Border>
                                 <StackPanel Grid.Column="1" Margin="8,0,0,0" Spacing="2">
                                     <Button Content="▲" Width="36" Height="28" FontSize="12"
-                                            Background="#34495E" Foreground="White" CornerRadius="4"
+                                            Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="4"
                                             Command="{Binding IncrementHeadlandPassesCommand}"/>
                                     <Button Content="▼" Width="36" Height="28" FontSize="12"
-                                            Background="#34495E" Foreground="White" CornerRadius="4"
+                                            Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="4"
                                             Command="{Binding DecrementHeadlandPassesCommand}"/>
                                 </StackPanel>
                             </Grid>
@@ -121,18 +121,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="*,*,*" Margin="0,8,0,0" IsVisible="{Binding HasBoundary}">
                     <Button Grid.Column="0" Content="Clear" Margin="0,0,4,0"
                             Command="{Binding ClearHeadlandCommand}"
-                            Background="#E74C3C" Foreground="White"
+                            Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="14"
                             HorizontalContentAlignment="Center" CornerRadius="6"
                             IsEnabled="{Binding HasHeadland}"/>
                     <Button Grid.Column="1" Content="Build" Margin="4,0,4,0"
                             Command="{Binding BuildHeadlandCommand}"
-                            Background="#1ABC9C" Foreground="White"
+                            Background="#1ABC9C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="14"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="2" Content="Close" Margin="4,0,0,0"
                             Command="{Binding CloseHeadlandBuilderCommand}"
-                            Background="#7F8C8D" Foreground="White"
+                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="14"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>
@@ -140,7 +140,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Close button for when no boundary -->
                 <Button Content="Close" Margin="0,8,0,0"
                         Command="{Binding CloseHeadlandBuilderCommand}"
-                        Background="#7F8C8D" Foreground="White"
+                        Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="44" FontSize="14"
                         HorizontalContentAlignment="Center" CornerRadius="6"
                         IsVisible="{Binding !HasBoundary}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandDialogPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="MinHeight" Value="50"/>
@@ -38,7 +38,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ToolButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ToolButton:pressed">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -46,7 +46,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.ActionButton">
             <Setter Property="Background" Value="#27AE60"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="MinHeight" Value="50"/>
@@ -59,7 +59,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.DangerButton">
             <Setter Property="Background" Value="#C0392B"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="MinHeight" Value="50"/>
@@ -72,7 +72,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="ToggleButton.ModeButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="MinHeight" Value="60"/>
@@ -80,7 +80,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="ToggleButton.ModeButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="ToggleButton.ModeButton:checked">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -114,7 +114,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
 
                     <!-- Canvas showing boundary and headland -->
-                    <Border Grid.Row="1" Background="#1a1a1a" CornerRadius="0,0,0,12" ClipToBounds="True">
+                    <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="0,0,0,12" ClipToBounds="True">
                         <controls:DrawingContextMapControl x:Name="HeadlandMapControl"
                                                            ShowVehicle="False"
                                                            IsGridVisible="False"
@@ -144,7 +144,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         </Style>
                                         <Style Selector="RadioButton:pointerover">
-                                            <Setter Property="Background" Value="#4A6278"/>
+                                            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         </Style>
                                         <Style Selector="RadioButton:checked">
                                             <Setter Property="Background" Value="#1ABC9C"/>
@@ -169,7 +169,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         </Style>
                                         <Style Selector="RadioButton:pointerover">
-                                            <Setter Property="Background" Value="#4A6278"/>
+                                            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         </Style>
                                         <Style Selector="RadioButton:checked">
                                             <Setter Property="Background" Value="#1ABC9C"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandDialogPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.ToolButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
@@ -71,7 +71,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
 
         <Style Selector="ToggleButton.ModeButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
@@ -92,7 +92,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50" CornerRadius="12" Margin="20" BoxShadow="0 8 32 #40000000">
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Margin="20" BoxShadow="0 8 32 #40000000">
             <Grid ColumnDefinitions="*,280">
                 <!-- Left: Boundary/Headland Canvas -->
                 <Grid Grid.Column="0">
@@ -102,14 +102,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Grid.RowDefinitions>
 
                     <!-- Header -->
-                    <Border Grid.Row="0" Background="#34495E" Padding="15" CornerRadius="12,0,0,0">
+                    <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Padding="15" CornerRadius="12,0,0,0">
                         <Grid ColumnDefinitions="Auto,*,Auto">
                             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="10">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandOn.png" Width="24" Height="24"/>
                                 <TextBlock Text="Headland Editor" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18" VerticalAlignment="Center"/>
                             </StackPanel>
                             <TextBlock Grid.Column="2" Text="Click 2 points on the boundary to define headland line"
-                                       Foreground="#BDC3C7" FontSize="13" VerticalAlignment="Center"/>
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" VerticalAlignment="Center"/>
                         </Grid>
                     </Border>
 
@@ -123,12 +123,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Grid>
 
                 <!-- Right: Control Panel -->
-                <Border Grid.Column="1" Background="#34495E" Padding="12" CornerRadius="0,12,12,0">
+                <Border Grid.Column="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Padding="12" CornerRadius="0,12,12,0">
                     <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
 
                         <!-- Track Type Selection -->
                         <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,12">
-                            <TextBlock Text="Track Type" Foreground="#BDC3C7" FontSize="12"/>
+                            <TextBlock Text="Track Type" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,*" Height="60">
                                 <RadioButton Grid.Column="0" GroupName="HeadlandTrackType" HorizontalAlignment="Stretch"
                                              IsChecked="{Binding IsHeadlandCurveMode}" Margin="0,0,4,0">
@@ -141,7 +141,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </RadioButton.Template>
                                     <RadioButton.Styles>
                                         <Style Selector="RadioButton">
-                                            <Setter Property="Background" Value="#34495E"/>
+                                            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         </Style>
                                         <Style Selector="RadioButton:pointerover">
                                             <Setter Property="Background" Value="#4A6278"/>
@@ -152,7 +152,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </RadioButton.Styles>
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackCurve.png" Width="32" Height="32"/>
-                                        <TextBlock Text="Curve" FontSize="10" HorizontalAlignment="Center" Foreground="White"/>
+                                        <TextBlock Text="Curve" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                     </StackPanel>
                                 </RadioButton>
                                 <RadioButton Grid.Column="1" GroupName="HeadlandTrackType" HorizontalAlignment="Stretch"
@@ -166,7 +166,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </RadioButton.Template>
                                     <RadioButton.Styles>
                                         <Style Selector="RadioButton">
-                                            <Setter Property="Background" Value="#34495E"/>
+                                            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
                                         </Style>
                                         <Style Selector="RadioButton:pointerover">
                                             <Setter Property="Background" Value="#4A6278"/>
@@ -177,7 +177,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </RadioButton.Styles>
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAB.png" Width="32" Height="32"/>
-                                        <TextBlock Text="Line" FontSize="10" HorizontalAlignment="Center" Foreground="White"/>
+                                        <TextBlock Text="Line" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                     </StackPanel>
                                 </RadioButton>
                             </Grid>
@@ -185,20 +185,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Distance Setting -->
                         <StackPanel Grid.Row="1" Spacing="8" Margin="0,0,0,12">
-                            <TextBlock Text="Headland Distance" Foreground="#BDC3C7" FontSize="12"/>
+                            <TextBlock Text="Headland Distance" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto">
-                                <Border Grid.Column="0" Background="#2C3E50" CornerRadius="6" Padding="12,8">
+                                <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandDistance, StringFormat={}{0:F1} m}"
-                                               FontSize="20" FontWeight="Bold" Foreground="White"
+                                               FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                 </Border>
                                 <StackPanel Grid.Column="1" Margin="8,0,0,0" Spacing="4">
                                     <Button Content="+" Width="36" Height="24" FontSize="16" FontWeight="Bold"
-                                            Background="#2C3E50" Foreground="White" CornerRadius="4" Padding="0"
+                                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="4" Padding="0"
                                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                                             Command="{Binding IncrementHeadlandDistanceCommand}"/>
                                     <Button Content="-" Width="36" Height="24" FontSize="16" FontWeight="Bold"
-                                            Background="#2C3E50" Foreground="White" CornerRadius="4" Padding="0"
+                                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="4" Padding="0"
                                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                                             Command="{Binding DecrementHeadlandDistanceCommand}"/>
                                 </StackPanel>
@@ -207,15 +207,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Tool Width Multiplier -->
                         <StackPanel Grid.Row="2" Spacing="8" Margin="0,0,0,12">
-                            <TextBlock Text="Tool Widths" Foreground="#BDC3C7" FontSize="12"/>
+                            <TextBlock Text="Tool Widths" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto">
-                                <Border Grid.Column="0" Background="#2C3E50" CornerRadius="6" Padding="8">
+                                <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="6" Padding="8">
                                     <TextBlock Text="{Binding HeadlandCalculatedWidth, StringFormat={}{0:F2} m}"
                                                FontSize="14" Foreground="#1ABC9C"
                                                HorizontalAlignment="Center" VerticalAlignment="Center"/>
                                 </Border>
                                 <ComboBox Grid.Column="1" Width="60" Margin="8,0,0,0" FontSize="16"
-                                          Background="#2C3E50" Foreground="White"
+                                          Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                           SelectedIndex="{Binding HeadlandToolWidthMultiplier}">
                                     <ComboBoxItem>0</ComboBoxItem>
                                     <ComboBoxItem>1</ComboBoxItem>
@@ -278,7 +278,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandSectionOff.png"
                                            Width="28" Height="28" IsVisible="{Binding !IsHeadlandSectionControlled}"/>
                                 </Panel>
-                                <TextBlock Text="Section Control" VerticalAlignment="Center" Foreground="White"/>
+                                <TextBlock Text="Section Control" VerticalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                             </StackPanel>
                         </ToggleButton>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <Style Selector="Button.HotkeyButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="MinWidth" Value="60"/>
             <Setter Property="Height" Value="32"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.HotkeyButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="MinWidth" Value="60"/>
@@ -42,7 +42,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.HotkeyButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -51,19 +51,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="20"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="420" MaxWidth="520" MaxHeight="650">
             <StackPanel Spacing="12">
                 <!-- Title -->
                 <TextBlock Text="Hotkey Configuration" FontSize="20" FontWeight="Bold"
-                           Foreground="White" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Click a key button, then press a new key to reassign."
-                           FontSize="12" Foreground="#AAA" HorizontalAlignment="Center"
+                           FontSize="12" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"
                            TextWrapping="Wrap" TextAlignment="Center"/>
 
-                <Separator Height="1" Background="#444" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Scrollable hotkey list -->
                 <ScrollViewer MaxHeight="440" VerticalScrollBarVisibility="Auto">
@@ -72,18 +72,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
                 </ScrollViewer>
 
-                <Separator Height="1" Background="#444" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Bottom buttons -->
                 <Grid ColumnDefinitions="*,Auto,Auto">
                     <Button Grid.Column="1" Content="Reset Defaults" Margin="0,0,8,0"
                             Command="{Binding ResetHotkeysToDefaultCommand}"
-                            Background="#E67E22" Foreground="White"
+                            Background="#E67E22" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Width="130" Height="40" FontSize="14"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="2" Content="OK"
                             Command="{Binding CloseHotkeyConfigDialogCommand}"
-                            Background="#3498DB" Foreground="White"
+                            Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Width="80" Height="40" FontSize="16" FontWeight="Bold"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
@@ -35,7 +35,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="FontSize" Value="14"/>
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="MinWidth" Value="48"/>
@@ -68,11 +68,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderThickness" Value="0"/>
         </Style>
         <Style Selector="Button.ToolButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="ListBox">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
@@ -90,7 +90,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="TextBox.DialogInput">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
@@ -99,15 +99,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput /template/ TextBlock">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
@@ -34,7 +34,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -59,7 +59,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2ECC71"/>
         </Style>
         <Style Selector="Button.ToolButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
@@ -82,35 +82,35 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="ListBoxItem:pointerover">
-            <Setter Property="Background" Value="#2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
 
         <Style Selector="TextBox.DialogInput">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#7F8C8D"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="FontSize" Value="16"/>
             <Setter Property="CaretBrush" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#3498DB"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput /template/ TextBlock">
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -119,7 +119,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
                 MaxWidth="500"
                 MaxHeight="480"
@@ -136,7 +136,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Info text -->
                 <TextBlock Grid.Row="1" Text="Place ISO-XML folders (containing TASKDATA.xml) in Documents/AgValoniaGPS/Import"
-                           Foreground="#95A5A6" FontSize="12" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="12" TextWrapping="Wrap" Margin="0,0,0,8"/>
 
                 <!-- ISO-XML Folders ListBox -->
                 <ListBox Grid.Row="2"
@@ -148,7 +148,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Grid ColumnDefinitions="*,Auto">
-                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="White" FontSize="14"/>
+                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"/>
                                 <TextBlock Grid.Column="1" Text="TASKDATA" Foreground="#E67E22" FontSize="11"
                                            IsVisible="{Binding IsTaskData}"/>
                             </Grid>
@@ -158,7 +158,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Field name input -->
                 <StackPanel Grid.Row="3" Margin="0,12,0,0" Spacing="6">
-                    <TextBlock Text="New Field Name:" Foreground="#BDC3C7" FontSize="13"/>
+                    <TextBlock Text="New Field Name:" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBox Grid.Column="0"
                                  Classes="DialogInput"
@@ -174,7 +174,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Append buttons -->
                 <Grid Grid.Row="4" ColumnDefinitions="Auto,Auto,*" Margin="0,10,0,0">
                     <StackPanel Grid.Column="0" Orientation="Horizontal">
-                        <TextBlock Text="+" Foreground="White" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="+" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button Classes="ToolButton" Width="48" Height="48"
                                 Command="{Binding IsoXmlAppendDateCommand}" ToolTip.Tip="Append date">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/JobNameCalendar.png" Width="32" Height="32"/>
@@ -182,7 +182,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="8,0,0,0">
-                        <TextBlock Text="+" Foreground="White" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="+" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button Classes="ToolButton" Width="48" Height="48"
                                 Command="{Binding IsoXmlAppendTimeCommand}" ToolTip.Tip="Append time">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/JobNameTime.png" Width="32" Height="32"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
@@ -35,7 +35,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="FontSize" Value="14"/>
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="MinWidth" Value="48"/>
@@ -68,11 +68,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderThickness" Value="0"/>
         </Style>
         <Style Selector="Button.ToolButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="ListBox">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
@@ -90,7 +90,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="TextBox.DialogInput">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
@@ -99,15 +99,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput /template/ TextBlock">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
@@ -34,7 +34,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -59,7 +59,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2ECC71"/>
         </Style>
         <Style Selector="Button.ToolButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8"/>
@@ -82,35 +82,35 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="ListBoxItem:pointerover">
-            <Setter Property="Background" Value="#2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
 
         <Style Selector="TextBox.DialogInput">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#7F8C8D"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="FontSize" Value="16"/>
             <Setter Property="CaretBrush" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#3498DB"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput /template/ TextBlock">
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -119,7 +119,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
                 MaxWidth="550"
                 MaxHeight="550"
@@ -136,7 +136,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Info text -->
                 <TextBlock Grid.Row="1" Text="Place KML files in Documents/AgValoniaGPS/Import"
-                           Foreground="#95A5A6" FontSize="12" Margin="0,0,0,8"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="12" Margin="0,0,0,8"/>
 
                 <!-- KML Files ListBox -->
                 <ListBox Grid.Row="2"
@@ -148,27 +148,27 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Grid ColumnDefinitions="*,Auto">
-                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="White" FontSize="14"/>
-                                <TextBlock Grid.Column="1" Text="{Binding FileSizeDisplay}" Foreground="#BDC3C7" FontSize="12"/>
+                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"/>
+                                <TextBlock Grid.Column="1" Text="{Binding FileSizeDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                             </Grid>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
 
                 <!-- KML Info display -->
-                <Border Grid.Row="3" Background="#34495E" CornerRadius="6" Padding="12" Margin="0,10,0,0">
+                <Border Grid.Row="3" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="12" Margin="0,10,0,0">
                     <StackPanel Spacing="4">
                         <StackPanel Orientation="Horizontal" Spacing="20">
-                            <TextBlock Foreground="White" FontSize="13">
-                                <Run Text="Points: " Foreground="#95A5A6"/>
+                            <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13">
+                                <Run Text="Points: " Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                                 <Run Text="{Binding KmlBoundaryPointCount}" Foreground="#1ABC9C"/>
                             </TextBlock>
-                            <TextBlock Foreground="White" FontSize="13">
-                                <Run Text="Lat: " Foreground="#95A5A6"/>
+                            <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13">
+                                <Run Text="Lat: " Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                                 <Run Text="{Binding KmlCenterLatitude, StringFormat='{}{0:F6}'}"/>
                             </TextBlock>
-                            <TextBlock Foreground="White" FontSize="13">
-                                <Run Text="Lon: " Foreground="#95A5A6"/>
+                            <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13">
+                                <Run Text="Lon: " Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                                 <Run Text="{Binding KmlCenterLongitude, StringFormat='{}{0:F6}'}"/>
                             </TextBlock>
                         </StackPanel>
@@ -177,7 +177,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Field name input -->
                 <StackPanel Grid.Row="4" Margin="0,12,0,0" Spacing="6">
-                    <TextBlock Text="New Field Name:" Foreground="#BDC3C7" FontSize="13"/>
+                    <TextBlock Text="New Field Name:" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBox Grid.Column="0"
                                  Classes="DialogInput"
@@ -193,7 +193,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Append buttons -->
                 <Grid Grid.Row="5" ColumnDefinitions="Auto,Auto,*" Margin="0,10,0,0">
                     <StackPanel Grid.Column="0" Orientation="Horizontal">
-                        <TextBlock Text="+" Foreground="White" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="+" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button Classes="ToolButton" Width="48" Height="48"
                                 Command="{Binding KmlAppendDateCommand}" ToolTip.Tip="Append date">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/JobNameCalendar.png" Width="32" Height="32"/>
@@ -201,7 +201,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="8,0,0,0">
-                        <TextBlock Text="+" Foreground="White" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <TextBlock Text="+" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button Classes="ToolButton" Width="48" Height="48"
                                 Command="{Binding KmlAppendTimeCommand}" ToolTip.Tip="Append time">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/JobNameTime.png" Width="32" Height="32"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
@@ -1,0 +1,92 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:logging="clr-namespace:AgValoniaGPS.Services.Logging;assembly=AgValoniaGPS.Services"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.LogViewerDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsLogViewerDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsLogViewerDialogVisible}">
+
+    <Grid>
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <Border Background="#2C3E50" CornerRadius="12" Padding="0"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                Width="750" Height="520">
+            <Grid RowDefinitions="Auto,Auto,*,Auto">
+                <!-- Header -->
+                <Border Grid.Row="0" Background="#1A252F" CornerRadius="12,12,0,0" Padding="16,12">
+                    <TextBlock Text="Application Log" FontSize="18" FontWeight="Bold"
+                               Foreground="#3498DB" HorizontalAlignment="Center"/>
+                </Border>
+
+                <!-- Filter bar -->
+                <Border Grid.Row="1" Background="#253545" Padding="12,8">
+                    <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
+                        <Button Content="Debug" Padding="10,4" CornerRadius="4"
+                                Background="#34495E" Foreground="White" FontSize="12"
+                                Command="{Binding SetLogFilterCommand}" CommandParameter="Debug"/>
+                        <Button Content="Info" Padding="10,4" CornerRadius="4"
+                                Background="#2980B9" Foreground="White" FontSize="12"
+                                Command="{Binding SetLogFilterCommand}" CommandParameter="Information"/>
+                        <Button Content="Warning" Padding="10,4" CornerRadius="4"
+                                Background="#F39C12" Foreground="White" FontSize="12"
+                                Command="{Binding SetLogFilterCommand}" CommandParameter="Warning"/>
+                        <Button Content="Error" Padding="10,4" CornerRadius="4"
+                                Background="#E74C3C" Foreground="White" FontSize="12"
+                                Command="{Binding SetLogFilterCommand}" CommandParameter="Error"/>
+                        <Border Width="1" Background="#555" Margin="4,0"/>
+                        <Button Content="Clear" Padding="10,4" CornerRadius="4"
+                                Background="#7F8C8D" Foreground="White" FontSize="12"
+                                Command="{Binding ClearLogEntriesCommand}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Log entries list -->
+                <Border Grid.Row="2" Margin="8" Background="#1A252F" CornerRadius="6" Padding="4">
+                    <ListBox ItemsSource="{Binding FilteredLogEntries}"
+                             Background="Transparent" BorderThickness="0">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="logging:LogEntry">
+                                <Grid ColumnDefinitions="140,70,*" Margin="2,1">
+                                    <TextBlock Grid.Column="0"
+                                               Text="{Binding Timestamp, StringFormat='{}{0:HH:mm:ss.fff}'}"
+                                               Foreground="#7F8C8D" FontSize="11" FontFamily="Consolas"
+                                               VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding Level}"
+                                               FontSize="11" FontWeight="SemiBold" FontFamily="Consolas"
+                                               VerticalAlignment="Center"
+                                               Margin="4,0"/>
+                                    <TextBlock Grid.Column="2"
+                                               Text="{Binding Message}"
+                                               Foreground="#ECF0F1" FontSize="11" FontFamily="Consolas"
+                                               TextWrapping="Wrap" VerticalAlignment="Center"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Border>
+
+                <!-- Close button -->
+                <Button Grid.Row="3" Content="Close" Margin="16,4,16,12"
+                        Command="{Binding CloseLogViewerDialogCommand}"
+                        Background="#3498DB" Foreground="White"
+                        HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
+                        HorizontalContentAlignment="Center" CornerRadius="6"/>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
@@ -22,40 +22,40 @@ the Free Software Foundation, either version 3 of the License, or
     <Grid>
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="#2C3E50" CornerRadius="12" Padding="0"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="0"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 Width="750" Height="520">
             <Grid RowDefinitions="Auto,Auto,*,Auto">
                 <!-- Header -->
-                <Border Grid.Row="0" Background="#1A252F" CornerRadius="12,12,0,0" Padding="16,12">
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12,12,0,0" Padding="16,12">
                     <TextBlock Text="Application Log" FontSize="18" FontWeight="Bold"
-                               Foreground="#3498DB" HorizontalAlignment="Center"/>
+                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
                 </Border>
 
                 <!-- Filter bar -->
-                <Border Grid.Row="1" Background="#253545" Padding="12,8">
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundListLowBrush}" Padding="12,8">
                     <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
                         <Button Content="Debug" Padding="10,4" CornerRadius="4"
-                                Background="#34495E" Foreground="White" FontSize="12"
+                                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Debug"/>
                         <Button Content="Info" Padding="10,4" CornerRadius="4"
-                                Background="#2980B9" Foreground="White" FontSize="12"
+                                Background="#2980B9" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Information"/>
                         <Button Content="Warning" Padding="10,4" CornerRadius="4"
-                                Background="#F39C12" Foreground="White" FontSize="12"
+                                Background="#F39C12" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Warning"/>
                         <Button Content="Error" Padding="10,4" CornerRadius="4"
-                                Background="#E74C3C" Foreground="White" FontSize="12"
+                                Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Error"/>
-                        <Border Width="1" Background="#555" Margin="4,0"/>
+                        <Border Width="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="4,0"/>
                         <Button Content="Clear" Padding="10,4" CornerRadius="4"
-                                Background="#7F8C8D" Foreground="White" FontSize="12"
+                                Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding ClearLogEntriesCommand}"/>
                     </StackPanel>
                 </Border>
 
                 <!-- Log entries list (non-virtualizing for headless rendering) -->
-                <Border Grid.Row="2" Margin="8" Background="#1A252F" CornerRadius="6" Padding="4">
+                <Border Grid.Row="2" Margin="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4">
                     <ScrollViewer>
                         <ItemsControl ItemsSource="{Binding FilteredLogEntries}">
                             <ItemsControl.ItemTemplate>
@@ -63,7 +63,7 @@ the Free Software Foundation, either version 3 of the License, or
                                     <Grid ColumnDefinitions="140,70,*" Margin="2,1">
                                         <TextBlock Grid.Column="0"
                                                    Text="{Binding Timestamp, StringFormat='{}{0:HH:mm:ss.fff}'}"
-                                                   Foreground="#7F8C8D" FontSize="11" FontFamily="Consolas"
+                                                   Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" FontFamily="Consolas"
                                                    VerticalAlignment="Center"/>
                                         <TextBlock Grid.Column="1"
                                                    Text="{Binding Level}"
@@ -72,7 +72,7 @@ the Free Software Foundation, either version 3 of the License, or
                                                    Margin="4,0"/>
                                         <TextBlock Grid.Column="2"
                                                    Text="{Binding Message}"
-                                                   Foreground="#ECF0F1" FontSize="11" FontFamily="Consolas"
+                                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="11" FontFamily="Consolas"
                                                    TextWrapping="Wrap" VerticalAlignment="Center"/>
                                     </Grid>
                                 </DataTemplate>
@@ -84,7 +84,7 @@ the Free Software Foundation, either version 3 of the License, or
                 <!-- Close button -->
                 <Button Grid.Row="3" Content="Close" Margin="16,4,16,12"
                         Command="{Binding CloseLogViewerDialogCommand}"
-                        Background="#3498DB" Foreground="White"
+                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
                         HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
@@ -54,30 +54,31 @@ the Free Software Foundation, either version 3 of the License, or
                     </StackPanel>
                 </Border>
 
-                <!-- Log entries list -->
+                <!-- Log entries list (non-virtualizing for headless rendering) -->
                 <Border Grid.Row="2" Margin="8" Background="#1A252F" CornerRadius="6" Padding="4">
-                    <ListBox ItemsSource="{Binding FilteredLogEntries}"
-                             Background="Transparent" BorderThickness="0">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate x:DataType="logging:LogEntry">
-                                <Grid ColumnDefinitions="140,70,*" Margin="2,1">
-                                    <TextBlock Grid.Column="0"
-                                               Text="{Binding Timestamp, StringFormat='{}{0:HH:mm:ss.fff}'}"
-                                               Foreground="#7F8C8D" FontSize="11" FontFamily="Consolas"
-                                               VerticalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1"
-                                               Text="{Binding Level}"
-                                               FontSize="11" FontWeight="SemiBold" FontFamily="Consolas"
-                                               VerticalAlignment="Center"
-                                               Margin="4,0"/>
-                                    <TextBlock Grid.Column="2"
-                                               Text="{Binding Message}"
-                                               Foreground="#ECF0F1" FontSize="11" FontFamily="Consolas"
-                                               TextWrapping="Wrap" VerticalAlignment="Center"/>
-                                </Grid>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                    <ScrollViewer>
+                        <ItemsControl ItemsSource="{Binding FilteredLogEntries}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="logging:LogEntry">
+                                    <Grid ColumnDefinitions="140,70,*" Margin="2,1">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding Timestamp, StringFormat='{}{0:HH:mm:ss.fff}'}"
+                                                   Foreground="#7F8C8D" FontSize="11" FontFamily="Consolas"
+                                                   VerticalAlignment="Center"/>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding Level}"
+                                                   FontSize="11" FontWeight="SemiBold" FontFamily="Consolas"
+                                                   VerticalAlignment="Center"
+                                                   Margin="4,0"/>
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding Message}"
+                                                   Foreground="#ECF0F1" FontSize="11" FontFamily="Consolas"
+                                                   TextWrapping="Wrap" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
                 </Border>
 
                 <!-- Close button -->
@@ -85,7 +86,7 @@ the Free Software Foundation, either version 3 of the License, or
                         Command="{Binding CloseLogViewerDialogCommand}"
                         Background="#3498DB" Foreground="White"
                         HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
-                        HorizontalContentAlignment="Center" CornerRadius="6"/>
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
             </Grid>
         </Border>
     </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml.cs
@@ -1,0 +1,28 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class LogViewerDialogPanel : UserControl
+{
+    public LogViewerDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CloseLogViewerDialogCommand?.Execute(null);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
@@ -27,7 +27,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="BorderThickness" Value="0"/>
@@ -43,7 +43,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.CancelButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="BorderThickness" Value="0"/>
@@ -59,7 +59,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="TextBox.DialogInput">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
@@ -68,16 +68,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <!-- Override the inner TextBlock for selection -->
         <Style Selector="TextBox.DialogInput /template/ TextBlock">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
@@ -26,7 +26,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -42,7 +42,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
 
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#7F8C8D"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -51,28 +51,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="MinWidth" Value="100"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#95A5A6"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pressed">
             <Setter Property="Background" Value="#6B7B7C"/>
         </Style>
 
         <Style Selector="TextBox.DialogInput">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#7F8C8D"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,10"/>
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="CaretBrush" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#3498DB"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="TextBox.DialogInput:pointerover">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <!-- Override the inner TextBlock for selection -->
@@ -80,7 +80,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="TextBox.DialogInput:focus /template/ Border#PART_BorderElement">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -89,7 +89,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
                 MaxWidth="450"
                 MaxHeight="380"
@@ -103,9 +103,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <TextBlock Text="Create New Field"
                                FontSize="24"
                                FontWeight="Bold"
-                               Foreground="White"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                     <TextBlock Text="Enter field name - origin will be set to current GPS position"
-                               Foreground="#BDC3C7"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                                FontSize="14"
                                TextWrapping="Wrap"/>
                 </StackPanel>
@@ -115,14 +115,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Field Name -->
                     <StackPanel Spacing="8">
                         <TextBlock Text="Field Name:"
-                                   Foreground="White"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    FontSize="16"/>
                         <TextBox Classes="DialogInput"
                                  Text="{Binding NewFieldName, Mode=TwoWay}"
                                  Watermark="Enter field name"
-                                 Background="#34495E"
-                                 Foreground="White"
-                                 BorderBrush="#7F8C8D"
+                                 Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                                 Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                                  CornerRadius="6"
                                  Padding="12,10"
                                  FontSize="18"
@@ -130,19 +130,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <!-- GPS Position Display -->
-                    <Border Background="#34495E" CornerRadius="8" Padding="16">
+                    <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="8" Padding="16">
                         <StackPanel Spacing="8">
                             <TextBlock Text="Current GPS Position:"
-                                       Foreground="#95A5A6"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                        FontSize="14"
                                        FontWeight="SemiBold"/>
                             <StackPanel Orientation="Horizontal" Spacing="20">
-                                <TextBlock Foreground="White" FontSize="14">
-                                    <Run Text="Lat: " Foreground="#95A5A6"/>
+                                <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14">
+                                    <Run Text="Lat: " Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                                     <Run Text="{Binding NewFieldLatitude, StringFormat='{}{0:F8}'}"/>
                                 </TextBlock>
-                                <TextBlock Foreground="White" FontSize="14">
-                                    <Run Text="Lon: " Foreground="#95A5A6"/>
+                                <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14">
+                                    <Run Text="Lon: " Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                                     <Run Text="{Binding NewFieldLongitude, StringFormat='{}{0:F8}'}"/>
                                 </TextBlock>
                             </StackPanel>
@@ -151,7 +151,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                     <!-- Helper text -->
                     <TextBlock Text="The field origin will be set to your current GPS position when you create the field."
-                               Foreground="#95A5A6"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                FontSize="13"
                                TextWrapping="Wrap"/>
                 </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
@@ -29,13 +29,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#3498DB"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
         <Style Selector="TextBlock.Label">
-            <Setter Property="Foreground" Value="#BDC3C7"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="Margin" Value="0,0,0,4"/>
         </Style>
@@ -48,10 +48,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontSize" Value="14"/>
         </Style>
         <Style Selector="TextBox:focus">
-            <Setter Property="BorderBrush" Value="#3498DB"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -86,9 +86,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
@@ -106,10 +106,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </StackPanel>
 
                 <!-- Separator -->
-                <Separator Height="1" Background="#444" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Caster Settings Section -->
-                <TextBlock Text="Caster Settings" Foreground="#3498DB" FontSize="14" FontWeight="SemiBold"/>
+                <TextBlock Text="Caster Settings" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
 
                 <!-- Host -->
                 <StackPanel>
@@ -147,17 +147,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding TestNtripConnectionCommand}"
                             IsEnabled="{Binding !IsTestingNtripConnection}"/>
                     <TextBlock Grid.Column="1" Text="{Binding NtripTestStatus}"
-                               Foreground="#BDC3C7"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                                FontSize="13" VerticalAlignment="Center" Margin="12,0,0,0"
                                TextWrapping="Wrap"/>
                 </Grid>
 
                 <!-- Separator -->
-                <Separator Height="1" Background="#444" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Field Associations Section -->
-                <TextBlock Text="Associated Fields" Foreground="#3498DB" FontSize="14" FontWeight="SemiBold"/>
-                <TextBlock Text="Select fields that will use this NTRIP profile:" Foreground="#7F8C8D" FontSize="12" Margin="0,0,0,4"/>
+                <TextBlock Text="Associated Fields" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
+                <TextBlock Text="Select fields that will use this NTRIP profile:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Margin="0,0,0,4"/>
 
                 <Border Background="#1E2930" BorderBrush="#4A5F73" BorderThickness="1" CornerRadius="4"
                         MaxHeight="120" Padding="4">
@@ -166,16 +166,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate x:DataType="ntrip:FieldAssociationItem">
                                     <CheckBox IsChecked="{Binding IsSelected}" Content="{Binding FieldName}"
-                                              Foreground="White" FontSize="13" Margin="4,2"/>
+                                              Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13" Margin="4,2"/>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
                     </ScrollViewer>
                 </Border>
-                <TextBlock Text="Fields not selected will use the default profile (if set)." Foreground="#7F8C8D" FontSize="11" Margin="0,4,0,0"/>
+                <TextBlock Text="Fields not selected will use the default profile (if set)." Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,4,0,0"/>
 
                 <!-- Separator -->
-                <Separator Height="1" Background="#444" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Options -->
                 <CheckBox IsChecked="{Binding EditingNtripProfile.AutoConnectOnFieldLoad, FallbackValue=True}"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
@@ -40,9 +40,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,0,0,4"/>
         </Style>
         <Style Selector="TextBox">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="FontSize" Value="14"/>
@@ -52,7 +52,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="FontSize" Value="14"/>
@@ -64,10 +64,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2980B9"/>
         </Style>
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#5D6D7E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#4A5A6A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.TestButton">
             <Setter Property="Background" Value="#27AE60"/>
@@ -76,7 +76,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#219A52"/>
         </Style>
         <Style Selector="CheckBox">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="FontSize" Value="14"/>
         </Style>
     </UserControl.Styles>
@@ -159,7 +159,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Text="Associated Fields" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
                 <TextBlock Text="Select fields that will use this NTRIP profile:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Margin="0,0,0,4"/>
 
-                <Border Background="#1E2930" BorderBrush="#4A5F73" BorderThickness="1" CornerRadius="4"
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" CornerRadius="4"
                         MaxHeight="120" Padding="4">
                     <ScrollViewer>
                         <ItemsControl ItemsSource="{Binding AvailableFieldsForProfile}">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="FontSize" Value="14"/>
@@ -48,10 +48,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2980B9"/>
         </Style>
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#5D6D7E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#4A5A6A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.DangerButton">
             <Setter Property="Background" Value="#E74C3C"/>
@@ -61,7 +61,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ToolbarButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Width" Value="48"/>
             <Setter Property="Height" Value="48"/>
@@ -70,11 +70,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="6"/>
         </Style>
         <Style Selector="Button.ToolbarButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="ListBox">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
@@ -29,13 +29,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#3498DB"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#C0392B"/>
         </Style>
         <Style Selector="Button.ToolbarButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Width" Value="48"/>
@@ -84,10 +84,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="ListBoxItem:pointerover">
-            <Setter Property="Background" Value="#2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -96,9 +96,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
@@ -111,7 +111,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Grid.Row="0" Classes="Header" Text="NTRIP Profiles"/>
 
                 <!-- Toolbar -->
-                <Border Grid.Row="1" Background="#34495E" CornerRadius="6" Padding="4" Margin="0,0,0,12">
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="4" Margin="0,0,0,12">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <!-- Add Profile -->
                         <Button Classes="ToolbarButton" ToolTip.Tip="Add New Profile"
@@ -134,7 +134,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="28" Height="28" Stretch="Uniform"/>
                         </Button>
 
-                        <Separator Background="#555" Width="2" Margin="4"/>
+                        <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Width="2" Margin="4"/>
 
                         <!-- Set as Default -->
                         <Button Classes="ToolbarButton" ToolTip.Tip="Set as Default Profile"
@@ -146,11 +146,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Border>
 
                 <!-- Column Headers -->
-                <Border Grid.Row="2" Background="#34495E" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
+                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
                     <Grid ColumnDefinitions="*,150,60">
-                        <TextBlock Grid.Column="0" Text="Profile Name" Foreground="#BDC3C7" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="1" Text="Caster" Foreground="#BDC3C7" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="2" Text="Default" Foreground="#BDC3C7" FontWeight="SemiBold" TextAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="Profile Name" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="1" Text="Caster" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="2" Text="Default" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
                     </Grid>
                 </Border>
 
@@ -166,10 +166,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <DataTemplate x:DataType="ntrip:NtripProfile">
                             <Grid ColumnDefinitions="*,150,60" Background="Transparent">
                                 <StackPanel Grid.Column="0" Spacing="2">
-                                    <TextBlock Text="{Binding Name}" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
-                                    <TextBlock Text="{Binding MountPoint}" Foreground="#7F8C8D" FontSize="12"/>
+                                    <TextBlock Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" FontWeight="SemiBold"/>
+                                    <TextBlock Text="{Binding MountPoint}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                                 </StackPanel>
-                                <TextBlock Grid.Column="1" Text="{Binding CasterHost}" Foreground="#BDC3C7" FontSize="13"
+                                <TextBlock Grid.Column="1" Text="{Binding CasterHost}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"
                                            VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
                                 <Panel Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <TextBlock Text="*" FontSize="24" FontWeight="Bold" Foreground="#F1C40F"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
@@ -33,7 +33,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
-        <Border Background="#2C3E50" CornerRadius="12" Padding="16"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="16"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="300" MaxWidth="350">
             <StackPanel Spacing="12">
@@ -44,7 +44,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Current Value Display -->
                 <Border Background="#1a1a1a" CornerRadius="6" Padding="12,8">
                     <TextBlock x:Name="ValueDisplay" FontSize="32" FontWeight="Bold"
-                               Foreground="White" HorizontalAlignment="Center"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"
                                Text="{Binding NumericInputDialogDisplayText}"/>
                 </Border>
 
@@ -59,12 +59,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="*,*" Margin="0,8,0,0">
                     <Button Grid.Column="0" Content="Cancel" Margin="0,0,4,0"
                             Command="{Binding CancelNumericInputDialogCommand}"
-                            Background="#E74C3C" Foreground="White"
+                            Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="16"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="1" Content="OK" Margin="4,0,0,0"
                             Command="{Binding ConfirmNumericInputDialogCommand}"
-                            Background="#1ABC9C" Foreground="White"
+                            Background="#1ABC9C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="16"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
@@ -42,7 +42,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            Foreground="#1ABC9C" HorizontalAlignment="Center"/>
 
                 <!-- Current Value Display -->
-                <Border Background="#1a1a1a" CornerRadius="6" Padding="12,8">
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="12,8">
                     <TextBlock x:Name="ValueDisplay" FontSize="32" FontWeight="Bold"
                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"
                                Text="{Binding NumericInputDialogDisplayText}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
@@ -28,7 +28,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.ModeButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
@@ -64,17 +64,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Compact selector panel - centered -->
-        <Border Background="#2C3E50" CornerRadius="12"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 Padding="20" BoxShadow="0 8 32 #40000000">
             <StackPanel Spacing="16">
                 <!-- Title -->
                 <TextBlock Text="Quick AB Line Creator"
-                           Foreground="White" FontSize="18" FontWeight="Bold"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" FontWeight="Bold"
                            HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Select creation mode:"
-                           Foreground="#BDC3C7" FontSize="14"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14"
                            HorizontalAlignment="Center"/>
 
                 <!-- Mode buttons in a row -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <Style Selector="Button.ModeButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
             <Setter Property="MinWidth" Value="100"/>
@@ -38,7 +38,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModeButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ModeButton:pressed">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -46,7 +46,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.CancelButton">
             <Setter Property="Background" Value="#C0392B"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
             <Setter Property="MinWidth" Value="100"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
@@ -34,13 +34,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,0,0,4"/>
         </Style>
         <Style Selector="TextBlock.Hint">
-            <Setter Property="Foreground" Value="#AAA"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
         </Style>
         <Style Selector="Border.InputField">
             <Setter Property="Background" Value="#2D2D2D"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -64,7 +64,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#1084D8"/>
         </Style>
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#555"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
             <Setter Property="Background" Value="#666"/>
@@ -80,7 +80,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Dialog panel positioned near top for mobile -->
         <Border Background="#1E1E1E"
                 CornerRadius="12"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
@@ -94,7 +94,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            Text="Enter GPS Coordinates"
                            FontSize="18"
                            FontWeight="Bold"
-                           Foreground="White"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            HorizontalAlignment="Center"
                            Margin="0,0,0,16"/>
 
@@ -106,7 +106,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock x:Name="LatitudeDisplay"
                                    FontSize="18"
                                    FontWeight="Bold"
-                                   Foreground="White"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"
                                    Text="0.00000000"/>
                     </Border>
@@ -120,7 +120,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock x:Name="LongitudeDisplay"
                                    FontSize="18"
                                    FontWeight="Bold"
-                                   Foreground="White"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"
                                    Text="0.00000000"/>
                     </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Label">
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Margin" Value="0,0,0,4"/>
         </Style>
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Margin" Value="0,0,0,8"/>
         </Style>
         <Style Selector="Border.InputField">
-            <Setter Property="Background" Value="#2D2D2D"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
@@ -51,8 +51,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="BorderThickness" Value="2"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#0078D4"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="24,12"/>
             <Setter Property="FontSize" Value="14"/>
@@ -61,13 +61,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="6"/>
         </Style>
         <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#1084D8"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#666"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -78,7 +78,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel positioned near top for mobile -->
-        <Border Background="#1E1E1E"
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 CornerRadius="12"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
@@ -30,13 +30,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#3498DB"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
         <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
@@ -61,7 +61,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#C0392B"/>
         </Style>
         <Style Selector="Button.ToolbarButton">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Width" Value="48"/>
@@ -85,10 +85,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
         </Style>
         <Style Selector="ListBoxItem:pointerover">
-            <Setter Property="Background" Value="#2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#3498DB"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -97,9 +97,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
-        <Border Background="#2C3E50"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
-                BorderBrush="#444"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
@@ -112,7 +112,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Grid.Row="0" Classes="Header" Text="AB Line Tracks"/>
 
                 <!-- Toolbar -->
-                <Border Grid.Row="1" Background="#34495E" CornerRadius="6" Padding="4" Margin="0,0,0,12">
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="4" Margin="0,0,0,12">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <!-- Delete Track -->
                         <Button Classes="ToolbarButton" ToolTip.Tip="Delete Selected Track"
@@ -128,7 +128,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="28" Height="28" Stretch="Uniform"/>
                         </Button>
 
-                        <Separator Background="#555" Width="2" Margin="4"/>
+                        <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Width="2" Margin="4"/>
 
                         <!-- Select/Activate Track -->
                         <Button Classes="ToolbarButton" ToolTip.Tip="Activate Selected Track"
@@ -140,11 +140,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Border>
 
                 <!-- Column Headers -->
-                <Border Grid.Row="2" Background="#34495E" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
+                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
                     <Grid ColumnDefinitions="*,80,60">
-                        <TextBlock Grid.Column="0" Text="Track Name" Foreground="#BDC3C7" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="1" Text="Type" Foreground="#BDC3C7" FontWeight="SemiBold" TextAlignment="Center"/>
-                        <TextBlock Grid.Column="2" Text="Active" Foreground="#BDC3C7" FontWeight="SemiBold" TextAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="Track Name" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="1" Text="Type" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="Active" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
                     </Grid>
                 </Border>
 
@@ -160,15 +160,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <DataTemplate x:DataType="track:Track">
                             <!-- Background="Transparent" makes entire row clickable, not just text -->
                             <Grid ColumnDefinitions="*,80,60" Background="Transparent" PointerReleased="TrackItem_PointerReleased">
-                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="White" FontSize="14"
+                                <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"
                                            VerticalAlignment="Center"/>
                                 <Panel Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                    <TextBlock Text="Curve" Foreground="#BDC3C7" FontSize="14" IsVisible="{Binding IsCurve}"/>
-                                    <TextBlock Text="Line" Foreground="#BDC3C7" FontSize="14" IsVisible="{Binding !IsCurve}"/>
+                                    <TextBlock Text="Curve" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding IsCurve}"/>
+                                    <TextBlock Text="Line" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding !IsCurve}"/>
                                 </Panel>
                                 <Panel Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <Ellipse Width="16" Height="16" Fill="#27AE60" IsVisible="{Binding IsActive}"/>
-                                    <Ellipse Width="16" Height="16" Fill="#7F8C8D" IsVisible="{Binding !IsActive}"/>
+                                    <Ellipse Width="16" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" IsVisible="{Binding !IsActive}"/>
                                 </Panel>
                             </Grid>
                         </DataTemplate>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.DialogButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="16,10"/>
             <Setter Property="FontSize" Value="14"/>
@@ -49,10 +49,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#2980B9"/>
         </Style>
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#5D6D7E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#4A5A6A"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.DangerButton">
             <Setter Property="Background" Value="#E74C3C"/>
@@ -62,7 +62,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ToolbarButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Width" Value="48"/>
             <Setter Property="Height" Value="48"/>
@@ -71,11 +71,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="6"/>
         </Style>
         <Style Selector="Button.ToolbarButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="ListBox">
-            <Setter Property="Background" Value="#1E2930"/>
-            <Setter Property="BorderBrush" Value="#4A5F73"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
@@ -21,31 +21,31 @@ the Free Software Foundation, either version 3 of the License, or
     <Grid>
         <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="#2C3E50" CornerRadius="12" Padding="0"
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="0"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 Width="650" Height="520">
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Header -->
-                <Border Grid.Row="0" Background="#1A252F" CornerRadius="12,12,0,0" Padding="16,12">
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12,12,0,0" Padding="16,12">
                     <StackPanel Spacing="4" HorizontalAlignment="Center">
                         <TextBlock Text="All Settings" FontSize="18" FontWeight="Bold"
-                                   Foreground="#3498DB" HorizontalAlignment="Center"/>
+                                   Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
                         <TextBlock Text="Read-only view of current configuration values"
-                                   FontSize="11" Foreground="#95A5A6" HorizontalAlignment="Center"/>
+                                   FontSize="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </Border>
 
                 <!-- Settings tree -->
-                <Border Grid.Row="1" Margin="8" Background="#1A252F" CornerRadius="6" Padding="4">
+                <Border Grid.Row="1" Margin="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4">
                     <ScrollViewer>
                         <ItemsControl ItemsSource="{Binding SettingsTree}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate x:DataType="vm:SettingsGroupItem">
                                     <StackPanel Margin="0,4">
                                         <!-- Group header -->
-                                        <Border Background="#253545" CornerRadius="4" Padding="10,6" Margin="4,2">
+                                        <Border Background="{DynamicResource SystemControlBackgroundListLowBrush}" CornerRadius="4" Padding="10,6" Margin="4,2">
                                             <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="Bold"
-                                                       Foreground="#3498DB"/>
+                                                       Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
                                         </Border>
                                         <!-- Values -->
                                         <ItemsControl ItemsSource="{Binding Items}" Margin="16,2,4,0">
@@ -53,10 +53,10 @@ the Free Software Foundation, either version 3 of the License, or
                                                 <DataTemplate x:DataType="vm:SettingsValueItem">
                                                     <Grid ColumnDefinitions="200,*" Margin="0,1">
                                                         <TextBlock Grid.Column="0" Text="{Binding Name}"
-                                                                   Foreground="#95A5A6" FontSize="12"
+                                                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="12"
                                                                    VerticalAlignment="Center"/>
                                                         <TextBlock Grid.Column="1" Text="{Binding Value}"
-                                                                   Foreground="#ECF0F1" FontSize="12"
+                                                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                                                    FontFamily="Consolas"
                                                                    TextWrapping="Wrap"
                                                                    VerticalAlignment="Center"/>
@@ -74,7 +74,7 @@ the Free Software Foundation, either version 3 of the License, or
                 <!-- Close button -->
                 <Button Grid.Row="2" Content="Close" Margin="16,4,16,12"
                         Command="{Binding CloseViewSettingsDialogCommand}"
-                        Background="#3498DB" Foreground="White"
+                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
                         HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
@@ -76,7 +76,7 @@ the Free Software Foundation, either version 3 of the License, or
                         Command="{Binding CloseViewSettingsDialogCommand}"
                         Background="#3498DB" Foreground="White"
                         HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
-                        HorizontalContentAlignment="Center" CornerRadius="6"/>
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
             </Grid>
         </Border>
     </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
@@ -1,0 +1,83 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="600"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.ViewSettingsDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsViewSettingsDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsViewSettingsDialogVisible}">
+
+    <Grid>
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <Border Background="#2C3E50" CornerRadius="12" Padding="0"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                Width="650" Height="520">
+            <Grid RowDefinitions="Auto,*,Auto">
+                <!-- Header -->
+                <Border Grid.Row="0" Background="#1A252F" CornerRadius="12,12,0,0" Padding="16,12">
+                    <StackPanel Spacing="4" HorizontalAlignment="Center">
+                        <TextBlock Text="All Settings" FontSize="18" FontWeight="Bold"
+                                   Foreground="#3498DB" HorizontalAlignment="Center"/>
+                        <TextBlock Text="Read-only view of current configuration values"
+                                   FontSize="11" Foreground="#95A5A6" HorizontalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Settings tree -->
+                <Border Grid.Row="1" Margin="8" Background="#1A252F" CornerRadius="6" Padding="4">
+                    <ScrollViewer>
+                        <ItemsControl ItemsSource="{Binding SettingsTree}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:SettingsGroupItem">
+                                    <StackPanel Margin="0,4">
+                                        <!-- Group header -->
+                                        <Border Background="#253545" CornerRadius="4" Padding="10,6" Margin="4,2">
+                                            <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="Bold"
+                                                       Foreground="#3498DB"/>
+                                        </Border>
+                                        <!-- Values -->
+                                        <ItemsControl ItemsSource="{Binding Items}" Margin="16,2,4,0">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:SettingsValueItem">
+                                                    <Grid ColumnDefinitions="200,*" Margin="0,1">
+                                                        <TextBlock Grid.Column="0" Text="{Binding Name}"
+                                                                   Foreground="#95A5A6" FontSize="12"
+                                                                   VerticalAlignment="Center"/>
+                                                        <TextBlock Grid.Column="1" Text="{Binding Value}"
+                                                                   Foreground="#ECF0F1" FontSize="12"
+                                                                   FontFamily="Consolas"
+                                                                   TextWrapping="Wrap"
+                                                                   VerticalAlignment="Center"/>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Border>
+
+                <!-- Close button -->
+                <Button Grid.Row="2" Content="Close" Margin="16,4,16,12"
+                        Command="{Binding CloseViewSettingsDialogCommand}"
+                        Background="#3498DB" Foreground="White"
+                        HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
+                        HorizontalContentAlignment="Center" CornerRadius="6"/>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml.cs
@@ -1,0 +1,28 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class ViewSettingsDialogPanel : UserControl
+{
+    public ViewSettingsDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CloseViewSettingsDialogCommand?.Execute(null);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/NumericKeyboardPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/NumericKeyboardPanel.axaml
@@ -23,7 +23,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Button.KeypadButton">
             <Setter Property="FontSize" Value="24"/>
             <Setter Property="FontWeight" Value="Bold"/>
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Margin" Value="3"/>
@@ -47,7 +47,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <Grid RowDefinitions="*,*,*,*" ColumnDefinitions="*,*,*,*" Background="#2C3E50">
+    <Grid RowDefinitions="*,*,*,*" ColumnDefinitions="*,*,*,*" Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
         <!-- Row 1: 1, 2, 3, Back -->
         <Button Grid.Row="0" Grid.Column="0" Content="1" Classes="KeypadButton" Click="OnDigitClick"/>
         <Button Grid.Row="0" Grid.Column="1" Content="2" Classes="KeypadButton" Click="OnDigitClick"/>

--- a/Shared/AgValoniaGPS.Views/Controls/NumericKeyboardPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/NumericKeyboardPanel.axaml
@@ -24,7 +24,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontSize" Value="24"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Margin" Value="3"/>
             <Setter Property="HorizontalContentAlignment" Value="Center"/>
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="MinHeight" Value="50"/>
         </Style>
         <Style Selector="Button.KeypadButton:pointerover">
-            <Setter Property="Background" Value="#4A6278"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.KeypadButton:pressed">
             <Setter Property="Background" Value="#1ABC9C"/>
@@ -40,7 +40,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Style Selector="Button.ClearButton">
             <Setter Property="Background" Value="#E67E22"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.ClearButton:pointerover">
             <Setter Property="Background" Value="#F39C12"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
@@ -35,16 +35,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Floating Panel Style -->
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="6"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
 
         <!-- Bottom Panel Button Style -->
         <Style Selector="Button.BottomPanelButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
@@ -53,10 +53,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.BottomPanelButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.BottomPanelButton:pressed">
-            <Setter Property="Background" Value="#DD3E5872"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
         </Style>
 
         <!-- Active State for toggle buttons -->
@@ -69,7 +69,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Menu Button (opens flyout) -->
         <Style Selector="Button.MenuButton">
-            <Setter Property="Background" Value="#DD2C3E50"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
@@ -89,13 +89,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="#EE1E2A38"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
 
         <!-- Panel Separator -->
         <Style Selector="Separator.BottomPanelSeparator">
-            <Setter Property="Background" Value="#444"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="Width" Value="2"/>
             <Setter Property="Margin" Value="4,8"/>
         </Style>
@@ -109,12 +109,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Touch Handle: Tap to rotate, Hold to drag -->
                 <Grid x:Name="DragHandle" Width="40" Margin="0"
-                      Background="#DD2C3E50"
+                      Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                       Cursor="Hand"
                       ToolTip.Tip="Tap to rotate | Hold and drag to move">
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="4">
-                        <TextBlock Text="=" Foreground="#AAA" FontSize="16" FontWeight="Bold" IsHitTestVisible="False"/>
-                        <TextBlock Text="R" Foreground="#AAA" FontSize="14" FontWeight="Bold" IsHitTestVisible="False"/>
+                        <TextBlock Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold" IsHitTestVisible="False"/>
+                        <TextBlock Text="R" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="14" FontWeight="Bold" IsHitTestVisible="False"/>
                     </StackPanel>
                 </Grid>
 
@@ -127,11 +127,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding CycleUTurnSkipRowsCommand}"
                         IsVisible="{Binding HasActiveTrack}"
                         ToolTip.Tip="U-Turn Skip Rows (tap to cycle 0-9)"
-                        Background="#DD34495E"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                         CornerRadius="4"
                         Padding="0">
                     <TextBlock Text="{Binding UTurnSkipRows}"
-                               Foreground="White"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                FontSize="28"
                                FontWeight="Bold"
                                HorizontalAlignment="Center"
@@ -246,7 +246,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABDraw.png" Stretch="Uniform"/>
                 </Button>
 
-                <Separator Background="#444" Height="2" Margin="4" IsVisible="{Binding HasActiveTrack}"/>
+                <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="2" Margin="4" IsVisible="{Binding HasActiveTrack}"/>
 
                 <!-- Cycle Lines -->
                 <Button Classes="BottomPanelButton" ToolTip.Tip="Cycle AB Lines"
@@ -269,7 +269,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TrashContourRef.png" Stretch="Uniform"/>
                 </Button>
 
-                <Separator Background="#444" Height="2" Margin="4" IsVisible="{Binding HasActiveTrack}"/>
+                <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="2" Margin="4" IsVisible="{Binding HasActiveTrack}"/>
 
                 <!-- Nudge Controls -->
                 <StackPanel Orientation="Horizontal" Spacing="4" IsVisible="{Binding HasActiveTrack}">
@@ -320,7 +320,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FlagYel.png" Stretch="Uniform"/>
                 </Button>
 
-                <Separator Background="#444" Height="2" Margin="4"/>
+                <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="2" Margin="4"/>
 
                 <!-- Delete Flags -->
                 <Button Classes="BottomPanelButton" ToolTip.Tip="Delete All Flags"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -44,7 +44,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -52,7 +52,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel Spacing="4" Background="Transparent">
             <!-- Header: Drag handle + Title -->
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*" Height="32" Margin="0,0,0,4"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" FontSize="18" FontWeight="Bold"
                            Foreground="#FFFFFF" VerticalAlignment="Center" Margin="8,0,0,0" IsHitTestVisible="False"/>
                 <TextBlock Grid.Column="1" Text="Stop Record Pause Boundary" FontSize="12" FontWeight="SemiBold"
@@ -68,7 +68,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                Foreground="Black" HorizontalAlignment="Center" IsHitTestVisible="False"/>
                 </Button>
                 <TextBlock Grid.Column="1" Text="cm" FontSize="14" FontWeight="Bold"
-                           Foreground="White" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
             </Grid>
 
             <!-- Two Column Layout -->
@@ -86,7 +86,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                               ToolTip.Tip="Record boundary when section is on">
                     <ToggleButton.Styles>
                         <Style Selector="ToggleButton">
-                            <Setter Property="Background" Value="#3498DB"/>
+                            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
                             <Setter Property="CornerRadius" Value="6"/>
                             <Setter Property="Cursor" Value="Hand"/>
                             <Setter Property="BorderThickness" Value="0"/>
@@ -146,13 +146,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Row 3: Points display | Area display -->
                 <StackPanel Grid.Column="0" Grid.Row="3" Margin="4">
-                    <TextBlock Text="Points:" Foreground="#888" FontSize="12"/>
-                    <TextBlock Text="{Binding BoundaryPointCount}" Foreground="White"
+                    <TextBlock Text="Points:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                    <TextBlock Text="{Binding BoundaryPointCount}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                FontSize="16" FontWeight="Bold"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1" Grid.Row="3" Margin="4">
-                    <TextBlock Text="Area:" Foreground="#888" FontSize="12"/>
-                    <TextBlock Text="{Binding BoundaryAreaHectares, StringFormat={}{0:F2} Ha}" Foreground="White"
+                    <TextBlock Text="Area:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                    <TextBlock Text="{Binding BoundaryAreaHectares, StringFormat={}{0:F2} Ha}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                FontSize="16" FontWeight="Bold"/>
                 </StackPanel>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
@@ -41,7 +41,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
@@ -33,14 +33,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -49,7 +49,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -57,7 +57,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel Spacing="4" Background="Transparent">
             <!-- Header: Drag handle + Title + Close button -->
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,4"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" FontSize="18" FontWeight="Bold"
                            Foreground="#FFFFFF" VerticalAlignment="Center" Margin="8,0,0,0" IsHitTestVisible="False"/>
                 <TextBlock Grid.Column="1" Text="Start or Delete A Boundary" FontSize="14" FontWeight="SemiBold"
@@ -103,13 +103,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Grid>
 
             <!-- Column Headers -->
-            <Grid ColumnDefinitions="*,*,*" Background="#3498DB" Margin="4,0,4,0">
+            <Grid ColumnDefinitions="*,*,*" Background="{DynamicResource SystemControlHighlightAccentBrush}" Margin="4,0,4,0">
                 <TextBlock Grid.Column="0" Text="Boundary" HorizontalAlignment="Center"
-                           FontWeight="Bold" Foreground="White" Padding="8,6"/>
+                           FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                 <TextBlock Grid.Column="1" Text="Area" HorizontalAlignment="Center"
-                           FontWeight="Bold" Foreground="White" Padding="8,6"/>
+                           FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                 <TextBlock Grid.Column="2" Text="Drive Thru" HorizontalAlignment="Center"
-                           FontWeight="Bold" Foreground="White" Padding="8,6"/>
+                           FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
             </Grid>
 
             <!-- Boundary List -->
@@ -122,9 +122,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <DataTemplate>
                             <Grid ColumnDefinitions="*,*,*">
                                 <TextBlock Grid.Column="0" Text="{Binding BoundaryType}"
-                                           HorizontalAlignment="Center" Foreground="White" Padding="8,6"/>
+                                           HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                                 <TextBlock Grid.Column="1" Text="{Binding AreaDisplay}"
-                                           HorizontalAlignment="Center" Foreground="White" Padding="8,6"/>
+                                           HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                                 <TextBlock Grid.Column="2" Text="{Binding DriveThruDisplay}"
                                            HorizontalAlignment="Center" Padding="8,6"
                                            Foreground="{Binding IsDriveThrough, Converter={StaticResource BoolToColorConverter}}"/>
@@ -138,7 +138,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Setter Property="Margin" Value="0,1,0,0"/>
                         </Style>
                         <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
-                            <Setter Property="Background" Value="#3498DB"/>
+                            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
                         </Style>
                     </ListBox.Styles>
                 </ListBox>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -44,7 +44,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -52,17 +52,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <Border Classes="FloatingPanel" MinWidth="360" IsVisible="{Binding IsConfigurationPanelVisible}">
         <StackPanel Spacing="4">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Vehicle Configuration" Foreground="White" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Vehicle Configuration" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="16" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
                         Command="{Binding ToggleConfigurationPanelCommand}" Margin="8,0,8,0"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,0,0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="4">
                 <!-- Row 0: Profile Management -->
@@ -94,7 +94,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Current Profile Display -->
             <Border Background="#DD1E8449" CornerRadius="6" Padding="8,4" Margin="0,8,0,0">
                 <TextBlock Text="{Binding CurrentProfileName, StringFormat='Profile: {0}'}"
-                           Foreground="White"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            FontSize="13"
                            FontWeight="SemiBold"
                            TextWrapping="Wrap"
@@ -107,25 +107,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <Border Classes="FloatingPanel" MinWidth="300" IsVisible="{Binding IsProfileSelectionVisible}"
             HorizontalAlignment="Center" VerticalAlignment="Center">
         <StackPanel Spacing="8">
-            <TextBlock Text="Select Profile" FontSize="16" FontWeight="Bold" Foreground="White"
+            <TextBlock Text="Select Profile" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        HorizontalAlignment="Center" Margin="0,4,0,8"/>
 
             <ListBox ItemsSource="{Binding AvailableProfiles}"
                      SelectedItem="{Binding SelectedProfile}"
-                     MaxHeight="200" MinWidth="260" Background="#DD2C3E50">
+                     MaxHeight="200" MinWidth="260" Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <TextBlock Text="{Binding}" Foreground="White" FontSize="14" Padding="8,6"/>
+                        <TextBlock Text="{Binding}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" Padding="8,6"/>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
 
             <Grid ColumnDefinitions="*,*" ColumnSpacing="8" Margin="0,8,0,0">
                 <Button Grid.Column="0" Content="Cancel" HorizontalContentAlignment="Center"
-                        Background="#E74C3C" Foreground="White" CornerRadius="6" Height="36"
+                        Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="6" Height="36"
                         Command="{Binding CancelProfileSelectionCommand}"/>
                 <Button Grid.Column="1" Content="Load" HorizontalContentAlignment="Center"
-                        Background="#4A9A7E" Foreground="White" CornerRadius="6" Height="36"
+                        Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="6" Height="36"
                         Command="{Binding LoadSelectedProfileCommand}"/>
             </Grid>
         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -44,24 +44,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <Border Classes="FloatingPanel" MinWidth="400" IsVisible="{Binding IsFieldToolsPanelVisible}" IsHitTestVisible="True">
         <StackPanel Spacing="4" Background="Transparent">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Field Tools" Foreground="White" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Field Tools" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="16" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
                         Command="{Binding ToggleFieldToolsPanelCommand}" Margin="8,0,8,0"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,0,0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <!-- Menu Items: 2-column layout (5 rows x 2 columns) -->
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="4" Background="Transparent">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -71,10 +71,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Separator Height="1" Background="#444" Margin="0,4"/>
 
             <!-- App Configuration -->
-            <Button Classes="ModernButton" Content="View All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
+            <Button Classes="ModernButton" Content="View All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding ShowViewSettingsDialogCommand}"/>
             <Button Classes="ModernButton" Content="App Directories" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAppDirectoriesDialogCommand}"/>
-            <Button Classes="ModernButton" Content="App Colors" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
+            <Button Classes="ModernButton" Content="Log Viewer" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding ShowLogViewerDialogCommand}"/>
             <Button Classes="ModernButton" Content="Hotkeys" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowHotkeyConfigDialogCommand}"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -44,31 +44,31 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <Border Classes="FloatingPanel" MinWidth="200" IsVisible="{Binding IsFileMenuPanelVisible}">
         <StackPanel Spacing="4">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Application Settings" Foreground="White" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Application Settings" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="16" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
                         Command="{Binding ToggleFileMenuPanelCommand}" Margin="8,0,8,0"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,0,0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <!-- General Settings -->
             <Button Classes="ModernButton" Content="Language" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
             <Button Classes="ModernButton" Content="Reset All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ResetAllSettingsCommand}"/>
 
-            <Separator Height="1" Background="#444" Margin="0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- App Configuration -->
             <Button Classes="ModernButton" Content="View All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
@@ -80,19 +80,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Button Classes="ModernButton" Content="Hotkeys" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowHotkeyConfigDialogCommand}"/>
 
-            <Separator Height="1" Background="#444" Margin="0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- NTRIP Profiles -->
             <Button Classes="ModernButton" Content="NTRIP Profiles" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowNtripProfilesDialogCommand}"/>
 
-            <Separator Height="1" Background="#444" Margin="0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- Simulator -->
             <Button Classes="ModernButton" Content="Simulator" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ToggleSimulatorPanelCommand}"/>
 
-            <Separator Height="1" Background="#444" Margin="0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- Help & Info -->
             <Button Classes="ModernButton" Content="AgShare API" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -44,24 +44,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <Border Classes="FloatingPanel" MinWidth="400" IsVisible="{Binding IsJobMenuPanelVisible}" IsHitTestVisible="True">
         <StackPanel Spacing="4" Background="Transparent">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Start New Field" Foreground="White" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Start New Field" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="16" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
                         Command="{Binding ToggleJobMenuPanelCommand}" Margin="8,0,8,0"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,0,0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <!-- Menu Items: 2-column layout (6 rows x 2 columns) -->
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="4" Background="Transparent">
@@ -160,7 +160,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="#DD1E8449" CornerRadius="6" Padding="8,4" Margin="0,8,0,0"
                     IsVisible="{Binding IsFieldOpen}">
                 <TextBlock Text="{Binding CurrentFieldName, StringFormat='Current Field: {0}'}"
-                           Foreground="White"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            FontSize="13"
                            FontWeight="SemiBold"
                            TextWrapping="Wrap"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
@@ -31,16 +31,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Floating Panel Style -->
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
 
         <!-- Left Panel Button Style -->
         <Style Selector="Button.LeftPanelButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
@@ -49,15 +49,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.LeftPanelButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.LeftPanelButton:pressed">
-            <Setter Property="Background" Value="#DD3E5872"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
         </Style>
 
         <!-- Left Panel Separator -->
         <Style Selector="Separator.LeftPanelSeparator">
-            <Setter Property="Background" Value="#444"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="Height" Value="2"/>
             <Setter Property="Margin" Value="8,4"/>
         </Style>
@@ -71,12 +71,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <StackPanel x:Name="ButtonStack" Spacing="6" Orientation="Vertical">
                 <!-- Touch Handle: Tap to rotate, Hold to drag -->
                 <Grid x:Name="DragHandle" Height="40" Margin="0"
-                      Background="#DD2C3E50"
+                      Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                       Cursor="Hand"
                       ToolTip.Tip="Tap to rotate | Hold and drag to move">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
-                        <TextBlock Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold" IsHitTestVisible="False"/>
-                        <TextBlock Text="R" Foreground="#AAA" FontSize="18" FontWeight="Bold" IsHitTestVisible="False"/>
+                        <TextBlock Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold" IsHitTestVisible="False"/>
+                        <TextBlock Text="R" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="18" FontWeight="Bold" IsHitTestVisible="False"/>
                     </StackPanel>
                 </Grid>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
@@ -35,16 +35,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Floating Panel Style -->
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
 
         <!-- Right Panel Button Style -->
         <Style Selector="Button.RightPanelButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
@@ -53,10 +53,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.RightPanelButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.RightPanelButton:pressed">
-            <Setter Property="Background" Value="#DD3E5872"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
         </Style>
 
         <!-- Active State for toggle buttons -->
@@ -69,7 +69,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Right Panel Separator -->
         <Style Selector="Separator.RightPanelSeparator">
-            <Setter Property="Background" Value="#444"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="Height" Value="2"/>
             <Setter Property="Margin" Value="8,4"/>
         </Style>
@@ -80,12 +80,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel x:Name="ButtonStack" Spacing="6" Orientation="Vertical">
             <!-- Touch Handle: Tap to rotate, Hold to drag -->
             <Grid x:Name="DragHandle" Height="40" Margin="0"
-                  Background="#DD2C3E50"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                   Cursor="Hand"
                   ToolTip.Tip="Tap to rotate | Hold and drag to move">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
-                    <TextBlock Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold" IsHitTestVisible="False"/>
-                    <TextBlock Text="R" Foreground="#AAA" FontSize="18" FontWeight="Bold" IsHitTestVisible="False"/>
+                    <TextBlock Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold" IsHitTestVisible="False"/>
+                    <TextBlock Text="R" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="18" FontWeight="Bold" IsHitTestVisible="False"/>
                 </StackPanel>
             </Grid>
 
@@ -142,13 +142,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ToolTip.Tip="Manual U-Turn Left"
                         Command="{Binding ManualYouTurnLeftCommand}"
                         Margin="0,0,2,0">
-                    <TextBlock Text="↰" FontSize="20" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="↰" FontSize="20" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 </Button>
                 <Button Grid.Column="1" Classes="RightPanelButton" Width="30" Height="32"
                         ToolTip.Tip="Manual U-Turn Right"
                         Command="{Binding ManualYouTurnRightCommand}"
                         Margin="2,0,0,0">
-                    <TextBlock Text="↱" FontSize="20" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="↱" FontSize="20" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 </Button>
             </Grid>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
@@ -69,14 +69,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <!-- Floating panel with section indicators -->
-    <Border Background="#DD2C3E50" CornerRadius="12" Padding="12"
+    <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="12"
             BoxShadow="0 4 16 2 #40000000">
         <StackPanel Orientation="Horizontal" Spacing="8">
             <!-- Drag handle and label -->
             <StackPanel Orientation="Vertical" VerticalAlignment="Center" Margin="0,0,4,0">
-                <TextBlock Text="&#x2261;" Foreground="#888" FontSize="16" FontWeight="Bold"
+                <TextBlock Text="&#x2261;" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
                            HorizontalAlignment="Center"/>
-                <TextBlock Text="Sect" Foreground="White" FontSize="10" FontWeight="Bold"
+                <TextBlock Text="Sect" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" FontWeight="Bold"
                            HorizontalAlignment="Center"/>
             </StackPanel>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Width" Value="40"/>
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="BorderThickness" Value="2"/>
-            <Setter Property="BorderBrush" Value="#333"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="Padding" Value="0"/>
             <Setter Property="Template">
                 <ControlTemplate>
@@ -62,7 +62,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Button.SectionButton > TextBlock">
             <Setter Property="HorizontalAlignment" Value="Center"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="FontSize" Value="12"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -44,24 +44,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <Border Classes="FloatingPanel" MinWidth="320" IsVisible="{Binding IsSimulatorPanelVisible}">
         <StackPanel Spacing="4">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="GPS Simulator" Foreground="White" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="GPS Simulator" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="16" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
                         Command="{Binding ToggleSimulatorPanelCommand}" Margin="8,0,8,0"/>
             </Grid>
 
-            <Separator Height="1" Background="#555"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
 
             <!-- Simulator Controls -->
             <StackPanel Spacing="8" Margin="12">
@@ -80,7 +80,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <TextBlock Text="Enter Sim Coords" FontSize="12" IsHitTestVisible="False"/>
                 </Button>
 
-                <Separator Height="1" Background="#555" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Row 1: Reset Position and Reset Steering -->
                 <Grid ColumnDefinitions="*,*">
@@ -124,24 +124,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            FontSize="12"
                            Foreground="#DDD"/>
 
-                <Separator Background="#555" Height="1" Margin="0,4"/>
+                <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="1" Margin="0,4"/>
 
                 <!-- Row 4: Speed Slider (-10 to +25 kph) -->
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Grid.Column="0" Text="Speed" Foreground="#AAA" FontSize="11" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    <TextBlock Grid.Column="0" Text="Speed" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center" Margin="0,4,0,0"/>
                     <CheckBox Grid.Column="1" Content="10x" IsChecked="{Binding IsSimulatorSpeed10x}"
-                              FontSize="10" Foreground="#AAA" Margin="0,0,0,0"
+                              FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,0"
                               ToolTip.Tip="10x speed multiplier for large fields"/>
                 </Grid>
                 <Grid ColumnDefinitions="Auto,*,Auto">
-                    <TextBlock Grid.Column="0" Text="-10" Foreground="#888" FontSize="10" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                    <TextBlock Grid.Column="0" Text="-10" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" VerticalAlignment="Center" Margin="0,0,4,0"/>
                     <Slider Grid.Column="1" Margin="0"
                             Minimum="-10" Maximum="25"
                             Value="{Binding SimulatorSpeedKph, Mode=TwoWay}"
                             TickFrequency="5"
                             IsSnapToTickEnabled="False"
                             ToolTip.Tip="Speed in kph (-10 reverse to +25 forward)"/>
-                    <TextBlock Grid.Column="2" Text="25" Foreground="#888" FontSize="10" VerticalAlignment="Center" Margin="4,0,0,0"/>
+                    <TextBlock Grid.Column="2" Text="25" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" VerticalAlignment="Center" Margin="4,0,0,0"/>
                 </Grid>
 
                 <!-- Speed Display -->

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -44,24 +44,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <Border Classes="FloatingPanel" MinWidth="360" IsVisible="{Binding IsToolsPanelVisible}">
         <StackPanel Spacing="4">
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="#DD2C3E50" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="#AAA" FontSize="20" FontWeight="Bold"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Tools" Foreground="White" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="Tools" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="#888" FontSize="16" Cursor="Hand"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
                         Command="{Binding ToggleToolsPanelCommand}" Margin="8,0,8,0"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,0,0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="4">
                 <!-- Row 0: Wizards -->

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
@@ -29,16 +29,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Floating Panel Style -->
         <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="#DD1E2A38"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="#444"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
 
         <!-- Modern Button Style -->
         <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="#DD34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
@@ -47,10 +47,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="#DD475A6E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.ModernButton:pressed">
-            <Setter Property="Background" Value="#DD3E5872"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -60,13 +60,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto"
                   Height="32"
                   Margin="0,0,0,8"
-                  Background="#DD2C3E50"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                   Cursor="Hand"
                   ToolTip.Tip="Drag to move">
                 <!-- Drag Handle Icon -->
                 <TextBlock Grid.Column="0"
                            Text="="
-                           Foreground="#AAA"
+                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                            FontSize="20"
                            FontWeight="Bold"
                            VerticalAlignment="Center"
@@ -75,7 +75,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Title -->
                 <TextBlock Grid.Column="1"
                            Text="View Settings"
-                           Foreground="White"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            FontSize="16"
                            FontWeight="Bold"
                            VerticalAlignment="Center"
@@ -87,7 +87,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Padding="0"
                         BorderThickness="0"
                         Background="Transparent"
-                        Foreground="#888"
+                        Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                         FontSize="16"
                         Cursor="Hand"
                         Command="{Binding ToggleViewSettingsPanelCommand}"
@@ -95,7 +95,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Margin="8,0,8,0"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,0,0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <!-- Camera Controls -->
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Background="Transparent">
@@ -113,7 +113,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ToolTip.Tip="Toggle 2D/3D view"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- Display Options -->
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Background="Transparent">
@@ -132,10 +132,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Grid.Row="1" Grid.Column="1"
                            Text="10 Hz" Margin="2" Padding="8"
                            HorizontalAlignment="Center" VerticalAlignment="Center"
-                           Foreground="White" FontWeight="Bold" FontSize="12"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="12"/>
             </Grid>
 
-            <Separator Height="1" Background="#444" Margin="0,4"/>
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- Brightness -->
             <Grid ColumnDefinitions="*,*" Background="Transparent">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Modern Button Style -->
         <Style Selector="Button.ModernButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="8,6"/>
             <Setter Property="BorderThickness" Value="0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/ADConverterStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/ADConverterStepView.axaml
@@ -30,8 +30,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <TextBlock Text="{Binding Title}"
                        FontSize="24"
                        FontWeight="Bold"
-                       Foreground="White"/>
-            <Border Background="#34495E"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                     CornerRadius="4"
                     Padding="8,4"
                     Margin="12,0,0,0"
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     IsVisible="{Binding CanSkip}">
                 <TextBlock Text="Optional"
                            FontSize="11"
-                           Foreground="#95A5A6"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
             </Border>
         </StackPanel>
 
@@ -47,7 +47,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -61,7 +61,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,*">
                     <Border Grid.Column="0"
                             Width="80" Height="60"
-                            Background="#2C3E50"
+                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                             CornerRadius="8"
                             Margin="0,0,16,0">
                         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
@@ -81,10 +81,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Differential (ADS1115)"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="16-bit ADC with differential input - best noise rejection"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
@@ -97,7 +97,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,*">
                     <Border Grid.Column="0"
                             Width="80" Height="60"
-                            Background="#2C3E50"
+                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                             CornerRadius="8"
                             Margin="0,0,16,0">
                         <TextBlock Text="ADC"
@@ -111,10 +111,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Single-Ended"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Standard single-ended ADC input (built-in or external)"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
@@ -129,7 +129,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>
@@ -137,7 +137,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.option-button">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Padding" Value="16"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AntennaHeightStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AntennaHeightStepView.axaml
@@ -30,8 +30,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <TextBlock Text="{Binding Title}"
                        FontSize="24"
                        FontWeight="Bold"
-                       Foreground="White"/>
-            <Border Background="#34495E"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                     CornerRadius="4"
                     Padding="8,4"
                     Margin="12,0,0,0"
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     IsVisible="{Binding CanSkip}">
                 <TextBlock Text="Optional"
                            FontSize="11"
-                           Foreground="#95A5A6"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
             </Border>
         </StackPanel>
 
@@ -47,7 +47,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -55,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Value input area -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="20">
             <!-- Antenna Height Diagram - side view showing height from ground -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="8"
                     Padding="20"
                     HorizontalAlignment="Center">
@@ -63,15 +63,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Ground line -->
                     <Line StartPoint="0,0" EndPoint="240,0"
                           Canvas.Left="20" Canvas.Top="100"
-                          Stroke="#7F8C8D" StrokeThickness="2" StrokeDashArray="4,2"/>
+                          Stroke="{DynamicResource SystemControlForegroundBaseLowBrush}" StrokeThickness="2" StrokeDashArray="4,2"/>
                     <!-- Vehicle body -->
                     <Rectangle Canvas.Left="80" Canvas.Top="50" Width="120" Height="35"
-                               Fill="#34495E" RadiusX="6" RadiusY="6"/>
+                               Fill="{DynamicResource SystemControlBackgroundBaseLowBrush}" RadiusX="6" RadiusY="6"/>
                     <!-- Wheels -->
                     <Ellipse Canvas.Left="85" Canvas.Top="75" Width="25" Height="25"
-                             Fill="#7F8C8D" Stroke="#6C7A89" StrokeThickness="2"/>
+                             Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Stroke="#6C7A89" StrokeThickness="2"/>
                     <Ellipse Canvas.Left="170" Canvas.Top="75" Width="25" Height="25"
-                             Fill="#7F8C8D" Stroke="#6C7A89" StrokeThickness="2"/>
+                             Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Stroke="#6C7A89" StrokeThickness="2"/>
                     <!-- GPS Antenna on roof -->
                     <Ellipse Canvas.Left="132" Canvas.Top="35" Width="16" Height="16"
                              Fill="#1ABC9C" Stroke="#16A085" StrokeThickness="2"/>
@@ -81,21 +81,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Height arrow (vertical) -->
                     <Line StartPoint="0,0" EndPoint="0,57"
                           Canvas.Left="230" Canvas.Top="43"
-                          Stroke="#3498DB" StrokeThickness="2"/>
+                          Stroke="{DynamicResource SystemControlHighlightAccentBrush}" StrokeThickness="2"/>
                     <!-- Arrow heads -->
-                    <Polygon Canvas.Left="225" Canvas.Top="38" Points="0,10 10,10 5,0" Fill="#3498DB"/>
-                    <Polygon Canvas.Left="225" Canvas.Top="95" Points="0,0 10,0 5,10" Fill="#3498DB"/>
+                    <Polygon Canvas.Left="225" Canvas.Top="38" Points="0,10 10,10 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
+                    <Polygon Canvas.Left="225" Canvas.Top="95" Points="0,0 10,0 5,10" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
                     <!-- Height label -->
                     <TextBlock Canvas.Left="240" Canvas.Top="65" Text="Height"
-                               Foreground="#3498DB" FontSize="11" FontWeight="SemiBold"/>
+                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="11" FontWeight="SemiBold"/>
                     <!-- Ground label -->
                     <TextBlock Canvas.Left="25" Canvas.Top="103" Text="Ground"
-                               Foreground="#7F8C8D" FontSize="10"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                 </Canvas>
             </Border>
 
             <!-- Input -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="12"
                     Padding="24,16"
                     HorizontalAlignment="Center">
@@ -110,13 +110,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="180"
                                    HorizontalContentAlignment="Center"
                                    Background="#1E2A35"
-                                   Foreground="White"
-                                   BorderBrush="#3498DB"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   BorderBrush="{DynamicResource SystemControlHighlightAccentBrush}"
                                    BorderThickness="2"
                                    CornerRadius="8"/>
                     <TextBlock Text="{Binding Unit}"
                                FontSize="24"
-                               Foreground="#95A5A6"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                VerticalAlignment="Center"
                                Margin="8,0,0,0"/>
                 </StackPanel>
@@ -131,7 +131,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AntennaOffsetStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AntennaOffsetStepView.axaml
@@ -30,8 +30,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <TextBlock Text="{Binding Title}"
                        FontSize="24"
                        FontWeight="Bold"
-                       Foreground="White"/>
-            <Border Background="#34495E"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                     CornerRadius="4"
                     Padding="8,4"
                     Margin="12,0,0,0"
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     IsVisible="{Binding CanSkip}">
                 <TextBlock Text="Optional"
                            FontSize="11"
-                           Foreground="#95A5A6"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
             </Border>
         </StackPanel>
 
@@ -47,7 +47,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -55,20 +55,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Value input area -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="20">
             <!-- Antenna Offset Diagram - rear view showing lateral offset -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="8"
                     Padding="20"
                     HorizontalAlignment="Center">
                 <Canvas Width="280" Height="100">
                     <!-- Vehicle body (rear view) -->
                     <Rectangle Canvas.Left="90" Canvas.Top="20" Width="100" Height="60"
-                               Fill="#34495E" RadiusX="4" RadiusY="4"/>
+                               Fill="{DynamicResource SystemControlBackgroundBaseLowBrush}" RadiusX="4" RadiusY="4"/>
                     <!-- Left wheel -->
                     <Rectangle Canvas.Left="60" Canvas.Top="50" Width="20" Height="35"
-                               Fill="#7F8C8D" RadiusX="3" RadiusY="3"/>
+                               Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" RadiusX="3" RadiusY="3"/>
                     <!-- Right wheel -->
                     <Rectangle Canvas.Left="200" Canvas.Top="50" Width="20" Height="35"
-                               Fill="#7F8C8D" RadiusX="3" RadiusY="3"/>
+                               Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" RadiusX="3" RadiusY="3"/>
                     <!-- Center line -->
                     <Line StartPoint="0,0" EndPoint="0,75"
                           Canvas.Left="140" Canvas.Top="15"
@@ -79,17 +79,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Offset arrow -->
                     <Line StartPoint="0,0" EndPoint="20,0"
                           Canvas.Left="140" Canvas.Top="12"
-                          Stroke="#3498DB" StrokeThickness="2"/>
-                    <Polygon Canvas.Left="157" Canvas.Top="7" Points="0,5 10,5 5,0" Fill="#3498DB"/>
+                          Stroke="{DynamicResource SystemControlHighlightAccentBrush}" StrokeThickness="2"/>
+                    <Polygon Canvas.Left="157" Canvas.Top="7" Points="0,5 10,5 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
                     <!-- Labels -->
                     <TextBlock Canvas.Left="130" Canvas.Top="88" Text="Center"
                                Foreground="#E74C3C" FontSize="9"/>
                     <TextBlock Canvas.Left="175" Canvas.Top="5" Text="GPS"
                                Foreground="#1ABC9C" FontSize="9"/>
                     <TextBlock Canvas.Left="20" Canvas.Top="40" Text="Left"
-                               Foreground="#7F8C8D" FontSize="10"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                     <TextBlock Canvas.Left="245" Canvas.Top="40" Text="Right"
-                               Foreground="#7F8C8D" FontSize="10"/>
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                 </Canvas>
             </Border>
 
@@ -99,29 +99,29 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Spacing="12">
                 <Button Content="Left"
                         Width="80" Height="44"
-                        Background="#34495E"
-                        Foreground="White"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         CornerRadius="8"
                         FontWeight="SemiBold"
                         Command="{Binding SetLeftCommand}"/>
                 <Button Content="Center"
                         Width="80" Height="44"
-                        Background="#34495E"
-                        Foreground="White"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         CornerRadius="8"
                         FontWeight="SemiBold"
                         Command="{Binding SetCenterCommand}"/>
                 <Button Content="Right"
                         Width="80" Height="44"
-                        Background="#34495E"
-                        Foreground="White"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         CornerRadius="8"
                         FontWeight="SemiBold"
                         Command="{Binding SetRightCommand}"/>
             </StackPanel>
 
             <!-- Input -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="12"
                     Padding="24,16"
                     HorizontalAlignment="Center">
@@ -136,13 +136,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="180"
                                    HorizontalContentAlignment="Center"
                                    Background="#1E2A35"
-                                   Foreground="White"
-                                   BorderBrush="#3498DB"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   BorderBrush="{DynamicResource SystemControlHighlightAccentBrush}"
                                    BorderThickness="2"
                                    CornerRadius="8"/>
                     <TextBlock Text="{Binding Unit}"
                                FontSize="24"
-                               Foreground="#95A5A6"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                VerticalAlignment="Center"
                                Margin="8,0,0,0"/>
                 </StackPanel>
@@ -151,7 +151,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Hint -->
             <TextBlock Text="Positive = right of center, Negative = left of center"
                        FontSize="12"
-                       Foreground="#7F8C8D"
+                       Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                        HorizontalAlignment="Center"/>
         </StackPanel>
 
@@ -163,7 +163,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AntennaPivotStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AntennaPivotStepView.axaml
@@ -30,14 +30,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,12"/>
 
         <!-- Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -45,17 +45,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Value input area -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="20">
             <!-- Antenna Pivot Diagram - side view showing antenna position -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="8"
                     Padding="20"
                     HorizontalAlignment="Center">
                 <Canvas Width="280" Height="120">
                     <!-- Vehicle body -->
                     <Rectangle Canvas.Left="40" Canvas.Top="35" Width="200" Height="40"
-                               Fill="#34495E" RadiusX="8" RadiusY="8"/>
+                               Fill="{DynamicResource SystemControlBackgroundBaseLowBrush}" RadiusX="8" RadiusY="8"/>
                     <!-- Front wheel -->
                     <Ellipse Canvas.Left="180" Canvas.Top="60" Width="30" Height="30"
-                             Fill="#7F8C8D" Stroke="#6C7A89" StrokeThickness="2"/>
+                             Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Stroke="#6C7A89" StrokeThickness="2"/>
                     <!-- Rear wheel (pivot point) -->
                     <Ellipse Canvas.Left="70" Canvas.Top="60" Width="30" Height="30"
                              Fill="#E74C3C" Stroke="#C0392B" StrokeThickness="2"/>
@@ -68,13 +68,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Pivot arrow line -->
                     <Line StartPoint="0,0" EndPoint="78,0"
                           Canvas.Left="85" Canvas.Top="100"
-                          Stroke="#3498DB" StrokeThickness="2"/>
+                          Stroke="{DynamicResource SystemControlHighlightAccentBrush}" StrokeThickness="2"/>
                     <!-- Arrow heads -->
-                    <Polygon Canvas.Left="80" Canvas.Top="95" Points="0,5 10,5 5,0" Fill="#3498DB"/>
-                    <Polygon Canvas.Left="158" Canvas.Top="95" Points="0,5 10,5 5,0" Fill="#3498DB"/>
+                    <Polygon Canvas.Left="80" Canvas.Top="95" Points="0,5 10,5 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
+                    <Polygon Canvas.Left="158" Canvas.Top="95" Points="0,5 10,5 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
                     <!-- Labels -->
                     <TextBlock Canvas.Left="100" Canvas.Top="103" Text="Antenna Pivot"
-                               Foreground="#3498DB" FontSize="11" FontWeight="SemiBold"/>
+                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="11" FontWeight="SemiBold"/>
                     <TextBlock Canvas.Left="62" Canvas.Top="78" Text="Pivot"
                                Foreground="#E74C3C" FontSize="9"/>
                     <TextBlock Canvas.Left="150" Canvas.Top="5" Text="GPS"
@@ -83,7 +83,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Input -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="12"
                     Padding="24,16"
                     HorizontalAlignment="Center">
@@ -98,13 +98,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="180"
                                    HorizontalContentAlignment="Center"
                                    Background="#1E2A35"
-                                   Foreground="White"
-                                   BorderBrush="#3498DB"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   BorderBrush="{DynamicResource SystemControlHighlightAccentBrush}"
                                    BorderThickness="2"
                                    CornerRadius="8"/>
                     <TextBlock Text="{Binding Unit}"
                                FontSize="24"
-                               Foreground="#95A5A6"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                VerticalAlignment="Center"
                                Margin="8,0,0,0"/>
                 </StackPanel>
@@ -113,7 +113,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Hint about positive/negative -->
             <TextBlock Text="Positive = ahead of rear axle, Negative = behind"
                        FontSize="12"
-                       Foreground="#7F8C8D"
+                       Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                        HorizontalAlignment="Center"/>
         </StackPanel>
 
@@ -125,7 +125,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/DanfossStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/DanfossStepView.axaml
@@ -30,8 +30,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <TextBlock Text="{Binding Title}"
                        FontSize="24"
                        FontWeight="Bold"
-                       Foreground="White"/>
-            <Border Background="#34495E"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                     CornerRadius="4"
                     Padding="8,4"
                     Margin="12,0,0,0"
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     IsVisible="{Binding CanSkip}">
                 <TextBlock Text="Optional"
                            FontSize="11"
-                           Foreground="#95A5A6"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
             </Border>
         </StackPanel>
 
@@ -47,7 +47,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -55,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Danfoss toggle -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="20">
             <!-- Info box -->
-            <Border Background="#2C3E50" CornerRadius="12" Padding="20">
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20">
                 <StackPanel Spacing="12">
                     <TextBlock Text="Danfoss Hydraulic Valves"
                                FontSize="18"
@@ -63,23 +63,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                Foreground="#E67E22"/>
                     <TextBlock Text="Danfoss OSPC/OSPB steering valves require specific PWM timing signals. Only enable this if you have confirmed Danfoss hardware installed."
                                FontSize="14"
-                               Foreground="#BDC3C7"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                                TextWrapping="Wrap"
                                LineHeight="20"/>
                 </StackPanel>
             </Border>
 
             <!-- Toggle -->
-            <Border Background="#34495E" CornerRadius="12" Padding="20">
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="12" Padding="20">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel Grid.Column="0" VerticalAlignment="Center">
                         <TextBlock Text="Enable Danfoss Mode"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Use Danfoss-specific PWM timing"
                                    FontSize="14"
-                                   Foreground="#95A5A6"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
                     </StackPanel>
                     <ToggleSwitch Grid.Column="1"
                                   IsChecked="{Binding DanfossEnabled}"
@@ -117,7 +117,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/FinishStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/FinishStepView.axaml
@@ -37,14 +37,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="15"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="24"
                    Margin="0,0,0,24"/>
 
         <!-- Success indicator -->
         <Border Grid.Row="2"
-                Background="#2C3E50"
+                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
                 Padding="24"
                 HorizontalAlignment="Center"
@@ -58,7 +58,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <TextBlock Text="OK"
                                FontSize="24"
                                FontWeight="Bold"
-                               Foreground="White"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center"/>
                 </Border>
@@ -66,12 +66,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Text="Configuration saved!"
                            FontSize="18"
                            FontWeight="SemiBold"
-                           Foreground="White"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            HorizontalAlignment="Center"/>
 
                 <TextBlock Text="Click Finish to close the wizard"
                            FontSize="14"
-                           Foreground="#95A5A6"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                            HorizontalAlignment="Center"/>
             </StackPanel>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/InvertSettingsStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/InvertSettingsStepView.axaml
@@ -30,8 +30,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <TextBlock Text="{Binding Title}"
                        FontSize="24"
                        FontWeight="Bold"
-                       Foreground="White"/>
-            <Border Background="#34495E"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                     CornerRadius="4"
                     Padding="8,4"
                     Margin="12,0,0,0"
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     IsVisible="{Binding CanSkip}">
                 <TextBlock Text="Optional"
                            FontSize="11"
-                           Foreground="#95A5A6"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
             </Border>
         </StackPanel>
 
@@ -47,7 +47,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -55,16 +55,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Toggle options -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="16">
             <!-- Invert WAS -->
-            <Border Background="#34495E" CornerRadius="12" Padding="16">
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="12" Padding="16">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel Grid.Column="0" VerticalAlignment="Center">
                         <TextBlock Text="Invert Wheel Angle Sensor"
                                    FontSize="16"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Enable if WAS reads backwards (left shows as right)"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                     <ToggleSwitch Grid.Column="1"
@@ -76,16 +76,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Invert Motor -->
-            <Border Background="#34495E" CornerRadius="12" Padding="16">
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="12" Padding="16">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel Grid.Column="0" VerticalAlignment="Center">
                         <TextBlock Text="Invert Motor Direction"
                                    FontSize="16"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Enable if motor turns the wrong direction"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                     <ToggleSwitch Grid.Column="1"
@@ -97,16 +97,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Invert Relays -->
-            <Border Background="#34495E" CornerRadius="12" Padding="16">
+            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="12" Padding="16">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel Grid.Column="0" VerticalAlignment="Center">
                         <TextBlock Text="Invert Relay Outputs"
                                    FontSize="16"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Enable if relays are active-low"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                     <ToggleSwitch Grid.Column="1"
@@ -126,7 +126,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/MotorDriverStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/MotorDriverStepView.axaml
@@ -30,14 +30,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,12"/>
 
         <!-- Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -51,13 +51,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,*">
                     <Border Grid.Column="0"
                             Width="80" Height="60"
-                            Background="#2C3E50"
+                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                             CornerRadius="8"
                             Margin="0,0,16,0">
                         <TextBlock Text="IBT2"
                                    FontSize="18"
                                    FontWeight="Bold"
-                                   Foreground="#3498DB"
+                                   Foreground="{DynamicResource SystemControlHighlightAccentBrush}"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"/>
                     </Border>
@@ -65,10 +65,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="IBT2 (Dual H-Bridge)"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Most common driver - uses two PWM signals for direction control"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
@@ -81,7 +81,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,*">
                     <Border Grid.Column="0"
                             Width="80" Height="60"
-                            Background="#2C3E50"
+                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                             CornerRadius="8"
                             Margin="0,0,16,0">
                         <TextBlock Text="Cytron"
@@ -95,10 +95,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Cytron (PWM + DIR)"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Single PWM signal with separate direction pin"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
@@ -113,7 +113,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>
@@ -121,7 +121,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.option-button">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Padding" Value="16"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/NumericStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/NumericStepView.axaml
@@ -29,14 +29,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,12"/>
 
         <!-- Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -44,7 +44,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Value input area -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="16">
             <!-- Current value display -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="12"
                     Padding="24,16"
                     HorizontalAlignment="Center">
@@ -60,13 +60,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="200"
                                    HorizontalContentAlignment="Center"
                                    Background="#1E2A35"
-                                   Foreground="White"
-                                   BorderBrush="#3498DB"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   BorderBrush="{DynamicResource SystemControlHighlightAccentBrush}"
                                    BorderThickness="2"
                                    CornerRadius="8"/>
                     <TextBlock Text="{Binding Unit, FallbackValue=m}"
                                FontSize="24"
-                               Foreground="#95A5A6"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                VerticalAlignment="Center"
                                Margin="8,0,0,0"/>
                 </StackPanel>
@@ -78,29 +78,29 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Spacing="8">
                 <Button Content="-0.5"
                         Width="60" Height="40"
-                        Background="#34495E"
-                        Foreground="White"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         CornerRadius="6"
                         Command="{Binding AdjustCommand}"
                         CommandParameter="-0.5"/>
                 <Button Content="-0.1"
                         Width="60" Height="40"
-                        Background="#34495E"
-                        Foreground="White"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         CornerRadius="6"
                         Command="{Binding AdjustCommand}"
                         CommandParameter="-0.1"/>
                 <Button Content="+0.1"
                         Width="60" Height="40"
-                        Background="#34495E"
-                        Foreground="White"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         CornerRadius="6"
                         Command="{Binding AdjustCommand}"
                         CommandParameter="0.1"/>
                 <Button Content="+0.5"
                         Width="60" Height="40"
-                        Background="#34495E"
-                        Foreground="White"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         CornerRadius="6"
                         Command="{Binding AdjustCommand}"
                         CommandParameter="0.5"/>
@@ -115,7 +115,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/SteerEnableStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/SteerEnableStepView.axaml
@@ -30,14 +30,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,12"/>
 
         <!-- Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -51,13 +51,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,*">
                     <Border Grid.Column="0"
                             Width="60" Height="60"
-                            Background="#2C3E50"
+                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                             CornerRadius="8"
                             Margin="0,0,16,0">
                         <TextBlock Text="SW"
                                    FontSize="20"
                                    FontWeight="Bold"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"/>
                     </Border>
@@ -65,10 +65,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="None (Software Only)"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Enable/disable AutoSteer from the touchscreen"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
@@ -81,13 +81,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,*">
                     <Border Grid.Column="0"
                             Width="60" Height="60"
-                            Background="#2C3E50"
+                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                             CornerRadius="8"
                             Margin="0,0,16,0">
                         <Canvas Width="40" Height="40">
                             <!-- Toggle switch icon -->
                             <Rectangle Canvas.Left="5" Canvas.Top="15" Width="30" Height="10"
-                                       Fill="#7F8C8D" RadiusX="5" RadiusY="5"/>
+                                       Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" RadiusX="5" RadiusY="5"/>
                             <Ellipse Canvas.Left="20" Canvas.Top="10" Width="20" Height="20"
                                      Fill="#1ABC9C"/>
                         </Canvas>
@@ -96,10 +96,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Toggle Switch"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Physical ON/OFF switch - AutoSteer active when switch is ON"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
@@ -112,13 +112,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="Auto,*">
                     <Border Grid.Column="0"
                             Width="60" Height="60"
-                            Background="#2C3E50"
+                            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                             CornerRadius="8"
                             Margin="0,0,16,0">
                         <Canvas Width="40" Height="40">
                             <!-- Momentary button icon -->
                             <Ellipse Canvas.Left="8" Canvas.Top="8" Width="24" Height="24"
-                                     Fill="#7F8C8D" Stroke="#95A5A6" StrokeThickness="2"/>
+                                     Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Stroke="{DynamicResource SystemControlForegroundBaseMediumBrush}" StrokeThickness="2"/>
                             <Ellipse Canvas.Left="12" Canvas.Top="12" Width="16" Height="16"
                                      Fill="#E74C3C"/>
                         </Canvas>
@@ -127,10 +127,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Momentary Button"
                                    FontSize="18"
                                    FontWeight="SemiBold"
-                                   Foreground="White"/>
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Press to toggle AutoSteer ON/OFF - latching behavior"
                                    FontSize="13"
-                                   Foreground="#95A5A6"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                    TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
@@ -145,7 +145,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>
@@ -153,7 +153,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Button.option-button">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Padding" Value="16"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/TrackWidthStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/TrackWidthStepView.axaml
@@ -30,14 +30,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,12"/>
 
         <!-- Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -45,14 +45,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Value input area -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="20">
             <!-- Track Width Diagram - top/rear view of vehicle -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="8"
                     Padding="20"
                     HorizontalAlignment="Center">
                 <Canvas Width="280" Height="100">
                     <!-- Vehicle body (top view) -->
                     <Rectangle Canvas.Left="90" Canvas.Top="10" Width="100" Height="80"
-                               Fill="#34495E" RadiusX="4" RadiusY="4"/>
+                               Fill="{DynamicResource SystemControlBackgroundBaseLowBrush}" RadiusX="4" RadiusY="4"/>
                     <!-- Left wheel -->
                     <Rectangle Canvas.Left="50" Canvas.Top="30" Width="30" Height="40"
                                Fill="#1ABC9C" RadiusX="4" RadiusY="4"/>
@@ -62,18 +62,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Track width arrow line -->
                     <Line StartPoint="0,0" EndPoint="150,0"
                           Canvas.Left="65" Canvas.Top="80"
-                          Stroke="#3498DB" StrokeThickness="2"/>
+                          Stroke="{DynamicResource SystemControlHighlightAccentBrush}" StrokeThickness="2"/>
                     <!-- Arrow heads -->
-                    <Polygon Canvas.Left="60" Canvas.Top="75" Points="0,5 10,5 5,0" Fill="#3498DB"/>
-                    <Polygon Canvas.Left="210" Canvas.Top="75" Points="0,5 10,5 5,0" Fill="#3498DB"/>
+                    <Polygon Canvas.Left="60" Canvas.Top="75" Points="0,5 10,5 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
+                    <Polygon Canvas.Left="210" Canvas.Top="75" Points="0,5 10,5 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
                     <!-- Track width label -->
                     <TextBlock Canvas.Left="110" Canvas.Top="83" Text="Track Width"
-                               Foreground="#3498DB" FontSize="12" FontWeight="SemiBold"/>
+                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12" FontWeight="SemiBold"/>
                 </Canvas>
             </Border>
 
             <!-- Input -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="12"
                     Padding="24,16"
                     HorizontalAlignment="Center">
@@ -88,13 +88,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="180"
                                    HorizontalContentAlignment="Center"
                                    Background="#1E2A35"
-                                   Foreground="White"
-                                   BorderBrush="#3498DB"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   BorderBrush="{DynamicResource SystemControlHighlightAccentBrush}"
                                    BorderThickness="2"
                                    CornerRadius="8"/>
                     <TextBlock Text="{Binding Unit}"
                                FontSize="24"
-                               Foreground="#95A5A6"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                VerticalAlignment="Center"
                                Margin="8,0,0,0"/>
                 </StackPanel>
@@ -109,7 +109,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/WelcomeStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/WelcomeStepView.axaml
@@ -30,21 +30,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,16"/>
 
         <!-- Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="15"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="24"
                    Margin="0,0,0,24"/>
 
         <!-- Icon/Image area -->
         <Border Grid.Row="2"
-                Background="#2C3E50"
+                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12"
                 Padding="20"
                 HorizontalAlignment="Center"
@@ -57,20 +57,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            HorizontalAlignment="Center"/>
                 <TextBlock Text="Configuration Wizard"
                            FontSize="18"
-                           Foreground="#95A5A6"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                            HorizontalAlignment="Center"/>
             </StackPanel>
         </Border>
 
         <!-- Tip -->
         <Border Grid.Row="3"
-                Background="#34495E"
+                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                 CornerRadius="8"
                 Padding="12"
                 Margin="0,20,0,0">
             <TextBlock Text="Tip: Have your vehicle measurements ready before starting."
                        FontSize="13"
-                       Foreground="#95A5A6"
+                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                        TextWrapping="Wrap"/>
         </Border>
     </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/WheelbaseStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/WheelbaseStepView.axaml
@@ -30,14 +30,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,12"/>
 
         <!-- Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#BDC3C7"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                    TextWrapping="Wrap"
                    LineHeight="22"
                    Margin="0,0,0,24"/>
@@ -45,14 +45,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Value input area -->
         <StackPanel Grid.Row="2" VerticalAlignment="Center" Spacing="20">
             <!-- Wheelbase Diagram - side view of vehicle -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="8"
                     Padding="20"
                     HorizontalAlignment="Center">
                 <Canvas Width="280" Height="100">
                     <!-- Vehicle body -->
                     <Rectangle Canvas.Left="40" Canvas.Top="25" Width="200" Height="40"
-                               Fill="#34495E" RadiusX="8" RadiusY="8"/>
+                               Fill="{DynamicResource SystemControlBackgroundBaseLowBrush}" RadiusX="8" RadiusY="8"/>
                     <!-- Front wheel -->
                     <Ellipse Canvas.Left="180" Canvas.Top="50" Width="30" Height="30"
                              Fill="#1ABC9C" Stroke="#16A085" StrokeThickness="2"/>
@@ -62,18 +62,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Wheelbase arrow line -->
                     <Line StartPoint="0,0" EndPoint="110,0"
                           Canvas.Left="85" Canvas.Top="90"
-                          Stroke="#3498DB" StrokeThickness="2"/>
+                          Stroke="{DynamicResource SystemControlHighlightAccentBrush}" StrokeThickness="2"/>
                     <!-- Arrow heads -->
-                    <Polygon Canvas.Left="80" Canvas.Top="85" Points="0,5 10,5 5,0" Fill="#3498DB"/>
-                    <Polygon Canvas.Left="190" Canvas.Top="85" Points="0,5 10,5 5,0" Fill="#3498DB"/>
+                    <Polygon Canvas.Left="80" Canvas.Top="85" Points="0,5 10,5 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
+                    <Polygon Canvas.Left="190" Canvas.Top="85" Points="0,5 10,5 5,0" Fill="{DynamicResource SystemControlHighlightAccentBrush}"/>
                     <!-- Wheelbase label -->
                     <TextBlock Canvas.Left="115" Canvas.Top="88" Text="Wheelbase"
-                               Foreground="#3498DB" FontSize="12" FontWeight="SemiBold"/>
+                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12" FontWeight="SemiBold"/>
                 </Canvas>
             </Border>
 
             <!-- Input -->
-            <Border Background="#2C3E50"
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                     CornerRadius="12"
                     Padding="24,16"
                     HorizontalAlignment="Center">
@@ -88,13 +88,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Width="180"
                                    HorizontalContentAlignment="Center"
                                    Background="#1E2A35"
-                                   Foreground="White"
-                                   BorderBrush="#3498DB"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   BorderBrush="{DynamicResource SystemControlHighlightAccentBrush}"
                                    BorderThickness="2"
                                    CornerRadius="8"/>
                     <TextBlock Text="{Binding Unit}"
                                FontSize="24"
-                               Foreground="#95A5A6"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                VerticalAlignment="Center"
                                Margin="8,0,0,0"/>
                 </StackPanel>
@@ -109,7 +109,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardHost.axaml
@@ -29,7 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Ellipse.step-dot">
             <Setter Property="Width" Value="12"/>
             <Setter Property="Height" Value="12"/>
-            <Setter Property="Fill" Value="#3498DB"/>
+            <Setter Property="Fill" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="Opacity" Value="0.4"/>
             <Setter Property="Margin" Value="4,0"/>
         </Style>
@@ -58,7 +58,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="Button.wizard-nav.secondary">
-            <Setter Property="Background" Value="#34495E"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="White"/>
         </Style>
         <Style Selector="Button.wizard-nav.cancel">
@@ -72,7 +72,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid RowDefinitions="Auto,Auto,*,Auto,Auto">
         <!-- Header with title and progress -->
-        <Border Grid.Row="0" Background="#2C3E50" Padding="16,12">
+        <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,12">
             <Grid ColumnDefinitions="*,Auto">
                 <TextBlock Text="{Binding WizardTitle}"
                            FontSize="22" FontWeight="Bold"
@@ -81,7 +81,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Grid.Column="1"
                            Text="{Binding StepDisplay}"
                            FontSize="14"
-                           Foreground="#95A5A6"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                            VerticalAlignment="Center"/>
             </Grid>
         </Border>
@@ -106,7 +106,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Border>
 
         <!-- Step indicator dots -->
-        <Border Grid.Row="3" Background="#2C3E50" Padding="12,8"
+        <Border Grid.Row="3" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="12,8"
                 IsVisible="{Binding !!TotalSteps}">
             <ItemsControl ItemsSource="{Binding Steps}"
                           HorizontalAlignment="Center">
@@ -125,7 +125,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Border>
 
         <!-- Navigation buttons -->
-        <Border Grid.Row="4" Background="#2C3E50" Padding="16,12">
+        <Border Grid.Row="4" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,12">
             <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto">
                 <!-- Cancel button (left) -->
                 <Button Grid.Column="0"

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardHost.axaml
@@ -55,15 +55,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.wizard-nav.primary">
             <Setter Property="Background" Value="#1ABC9C"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.wizard-nav.secondary">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.wizard-nav.cancel">
             <Setter Property="Background" Value="#E74C3C"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
         <Style Selector="Button.wizard-nav:disabled">
             <Setter Property="Opacity" Value="0.5"/>
@@ -91,7 +91,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                      Minimum="0" Maximum="100"
                      Value="{Binding ProgressPercent}"
                      Height="6"
-                     Background="#1a1a1a"
+                     Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                      Foreground="#1ABC9C"/>
 
         <!-- Step content area -->

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardStepView.axaml
@@ -31,14 +31,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                    Text="{Binding Title}"
                    FontSize="24"
                    FontWeight="Bold"
-                   Foreground="White"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                    Margin="0,0,0,8"/>
 
         <!-- Step Description -->
         <TextBlock Grid.Row="1"
                    Text="{Binding Description}"
                    FontSize="14"
-                   Foreground="#95A5A6"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                    TextWrapping="Wrap"
                    Margin="0,0,0,20"/>
 
@@ -56,7 +56,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Margin="0,16,0,0"
                 IsVisible="{Binding HasValidationError}">
             <TextBlock Text="{Binding ValidationMessage}"
-                       Foreground="White"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        FontSize="14"
                        TextWrapping="Wrap"/>
         </Border>

--- a/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
@@ -34,8 +34,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <converters:GreaterThanConverter x:Key="GreaterThanConverter"/>
     <converters:EqualityConverter x:Key="EqualityConverter"/>
 
-    <!-- Dark theme overrides: use dark gray instead of pure black -->
+    <!-- Theme overrides for both variants -->
     <ResourceDictionary.ThemeDictionaries>
+        <!-- Light: replace semi-transparent overlays with solid colors for readability -->
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="#FAFAFA"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumBrush" Color="#E8E8E8"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumLowBrush" Color="#EFEFEF"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundListLowBrush" Color="#F2F2F2"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundBaseLowBrush" Color="#CCCCCC"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundBaseMediumLowBrush" Color="#BBBBBB"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundBaseMediumBrush" Color="#AAAAAA"/>
+            <SolidColorBrush x:Key="SystemControlForegroundBaseHighBrush" Color="#1A1A1A"/>
+            <SolidColorBrush x:Key="SystemControlForegroundBaseMediumHighBrush" Color="#333333"/>
+            <SolidColorBrush x:Key="SystemControlForegroundBaseMediumBrush" Color="#555555"/>
+            <SolidColorBrush x:Key="SystemControlForegroundBaseLowBrush" Color="#888888"/>
+        </ResourceDictionary>
+        <!-- Dark: use dark blue-gray instead of pure black -->
         <ResourceDictionary x:Key="Dark">
             <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="#1E1E2E"/>
             <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumBrush" Color="#282838"/>

--- a/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
@@ -34,4 +34,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <converters:GreaterThanConverter x:Key="GreaterThanConverter"/>
     <converters:EqualityConverter x:Key="EqualityConverter"/>
 
+    <!-- Dark theme overrides: use dark gray instead of pure black -->
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Dark">
+            <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="#1E1E2E"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumBrush" Color="#282838"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumLowBrush" Color="#2D2D3D"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundListLowBrush" Color="#323245"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundBaseLowBrush" Color="#3A3A4E"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundBaseMediumLowBrush" Color="#45455A"/>
+            <SolidColorBrush x:Key="SystemControlBackgroundBaseMediumBrush" Color="#505068"/>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
 </ResourceDictionary>

--- a/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
@@ -25,7 +25,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <!-- Floating Panel Style -->
     <Style Selector="Border.FloatingPanel">
-        <Setter Property="Background" Value="#DD2C3E50"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         <Setter Property="CornerRadius" Value="12"/>
         <Setter Property="Padding" Value="15"/>
         <Setter Property="BoxShadow" Value="0 4 16 2 #40000000"/>
@@ -33,7 +33,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <!-- Modern Button Style -->
     <Style Selector="Button.ModernButton">
-        <Setter Property="Background" Value="#3498DB"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         <Setter Property="Foreground" Value="White"/>
         <Setter Property="CornerRadius" Value="6"/>
         <Setter Property="Padding" Value="12,6"/>
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <!-- Icon Button Style -->
     <Style Selector="Button.IconButton">
-        <Setter Property="Background" Value="#DD34495E"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         <Setter Property="Foreground" Value="White"/>
         <Setter Property="CornerRadius" Value="8"/>
         <Setter Property="Width" Value="48"/>
@@ -71,12 +71,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Setter Property="FontSize" Value="20"/>
     </Style>
     <Style Selector="Button.IconButton:pointerover">
-        <Setter Property="Background" Value="#DD475A6E"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
     </Style>
 
     <!-- Left Panel Button Style (for image-based icons) -->
     <Style Selector="Button.LeftPanelButton">
-        <Setter Property="Background" Value="#DD34495E"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         <Setter Property="CornerRadius" Value="8"/>
         <Setter Property="Width" Value="64"/>
         <Setter Property="Height" Value="64"/>
@@ -85,15 +85,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Setter Property="Cursor" Value="Hand"/>
     </Style>
     <Style Selector="Button.LeftPanelButton:pointerover">
-        <Setter Property="Background" Value="#DD475A6E"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
     </Style>
     <Style Selector="Button.LeftPanelButton:pressed">
-        <Setter Property="Background" Value="#DD3E5872"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
     </Style>
 
     <!-- Left Panel Separator -->
     <Style Selector="Separator.LeftPanelSeparator">
-        <Setter Property="Background" Value="#444"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         <Setter Property="Height" Value="2"/>
         <Setter Property="Margin" Value="8,4"/>
     </Style>

--- a/Tests/AgValoniaGPS.IntegrationTests/Program.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/Program.cs
@@ -179,12 +179,59 @@ sealed class Program
             vm.ConfigurationViewModel.IsDialogVisible = false;
         Console.WriteLine("OK");
 
-        // Step 7: Night mode
-        Console.Write("[Step 7] Night mode... ");
-        // FluentTheme dark/light switching requires PR #81 which is not merged here.
-        // SetDayMode only affects map background, not the full theme.
-        Console.Write("[theme switching not available on this branch] ");
-        CaptureScreenshot(window, "07_current_theme");
+        // Step 7+: Theme switching and new dialogs (PR #81)
+        await RunThemeAndDialogsScenario(window, vm);
+    }
+
+    static async Task RunThemeAndDialogsScenario(Window window, MainViewModel vm)
+    {
+        // Step 7: Current theme (light/day mode) screenshot
+        Console.Write("[Step 7] Current theme (light)... ");
+        CaptureScreenshot(window, "theme_01_light");
+        Console.WriteLine("OK");
+
+        // Step 8: Toggle to dark/night theme
+        Console.Write("[Step 8] Toggle to dark theme... ");
+        vm.ToggleDayNightCommand?.Execute(null);
+        await Delay(500);
+        CaptureScreenshot(window, "theme_02_dark");
+        Console.WriteLine("OK");
+
+        // Step 9: Toggle back to light (verify round-trip)
+        Console.Write("[Step 9] Toggle back to light... ");
+        vm.ToggleDayNightCommand?.Execute(null);
+        await Delay(500);
+        CaptureScreenshot(window, "theme_03_light_roundtrip");
+        Console.WriteLine("OK");
+
+        // Step 10: Open Log Viewer dialog
+        Console.Write("[Step 10] Log Viewer dialog... ");
+        vm.ShowLogViewerDialogCommand?.Execute(null);
+        await Delay(500);
+        CaptureScreenshot(window, "theme_04_log_viewer");
+        vm.CloseLogViewerDialogCommand?.Execute(null);
+        await Delay(200);
+        Console.WriteLine("OK");
+
+        // Step 11: Open Flag By Lat/Lon dialog
+        Console.Write("[Step 11] Flag by Lat/Lon dialog... ");
+        vm.ShowFlagByLatLonDialogCommand?.Execute(null);
+        await Delay(500);
+        vm.FlagLatitudeInput = "43.653225";
+        vm.FlagLongitudeInput = "-79.383186";
+        await Delay(200);
+        CaptureScreenshot(window, "theme_05_flag_by_latlon");
+        vm.CloseFlagByLatLonDialogCommand?.Execute(null);
+        await Delay(200);
+        Console.WriteLine("OK");
+
+        // Step 12: Open View All Settings dialog
+        Console.Write("[Step 12] View All Settings dialog... ");
+        vm.ShowViewSettingsDialogCommand?.Execute(null);
+        await Delay(500);
+        CaptureScreenshot(window, "theme_06_view_all_settings");
+        vm.CloseViewSettingsDialogCommand?.Execute(null);
+        await Delay(200);
         Console.WriteLine("OK");
     }
 

--- a/Tests/AgValoniaGPS.UI.Tests/AgValoniaGPS.UI.Tests.csproj
+++ b/Tests/AgValoniaGPS.UI.Tests/AgValoniaGPS.UI.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Headless.NUnit" Version="11.3.9" />
     <PackageReference Include="Avalonia.Skia" Version="11.3.9" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
@@ -1,0 +1,267 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.Logging;
+using AgValoniaGPS.Views.Controls.Dialogs;
+using Microsoft.Extensions.Logging;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Screenshot capture tests for Phase 2 Quick Win features (#17, #22, #23, #29).
+/// Each test renders a dialog in a headless window, verifies dialog state,
+/// and attempts to save a PNG screenshot to the test output directory.
+///
+/// Screenshot capture requires Skia rendering; in headless-only mode (CI)
+/// the state assertions still pass while the PNG is skipped gracefully.
+/// </summary>
+[TestFixture]
+public class QuickWinScreenshotTests
+{
+    private string _screenshotDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _screenshotDir = Path.Combine(
+            TestContext.CurrentContext.TestDirectory, "screenshots");
+        Directory.CreateDirectory(_screenshotDir);
+    }
+
+    /// <summary>
+    /// Attempts to capture a screenshot. Returns true if file was saved.
+    /// Does not throw if headless rendering does not support pixel capture.
+    /// </summary>
+    private static bool TryCaptureScreenshot(Window window, string fileName, string outputDir)
+    {
+        var path = Path.Combine(outputDir, fileName);
+        try
+        {
+            var frame = window.CaptureRenderedFrame();
+            if (frame != null)
+            {
+                frame.Save(path);
+                return File.Exists(path);
+            }
+        }
+        catch (NotSupportedException)
+        {
+            // Headless without Skia -- fall through to RenderTargetBitmap
+        }
+
+        try
+        {
+            var size = new PixelSize(
+                Math.Max(1, (int)window.ClientSize.Width),
+                Math.Max(1, (int)window.ClientSize.Height));
+            var bitmap = new RenderTargetBitmap(size);
+            bitmap.Render(window);
+            bitmap.Save(path);
+            return File.Exists(path);
+        }
+        catch
+        {
+            // Pixel rendering not available in this environment
+            TestContext.WriteLine($"[screenshot] Could not capture {fileName} (headless without Skia)");
+            return false;
+        }
+    }
+
+    // --- Theme (#17) ---
+
+    [AvaloniaTest]
+    public void Theme_LightMode_Screenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var panel = new AboutDialogPanel { DataContext = vm };
+
+        var window = new Window
+        {
+            Content = panel,
+            Width = 800,
+            Height = 600
+        };
+        window.Show();
+
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Light;
+
+        vm.State.UI.ShowDialog(DialogType.About);
+
+        var captured = TryCaptureScreenshot(window, "theme_light.png", _screenshotDir);
+
+        // State assertions always pass regardless of rendering support
+        Assert.That(vm.State.UI.IsAboutDialogVisible, Is.True);
+        Assert.That(panel.IsVisible, Is.True);
+        if (captured)
+            TestContext.WriteLine("[screenshot] theme_light.png saved");
+    }
+
+    [AvaloniaTest]
+    public void Theme_DarkMode_Screenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var panel = new AboutDialogPanel { DataContext = vm };
+
+        var window = new Window
+        {
+            Content = panel,
+            Width = 800,
+            Height = 600
+        };
+        window.Show();
+
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Dark;
+
+        vm.State.UI.ShowDialog(DialogType.About);
+
+        var captured = TryCaptureScreenshot(window, "theme_dark.png", _screenshotDir);
+
+        Assert.That(vm.State.UI.IsAboutDialogVisible, Is.True);
+        Assert.That(panel.IsVisible, Is.True);
+        if (captured)
+            TestContext.WriteLine("[screenshot] theme_dark.png saved");
+    }
+
+    // --- Log Viewer (#22) ---
+
+    [AvaloniaTest]
+    public void LogViewer_WithEntries_Screenshot()
+    {
+        LogStore.Instance.Clear();
+        LogStore.Instance.Add(new LogEntry
+        {
+            Timestamp = DateTime.Now.AddSeconds(-10),
+            Level = LogLevel.Debug,
+            Category = "GpsService",
+            Message = "GPS data received: 12 satellites"
+        });
+        LogStore.Instance.Add(new LogEntry
+        {
+            Timestamp = DateTime.Now.AddSeconds(-8),
+            Level = LogLevel.Information,
+            Category = "FieldService",
+            Message = "Field 'North40' loaded successfully"
+        });
+        LogStore.Instance.Add(new LogEntry
+        {
+            Timestamp = DateTime.Now.AddSeconds(-5),
+            Level = LogLevel.Warning,
+            Category = "NtripService",
+            Message = "NTRIP connection timeout, retrying..."
+        });
+        LogStore.Instance.Add(new LogEntry
+        {
+            Timestamp = DateTime.Now.AddSeconds(-2),
+            Level = LogLevel.Error,
+            Category = "UdpService",
+            Message = "Failed to bind UDP port 9999: Address already in use"
+        });
+        LogStore.Instance.Add(new LogEntry
+        {
+            Timestamp = DateTime.Now,
+            Level = LogLevel.Information,
+            Category = "MainViewModel",
+            Message = "AutoSteer engaged on track 'AB Line 1'"
+        });
+
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new LogViewerDialogPanel { DataContext = vm };
+
+        var window = new Window
+        {
+            Content = dialog,
+            Width = 800,
+            Height = 600
+        };
+        window.Show();
+
+        vm.ShowLogViewerDialogCommand!.Execute(null);
+
+        var captured = TryCaptureScreenshot(window, "log_viewer.png", _screenshotDir);
+
+        Assert.That(vm.State.UI.IsLogViewerDialogVisible, Is.True);
+        Assert.That(vm.FilteredLogEntries, Has.Count.GreaterThanOrEqualTo(5),
+            "Should show all 5 seeded log entries");
+        if (captured)
+            TestContext.WriteLine("[screenshot] log_viewer.png saved");
+
+        vm.CloseLogViewerDialogCommand!.Execute(null);
+    }
+
+    // --- Flag By Lat/Lon (#23) ---
+
+    [AvaloniaTest]
+    public void FlagByLatLon_WithCoordinates_Screenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new FlagByLatLonDialogPanel { DataContext = vm };
+
+        var window = new Window
+        {
+            Content = dialog,
+            Width = 800,
+            Height = 600
+        };
+        window.Show();
+
+        vm.ShowFlagByLatLonDialogCommand!.Execute(null);
+        vm.FlagLatitudeInput = "43.653225";
+        vm.FlagLongitudeInput = "-79.383186";
+
+        var captured = TryCaptureScreenshot(window, "flag_by_latlon.png", _screenshotDir);
+
+        Assert.That(vm.State.UI.IsFlagByLatLonDialogVisible, Is.True);
+        Assert.That(vm.FlagLatitudeInput, Is.EqualTo("43.653225"));
+        Assert.That(vm.FlagLongitudeInput, Is.EqualTo("-79.383186"));
+        if (captured)
+            TestContext.WriteLine("[screenshot] flag_by_latlon.png saved");
+    }
+
+    // --- View All Settings (#29) ---
+
+    [AvaloniaTest]
+    public void ViewAllSettings_Populated_Screenshot()
+    {
+        var store = ConfigurationStore.Instance;
+        store.Vehicle.AntennaHeight = 2.5;
+        store.Vehicle.Wheelbase = 3.2;
+        store.Tool.Width = 12.0;
+        store.Guidance.UTurnRadius = 6.0;
+        store.Display.IsDayMode = true;
+        store.Display.GridVisible = true;
+        store.IsMetric = true;
+        store.NumSections = 5;
+
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new ViewSettingsDialogPanel { DataContext = vm };
+
+        var window = new Window
+        {
+            Content = dialog,
+            Width = 800,
+            Height = 600
+        };
+        window.Show();
+
+        vm.ShowViewSettingsDialogCommand!.Execute(null);
+
+        var captured = TryCaptureScreenshot(window, "view_all_settings.png", _screenshotDir);
+
+        Assert.That(vm.State.UI.IsViewSettingsDialogVisible, Is.True);
+        Assert.That(vm.SettingsTree, Has.Count.GreaterThan(0),
+            "Settings tree should be populated with config groups");
+        // Verify specific groups are present
+        var groupNames = vm.SettingsTree.Select(g => g.Name).ToList();
+        Assert.That(groupNames, Does.Contain("Vehicle"));
+        Assert.That(groupNames, Does.Contain("Display"));
+        Assert.That(groupNames, Does.Contain("Global"));
+        if (captured)
+            TestContext.WriteLine("[screenshot] view_all_settings.png saved");
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
@@ -92,16 +92,17 @@ public class QuickWinScreenshotTests
     }
 
     // --- Theme (#17) ---
+    // Uses FlagByLatLon dialog because its TextBoxes respond visibly to FluentTheme variant
 
     [AvaloniaTest]
     public void Theme_LightMode_Screenshot()
     {
         var vm = new MainViewModelBuilder().Build();
-        var panel = new AboutDialogPanel { DataContext = vm };
+        var dialog = new FlagByLatLonDialogPanel { DataContext = vm };
 
         var window = new Window
         {
-            Content = panel,
+            Content = dialog,
             Width = 800,
             Height = 600
         };
@@ -110,13 +111,13 @@ public class QuickWinScreenshotTests
         if (Application.Current != null)
             Application.Current.RequestedThemeVariant = ThemeVariant.Light;
 
-        vm.State.UI.ShowDialog(DialogType.About);
+        vm.ShowFlagByLatLonDialogCommand!.Execute(null);
+        vm.FlagLatitudeInput = "43.653225";
+        vm.FlagLongitudeInput = "-79.383186";
 
         var captured = TryCaptureScreenshot(window, "theme_light.png", _screenshotDir);
 
-        // State assertions always pass regardless of rendering support
-        Assert.That(vm.State.UI.IsAboutDialogVisible, Is.True);
-        Assert.That(panel.IsVisible, Is.True);
+        Assert.That(vm.State.UI.IsFlagByLatLonDialogVisible, Is.True);
         if (captured)
             TestContext.WriteLine("[screenshot] theme_light.png saved");
     }
@@ -125,11 +126,11 @@ public class QuickWinScreenshotTests
     public void Theme_DarkMode_Screenshot()
     {
         var vm = new MainViewModelBuilder().Build();
-        var panel = new AboutDialogPanel { DataContext = vm };
+        var dialog = new FlagByLatLonDialogPanel { DataContext = vm };
 
         var window = new Window
         {
-            Content = panel,
+            Content = dialog,
             Width = 800,
             Height = 600
         };
@@ -138,12 +139,13 @@ public class QuickWinScreenshotTests
         if (Application.Current != null)
             Application.Current.RequestedThemeVariant = ThemeVariant.Dark;
 
-        vm.State.UI.ShowDialog(DialogType.About);
+        vm.ShowFlagByLatLonDialogCommand!.Execute(null);
+        vm.FlagLatitudeInput = "43.653225";
+        vm.FlagLongitudeInput = "-79.383186";
 
         var captured = TryCaptureScreenshot(window, "theme_dark.png", _screenshotDir);
 
-        Assert.That(vm.State.UI.IsAboutDialogVisible, Is.True);
-        Assert.That(panel.IsVisible, Is.True);
+        Assert.That(vm.State.UI.IsFlagByLatLonDialogVisible, Is.True);
         if (captured)
             TestContext.WriteLine("[screenshot] theme_dark.png saved");
     }

--- a/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
@@ -374,45 +374,38 @@ public class QuickWinScreenshotTests
         if (captured) TestContext.WriteLine("[screenshot] view_all_settings_light.png saved");
     }
 
-    // --- Whole UI screenshots using shared Full UI layout with dialog overlay ---
+    // --- Whole UI screenshots using shared Full UI layout ---
 
-    [AvaloniaTest]
-    public void WholeUI_LightMode_Screenshot()
+    private static void CaptureWholeUI(string fileName, ThemeVariant theme, string screenshotDir)
     {
+        // Set theme BEFORE building layout so ThemeBrush() resolves correctly
         if (Application.Current != null)
-            Application.Current.RequestedThemeVariant = ThemeVariant.Light;
+            Application.Current.RequestedThemeVariant = theme;
 
         var (window, vm) = ScreenshotCaptureTests.CreateUIOnly();
+        // Set on window so child AXAML DynamicResource bindings inherit the variant
+        window.RequestedThemeVariant = theme;
         window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs(DispatcherPriority.Render);
 
-        // Open About dialog to show a themed dialog on top of the Full UI
-        vm.State.UI.ShowDialog(DialogType.About);
-
-        var path = Path.Combine(_screenshotDir, "whole_ui_light.png");
+        var path = Path.Combine(screenshotDir, fileName);
         ScreenshotCaptureTests.CaptureScreenshot(window,
             ScreenshotCaptureTests.WindowWidth, ScreenshotCaptureTests.WindowHeight, path);
 
         Assert.That(File.Exists(path), Is.True);
-        TestContext.WriteLine("[screenshot] whole_ui_light.png saved");
+        TestContext.WriteLine($"[screenshot] {fileName} saved ({new FileInfo(path).Length} bytes)");
+    }
+
+    [AvaloniaTest]
+    public void WholeUI_LightMode_Screenshot()
+    {
+        CaptureWholeUI("whole_ui_light.png", ThemeVariant.Light, _screenshotDir);
     }
 
     [AvaloniaTest]
     public void WholeUI_DarkMode_Screenshot()
     {
-        if (Application.Current != null)
-            Application.Current.RequestedThemeVariant = ThemeVariant.Dark;
-
-        var (window, vm) = ScreenshotCaptureTests.CreateUIOnly();
-        window.Show();
-
-        // Open About dialog to show a themed dialog on top of the Full UI
-        vm.State.UI.ShowDialog(DialogType.About);
-
-        var path = Path.Combine(_screenshotDir, "whole_ui_dark.png");
-        ScreenshotCaptureTests.CaptureScreenshot(window,
-            ScreenshotCaptureTests.WindowWidth, ScreenshotCaptureTests.WindowHeight, path);
-
-        Assert.That(File.Exists(path), Is.True);
-        TestContext.WriteLine("[screenshot] whole_ui_dark.png saved");
+        CaptureWholeUI("whole_ui_dark.png", ThemeVariant.Dark, _screenshotDir);
     }
 }

--- a/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
@@ -378,12 +378,13 @@ public class QuickWinScreenshotTests
 
     private static void CaptureWholeUI(string fileName, ThemeVariant theme, string screenshotDir)
     {
-        // Set theme BEFORE building layout so ThemeBrush() resolves correctly
+        // Set theme and pump dispatcher so ActualThemeVariant updates
+        // BEFORE ThemeBrush() calls in CreateUIOnly()
         if (Application.Current != null)
             Application.Current.RequestedThemeVariant = theme;
+        Dispatcher.UIThread.RunJobs();
 
-        var (window, vm) = ScreenshotCaptureTests.CreateUIOnly();
-        // Set on window so child AXAML DynamicResource bindings inherit the variant
+        var (window, vm) = ScreenshotCaptureTests.CreateUIOnly(theme);
         window.RequestedThemeVariant = theme;
         window.Show();
         window.UpdateLayout();

--- a/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Media.Imaging;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Services.Logging;
@@ -33,11 +34,30 @@ public class QuickWinScreenshotTests
     }
 
     /// <summary>
+    /// Pumps the dispatcher to process pending layout, binding, and render jobs.
+    /// Cycles through measure/arrange/render passes to force data-bound content
+    /// (ListBox items, ItemsControl, TextBox values) to materialize.
+    /// </summary>
+    private static void PumpFrames(Window window, int passes = 5)
+    {
+        for (int i = 0; i < passes; i++)
+        {
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Background);
+            window.InvalidateMeasure();
+            window.InvalidateArrange();
+            window.InvalidateVisual();
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Render);
+        }
+    }
+
+    /// <summary>
     /// Attempts to capture a screenshot. Returns true if file was saved.
     /// Does not throw if headless rendering does not support pixel capture.
     /// </summary>
     private static bool TryCaptureScreenshot(Window window, string fileName, string outputDir)
     {
+        PumpFrames(window);
+
         var path = Path.Combine(outputDir, fileName);
         try
         {

--- a/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
@@ -373,4 +373,46 @@ public class QuickWinScreenshotTests
         Assert.That(vm.SettingsTree, Has.Count.GreaterThan(0));
         if (captured) TestContext.WriteLine("[screenshot] view_all_settings_light.png saved");
     }
+
+    // --- Whole UI screenshots using shared Full UI layout with dialog overlay ---
+
+    [AvaloniaTest]
+    public void WholeUI_LightMode_Screenshot()
+    {
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Light;
+
+        var (window, vm) = ScreenshotCaptureTests.CreateUIOnly();
+        window.Show();
+
+        // Open About dialog to show a themed dialog on top of the Full UI
+        vm.State.UI.ShowDialog(DialogType.About);
+
+        var path = Path.Combine(_screenshotDir, "whole_ui_light.png");
+        ScreenshotCaptureTests.CaptureScreenshot(window,
+            ScreenshotCaptureTests.WindowWidth, ScreenshotCaptureTests.WindowHeight, path);
+
+        Assert.That(File.Exists(path), Is.True);
+        TestContext.WriteLine("[screenshot] whole_ui_light.png saved");
+    }
+
+    [AvaloniaTest]
+    public void WholeUI_DarkMode_Screenshot()
+    {
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Dark;
+
+        var (window, vm) = ScreenshotCaptureTests.CreateUIOnly();
+        window.Show();
+
+        // Open About dialog to show a themed dialog on top of the Full UI
+        vm.State.UI.ShowDialog(DialogType.About);
+
+        var path = Path.Combine(_screenshotDir, "whole_ui_dark.png");
+        ScreenshotCaptureTests.CaptureScreenshot(window,
+            ScreenshotCaptureTests.WindowWidth, ScreenshotCaptureTests.WindowHeight, path);
+
+        Assert.That(File.Exists(path), Is.True);
+        TestContext.WriteLine("[screenshot] whole_ui_dark.png saved");
+    }
 }

--- a/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/QuickWinScreenshotTests.cs
@@ -286,4 +286,91 @@ public class QuickWinScreenshotTests
         if (captured)
             TestContext.WriteLine("[screenshot] view_all_settings.png saved");
     }
+
+    // --- Light vs Dark comparison for multiple dialogs ---
+
+    [AvaloniaTest]
+    public void About_LightMode_Screenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new AboutDialogPanel { DataContext = vm };
+
+        var window = new Window { Content = dialog, Width = 800, Height = 600 };
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Light;
+        window.Show();
+
+        vm.State.UI.ShowDialog(DialogType.About);
+        var captured = TryCaptureScreenshot(window, "about_light.png", _screenshotDir);
+
+        Assert.That(vm.State.UI.IsAboutDialogVisible, Is.True);
+        if (captured) TestContext.WriteLine("[screenshot] about_light.png saved");
+    }
+
+    [AvaloniaTest]
+    public void About_DarkMode_Screenshot()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new AboutDialogPanel { DataContext = vm };
+
+        var window = new Window { Content = dialog, Width = 800, Height = 600 };
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Dark;
+        window.Show();
+
+        vm.State.UI.ShowDialog(DialogType.About);
+        var captured = TryCaptureScreenshot(window, "about_dark.png", _screenshotDir);
+
+        Assert.That(vm.State.UI.IsAboutDialogVisible, Is.True);
+        if (captured) TestContext.WriteLine("[screenshot] about_dark.png saved");
+    }
+
+    [AvaloniaTest]
+    public void LogViewer_LightMode_Screenshot()
+    {
+        LogStore.Instance.Clear();
+        LogStore.Instance.Add(new LogEntry { Timestamp = DateTime.Now.AddSeconds(-6), Level = LogLevel.Debug, Category = "GpsService", Message = "GPS data received: 12 satellites" });
+        LogStore.Instance.Add(new LogEntry { Timestamp = DateTime.Now.AddSeconds(-4), Level = LogLevel.Information, Category = "FieldService", Message = "Field 'North40' loaded successfully" });
+        LogStore.Instance.Add(new LogEntry { Timestamp = DateTime.Now.AddSeconds(-2), Level = LogLevel.Warning, Category = "NtripService", Message = "NTRIP connection timeout, retrying..." });
+        LogStore.Instance.Add(new LogEntry { Timestamp = DateTime.Now, Level = LogLevel.Error, Category = "UdpService", Message = "Failed to bind UDP port 9999: Address already in use" });
+
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new LogViewerDialogPanel { DataContext = vm };
+
+        var window = new Window { Content = dialog, Width = 800, Height = 600 };
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Light;
+        window.Show();
+
+        vm.ShowLogViewerDialogCommand!.Execute(null);
+        var captured = TryCaptureScreenshot(window, "log_viewer_light.png", _screenshotDir);
+
+        Assert.That(vm.FilteredLogEntries, Has.Count.GreaterThanOrEqualTo(4));
+        if (captured) TestContext.WriteLine("[screenshot] log_viewer_light.png saved");
+        vm.CloseLogViewerDialogCommand!.Execute(null);
+    }
+
+    [AvaloniaTest]
+    public void ViewAllSettings_LightMode_Screenshot()
+    {
+        var store = ConfigurationStore.Instance;
+        store.Vehicle.AntennaHeight = 2.5;
+        store.Vehicle.Wheelbase = 3.2;
+        store.IsMetric = true;
+        store.NumSections = 5;
+
+        var vm = new MainViewModelBuilder().Build();
+        var dialog = new ViewSettingsDialogPanel { DataContext = vm };
+
+        var window = new Window { Content = dialog, Width = 800, Height = 600 };
+        if (Application.Current != null)
+            Application.Current.RequestedThemeVariant = ThemeVariant.Light;
+        window.Show();
+
+        vm.ShowViewSettingsDialogCommand!.Execute(null);
+        var captured = TryCaptureScreenshot(window, "view_all_settings_light.png", _screenshotDir);
+
+        Assert.That(vm.SettingsTree, Has.Count.GreaterThan(0));
+        if (captured) TestContext.WriteLine("[screenshot] view_all_settings_light.png saved");
+    }
 }

--- a/Tests/AgValoniaGPS.UI.Tests/ScreenshotCaptureTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ScreenshotCaptureTests.cs
@@ -19,6 +19,7 @@ using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Styling;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Base;
 using AgValoniaGPS.Models.Coverage;
@@ -121,15 +122,18 @@ public class ScreenshotCaptureTests
     }
 
     internal static (Window window, MainViewModel vm) CreateUIOnly()
+        => CreateUIOnly(null);
+
+    internal static (Window window, MainViewModel vm) CreateUIOnly(ThemeVariant? theme)
     {
         var vm = new MainViewModelBuilder().Build();
 
         var panelCanvas = CreatePanelCanvas(vm);
-        var zoomButtons = CreateZoomButtons();
+        var zoomButtons = CreateZoomButtons(theme);
 
         var placeholder = new Border
         {
-            Background = ThemeBrush("SystemControlBackgroundAltHighBrush", "#1a1a1a")
+            Background = ThemeBrush("SystemControlBackgroundAltHighBrush", theme, "#1a1a1a")
         };
 
         var mapArea = new Grid();
@@ -140,9 +144,9 @@ public class ScreenshotCaptureTests
         var rootGrid = new Grid
         {
             RowDefinitions = new RowDefinitions("Auto,*"),
-            Background = ThemeBrush("SystemControlBackgroundAltHighBrush", "#1a1a1a")
+            Background = ThemeBrush("SystemControlBackgroundAltHighBrush", theme, "#1a1a1a")
         };
-        var statusBar = CreateStatusBar();
+        var statusBar = CreateStatusBar(theme);
         Grid.SetRow(statusBar, 0);
         Grid.SetRow(mapArea, 1);
         rootGrid.Children.Add(statusBar);
@@ -168,22 +172,24 @@ public class ScreenshotCaptureTests
     /// Falls back to the provided default if the resource is not found.
     /// </summary>
     internal static IBrush ThemeBrush(string key, string fallback = "#1a1a1a")
+        => ThemeBrush(key, Application.Current?.ActualThemeVariant, fallback);
+
+    internal static IBrush ThemeBrush(string key, ThemeVariant? variant, string fallback = "#1a1a1a")
     {
         var app = Application.Current;
-        if (app != null)
+        if (app != null && variant != null)
         {
-            var variant = app.ActualThemeVariant;
-            if (app.TryGetResource(key, variant, out var value) && value is IBrush brush)
-                return brush;
+            if (app.TryGetResource(key, variant, out var value) && value is ISolidColorBrush scb)
+                return new SolidColorBrush(scb.Color);
         }
         return new SolidColorBrush(Color.Parse(fallback));
     }
 
-    private static Border CreateStatusBar()
+    private static Border CreateStatusBar(ThemeVariant? theme = null)
     {
         return new Border
         {
-            Background = ThemeBrush("SystemControlBackgroundChromeMediumBrush", "#2d2d2d"),
+            Background = ThemeBrush("SystemControlBackgroundChromeMediumBrush", theme, "#2d2d2d"),
             Padding = new Thickness(10),
             Child = new StackPanel
             {
@@ -192,11 +198,11 @@ public class ScreenshotCaptureTests
                 Children =
                 {
                     new TextBlock { Text = "Ready", Foreground = Brushes.LimeGreen, FontSize = 14 },
-                    new TextBlock { Text = "RTK Fix", Foreground = ThemeBrush("SystemControlHighlightAccentBrush", "#3498DB"), FontSize = 12 },
+                    new TextBlock { Text = "RTK Fix", Foreground = ThemeBrush("SystemControlHighlightAccentBrush", theme, "#3498DB"), FontSize = 12 },
                     new TextBlock { Text = "FPS: 30", Foreground = new SolidColorBrush(Color.Parse("#F1C40F")), FontSize = 12 },
                     new TextBlock { Text = "Lat: 2.1ms", Foreground = new SolidColorBrush(Color.Parse("#F39C12")), FontSize = 12 },
                     new Border { Width = 200 },
-                    new TextBlock { Text = "12.4 ha", Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", "#FFFFFF"), FontSize = 12 },
+                    new TextBlock { Text = "12.4 ha", Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", theme, "#FFFFFF"), FontSize = 12 },
                     new TextBlock { Text = "5.2 ha done", Foreground = Brushes.LimeGreen, FontSize = 12, FontWeight = FontWeight.Bold },
                     new TextBlock { Text = "58%", Foreground = new SolidColorBrush(Color.Parse("#F39C12")), FontSize = 12 },
                 }
@@ -230,7 +236,7 @@ public class ScreenshotCaptureTests
         return canvas;
     }
 
-    private static StackPanel CreateZoomButtons()
+    private static StackPanel CreateZoomButtons(ThemeVariant? theme = null)
     {
         return new StackPanel
         {
@@ -246,8 +252,8 @@ public class ScreenshotCaptureTests
                     FontWeight = FontWeight.Bold,
                     HorizontalContentAlignment = HorizontalAlignment.Center,
                     VerticalContentAlignment = VerticalAlignment.Center,
-                    Background = ThemeBrush("SystemControlBackgroundBaseLowBrush", "#4A5568"),
-                    Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", "#FFFFFF"),
+                    Background = ThemeBrush("SystemControlBackgroundBaseLowBrush", theme, "#4A5568"),
+                    Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", theme, "#FFFFFF"),
                     CornerRadius = new CornerRadius(8)
                 },
                 new Button
@@ -256,8 +262,8 @@ public class ScreenshotCaptureTests
                     FontWeight = FontWeight.Bold,
                     HorizontalContentAlignment = HorizontalAlignment.Center,
                     VerticalContentAlignment = VerticalAlignment.Center,
-                    Background = ThemeBrush("SystemControlBackgroundBaseLowBrush", "#4A5568"),
-                    Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", "#FFFFFF"),
+                    Background = ThemeBrush("SystemControlBackgroundBaseLowBrush", theme, "#4A5568"),
+                    Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", theme, "#FFFFFF"),
                     CornerRadius = new CornerRadius(8)
                 },
             }

--- a/Tests/AgValoniaGPS.UI.Tests/ScreenshotCaptureTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ScreenshotCaptureTests.cs
@@ -40,8 +40,8 @@ namespace AgValoniaGPS.UI.Tests;
 [TestFixture]
 public class ScreenshotCaptureTests
 {
-    private const int WindowWidth = 1024;
-    private const int WindowHeight = 768;
+    internal const int WindowWidth = 1024;
+    internal const int WindowHeight = 768;
     private const int MapOnlyWidth = 800;
     private const int MapOnlyHeight = 600;
 
@@ -86,7 +86,7 @@ public class ScreenshotCaptureTests
         var rootGrid = new Grid
         {
             RowDefinitions = new RowDefinitions("Auto,*"),
-            Background = new SolidColorBrush(Color.Parse("#1a1a1a"))
+            Background = ThemeBrush("SystemControlBackgroundAltHighBrush", "#1a1a1a")
         };
         var statusBar = CreateStatusBar();
         Grid.SetRow(statusBar, 0);
@@ -120,7 +120,7 @@ public class ScreenshotCaptureTests
         return (window, mapControl);
     }
 
-    private static (Window window, MainViewModel vm) CreateUIOnly()
+    internal static (Window window, MainViewModel vm) CreateUIOnly()
     {
         var vm = new MainViewModelBuilder().Build();
 
@@ -129,7 +129,7 @@ public class ScreenshotCaptureTests
 
         var placeholder = new Border
         {
-            Background = new SolidColorBrush(Color.Parse("#1a1a1a"))
+            Background = ThemeBrush("SystemControlBackgroundAltHighBrush", "#1a1a1a")
         };
 
         var mapArea = new Grid();
@@ -140,7 +140,7 @@ public class ScreenshotCaptureTests
         var rootGrid = new Grid
         {
             RowDefinitions = new RowDefinitions("Auto,*"),
-            Background = new SolidColorBrush(Color.Parse("#1a1a1a"))
+            Background = ThemeBrush("SystemControlBackgroundAltHighBrush", "#1a1a1a")
         };
         var statusBar = CreateStatusBar();
         Grid.SetRow(statusBar, 0);
@@ -163,11 +163,21 @@ public class ScreenshotCaptureTests
     // Shared UI component builders
     // ---------------------------------------------------------------
 
+    /// <summary>
+    /// Resolves a theme-aware brush by resource key. Falls back to the provided
+    /// default if the resource is not found (e.g., no FluentTheme loaded).
+    /// </summary>
+    internal static IBrush ThemeBrush(string key, string fallback = "#1a1a1a")
+    {
+        return Application.Current?.FindResource(key) as IBrush
+            ?? new SolidColorBrush(Color.Parse(fallback));
+    }
+
     private static Border CreateStatusBar()
     {
         return new Border
         {
-            Background = new SolidColorBrush(Color.Parse("#2d2d2d")),
+            Background = ThemeBrush("SystemControlBackgroundChromeMediumBrush", "#2d2d2d"),
             Padding = new Thickness(10),
             Child = new StackPanel
             {
@@ -176,11 +186,11 @@ public class ScreenshotCaptureTests
                 Children =
                 {
                     new TextBlock { Text = "Ready", Foreground = Brushes.LimeGreen, FontSize = 14 },
-                    new TextBlock { Text = "RTK Fix", Foreground = new SolidColorBrush(Color.Parse("#3498DB")), FontSize = 12 },
+                    new TextBlock { Text = "RTK Fix", Foreground = ThemeBrush("SystemControlHighlightAccentBrush", "#3498DB"), FontSize = 12 },
                     new TextBlock { Text = "FPS: 30", Foreground = new SolidColorBrush(Color.Parse("#F1C40F")), FontSize = 12 },
                     new TextBlock { Text = "Lat: 2.1ms", Foreground = new SolidColorBrush(Color.Parse("#F39C12")), FontSize = 12 },
                     new Border { Width = 200 },
-                    new TextBlock { Text = "12.4 ha", Foreground = Brushes.White, FontSize = 12 },
+                    new TextBlock { Text = "12.4 ha", Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", "#FFFFFF"), FontSize = 12 },
                     new TextBlock { Text = "5.2 ha done", Foreground = Brushes.LimeGreen, FontSize = 12, FontWeight = FontWeight.Bold },
                     new TextBlock { Text = "58%", Foreground = new SolidColorBrush(Color.Parse("#F39C12")), FontSize = 12 },
                 }
@@ -230,8 +240,9 @@ public class ScreenshotCaptureTests
                     FontWeight = FontWeight.Bold,
                     HorizontalContentAlignment = HorizontalAlignment.Center,
                     VerticalContentAlignment = VerticalAlignment.Center,
-                    Background = new SolidColorBrush(Color.Parse("#4A5568")),
-                    Foreground = Brushes.White, CornerRadius = new CornerRadius(8)
+                    Background = ThemeBrush("SystemControlBackgroundBaseLowBrush", "#4A5568"),
+                    Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", "#FFFFFF"),
+                    CornerRadius = new CornerRadius(8)
                 },
                 new Button
                 {
@@ -239,8 +250,9 @@ public class ScreenshotCaptureTests
                     FontWeight = FontWeight.Bold,
                     HorizontalContentAlignment = HorizontalAlignment.Center,
                     VerticalContentAlignment = VerticalAlignment.Center,
-                    Background = new SolidColorBrush(Color.Parse("#4A5568")),
-                    Foreground = Brushes.White, CornerRadius = new CornerRadius(8)
+                    Background = ThemeBrush("SystemControlBackgroundBaseLowBrush", "#4A5568"),
+                    Foreground = ThemeBrush("SystemControlForegroundBaseHighBrush", "#FFFFFF"),
+                    CornerRadius = new CornerRadius(8)
                 },
             }
         };
@@ -333,7 +345,7 @@ public class ScreenshotCaptureTests
     // Screenshot capture helpers
     // ---------------------------------------------------------------
 
-    private static void CaptureScreenshot(Window window, int width, int height, string filePath)
+    internal static void CaptureScreenshot(Window window, int width, int height, string filePath)
     {
         window.UpdateLayout();
 

--- a/Tests/AgValoniaGPS.UI.Tests/ScreenshotCaptureTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/ScreenshotCaptureTests.cs
@@ -164,13 +164,19 @@ public class ScreenshotCaptureTests
     // ---------------------------------------------------------------
 
     /// <summary>
-    /// Resolves a theme-aware brush by resource key. Falls back to the provided
-    /// default if the resource is not found (e.g., no FluentTheme loaded).
+    /// Resolves a theme-aware brush by resource key using the active theme variant.
+    /// Falls back to the provided default if the resource is not found.
     /// </summary>
     internal static IBrush ThemeBrush(string key, string fallback = "#1a1a1a")
     {
-        return Application.Current?.FindResource(key) as IBrush
-            ?? new SolidColorBrush(Color.Parse(fallback));
+        var app = Application.Current;
+        if (app != null)
+        {
+            var variant = app.ActualThemeVariant;
+            if (app.TryGetResource(key, variant, out var value) && value is IBrush brush)
+                return brush;
+        }
+        return new SolidColorBrush(Color.Parse(fallback));
     }
 
     private static Border CreateStatusBar()

--- a/Tests/AgValoniaGPS.UI.Tests/TestApp.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/TestApp.cs
@@ -1,6 +1,10 @@
+using System;
 using Avalonia;
 using Avalonia.Headless;
+using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
+using Avalonia.Skia;
+using Avalonia.Themes.Fluent;
 
 [assembly: AvaloniaTestApplication(typeof(AgValoniaGPS.UI.Tests.TestApp))]
 
@@ -8,14 +12,21 @@ namespace AgValoniaGPS.UI.Tests;
 
 public class TestApp : Application
 {
-    public override void Initialize() { }
+    public override void Initialize()
+    {
+        Styles.Add(new FluentTheme());
+
+        Resources.MergedDictionaries.Add(
+            (Avalonia.Controls.ResourceDictionary)AvaloniaXamlLoader.Load(
+                new Uri("avares://AgValoniaGPS.Views/Styles/SharedResources.axaml")));
+    }
 
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<TestApp>()
+            .UseSkia()
             .UseHeadless(new AvaloniaHeadlessPlatformOptions
             {
                 UseHeadlessDrawing = false
             })
-            .UseSkia()
             .UseReactiveUI();
 }

--- a/Tests/AgValoniaGPS.UI.Tests/TestApp.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/TestApp.cs
@@ -16,6 +16,7 @@ public class TestApp : Application
     {
         Styles.Add(new FluentTheme());
 
+        // Load shared resources (includes dark theme overrides)
         Resources.MergedDictionaries.Add(
             (Avalonia.Controls.ResourceDictionary)AvaloniaXamlLoader.Load(
                 new Uri("avares://AgValoniaGPS.Views/Styles/SharedResources.axaml")));


### PR DESCRIPTION
## What changed

Four independent UX improvements:

- **App Colors / Theme (#17)** -- light/dark theme switching via FluentTheme variants, wired to Day/Night toggle, persists across sessions
- **Log Viewer (#22)** -- dialog showing application log messages with level filtering (Debug/Info/Warning/Error), backed by in-memory ring buffer (2000 entries)
- **Flag By Lat/Lon (#23)** -- dialog to place a flag marker by entering decimal degree coordinates, converts to local plane via GeoConversion
- **View All Settings (#29)** -- read-only dialog showing all ConfigurationStore values grouped by category, uses reflection to auto-update as config grows

## Related issue

Relates to #17, relates to #22, relates to #23, relates to #29

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes (185 tests)
- [ ] Tested on: Desktop -- awaiting manual UI verification