### PR TITLE
Persist SvennArrowVisible setting across restarts

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -31,6 +31,7 @@ namespace AgValoniaGPS.Models
         public double WindowY { get; set; } = 100;
         public bool WindowMaximized { get; set; } = false;
         public bool StartFullscreen { get; set; } = false;
+        public bool SvennArrowVisible { get; set; } = false;
 
         // Panel positions
         public double SimulatorPanelX { get; set; } = double.NaN; // NaN means not set

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -298,6 +298,7 @@ public class ConfigurationService(
         store.Display.WindowY = settings.WindowY;
         store.Display.WindowMaximized = settings.WindowMaximized;
         store.Display.StartFullscreen = settings.StartFullscreen;
+        store.Display.SvennArrowVisible = settings.SvennArrowVisible;
         store.Display.SimulatorPanelX = settings.SimulatorPanelX;
         store.Display.SimulatorPanelY = settings.SimulatorPanelY;
         store.Display.SimulatorPanelVisible = settings.SimulatorPanelVisible;
@@ -356,6 +357,7 @@ public class ConfigurationService(
         settings.WindowY = store.Display.WindowY;
         settings.WindowMaximized = store.Display.WindowMaximized;
         settings.StartFullscreen = store.Display.StartFullscreen;
+        settings.SvennArrowVisible = store.Display.SvennArrowVisible;
         settings.SimulatorPanelX = store.Display.SimulatorPanelX;
         settings.SimulatorPanelY = store.Display.SimulatorPanelY;
         settings.SimulatorPanelVisible = store.Display.SimulatorPanelVisible;


### PR DESCRIPTION
Closes #115

## Summary
- Add `SvennArrowVisible` property to `AppSettings` (default: false, matches legacy)
- Wire bidirectional mapping in `ConfigurationService`

Rendering and UI toggle already exist. This adds persistence so the setting survives app restart.

## Test plan
- [ ] Toggle Svenn arrow on in configuration, restart app, verify still on
- [ ] Toggle off, restart, verify still off