### PR TITLE
Wire StartFullscreen persistence and immediate toggle

### DIFF
--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -73,6 +73,20 @@ public partial class MainWindow : Window
             // Wire zoom commands to map control
             ViewModel.ZoomInRequested += () => MapControl?.Zoom(1.2);
             ViewModel.ZoomOutRequested += () => MapControl?.Zoom(1.0 / 1.2);
+
+            // Wire fullscreen toggle for immediate effect
+            if (ViewModel.ConfigurationViewModel != null)
+            {
+                ViewModel.ConfigurationViewModel.FullscreenChanged += (isFullscreen) =>
+                {
+                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                    {
+                        WindowState = isFullscreen
+                            ? WindowState.FullScreen
+                            : WindowState.Normal;
+                    });
+                };
+            }
         }
 
         // Subscribe to FPS updates from map control (instance-based)

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -74,19 +74,24 @@ public partial class MainWindow : Window
             ViewModel.ZoomInRequested += () => MapControl?.Zoom(1.2);
             ViewModel.ZoomOutRequested += () => MapControl?.Zoom(1.0 / 1.2);
 
-            // Wire fullscreen toggle for immediate effect
-            if (ViewModel.ConfigurationViewModel != null)
+            // Wire fullscreen toggle for immediate effect (ConfigurationViewModel
+            // is created lazily, so subscribe when it appears)
+            ViewModel.PropertyChanged += (s, e) =>
             {
-                ViewModel.ConfigurationViewModel.FullscreenChanged += (isFullscreen) =>
+                if (e.PropertyName == nameof(MainViewModel.ConfigurationViewModel)
+                    && ViewModel?.ConfigurationViewModel != null)
                 {
-                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                    ViewModel.ConfigurationViewModel.FullscreenChanged += (isFullscreen) =>
                     {
-                        WindowState = isFullscreen
-                            ? WindowState.FullScreen
-                            : WindowState.Normal;
-                    });
-                };
-            }
+                        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                        {
+                            WindowState = isFullscreen
+                                ? WindowState.FullScreen
+                                : WindowState.Normal;
+                        });
+                    };
+                }
+            };
         }
 
         // Subscribe to FPS updates from map control (instance-based)

--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -30,6 +30,7 @@ namespace AgValoniaGPS.Models
         public double WindowX { get; set; } = 100;
         public double WindowY { get; set; } = 100;
         public bool WindowMaximized { get; set; } = false;
+        public bool StartFullscreen { get; set; } = false;
 
         // Panel positions
         public double SimulatorPanelX { get; set; } = double.NaN; // NaN means not set

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -297,6 +297,7 @@ public class ConfigurationService(
         store.Display.WindowX = settings.WindowX;
         store.Display.WindowY = settings.WindowY;
         store.Display.WindowMaximized = settings.WindowMaximized;
+        store.Display.StartFullscreen = settings.StartFullscreen;
         store.Display.SimulatorPanelX = settings.SimulatorPanelX;
         store.Display.SimulatorPanelY = settings.SimulatorPanelY;
         store.Display.SimulatorPanelVisible = settings.SimulatorPanelVisible;
@@ -354,6 +355,7 @@ public class ConfigurationService(
         settings.WindowX = store.Display.WindowX;
         settings.WindowY = store.Display.WindowY;
         settings.WindowMaximized = store.Display.WindowMaximized;
+        settings.StartFullscreen = store.Display.StartFullscreen;
         settings.SimulatorPanelX = store.Display.SimulatorPanelX;
         settings.SimulatorPanelY = store.Display.SimulatorPanelY;
         settings.SimulatorPanelVisible = store.Display.SimulatorPanelVisible;

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -927,6 +927,7 @@ public partial class ConfigurationViewModel : ReactiveObject
     public ICommand ToggleAutoDayNightCommand { get; private set; } = null!;
     public ICommand ToggleSvennArrowCommand { get; private set; } = null!;
     public ICommand ToggleStartFullscreenCommand { get; private set; } = null!;
+    public event Action<bool>? FullscreenChanged;
     public ICommand ToggleElevationLogCommand { get; private set; } = null!;
     public ICommand ToggleFieldTextureCommand { get; private set; } = null!;
     public ICommand ToggleGridCommand { get; private set; } = null!;
@@ -1558,6 +1559,7 @@ public partial class ConfigurationViewModel : ReactiveObject
         {
             Display.StartFullscreen = !Display.StartFullscreen;
             Config.MarkChanged();
+            FullscreenChanged?.Invoke(Display.StartFullscreen);
         });
 
         ToggleElevationLogCommand = ReactiveCommand.Create(() =>


### PR DESCRIPTION
Closes #116

## Summary
- Add `StartFullscreen` setting to `AppSettings` and wire through `ConfigurationService` for persistence
- Fire `FullscreenChanged` event from `ConfigurationViewModel` when toggled
- Subscribe in `MainWindow` to immediately switch window state (handles lazy `ConfigurationViewModel` creation)

## Test plan
- [ ] Toggle fullscreen in configuration, verify window switches immediately
- [ ] Restart app, verify fullscreen setting is restored
- [ ] Toggle off, restart, verify normal window state