### PR TITLE
Hide non-functional Section Lines and Direction Markers buttons

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -252,7 +252,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="Line Smooth" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
-                        <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
+                        <!-- Hidden: bitmap coverage system does not populate geometry cache (#117) -->
+                        <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center"
+                                    IsVisible="False">
                             <Button Classes="DisplayToggle"
                                     Background="{Binding Display.DirectionMarkersVisible, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
                                     BorderBrush="{Binding Display.DirectionMarkersVisible, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
@@ -263,7 +265,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="Direction" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
-                        <StackPanel Grid.Row="3" Grid.Column="2" Spacing="4" HorizontalAlignment="Center">
+                        <!-- Hidden: bitmap coverage system does not populate geometry cache (#118) -->
+                        <StackPanel Grid.Row="3" Grid.Column="2" Spacing="4" HorizontalAlignment="Center"
+                                    IsVisible="False">
                             <Button Classes="DisplayToggle"
                                     Background="{Binding Display.SectionLinesVisible, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
                                     BorderBrush="{Binding Display.SectionLinesVisible, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"


### PR DESCRIPTION
Refs #118, #117

## Summary
- Hide Section Lines button (non-functional with bitmap coverage system)
- Hide Direction Markers button (same reason)
- Added AXAML comments referencing issue numbers

The bitmap coverage system (`WriteableBitmap` + `CoverageMapService`) does not populate `_cachedCoverageGeometry` because `CoverageMapService.GetPatches()` returns empty. These geometry-dependent features need to be reimplemented for the bitmap path before the buttons can be re-enabled.

## Test plan
- [ ] Open configuration dialog, verify Section Lines and Direction Markers buttons are not visible
- [ ] Verify no layout issues from hidden buttons