### PR TITLE
Wire KeyboardEnabled toggle with on-screen keyboard visibility and TextBox fallback

### DIFF
--- a/Docs/TESTING.md
+++ b/Docs/TESTING.md
@@ -1,0 +1,338 @@
+# Testing Guide
+
+Comprehensive guide to the AgValoniaGPS test suite: what exists, how to run it, how to write new tests, and when tests are required.
+
+**Last Updated:** April 2026
+
+---
+
+## Quick Reference
+
+```bash
+# Run all tests (317 total)
+dotnet test Tests/AgValoniaGPS.Models.Tests/
+dotnet test Tests/AgValoniaGPS.Services.Tests/
+dotnet test Tests/AgValoniaGPS.UI.Tests/
+
+# Run with coverage
+dotnet test Tests/AgValoniaGPS.Services.Tests/ --collect:"XPlat Code Coverage"
+
+# Run specific test class
+dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "TrackGuidanceServiceTests"
+
+# Run single test
+dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "PurePursuit_VehicleLeftOfLine_SteersRight"
+```
+
+**Current counts:** 72 model + 150 service + 95 UI = 317 tests
+**Coverage:** ~6% models, ~20% services (critical paths covered, large gaps elsewhere)
+
+---
+
+## Test Projects
+
+### AgValoniaGPS.Models.Tests (72 tests)
+
+Pure unit tests for geometry, coordinate conversion, and math utilities. No mocking needed - these test pure functions.
+
+| File | Tests | What it covers |
+|------|-------|---------------|
+| `GeometryMathTests.cs` | 37 | Angle conversion, distance, point-in-polygon, ray intersection, Catmull-Rom splines, unit constants |
+| `GeoConversionTests.cs` | 21 | WGS84 to/from local coordinates, heading calculation, area computation |
+| `BoundaryUtilsTests.cs` | 2 | Boundary polygon utilities |
+| `CurveUtilsTests.cs` | 2 | Curve spline utilities |
+| `GeoCalculationsTests.cs` | 3 | Geographic distance and area calculations |
+
+**When to add tests here:** Any new method in `GeometryMath`, coordinate conversion, or pure data model logic.
+
+### AgValoniaGPS.Services.Tests (150 tests)
+
+Service-level tests that verify business logic. Some use mocks (NSubstitute), some are integration tests with real service instances.
+
+| File | Tests | What it covers |
+|------|-------|---------------|
+| `TrackGuidanceServiceTests.cs` | 20 | Pure Pursuit and Stanley algorithms, heading scenarios, multi-frame state, edge cases |
+| `NmeaParserServiceTests.cs` | 16 | NMEA sentence parsing, checksum, lat/lon, fix quality, speed conversion |
+| `FileIOTests.cs` | 16 | Track/boundary/settings file round-trips, heading accuracy |
+| `GeoJsonFieldServiceTests.cs` | 13 | GeoJSON field format round-trips, boundary/track preservation |
+| `SectionControlServiceTests.cs` | 12 | Section on/off logic, speed cutoff, master state, bitmask generation |
+| `SwathOrderingTests.cs` | 11 | Boustrophedon, snake, spiral swath patterns |
+| `YouTurnGuidanceServiceTests.cs` | 11 | U-turn path following, steer angle clamping, completion detection |
+| `ChartDataServiceTests.cs` | 19 | Chart data lifecycle, time windows, series management |
+| `ProfileJsonServiceTests.cs` | 11 | Vehicle profile JSON serialization for all config types |
+| `DisplayTogglePersistenceTests.cs` | 8 | AppSettings JSON round-trip, backward compat, reactive properties |
+| `GpsServiceTests.cs` | 7 | GPS connection state, timeout detection, recovery |
+| `FieldSaveLoadVerificationTests.cs` | 6 | End-to-end field I/O, legacy format support |
+| `GuidancePipelineIntegrationTests.cs` | 5 | Closed-loop guidance: NMEA -> guidance -> steer angle convergence |
+
+**When to add tests here:** Any new service, algorithm, file format, or configuration persistence change.
+
+### AgValoniaGPS.UI.Tests (95 tests)
+
+Headless Avalonia UI tests. Uses `[AvaloniaTest]` attribute for tests that need a rendering context, plain `[Test]` for ViewModel-only tests.
+
+| File | Tests | What it covers |
+|------|-------|---------------|
+| `BottomPanelHeadlessTests.cs` | 12 | Bottom nav panel buttons, snap/nudge commands with headless rendering |
+| `P1CommandTests.cs` | 12 | U-turn, cycle AB lines, flag placement, headland extend/shrink |
+| `TrackNudgeAndSnapTests.cs` | 11 | Nudge left/right, fine nudge, snap to pivot, accumulating nudges |
+| `TrackManagementScreenshotTests.cs` | 11 | Track dialog, recorded paths, import, delete confirmation |
+| `QuickWinScreenshotTests.cs` | 10 | Theme switching, log viewer, flag dialog, about dialog screenshots |
+| `UIStateDialogTests.cs` | 8 | Dialog state machine: show/close, visibility, mutual exclusivity |
+| `ScreenshotCaptureTests.cs` | 4 | Display toggle screenshots (grid, day/night, north-up) |
+| `DisplayWiringScreenshots.cs` | 4 | Before/after screenshots for display feature toggles |
+| `AppDirectoriesDialogTests.cs` | 4 | App directories dialog visibility and path population |
+| `ResetAllSettingsTests.cs` | 4 | Reset settings: confirmation, service calls, cancellation |
+| `ChartScreenshotTests.cs` | 3 | Steer/heading/XTE chart rendering with empty and populated data |
+| `ResetToolHeadingTests.cs` | 3 | Tool heading sync with vehicle heading |
+
+**When to add tests here:** Any new dialog, panel, command, or UI state change.
+
+---
+
+## Test Infrastructure
+
+### MainViewModelBuilder
+
+Builder pattern for creating a fully-mocked `MainViewModel` for testing:
+
+```csharp
+var vm = new MainViewModelBuilder().Build();
+
+// Access mocked services for verification
+var builder = new MainViewModelBuilder();
+var vm = builder.Build();
+builder.SettingsService.Received(1).Save();
+```
+
+All services are mocked via NSubstitute with sensible defaults (temp paths, empty collections).
+
+### TestApp (Avalonia Headless)
+
+Provides a headless Avalonia application context for UI tests:
+
+```csharp
+[AvaloniaTest]  // Runs in headless Avalonia context
+public void MyUiTest()
+{
+    var window = new Window { Content = new MyPanel() };
+    window.Show();
+    // Assert visual state...
+}
+```
+
+Configured with Fluent theme (dark mode) and shared resources matching the production app.
+
+### TestSettingsService (Integration Tests)
+
+Isolated settings service for integration tests that redirects all I/O to a temp directory:
+
+```csharp
+var settings = new TestSettingsService();
+// All reads/writes go to temp dir, never touches user's Documents
+```
+
+### Integration Test Harness
+
+`Tests/AgValoniaGPS.IntegrationTests/Program.cs` provides 14+ multi-step scenarios (app startup, field loading, simulator driving, coverage painting, etc.) that can run with a real window or headless.
+
+---
+
+## When to Write Tests
+
+### Required (must have tests)
+
+- **New algorithm or calculation** - Guidance, geometry, coordinate conversion
+  - Test in `AgValoniaGPS.Models.Tests` or `AgValoniaGPS.Services.Tests`
+  - Cover: normal case, edge cases, boundary values
+
+- **New file format or I/O** - Any new file read/write
+  - Test round-trip: write -> read -> assert equal
+  - Test backward compatibility: can read old format files
+  - Test missing/corrupt data handling
+
+- **New AppSettings property** - Any persisted setting
+  - Test JSON round-trip serialization
+  - Test default value
+  - Test backward compat (old settings file missing the property)
+  - See `DisplayTogglePersistenceTests.cs` as template
+
+- **Bug fix** - Reproduce the bug in a test first, then fix
+  - Prevents regression
+
+### Recommended (should have tests)
+
+- **New ViewModel command** - Test execution and state changes
+  - Use `MainViewModelBuilder` to create isolated ViewModel
+  - Assert state transitions and service calls
+
+- **New dialog** - Test visibility state
+  - Test `ShowDialog()` / `CloseDialog()` via `UIState`
+  - See `UIStateDialogTests.cs` as template
+
+- **New service** - Test public API
+  - Mock dependencies via NSubstitute
+  - Test state lifecycle (start, process, stop)
+  - See `SectionControlServiceTests.cs` as template
+
+### Optional (nice to have)
+
+- **Screenshot tests** - Visual verification of UI changes
+  - Use `[AvaloniaTest]` with headless window
+  - Capture before/after for toggle features
+  - See `DisplayWiringScreenshots.cs` as template
+
+- **Integration scenarios** - Multi-step workflows
+  - Add to `IntegrationTests/Program.cs`
+  - Good for verifying end-to-end data flow
+
+---
+
+## Writing a New Test
+
+### Model Test (pure function)
+
+```csharp
+[TestFixture]
+public class MyMathTests
+{
+    [Test]
+    public void MyFunction_GivenInput_ReturnsExpected()
+    {
+        var result = GeometryMath.MyFunction(input);
+        Assert.That(result, Is.EqualTo(expected).Within(0.001));
+    }
+}
+```
+
+### Service Test (with mocks)
+
+```csharp
+[TestFixture]
+public class MyServiceTests
+{
+    private MyService _service;
+    private IDependency _dependency;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dependency = Substitute.For<IDependency>();
+        _service = new MyService(_dependency);
+    }
+
+    [Test]
+    public void Process_WhenCondition_DoesExpectedThing()
+    {
+        _dependency.GetValue().Returns(42);
+
+        _service.Process();
+
+        Assert.That(_service.Result, Is.EqualTo(42));
+        _dependency.Received(1).GetValue();
+    }
+}
+```
+
+### ViewModel Test
+
+```csharp
+[TestFixture]
+public class MyCommandTests
+{
+    [Test]
+    public void MyCommand_WhenExecuted_UpdatesState()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        vm.MyCommand!.Execute(null);
+
+        Assert.That(vm.State.SomeProperty, Is.EqualTo(expected));
+    }
+}
+```
+
+### AppSettings Persistence Test
+
+```csharp
+[Test]
+public void AppSettings_MyProperty_SurvivesJsonRoundTrip()
+{
+    var options = new JsonSerializerOptions
+    {
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
+    };
+    var original = new AppSettings { MyProperty = true };
+
+    var json = JsonSerializer.Serialize(original, options);
+    var deserialized = JsonSerializer.Deserialize<AppSettings>(json, options);
+
+    Assert.That(deserialized!.MyProperty, Is.True);
+}
+```
+
+### Headless UI Test
+
+```csharp
+[AvaloniaTest]
+public void MyPanel_WhenToggled_ChangesVisibility()
+{
+    var vm = new MainViewModelBuilder().Build();
+    var window = new Window
+    {
+        Width = 800, Height = 600,
+        Content = new MyPanel { DataContext = vm }
+    };
+    window.Show();
+
+    vm.ToggleMyPanelCommand!.Execute(null);
+
+    // Assert visual state via DataContext or find controls
+    Assert.That(vm.State.UI.IsMyPanelVisible, Is.True);
+}
+```
+
+---
+
+## Coverage
+
+Coverage collection is set up via `coverlet.collector` in all test projects.
+
+```bash
+# Collect coverage
+dotnet test Tests/AgValoniaGPS.Services.Tests/ --collect:"XPlat Code Coverage"
+
+# Output: TestResults/{guid}/coverage.cobertura.xml
+```
+
+**Current coverage (April 2026):**
+- Models: ~6% line coverage
+- Services: ~20% line coverage
+
+Coverage is low overall but focused on critical paths:
+- Guidance algorithms (Pure Pursuit, Stanley)
+- NMEA parsing
+- Section control logic
+- File I/O round-trips
+- Coordinate conversion
+
+### Coverage Gaps (known)
+
+- `DrawingContextMapControl` - No rendering tests (visual-only)
+- `UdpCommunicationService` - Network I/O, tested via integration harness
+- `NtripClientService` - Network I/O
+- `ConfigurationViewModel` - Large, partially tested via UI tests
+- `MainViewModel` partial files - Most commands tested, some gaps in GPS handling and section control orchestration
+- Coverage painting pipeline - Tested in integration harness, not unit tests
+
+---
+
+## Conventions
+
+- **Framework:** NUnit 4.3 with `Assert.That()` syntax
+- **Mocking:** NSubstitute
+- **Headless UI:** Avalonia.Headless.NUnit with `[AvaloniaTest]`
+- **Naming:** `MethodName_Condition_ExpectedResult` or descriptive sentence
+- **Parallelism:** Tests run in parallel by default. Use `[NonParallelizable]` for tests that modify `ConfigurationStore.Instance` or other static state
+- **Screenshots:** Saved to `TestResults/` directory, useful for visual verification in CI
+- **Tolerances:** Use `Is.EqualTo(x).Within(tolerance)` for floating-point comparisons

--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -32,6 +32,7 @@ namespace AgValoniaGPS.Models
         public bool WindowMaximized { get; set; } = false;
         public bool StartFullscreen { get; set; } = false;
         public bool SvennArrowVisible { get; set; } = false;
+        public bool KeyboardEnabled { get; set; } = false;
 
         // Panel positions
         public double SimulatorPanelX { get; set; } = double.NaN; // NaN means not set

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -299,6 +299,7 @@ public class ConfigurationService(
         store.Display.WindowMaximized = settings.WindowMaximized;
         store.Display.StartFullscreen = settings.StartFullscreen;
         store.Display.SvennArrowVisible = settings.SvennArrowVisible;
+        store.Display.KeyboardEnabled = settings.KeyboardEnabled;
         store.Display.SimulatorPanelX = settings.SimulatorPanelX;
         store.Display.SimulatorPanelY = settings.SimulatorPanelY;
         store.Display.SimulatorPanelVisible = settings.SimulatorPanelVisible;
@@ -358,6 +359,7 @@ public class ConfigurationService(
         settings.WindowMaximized = store.Display.WindowMaximized;
         settings.StartFullscreen = store.Display.StartFullscreen;
         settings.SvennArrowVisible = store.Display.SvennArrowVisible;
+        settings.KeyboardEnabled = store.Display.KeyboardEnabled;
         settings.SimulatorPanelX = store.Display.SimulatorPanelX;
         settings.SimulatorPanelY = store.Display.SimulatorPanelY;
         settings.SimulatorPanelVisible = store.Display.SimulatorPanelVisible;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -80,6 +80,7 @@ public partial class MainViewModel : ReactiveObject
     /// Use this for new code. Existing properties will gradually migrate to use State.
     /// </summary>
     public ApplicationState State => _appState;
+    public DisplayConfig Display => ConfigurationStore.Instance.Display;
 
     // Convenience accessors for ConfigurationStore (replaces _vehicleConfig usage)
     private static ConfigurationStore ConfigStore => ConfigurationStore.Instance;

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
@@ -154,8 +154,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                               VerticalAlignment="Center"/>
                 </Grid>
 
-                <!-- Alphanumeric Keyboard -->
+                <!-- Alphanumeric Keyboard (visible when KeyboardEnabled) -->
                 <controls:AlphanumericKeyboardPanel x:Name="KeyboardPanel"
+                                                    IsVisible="{Binding Display.KeyboardEnabled}"
                                                     Grid.Row="4"
                                                     MaxLength="200"
                                                     Margin="0,0,0,12"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="620" d:DesignHeight="500"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.DisplayConfigTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -70,21 +71,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Setter>
         </Style>
 
-        <!-- Tappable Value Button -->
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Width" Value="90"/>
-            <Setter Property="Height" Value="90"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Padding" Value="8"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
-        </Style>
     </UserControl.Styles>
 
     <Grid RowDefinitions="Auto,*">
@@ -232,11 +218,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         </StackPanel>
 
                         <StackPanel Grid.Row="2" Grid.Column="3" Spacing="4" HorizontalAlignment="Center">
-                            <Button Classes="TappableValue" Command="{Binding EditExtraGuidelinesCountCommand}">
-                                <TextBlock Text="{Binding Display.ExtraGuidelinesCount}"
-                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="32"
-                                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                            </Button>
+                            <controls:EditableNumericField
+                                Value="{Binding Display.ExtraGuidelinesCount, Mode=TwoWay}"
+                                Unit="" FormatString="F0"
+                                EditCommand="{Binding EditExtraGuidelinesCountCommand}"/>
                             <TextBlock Text="Guide Count" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
@@ -21,26 +21,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="620" d:DesignHeight="550"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.MachineSubTabs.MachineModuleSubTab"
              x:DataType="vm:ConfigurationViewModel">
 
     <UserControl.Styles>
-        <!-- Tappable Value Button -->
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="80"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
-        </Style>
-
         <!-- Toggle Button with custom template for instant feedback -->
         <Style Selector="Button.ToggleButton">
             <Setter Property="BorderThickness" Value="1"/>
@@ -114,9 +100,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Raise Time -->
                     <StackPanel Grid.Column="1" Spacing="4">
                         <TextBlock Text="Raise Time" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        <Button Classes="TappableValue" Command="{Binding EditRaiseTimeCommand}" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Machine.RaiseTime}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Center"
+                            Value="{Binding Machine.RaiseTime, Mode=TwoWay}"
+                            Unit="" FormatString="F0"
+                            EditCommand="{Binding EditRaiseTimeCommand}"/>
                         <TextBlock Text="Plant Pop" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                     </StackPanel>
 
@@ -131,18 +118,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Look Ahead -->
                     <StackPanel Grid.Column="0" Spacing="4">
                         <TextBlock Text="Look Ahead" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        <Button Classes="TappableValue" Command="{Binding EditLookAheadCommand}" HorizontalAlignment="Center"
-                                Width="70" Height="70">
-                            <TextBlock Text="{Binding Machine.LookAhead, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Center"
+                            Value="{Binding Machine.LookAhead, Mode=TwoWay}"
+                            Unit="" FormatString="F1"
+                            EditCommand="{Binding EditLookAheadCommand}"/>
                     </StackPanel>
 
                     <!-- Lower Time -->
                     <StackPanel Grid.Column="1" Spacing="4">
                         <TextBlock Text="Lower Time" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        <Button Classes="TappableValue" Command="{Binding EditLowerTimeCommand}" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Machine.LowerTime}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Center"
+                            Value="{Binding Machine.LowerTime, Mode=TwoWay}"
+                            Unit="" FormatString="F0"
+                            EditCommand="{Binding EditLowerTimeCommand}"/>
                     </StackPanel>
 
                     <!-- Lower Time Graphic -->
@@ -181,33 +169,37 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- User 1 -->
                     <StackPanel Spacing="2">
                         <TextBlock Text="User 1" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        <Button Classes="TappableValue" Command="{Binding EditUser1Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User1Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Stretch"
+                            Value="{Binding Machine.User1Value, Mode=TwoWay}"
+                            Unit="" FormatString="F0"
+                            EditCommand="{Binding EditUser1Command}"/>
                     </StackPanel>
 
                     <!-- User 2 -->
                     <StackPanel Spacing="2">
                         <TextBlock Text="User 2" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        <Button Classes="TappableValue" Command="{Binding EditUser2Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User2Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Stretch"
+                            Value="{Binding Machine.User2Value, Mode=TwoWay}"
+                            Unit="" FormatString="F0"
+                            EditCommand="{Binding EditUser2Command}"/>
                     </StackPanel>
 
                     <!-- User 3 -->
                     <StackPanel Spacing="2">
                         <TextBlock Text="User 3" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        <Button Classes="TappableValue" Command="{Binding EditUser3Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User3Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Stretch"
+                            Value="{Binding Machine.User3Value, Mode=TwoWay}"
+                            Unit="" FormatString="F0"
+                            EditCommand="{Binding EditUser3Command}"/>
                     </StackPanel>
 
                     <!-- User 4 -->
                     <StackPanel Spacing="2">
                         <TextBlock Text="User 4" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        <Button Classes="TappableValue" Command="{Binding EditUser4Command}" HorizontalAlignment="Stretch">
-                            <TextBlock Text="{Binding Machine.User4Value}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="20" HorizontalAlignment="Center"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Stretch"
+                            Value="{Binding Machine.User4Value, Mode=TwoWay}"
+                            Unit="" FormatString="F0"
+                            EditCommand="{Binding EditUser4Command}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SectionsConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SectionsConfigTab.axaml
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="400"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.SectionsConfigTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -39,19 +40,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="MinWidth" Value="80"/>
         </Style>
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="120"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
-        </Style>
     </UserControl.Styles>
 
     <ScrollViewer>
@@ -61,9 +49,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBlock Text="Number of Sections" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditNumSectionsCommand}">
-                        <TextBlock Text="{Binding Config.NumSections}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Config.NumSections, Mode=TwoWay}"
+                        Unit="" FormatString="F0"
+                        EditCommand="{Binding EditNumSectionsCommand}"/>
                 </Grid>
             </Border>
 
@@ -71,25 +60,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBlock Text="Look Ahead On" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditLookAheadOnCommand}">
-                        <TextBlock Text="{Binding Tool.LookAheadOnSetting, StringFormat='{}{0:F1} s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.LookAheadOnSetting, Mode=TwoWay}"
+                        Unit="s" FormatString="F1"
+                        EditCommand="{Binding EditLookAheadOnCommand}"/>
                 </Grid>
             </Border>
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBlock Text="Look Ahead Off" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditLookAheadOffCommand}">
-                        <TextBlock Text="{Binding Tool.LookAheadOffSetting, StringFormat='{}{0:F1} s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.LookAheadOffSetting, Mode=TwoWay}"
+                        Unit="s" FormatString="F1"
+                        EditCommand="{Binding EditLookAheadOffCommand}"/>
                 </Grid>
             </Border>
             <Border Classes="SettingRow">
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBlock Text="Turn Off Delay" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTurnOffDelayCommand}">
-                        <TextBlock Text="{Binding Tool.TurnOffDelay, StringFormat='{}{0:F1} s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.TurnOffDelay, Mode=TwoWay}"
+                        Unit="s" FormatString="F1"
+                        EditCommand="{Binding EditTurnOffDelayCommand}"/>
                 </Grid>
             </Border>
         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="620" d:DesignHeight="600"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.SourcesSubTabs.GpsSubTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -64,26 +65,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12"/>
-        </Style>
-
-        <!-- Tappable Value Button Style -->
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="8,4"/>
-            <Setter Property="MinWidth" Value="80"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
-        </Style>
-        <Style Selector="Button.TappableValue:disabled">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
         </Style>
 
         <!-- Toggle Button with custom template for instant feedback -->
@@ -180,17 +161,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Heading Offset -->
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Heading Offset (Degree)" Foreground="{Binding Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
-                            <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDualHeadingOffsetCommand}" IsEnabled="{Binding Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.DualHeadingOffset, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                            </Button>
+                            <controls:EditableNumericField Grid.Column="1"
+                                Value="{Binding Connections.DualHeadingOffset, Mode=TwoWay}"
+                                Unit="deg" FormatString="F1"
+                                EditCommand="{Binding EditDualHeadingOffsetCommand}"
+                                IsEnabled="{Binding Connections.IsDualGps}"/>
                         </Grid>
 
                         <!-- Reverse Distance -->
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Reverse Distance" Foreground="{Binding Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
-                            <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDualReverseDistanceCommand}" IsEnabled="{Binding Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.DualReverseDistance, StringFormat='{}{0:F2}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                            </Button>
+                            <controls:EditableNumericField Grid.Column="1"
+                                Value="{Binding Connections.DualReverseDistance, Mode=TwoWay}"
+                                Unit="m" FormatString="F2"
+                                EditCommand="{Binding EditDualReverseDistanceCommand}"
+                                IsEnabled="{Binding Connections.IsDualGps}"/>
                         </Grid>
 
                         <!-- Auto Dual <> Fix -->
@@ -205,9 +190,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Switch Speed -->
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Switch Speed" Foreground="{Binding Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
-                            <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDualSwitchSpeedCommand}" IsEnabled="{Binding Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.DualSwitchSpeed, StringFormat='{}{0:F1}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                            </Button>
+                            <controls:EditableNumericField Grid.Column="1"
+                                Value="{Binding Connections.DualSwitchSpeed, Mode=TwoWay}"
+                                Unit="" FormatString="F1"
+                                EditCommand="{Binding EditDualSwitchSpeedCommand}"
+                                IsEnabled="{Binding Connections.IsDualGps}"/>
                         </Grid>
                     </StackPanel>
                 </Border>
@@ -222,17 +209,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Minimum GPS Step -->
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Minimum GPS Step" Foreground="{Binding !Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
-                            <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditMinGpsStepCommand}" IsEnabled="{Binding !Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.MinGpsStep, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                            </Button>
+                            <controls:EditableNumericField Grid.Column="1"
+                                Value="{Binding Connections.MinGpsStep, Mode=TwoWay}"
+                                Unit="m" FormatString="F2"
+                                EditCommand="{Binding EditMinGpsStepCommand}"
+                                IsEnabled="{Binding !Connections.IsDualGps}"/>
                         </Grid>
 
                         <!-- Fix to Fix Distance -->
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Fix to Fix Distance" Foreground="{Binding !Connections.IsDualGps, Converter={StaticResource BoolToColorConverter}, ConverterParameter=White|#555}" FontSize="11" VerticalAlignment="Center"/>
-                            <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditFixToFixDistanceCommand}" IsEnabled="{Binding !Connections.IsDualGps}">
-                                <TextBlock Text="{Binding Connections.FixToFixDistance, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                            </Button>
+                            <controls:EditableNumericField Grid.Column="1"
+                                Value="{Binding Connections.FixToFixDistance, Mode=TwoWay}"
+                                Unit="m" FormatString="F2"
+                                EditCommand="{Binding EditFixToFixDistanceCommand}"
+                                IsEnabled="{Binding !Connections.IsDualGps}"/>
                         </Grid>
 
                         <!-- Fusion Slider -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="500"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.SourcesSubTabs.RollSubTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -39,21 +40,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
-        </Style>
-
-        <!-- Tappable Value Button Style -->
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="100"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
 
         <!-- Action Button Style -->
@@ -110,9 +96,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Roll Zero Offset" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="Manual offset adjustment" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                     </StackPanel>
-                    <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditRollZeroCommand}">
-                        <TextBlock Text="{Binding Ahrs.RollZero, StringFormat='{}{0:F1}°'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="2"
+                        Value="{Binding Ahrs.RollZero, Mode=TwoWay}"
+                        Unit="deg" FormatString="F1"
+                        EditCommand="{Binding EditRollZeroCommand}"/>
                 </Grid>
             </Border>
 
@@ -125,9 +112,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Roll Filter" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <TextBlock Text="0 = no filtering, 1 = max filtering" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditRollFilterCommand}">
-                        <TextBlock Text="{Binding Ahrs.RollFilter, StringFormat='{}{0:F2}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Ahrs.RollFilter, Mode=TwoWay}"
+                        Unit="" FormatString="F2"
+                        EditCommand="{Binding EditRollFilterCommand}"/>
                 </Grid>
             </Border>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.ToolSubTabs.ToolHitchSubTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -30,19 +31,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
-        </Style>
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="120"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>
 
@@ -69,9 +57,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Hitch Length" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Text="Distance from rear axle to hitch point" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditToolHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.HitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.HitchLength, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditToolHitchLengthCommand}"/>
                 </Grid>
             </Border>
 
@@ -82,9 +71,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Trailing Hitch Length" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Text="Distance from hitch to trailing tool" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTrailingHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.TrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.TrailingHitchLength, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditTrailingHitchLengthCommand}"/>
                 </Grid>
             </Border>
 
@@ -95,9 +85,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Trailing Hitch Length" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Text="Distance from hitch to implement" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTrailingHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.TrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.TrailingHitchLength, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditTrailingHitchLengthCommand}"/>
                 </Grid>
             </Border>
 
@@ -108,9 +99,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Tank Trailing Hitch" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Text="Distance from implement to tank trailer" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditTankHitchLengthCommand}">
-                        <TextBlock Text="{Binding Tool.TankTrailingHitchLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.TankTrailingHitchLength, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditTankHitchLengthCommand}"/>
                 </Grid>
             </Border>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="500"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.ToolSubTabs.ToolOffsetSubTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -30,19 +31,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
-        </Style>
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="100"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.DirectionBtn">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
@@ -67,9 +55,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Classes="DirectionBtn" Content="Left"/>
                         <Button Classes="DirectionBtn" Content="Right"/>
-                        <Button Classes="TappableValue" Command="{Binding EditToolOffsetCommand}">
-                            <TextBlock Text="{Binding Tool.Offset, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                        </Button>
+                        <controls:EditableNumericField
+                            Value="{Binding Tool.Offset, Mode=TwoWay}"
+                            Unit="m" FormatString="F2"
+                            EditCommand="{Binding EditToolOffsetCommand}"/>
                         <Button Content="Zero" Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </StackPanel>
@@ -86,9 +75,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Classes="DirectionBtn" Content="Overlap"/>
                         <Button Classes="DirectionBtn" Content="Gap"/>
-                        <Button Classes="TappableValue" Command="{Binding EditToolOverlapCommand}">
-                            <TextBlock Text="{Binding Tool.Overlap, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                        </Button>
+                        <controls:EditableNumericField
+                            Value="{Binding Tool.Overlap, Mode=TwoWay}"
+                            Unit="m" FormatString="F2"
+                            EditCommand="{Binding EditToolOverlapCommand}"/>
                         <Button Content="Zero" Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.ToolSubTabs.ToolPivotSubTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -30,19 +31,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
-        </Style>
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="100"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.DirectionBtn">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
@@ -95,9 +83,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                     <!-- Value -->
                     <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8">
-                        <Button Classes="TappableValue" Command="{Binding EditToolPivotCommand}">
-                            <TextBlock Text="{Binding Tool.TrailingToolToPivotLength, StringFormat='{}{0:F2} m'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                        </Button>
+                        <controls:EditableNumericField
+                            Value="{Binding Tool.TrailingToolToPivotLength, Mode=TwoWay}"
+                            Unit="m" FormatString="F2"
+                            EditCommand="{Binding EditToolPivotCommand}"/>
                         <Button Content="Zero" Command="{Binding ZeroToolPivotCommand}"
                                 Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:converters="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="800"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.ToolSubTabs.ToolSectionsSubTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -36,19 +37,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
-        </Style>
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="80"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
         <Style Selector="Button.SectionWidthBtn">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
@@ -92,9 +80,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Number of Sections" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Text="Total implement sections (1-16)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditNumSectionsCommand}">
-                        <TextBlock Text="{Binding Config.NumSections}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Config.NumSections, Mode=TwoWay}"
+                        Unit="" FormatString="F0"
+                        EditCommand="{Binding EditNumSectionsCommand}"/>
                 </Grid>
             </Border>
 
@@ -105,9 +94,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Default Section Width" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Text="Width applied to new sections (or all sections in zone mode)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditDefaultSectionWidthCommand}">
-                        <TextBlock Text="{Binding Tool.DefaultSectionWidth, StringFormat='{}{0:F0} cm'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.DefaultSectionWidth, Mode=TwoWay}"
+                        Unit="cm" FormatString="F0"
+                        EditCommand="{Binding EditDefaultSectionWidthCommand}"/>
                 </Grid>
             </Border>
 
@@ -260,9 +250,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <TextBlock Text="Number of Zones" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                                 <TextBlock Text="How many control zones (2-8)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             </StackPanel>
-                            <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditNumZonesCommand}">
-                                <TextBlock Text="{Binding Tool.Zones}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                            </Button>
+                            <controls:EditableNumericField Grid.Column="1"
+                                Value="{Binding Tool.Zones, Mode=TwoWay}"
+                                Unit="" FormatString="F0"
+                                EditCommand="{Binding EditNumZonesCommand}"/>
                         </Grid>
                     </Border>
 
@@ -532,9 +523,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Minimum % of section in uncovered area to turn on"
                                    Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditMinCoverageCommand}">
-                        <TextBlock Text="{Binding Tool.MinCoverage, StringFormat='{}{0} %'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.MinCoverage, Mode=TwoWay}"
+                        Unit="%" FormatString="F0"
+                        EditCommand="{Binding EditMinCoverageCommand}"/>
                 </Grid>
             </Border>
 
@@ -545,9 +537,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Speed below which sections turn off"
                                    Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditCutoffSpeedCommand}">
-                        <TextBlock Text="{Binding Tool.SlowSpeedCutoff, StringFormat='{}{0:F1} km/h'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.SlowSpeedCutoff, Mode=TwoWay}"
+                        Unit="km/h" FormatString="F1"
+                        EditCommand="{Binding EditCutoffSpeedCommand}"/>
                 </Grid>
             </Border>
 
@@ -558,9 +551,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Expand recorded coverage to prevent gaps between passes"
                                    Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                     </StackPanel>
-                    <Button Grid.Column="1" Classes="TappableValue" Command="{Binding EditCoverageMarginCommand}">
-                        <TextBlock Text="{Binding Tool.CoverageMargin, StringFormat='{}{0:F0} cm'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                    </Button>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.CoverageMargin, Mode=TwoWay}"
+                        Unit="cm" FormatString="F0"
+                        EditCommand="{Binding EditCoverageMarginCommand}"/>
                 </Grid>
             </Border>
         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:gif="using:Avalonia.Labs.Gif"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.ToolSubTabs.ToolTimingSubTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -31,19 +32,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="Margin" Value="0,4"/>
-        </Style>
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="120"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
         </Style>
     </UserControl.Styles>
 
@@ -58,9 +46,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <TextBlock Text="Look Ahead On" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                     <TextBlock Text="Time before entering coverage to turn ON" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                 </StackPanel>
-                <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditLookAheadOnCommand}" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Tool.LookAheadOnSetting, StringFormat='{}{0:F1} sec'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                </Button>
+                <controls:EditableNumericField Grid.Column="2" VerticalAlignment="Center"
+                    Value="{Binding Tool.LookAheadOnSetting, Mode=TwoWay}"
+                    Unit="sec" FormatString="F1"
+                    EditCommand="{Binding EditLookAheadOnCommand}"/>
             </Grid>
 
             <!-- Look Ahead Off -->
@@ -72,9 +61,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <TextBlock Text="Look Ahead Off" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                     <TextBlock Text="Time before leaving coverage to turn OFF" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                 </StackPanel>
-                <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditLookAheadOffCommand}" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Tool.LookAheadOffSetting, StringFormat='{}{0:F1} sec'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                </Button>
+                <controls:EditableNumericField Grid.Column="2" VerticalAlignment="Center"
+                    Value="{Binding Tool.LookAheadOffSetting, Mode=TwoWay}"
+                    Unit="sec" FormatString="F1"
+                    EditCommand="{Binding EditLookAheadOffCommand}"/>
             </Grid>
 
             <!-- Turn Off Delay -->
@@ -86,9 +76,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <TextBlock Text="Turn Off Delay" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                     <TextBlock Text="Delay before turning OFF (alt to Look Ahead Off)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                 </StackPanel>
-                <Button Grid.Column="2" Classes="TappableValue" Command="{Binding EditTurnOffDelayCommand}" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Tool.TurnOffDelay, StringFormat='{}{0:F1} sec'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
-                </Button>
+                <controls:EditableNumericField Grid.Column="2" VerticalAlignment="Center"
+                    Value="{Binding Tool.TurnOffDelay, Mode=TwoWay}"
+                    Unit="sec" FormatString="F1"
+                    EditCommand="{Binding EditTurnOffDelayCommand}"/>
             </Grid>
 
             <!-- Info box -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/TramConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/TramConfigTab.axaml
@@ -21,26 +21,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="620" d:DesignHeight="400"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.TramConfigTab"
              x:DataType="vm:ConfigurationViewModel">
 
     <UserControl.Styles>
-        <!-- Tappable Value Button -->
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="16,8"/>
-            <Setter Property="MinWidth" Value="80"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
-        </Style>
-
         <!-- Toggle Button with custom template for instant feedback -->
         <Style Selector="Button.ToggleButton">
             <Setter Property="BorderThickness" Value="1"/>
@@ -89,9 +75,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Passes Value -->
                         <StackPanel Spacing="4" HorizontalAlignment="Center">
                             <TextBlock Text="Passes" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" HorizontalAlignment="Center"/>
-                            <Button Classes="TappableValue" Command="{Binding EditTramPassesCommand}" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding Guidance.TramPasses}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
-                            </Button>
+                            <controls:EditableNumericField HorizontalAlignment="Center"
+                                Value="{Binding Guidance.TramPasses, Mode=TwoWay}"
+                                Unit="" FormatString="F0"
+                                EditCommand="{Binding EditTramPassesCommand}"/>
                         </StackPanel>
 
                         <!-- Display Toggle -->
@@ -120,9 +107,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Tram Line Value -->
                         <StackPanel Spacing="4" HorizontalAlignment="Center">
                             <TextBlock Text="Tram Line" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" HorizontalAlignment="Center"/>
-                            <Button Classes="TappableValue" Command="{Binding EditTramLineCommand}" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding Guidance.TramLine}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="24"/>
-                            </Button>
+                            <controls:EditableNumericField HorizontalAlignment="Center"
+                                Value="{Binding Guidance.TramLine, Mode=TwoWay}"
+                                Unit="" FormatString="F0"
+                                EditCommand="{Binding EditTramLineCommand}"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
@@ -20,26 +20,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="620" d:DesignHeight="550"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.UTurnConfigTab"
              x:DataType="vm:ConfigurationViewModel">
 
     <UserControl.Styles>
-        <!-- Tappable Value Button -->
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="16,8"/>
-            <Setter Property="MinWidth" Value="100"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
-        </Style>
-
         <!-- Parameter Card -->
         <Style Selector="Border.ParamCard">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
@@ -65,10 +51,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         </Border>
 
                         <!-- Value Display -->
-                        <Button Classes="TappableValue" Command="{Binding EditUTurnExtensionCommand}" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Guidance.UTurnExtension, StringFormat='{}{0:F1} m'}"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Center"
+                            Value="{Binding Guidance.UTurnExtension, Mode=TwoWay}"
+                            Unit="m" FormatString="F1"
+                            EditCommand="{Binding EditUTurnExtensionCommand}"/>
 
                         <!-- Tip Text -->
                         <TextBlock Text="Set extension length to 2 or 3x Radius"
@@ -86,10 +72,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         </Border>
 
                         <!-- Value Display -->
-                        <Button Classes="TappableValue" Command="{Binding EditUTurnSmoothingCommand}" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Guidance.UTurnSmoothing}"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18"/>
-                        </Button>
+                        <controls:EditableNumericField HorizontalAlignment="Center"
+                            Value="{Binding Guidance.UTurnSmoothing, Mode=TwoWay}"
+                            Unit="" FormatString="F0"
+                            EditCommand="{Binding EditUTurnSmoothingCommand}"/>
 
                         <!-- Tip Text -->
                         <TextBlock Text="Set Smoothing 3-4x Radius"
@@ -109,13 +95,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             </Border>
 
                             <!-- Value Display -->
-                            <Button Classes="TappableValue" Command="{Binding EditUTurnRadiusCommand}" HorizontalAlignment="Center">
-                                <StackPanel>
-                                    <TextBlock Text="{Binding Guidance.UTurnRadius, StringFormat='{}{0:F2}'}"
-                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="m" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                                </StackPanel>
-                            </Button>
+                            <controls:EditableNumericField HorizontalAlignment="Center"
+                                Value="{Binding Guidance.UTurnRadius, Mode=TwoWay}"
+                                Unit="m" FormatString="F2"
+                                EditCommand="{Binding EditUTurnRadiusCommand}"/>
                         </StackPanel>
                     </Border>
 
@@ -128,13 +111,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             </Border>
 
                             <!-- Value Display -->
-                            <Button Classes="TappableValue" Command="{Binding EditUTurnDistanceCommand}" HorizontalAlignment="Center">
-                                <StackPanel>
-                                    <TextBlock Text="{Binding Guidance.UTurnDistanceFromBoundary, StringFormat='{}{0:F2}'}"
-                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="m" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                                </StackPanel>
-                            </Button>
+                            <controls:EditableNumericField HorizontalAlignment="Center"
+                                Value="{Binding Guidance.UTurnDistanceFromBoundary, Mode=TwoWay}"
+                                Unit="m" FormatString="F2"
+                                EditCommand="{Binding EditUTurnDistanceCommand}"/>
                         </StackPanel>
                     </Border>
                 </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="500"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.Configuration.VehicleConfigTab"
              x:DataType="vm:ConfigurationViewModel">
@@ -256,34 +257,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid Grid.Row="1" ColumnDefinitions="*,*,*" Margin="0,16,0,0">
                     <!-- Hitch Length -->
                     <StackPanel Grid.Column="0" HorizontalAlignment="Center">
-                        <Button Classes="TappableValue" Command="{Binding EditHitchLengthCommand}">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding Tool.HitchLength, StringFormat='{}{0:F2}'}" Classes="LargeValue"/>
-                                <TextBlock Text="m" Classes="UnitLabel" Margin="4,0,0,8"/>
-                            </StackPanel>
-                        </Button>
+                        <controls:EditableNumericField
+                            Value="{Binding Tool.HitchLength, Mode=TwoWay}"
+                            Unit="m" FormatString="F2"
+                            EditCommand="{Binding EditHitchLengthCommand}"/>
                         <TextBlock Text="Hitch Length" Classes="SectionLabel" Margin="0,4,0,0"/>
                     </StackPanel>
 
                     <!-- Wheelbase -->
                     <StackPanel Grid.Column="1" HorizontalAlignment="Center">
-                        <Button Classes="TappableValue" Command="{Binding EditWheelbaseCommand}">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding Vehicle.Wheelbase, StringFormat='{}{0:F2}'}" Classes="LargeValue"/>
-                                <TextBlock Text="m" Classes="UnitLabel" Margin="4,0,0,8"/>
-                            </StackPanel>
-                        </Button>
+                        <controls:EditableNumericField
+                            Value="{Binding Vehicle.Wheelbase, Mode=TwoWay}"
+                            Unit="m" FormatString="F2"
+                            EditCommand="{Binding EditWheelbaseCommand}"/>
                         <TextBlock Text="Wheelbase" Classes="SectionLabel" Margin="0,4,0,0"/>
                     </StackPanel>
 
                     <!-- Track -->
                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
-                        <Button Classes="TappableValue" Command="{Binding EditTrackWidthCommand}">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                <TextBlock Text="{Binding Vehicle.TrackWidth, StringFormat='{}{0:F2}'}" Classes="LargeValue"/>
-                                <TextBlock Text="m" Classes="UnitLabel" Margin="4,0,0,8"/>
-                            </StackPanel>
-                        </Button>
+                        <controls:EditableNumericField
+                            Value="{Binding Vehicle.TrackWidth, Mode=TwoWay}"
+                            Unit="m" FormatString="F2"
+                            EditCommand="{Binding EditTrackWidthCommand}"/>
                         <TextBlock Text="Track" Classes="SectionLabel" Margin="0,4,0,0"/>
                     </StackPanel>
                 </Grid>
@@ -299,12 +294,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,*,Auto" Margin="16">
                 <!-- Pivot Distance -->
                 <StackPanel Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" Margin="0,0,0,8">
-                    <Button Classes="TappableValue" Command="{Binding EditAntennaPivotCommand}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Vehicle.AntennaPivot, StringFormat='{}{0:F2}'}" Classes="LargeValue"/>
-                            <TextBlock Text="m" Classes="UnitLabel" Margin="4,0,0,8"/>
-                        </StackPanel>
-                    </Button>
+                    <controls:EditableNumericField
+                        Value="{Binding Vehicle.AntennaPivot, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditAntennaPivotCommand}"/>
                     <TextBlock Text="Pivot Distance" Classes="SectionLabel" Margin="0,4,0,0"/>
                 </StackPanel>
 
@@ -316,23 +309,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Antenna Height -->
                 <StackPanel Grid.Row="1" Grid.Column="1" VerticalAlignment="Top" Margin="16,20,0,0">
-                    <Button Classes="TappableValue" Command="{Binding EditAntennaHeightCommand}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Vehicle.AntennaHeight, StringFormat='{}{0:F2}'}" Classes="LargeValue"/>
-                            <TextBlock Text="m" Classes="UnitLabel" Margin="4,0,0,8"/>
-                        </StackPanel>
-                    </Button>
+                    <controls:EditableNumericField
+                        Value="{Binding Vehicle.AntennaHeight, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditAntennaHeightCommand}"/>
                     <TextBlock Text="Antenna Height" Classes="SectionLabel" Margin="0,4,0,0"/>
                 </StackPanel>
 
                 <!-- Antenna Offset -->
                 <StackPanel Grid.Row="2" Grid.Column="0" HorizontalAlignment="Left" Margin="10,8,0,0">
-                    <Button Classes="TappableValue" HorizontalAlignment="Left" Command="{Binding EditAntennaOffsetCommand}">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                            <TextBlock Text="{Binding Vehicle.AntennaOffset, StringFormat='{}{0:F2}'}" Classes="LargeValue"/>
-                            <TextBlock Text="m" Classes="UnitLabel" Margin="4,0,0,8"/>
-                        </StackPanel>
-                    </Button>
+                    <controls:EditableNumericField
+                        Value="{Binding Vehicle.AntennaOffset, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditAntennaOffsetCommand}"/>
                     <TextBlock Text="Antenna Offset" Classes="SectionLabel" HorizontalAlignment="Left" Margin="0,4,0,0"/>
 
                     <!-- Offset selector buttons: Left = antenna left of center (negative), Right = antenna right of center (positive) -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
@@ -54,19 +54,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Padding" Value="12,8"/>
             <Setter Property="MinWidth" Value="80"/>
         </Style>
-        <Style Selector="Button.TappableValue">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="CornerRadius" Value="4"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="MinWidth" Value="120"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.TappableValue:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
-        </Style>
         <Style Selector="TextBlock.LargeValue">
             <Setter Property="FontSize" Value="32"/>
             <Setter Property="FontWeight" Value="Bold"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -27,10 +27,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              x:DataType="vm:ConfigurationViewModel"
              IsVisible="{Binding IsDialogVisible, FallbackValue=False}">
 
-    <UserControl.Resources>
-        <conv:InverseBoolConverter x:Key="InverseBool"/>
-    </UserControl.Resources>
-
     <UserControl.Styles>
         <!-- Main TabControl styling for left icon strip -->
         <Style Selector="TabControl.MainConfigTabs">
@@ -176,18 +172,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 </StackPanel>
                             </Border>
 
-                            <!-- Direct text input (when on-screen keyboard disabled) -->
-                            <TextBox Grid.Row="2" x:Name="ConfigNumericDirectInput"
-                                     IsVisible="{Binding Display.KeyboardEnabled, Converter={StaticResource InverseBool}}"
-                                     Text="{Binding NumericInputDisplayText, Mode=TwoWay}"
-                                     FontSize="32" FontWeight="Bold"
-                                     HorizontalContentAlignment="Center"
-                                     Watermark="Enter value..."
-                                     Margin="0,0,0,16"/>
-
-                            <!-- Keypad Grid (when on-screen keyboard enabled) -->
-                            <Grid Grid.Row="2" ColumnDefinitions="*,*,*,*" RowDefinitions="*,*,*,*" Margin="0,0,0,16"
-                                  IsVisible="{Binding Display.KeyboardEnabled}">
+                            <!-- Keypad Grid -->
+                            <Grid Grid.Row="2" ColumnDefinitions="*,*,*,*" RowDefinitions="*,*,*,*" Margin="0,0,0,16">
                                 <Grid.Styles>
                                     <Style Selector="Button.KeypadButton">
                                         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -27,6 +27,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              x:DataType="vm:ConfigurationViewModel"
              IsVisible="{Binding IsDialogVisible, FallbackValue=False}">
 
+    <UserControl.Resources>
+        <conv:InverseBoolConverter x:Key="InverseBool"/>
+    </UserControl.Resources>
+
     <UserControl.Styles>
         <!-- Main TabControl styling for left icon strip -->
         <Style Selector="TabControl.MainConfigTabs">
@@ -172,8 +176,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 </StackPanel>
                             </Border>
 
-                            <!-- Keypad Grid -->
-                            <Grid Grid.Row="2" ColumnDefinitions="*,*,*,*" RowDefinitions="*,*,*,*" Margin="0,0,0,16">
+                            <!-- Direct text input (when on-screen keyboard disabled) -->
+                            <TextBox Grid.Row="2" x:Name="ConfigNumericDirectInput"
+                                     IsVisible="{Binding Display.KeyboardEnabled, Converter={StaticResource InverseBool}}"
+                                     Text="{Binding NumericInputDisplayText, Mode=TwoWay}"
+                                     FontSize="32" FontWeight="Bold"
+                                     HorizontalContentAlignment="Center"
+                                     Watermark="Enter value..."
+                                     Margin="0,0,0,16"/>
+
+                            <!-- Keypad Grid (when on-screen keyboard enabled) -->
+                            <Grid Grid.Row="2" ColumnDefinitions="*,*,*,*" RowDefinitions="*,*,*,*" Margin="0,0,0,16"
+                                  IsVisible="{Binding Display.KeyboardEnabled}">
                                 <Grid.Styles>
                                     <Style Selector="Button.KeypadButton">
                                         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
@@ -48,8 +48,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                Text="{Binding NumericInputDialogDisplayText}"/>
                 </Border>
 
-                <!-- Numeric Keyboard -->
+                <!-- Numeric Keyboard (visible when KeyboardEnabled) -->
                 <controls:NumericKeyboardPanel x:Name="Keyboard"
+                    IsVisible="{Binding Display.KeyboardEnabled}"
                     Value="{Binding NumericInputDialogValue, Mode=TwoWay}"
                     DisplayText="{Binding NumericInputDialogDisplayText, Mode=OneWayToSource}"
                     IntegerOnly="{Binding NumericInputDialogIntegerOnly}"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
@@ -21,11 +21,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
+             xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.NumericInputDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsNumericInputDialogVisible}"
              IsHitTestVisible="{Binding State.UI.IsNumericInputDialogVisible}">
+
+    <UserControl.Resources>
+        <conv:InverseBoolConverter x:Key="InverseBool"/>
+    </UserControl.Resources>
 
     <!-- Full screen overlay with backdrop -->
     <Grid>
@@ -41,8 +46,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <TextBlock Text="{Binding NumericInputDialogTitle}" FontSize="18" FontWeight="Bold"
                            Foreground="#1ABC9C" HorizontalAlignment="Center"/>
 
-                <!-- Current Value Display -->
-                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="12,8">
+                <!-- Current Value Display (shown with on-screen keyboard) -->
+                <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="12,8"
+                        IsVisible="{Binding Display.KeyboardEnabled}">
                     <TextBlock x:Name="ValueDisplay" FontSize="32" FontWeight="Bold"
                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"
                                Text="{Binding NumericInputDialogDisplayText}"/>
@@ -55,6 +61,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     DisplayText="{Binding NumericInputDialogDisplayText, Mode=OneWayToSource}"
                     IntegerOnly="{Binding NumericInputDialogIntegerOnly}"
                     AllowNegative="{Binding NumericInputDialogAllowNegative}"/>
+
+                <!-- Text input fallback (shown when on-screen keyboard is disabled) -->
+                <TextBox x:Name="DirectInput"
+                         IsVisible="{Binding Display.KeyboardEnabled, Converter={StaticResource InverseBool}}"
+                         Text="{Binding NumericInputDialogDisplayText, Mode=TwoWay}"
+                         FontSize="32" FontWeight="Bold"
+                         HorizontalContentAlignment="Center"
+                         Watermark="Enter value..."
+                         Margin="0,4"/>
 
                 <!-- Action Buttons -->
                 <Grid ColumnDefinitions="*,*" Margin="0,8,0,0">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Input;
 
@@ -24,6 +25,19 @@ public partial class NumericInputDialogPanel : UserControl
     public NumericInputDialogPanel()
     {
         InitializeComponent();
+        DirectInput.TextChanged += DirectInput_TextChanged;
+    }
+
+    private void DirectInput_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        // Parse direct text input into the ViewModel's numeric value
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            if (decimal.TryParse(DirectInput.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+            {
+                vm.NumericInputDialogValue = value;
+            }
+        }
     }
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
@@ -126,8 +126,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
                 </StackPanel>
 
-                <!-- Numeric Keyboard -->
+                <!-- Numeric Keyboard (visible when KeyboardEnabled) -->
                 <controls:NumericKeyboardPanel x:Name="KeyboardPanel"
+                                               IsVisible="{Binding Display.KeyboardEnabled}"
                                                Grid.Row="3"
                                                MaxDecimalPlaces="8"
                                                AllowNegative="True"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
@@ -21,11 +21,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              xmlns:controls="using:AgValoniaGPS.Views.Controls"
+             xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.SimCoordsDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsSimCoordsDialogVisible}"
              IsHitTestVisible="{Binding State.UI.IsSimCoordsDialogVisible}">
+
+    <UserControl.Resources>
+        <conv:InverseBoolConverter x:Key="InverseBool"/>
+    </UserControl.Resources>
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Label">
@@ -98,8 +103,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            HorizontalAlignment="Center"
                            Margin="0,0,0,16"/>
 
-                <!-- Latitude Field -->
-                <StackPanel Grid.Row="1" Margin="0,0,0,8">
+                <!-- Latitude Field (on-screen keyboard mode) -->
+                <StackPanel Grid.Row="1" Margin="0,0,0,8"
+                            IsVisible="{Binding Display.KeyboardEnabled}">
                     <TextBlock Classes="Label" Text="Latitude (-90 to +90)"/>
                     <Border x:Name="LatitudeBorder" Classes="InputField"
                             PointerPressed="Latitude_PointerPressed">
@@ -112,8 +118,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
                 </StackPanel>
 
-                <!-- Longitude Field -->
-                <StackPanel Grid.Row="2" Margin="0,0,0,12">
+                <!-- Longitude Field (on-screen keyboard mode) -->
+                <StackPanel Grid.Row="2" Margin="0,0,0,12"
+                            IsVisible="{Binding Display.KeyboardEnabled}">
                     <TextBlock Classes="Label" Text="Longitude (-180 to +180)"/>
                     <Border x:Name="LongitudeBorder" Classes="InputField"
                             PointerPressed="Longitude_PointerPressed">
@@ -134,6 +141,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                AllowNegative="True"
                                                Height="220"
                                                Margin="0,0,0,12"/>
+
+                <!-- Direct text input fallback (when on-screen keyboard disabled) -->
+                <StackPanel Grid.Row="1" Margin="0,0,0,8"
+                            IsVisible="{Binding Display.KeyboardEnabled, Converter={StaticResource InverseBool}}">
+                    <TextBlock Classes="Label" Text="Latitude (-90 to +90)"/>
+                    <TextBox x:Name="LatitudeInput" FontSize="18" FontWeight="Bold"
+                             Watermark="0.00000000" Margin="0,4"/>
+                </StackPanel>
+                <StackPanel Grid.Row="2" Margin="0,0,0,12"
+                            IsVisible="{Binding Display.KeyboardEnabled, Converter={StaticResource InverseBool}}">
+                    <TextBlock Classes="Label" Text="Longitude (-180 to +180)"/>
+                    <TextBox x:Name="LongitudeInput" FontSize="18" FontWeight="Bold"
+                             Watermark="0.00000000" Margin="0,4"/>
+                </StackPanel>
 
                 <!-- Buttons -->
                 <Grid Grid.Row="4" ColumnDefinitions="*,*" Margin="0,4,0,0">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml.cs
@@ -20,6 +20,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Views.Controls;
 
 namespace AgValoniaGPS.Views.Controls.Dialogs;
@@ -54,6 +55,10 @@ public partial class SimCoordsDialogPanel : UserControl
                 _longitudeValue = vm.SimCoordsDialogLongitude;
 
                 UpdateDisplays();
+
+                // Also populate direct input TextBoxes
+                LatitudeInput.Text = FormatValue(_latitudeValue);
+                LongitudeInput.Text = FormatValue(_longitudeValue);
 
                 // Default to latitude field
                 SelectLatitude();
@@ -141,6 +146,15 @@ public partial class SimCoordsDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
+            // Read from direct input TextBoxes when on-screen keyboard is disabled
+            if (!ConfigurationStore.Instance.Display.KeyboardEnabled)
+            {
+                if (decimal.TryParse(LatitudeInput.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedLat))
+                    _latitudeValue = parsedLat;
+                if (decimal.TryParse(LongitudeInput.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedLon))
+                    _longitudeValue = parsedLon;
+            }
+
             // Clamp values to valid ranges
             var lat = _latitudeValue ?? 0m;
             var lon = _longitudeValue ?? 0m;

--- a/Shared/AgValoniaGPS.Views/Controls/EditableNumericField.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/EditableNumericField.axaml
@@ -1,0 +1,29 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="AgValoniaGPS.Views.Controls.EditableNumericField">
+
+    <!-- When KeyboardEnabled: tappable button that opens numpad overlay -->
+    <Panel>
+        <Button x:Name="TapButton" Classes="TappableValue"
+                IsVisible="True">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <TextBlock x:Name="DisplayText" Classes="LargeValue"/>
+                <TextBlock x:Name="UnitText" Classes="UnitLabel" Margin="4,0,0,8"/>
+            </StackPanel>
+        </Button>
+
+        <!-- When KeyboardEnabled OFF: inline TextBox for direct editing -->
+        <StackPanel x:Name="DirectEditPanel" Orientation="Horizontal"
+                    HorizontalAlignment="Center" IsVisible="False">
+            <TextBox x:Name="DirectInput" Width="100"
+                     FontSize="20" FontWeight="Bold"
+                     HorizontalContentAlignment="Center"
+                     VerticalAlignment="Center"/>
+            <TextBlock x:Name="DirectUnitText" Classes="UnitLabel" Margin="4,0,0,0"
+                       VerticalAlignment="Center"/>
+        </StackPanel>
+    </Panel>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/EditableNumericField.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/EditableNumericField.axaml.cs
@@ -1,0 +1,151 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Globalization;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using AgValoniaGPS.Models.Configuration;
+
+namespace AgValoniaGPS.Views.Controls;
+
+/// <summary>
+/// A numeric field that switches between tap-to-edit (shows numpad overlay)
+/// and inline TextBox based on Display.KeyboardEnabled.
+///
+/// KeyboardEnabled ON (touch): Button that fires EditCommand (opens numpad)
+/// KeyboardEnabled OFF (desktop): Inline editable TextBox
+/// </summary>
+public partial class EditableNumericField : UserControl
+{
+    public static readonly StyledProperty<double> ValueProperty =
+        AvaloniaProperty.Register<EditableNumericField, double>(nameof(Value));
+
+    public static readonly StyledProperty<string> UnitProperty =
+        AvaloniaProperty.Register<EditableNumericField, string>(nameof(Unit), "m");
+
+    public static readonly StyledProperty<string> FormatStringProperty =
+        AvaloniaProperty.Register<EditableNumericField, string>(nameof(FormatString), "F2");
+
+    public static readonly StyledProperty<ICommand?> EditCommandProperty =
+        AvaloniaProperty.Register<EditableNumericField, ICommand?>(nameof(EditCommand));
+
+    public double Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public string Unit
+    {
+        get => GetValue(UnitProperty);
+        set => SetValue(UnitProperty, value);
+    }
+
+    public string FormatString
+    {
+        get => GetValue(FormatStringProperty);
+        set => SetValue(FormatStringProperty, value);
+    }
+
+    public ICommand? EditCommand
+    {
+        get => GetValue(EditCommandProperty);
+        set => SetValue(EditCommandProperty, value);
+    }
+
+    public EditableNumericField()
+    {
+        InitializeComponent();
+
+        TapButton.Click += TapButton_Click;
+        DirectInput.LostFocus += DirectInput_LostFocus;
+        DirectInput.KeyDown += DirectInput_KeyDown;
+
+        // React to KeyboardEnabled changes
+        var display = ConfigurationStore.Instance.Display;
+        display.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(DisplayConfig.KeyboardEnabled))
+                UpdateMode();
+        };
+
+        UpdateMode();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == ValueProperty)
+        {
+            UpdateDisplay();
+        }
+        else if (change.Property == UnitProperty)
+        {
+            UnitText.Text = Unit;
+            DirectUnitText.Text = Unit;
+        }
+    }
+
+    private void UpdateMode()
+    {
+        bool keyboard = ConfigurationStore.Instance.Display.KeyboardEnabled;
+        TapButton.IsVisible = keyboard;
+        DirectEditPanel.IsVisible = !keyboard;
+        UpdateDisplay();
+    }
+
+    private void UpdateDisplay()
+    {
+        var text = Value.ToString(FormatString, CultureInfo.InvariantCulture);
+        DisplayText.Text = text;
+        UnitText.Text = Unit;
+        DirectUnitText.Text = Unit;
+
+        // Only update TextBox if not focused (avoid overwriting user input)
+        if (!DirectInput.IsFocused)
+        {
+            DirectInput.Text = text;
+        }
+    }
+
+    private void TapButton_Click(object? sender, RoutedEventArgs e)
+    {
+        EditCommand?.Execute(null);
+    }
+
+    private void DirectInput_LostFocus(object? sender, RoutedEventArgs e)
+    {
+        ApplyDirectInput();
+    }
+
+    private void DirectInput_KeyDown(object? sender, Avalonia.Input.KeyEventArgs e)
+    {
+        if (e.Key == Avalonia.Input.Key.Enter)
+        {
+            ApplyDirectInput();
+            e.Handled = true;
+        }
+    }
+
+    private void ApplyDirectInput()
+    {
+        if (double.TryParse(DirectInput.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+        {
+            Value = parsed;
+        }
+        else
+        {
+            // Reset to current value on invalid input
+            DirectInput.Text = Value.ToString(FormatString, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -1,0 +1,655 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Verifies that ConfigurationService correctly maps every AppSettings property
+/// to/from ConfigurationStore. Catches missing mappings when new settings are added.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // Modifies ConfigurationStore.Instance
+public class ConfigurationServiceMappingTests
+{
+    private AppSettings _settings = null!;
+    private ISettingsService _settingsService = null!;
+    private ConfigurationService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Reset ConfigurationStore to defaults before each test
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+
+        _settings = new AppSettings();
+        _settingsService = Substitute.For<ISettingsService>();
+        _settingsService.Settings.Returns(_settings);
+
+        _service = new ConfigurationService(
+            Substitute.For<IVehicleProfileService>(),
+            _settingsService);
+    }
+
+    // =====================================================================
+    // LoadAppSettings -> ConfigurationStore (AppSettings -> Store)
+    // =====================================================================
+
+    #region Display Settings: Load
+
+    [TestCase(1920.0)]
+    public void Load_WindowWidth(double value)
+    {
+        _settings.WindowWidth = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.WindowWidth, Is.EqualTo(value));
+    }
+
+    [TestCase(1080.0)]
+    public void Load_WindowHeight(double value)
+    {
+        _settings.WindowHeight = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.WindowHeight, Is.EqualTo(value));
+    }
+
+    [TestCase(250.0)]
+    public void Load_WindowX(double value)
+    {
+        _settings.WindowX = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.WindowX, Is.EqualTo(value));
+    }
+
+    [TestCase(150.0)]
+    public void Load_WindowY(double value)
+    {
+        _settings.WindowY = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.WindowY, Is.EqualTo(value));
+    }
+
+    [Test]
+    public void Load_WindowMaximized()
+    {
+        _settings.WindowMaximized = true;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.WindowMaximized, Is.True);
+    }
+
+    [Test]
+    public void Load_StartFullscreen()
+    {
+        _settings.StartFullscreen = true;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.StartFullscreen, Is.True);
+    }
+
+    [Test]
+    public void Load_SvennArrowVisible()
+    {
+        _settings.SvennArrowVisible = true;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.SvennArrowVisible, Is.True);
+    }
+
+    [Test]
+    public void Load_KeyboardEnabled()
+    {
+        _settings.KeyboardEnabled = true;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.KeyboardEnabled, Is.True);
+    }
+
+    [TestCase(500.0)]
+    public void Load_SimulatorPanelX(double value)
+    {
+        _settings.SimulatorPanelX = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.SimulatorPanelX, Is.EqualTo(value));
+    }
+
+    [TestCase(300.0)]
+    public void Load_SimulatorPanelY(double value)
+    {
+        _settings.SimulatorPanelY = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.SimulatorPanelY, Is.EqualTo(value));
+    }
+
+    [Test]
+    public void Load_SimulatorPanelVisible()
+    {
+        _settings.SimulatorPanelVisible = true;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.SimulatorPanelVisible, Is.True);
+    }
+
+    [Test]
+    public void Load_GridVisible()
+    {
+        _settings.GridVisible = false;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.GridVisible, Is.False);
+    }
+
+    [Test]
+    public void Load_CompassVisible()
+    {
+        _settings.CompassVisible = false;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.CompassVisible, Is.False);
+    }
+
+    [Test]
+    public void Load_SpeedVisible()
+    {
+        _settings.SpeedVisible = false;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.SpeedVisible, Is.False);
+    }
+
+    [TestCase(75.5)]
+    public void Load_CameraZoom(double value)
+    {
+        _settings.CameraZoom = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.CameraZoom, Is.EqualTo(value));
+    }
+
+    [TestCase(-45.0)]
+    public void Load_CameraPitch(double value)
+    {
+        _settings.CameraPitch = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.CameraPitch, Is.EqualTo(value));
+    }
+
+    #endregion
+
+    #region Connection Settings: Load
+
+    [Test]
+    public void Load_NtripCasterHost()
+    {
+        _settings.NtripCasterIp = "rtk.example.com";
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.NtripCasterHost, Is.EqualTo("rtk.example.com"));
+    }
+
+    [TestCase(2102)]
+    public void Load_NtripCasterPort(int value)
+    {
+        _settings.NtripCasterPort = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.NtripCasterPort, Is.EqualTo(value));
+    }
+
+    [Test]
+    public void Load_NtripMountPoint()
+    {
+        _settings.NtripMountPoint = "RTCM3_Mount";
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.NtripMountPoint, Is.EqualTo("RTCM3_Mount"));
+    }
+
+    [Test]
+    public void Load_NtripUsername()
+    {
+        _settings.NtripUsername = "user123";
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.NtripUsername, Is.EqualTo("user123"));
+    }
+
+    [Test]
+    public void Load_NtripPassword()
+    {
+        _settings.NtripPassword = "secret";
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.NtripPassword, Is.EqualTo("secret"));
+    }
+
+    [Test]
+    public void Load_NtripAutoConnect()
+    {
+        _settings.NtripAutoConnect = true;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.NtripAutoConnect, Is.True);
+    }
+
+    [Test]
+    public void Load_AgShareServer()
+    {
+        _settings.AgShareServer = "https://custom.server";
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.AgShareServer, Is.EqualTo("https://custom.server"));
+    }
+
+    [Test]
+    public void Load_AgShareApiKey()
+    {
+        _settings.AgShareApiKey = "api-key-123";
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.AgShareApiKey, Is.EqualTo("api-key-123"));
+    }
+
+    [Test]
+    public void Load_AgShareEnabled()
+    {
+        _settings.AgShareEnabled = true;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.AgShareEnabled, Is.True);
+    }
+
+    [TestCase(20)]
+    public void Load_GpsUpdateRate(int value)
+    {
+        _settings.GpsUpdateRate = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.GpsUpdateRate, Is.EqualTo(value));
+    }
+
+    [Test]
+    public void Load_UseRtk()
+    {
+        _settings.UseRtk = false;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Connections.UseRtk, Is.False);
+    }
+
+    #endregion
+
+    #region Simulator Settings: Load
+
+    [Test]
+    public void Load_SimulatorEnabled()
+    {
+        _settings.SimulatorEnabled = false;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Simulator.Enabled, Is.False);
+    }
+
+    [TestCase(51.5074)]
+    public void Load_SimulatorLatitude(double value)
+    {
+        _settings.SimulatorLatitude = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Simulator.Latitude, Is.EqualTo(value));
+    }
+
+    [TestCase(-0.1278)]
+    public void Load_SimulatorLongitude(double value)
+    {
+        _settings.SimulatorLongitude = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Simulator.Longitude, Is.EqualTo(value));
+    }
+
+    [TestCase(8.5)]
+    public void Load_SimulatorSpeed(double value)
+    {
+        _settings.SimulatorSpeed = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Simulator.Speed, Is.EqualTo(value));
+    }
+
+    [TestCase(15.0)]
+    public void Load_SimulatorSteerAngle(double value)
+    {
+        _settings.SimulatorSteerAngle = value;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Simulator.SteerAngle, Is.EqualTo(value));
+    }
+
+    #endregion
+
+    #region Hotkeys: Load
+
+    [Test]
+    public void Load_HotkeyBindings()
+    {
+        _settings.HotkeyBindings = new Dictionary<string, string>
+        {
+            { "AutoSteer", "Z" },
+            { "CycleLines", "X" }
+        };
+        _service.LoadAppSettings();
+        // Verify hotkeys were loaded (ToDictionary uses camelCase keys)
+        var dict = _service.Store.Hotkeys.ToDictionary();
+        Assert.That(dict, Does.ContainKey("autoSteer"));
+        Assert.That(dict["autoSteer"], Is.EqualTo("Z"));
+    }
+
+    [Test]
+    public void Load_EmptyHotkeyBindings_DoesNotCrash()
+    {
+        _settings.HotkeyBindings = new Dictionary<string, string>();
+        Assert.DoesNotThrow(() => _service.LoadAppSettings());
+    }
+
+    #endregion
+
+    // =====================================================================
+    // SaveAppSettings -> AppSettings (Store -> AppSettings)
+    // =====================================================================
+
+    #region Display Settings: Save
+
+    [Test]
+    public void Save_DisplaySettings_RoundTrip()
+    {
+        // Set non-default values on store
+        var store = _service.Store;
+        store.Display.WindowWidth = 1920;
+        store.Display.WindowHeight = 1080;
+        store.Display.WindowX = 250;
+        store.Display.WindowY = 150;
+        store.Display.WindowMaximized = true;
+        store.Display.StartFullscreen = true;
+        store.Display.SvennArrowVisible = true;
+        store.Display.KeyboardEnabled = true;
+        store.Display.SimulatorPanelX = 500;
+        store.Display.SimulatorPanelY = 300;
+        store.Display.SimulatorPanelVisible = true;
+        store.Display.GridVisible = false;
+        store.Display.CompassVisible = false;
+        store.Display.SpeedVisible = false;
+        store.Display.CameraZoom = 75.5;
+        store.Display.CameraPitch = -45.0;
+
+        _service.SaveAppSettings();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_settings.WindowWidth, Is.EqualTo(1920));
+            Assert.That(_settings.WindowHeight, Is.EqualTo(1080));
+            Assert.That(_settings.WindowX, Is.EqualTo(250));
+            Assert.That(_settings.WindowY, Is.EqualTo(150));
+            Assert.That(_settings.WindowMaximized, Is.True);
+            Assert.That(_settings.StartFullscreen, Is.True);
+            Assert.That(_settings.SvennArrowVisible, Is.True);
+            Assert.That(_settings.KeyboardEnabled, Is.True);
+            Assert.That(_settings.SimulatorPanelX, Is.EqualTo(500));
+            Assert.That(_settings.SimulatorPanelY, Is.EqualTo(300));
+            Assert.That(_settings.SimulatorPanelVisible, Is.True);
+            Assert.That(_settings.GridVisible, Is.False);
+            Assert.That(_settings.CompassVisible, Is.False);
+            Assert.That(_settings.SpeedVisible, Is.False);
+            Assert.That(_settings.CameraZoom, Is.EqualTo(75.5));
+            Assert.That(_settings.CameraPitch, Is.EqualTo(-45.0));
+        });
+
+        _settingsService.Received(1).Save();
+    }
+
+    #endregion
+
+    #region Connection Settings: Save
+
+    [Test]
+    public void Save_ConnectionSettings_RoundTrip()
+    {
+        var store = _service.Store;
+        store.Connections.NtripCasterHost = "rtk.example.com";
+        store.Connections.NtripCasterPort = 2102;
+        store.Connections.NtripMountPoint = "RTCM3";
+        store.Connections.NtripUsername = "user";
+        store.Connections.NtripPassword = "pass";
+        store.Connections.NtripAutoConnect = true;
+        store.Connections.AgShareServer = "https://custom";
+        store.Connections.AgShareApiKey = "key-123";
+        store.Connections.AgShareEnabled = true;
+        store.Connections.GpsUpdateRate = 20;
+        store.Connections.UseRtk = false;
+
+        _service.SaveAppSettings();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_settings.NtripCasterIp, Is.EqualTo("rtk.example.com"));
+            Assert.That(_settings.NtripCasterPort, Is.EqualTo(2102));
+            Assert.That(_settings.NtripMountPoint, Is.EqualTo("RTCM3"));
+            Assert.That(_settings.NtripUsername, Is.EqualTo("user"));
+            Assert.That(_settings.NtripPassword, Is.EqualTo("pass"));
+            Assert.That(_settings.NtripAutoConnect, Is.True);
+            Assert.That(_settings.AgShareServer, Is.EqualTo("https://custom"));
+            Assert.That(_settings.AgShareApiKey, Is.EqualTo("key-123"));
+            Assert.That(_settings.AgShareEnabled, Is.True);
+            Assert.That(_settings.GpsUpdateRate, Is.EqualTo(20));
+            Assert.That(_settings.UseRtk, Is.False);
+        });
+    }
+
+    #endregion
+
+    #region Simulator Settings: Save
+
+    [Test]
+    public void Save_SimulatorSettings_RoundTrip()
+    {
+        var store = _service.Store;
+        store.Simulator.Enabled = false;
+        store.Simulator.Latitude = 51.5074;
+        store.Simulator.Longitude = -0.1278;
+        store.Simulator.Speed = 8.5;
+        store.Simulator.SteerAngle = 15.0;
+
+        _service.SaveAppSettings();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_settings.SimulatorEnabled, Is.False);
+            Assert.That(_settings.SimulatorLatitude, Is.EqualTo(51.5074));
+            Assert.That(_settings.SimulatorLongitude, Is.EqualTo(-0.1278));
+            Assert.That(_settings.SimulatorSpeed, Is.EqualTo(8.5));
+            Assert.That(_settings.SimulatorSteerAngle, Is.EqualTo(15.0));
+        });
+    }
+
+    #endregion
+
+    #region Hotkeys: Save
+
+    [Test]
+    public void Save_HotkeyBindings()
+    {
+        _service.Store.Hotkeys.LoadFromDictionary(new Dictionary<string, string>
+        {
+            { "AutoSteer", "Z" },
+            { "CycleLines", "X" }
+        });
+
+        _service.SaveAppSettings();
+
+        Assert.That(_settings.HotkeyBindings, Does.ContainKey("autoSteer"));
+        Assert.That(_settings.HotkeyBindings["autoSteer"], Is.EqualTo("Z"));
+    }
+
+    #endregion
+
+    #region ActiveProfile: Save
+
+    [Test]
+    public void Save_ActiveProfileName()
+    {
+        _service.Store.ActiveProfileName = "MyTractor";
+
+        _service.SaveAppSettings();
+
+        Assert.That(_settings.LastUsedVehicleProfile, Is.EqualTo("MyTractor"));
+    }
+
+    #endregion
+
+    // =====================================================================
+    // Full round-trip: Settings -> Store -> Settings
+    // =====================================================================
+
+    [Test]
+    public void FullRoundTrip_AllMappedProperties_Preserved()
+    {
+        // Set non-default values on AppSettings
+        _settings.WindowWidth = 1600;
+        _settings.WindowHeight = 900;
+        _settings.WindowX = 200;
+        _settings.WindowY = 100;
+        _settings.WindowMaximized = true;
+        _settings.StartFullscreen = true;
+        _settings.SvennArrowVisible = true;
+        _settings.KeyboardEnabled = true;
+        _settings.GridVisible = false;
+        _settings.CompassVisible = false;
+        _settings.SpeedVisible = false;
+        _settings.CameraZoom = 50.0;
+        _settings.CameraPitch = -30.0;
+        _settings.NtripCasterIp = "ntrip.test";
+        _settings.NtripCasterPort = 9999;
+        _settings.NtripMountPoint = "MP1";
+        _settings.NtripUsername = "u";
+        _settings.NtripPassword = "p";
+        _settings.NtripAutoConnect = true;
+        _settings.AgShareServer = "https://test";
+        _settings.AgShareApiKey = "k";
+        _settings.AgShareEnabled = true;
+        _settings.GpsUpdateRate = 5;
+        _settings.UseRtk = false;
+        _settings.SimulatorEnabled = false;
+        _settings.SimulatorLatitude = 48.8566;
+        _settings.SimulatorLongitude = 2.3522;
+        _settings.SimulatorSpeed = 12.0;
+        _settings.SimulatorSteerAngle = -5.0;
+
+        // Load into store
+        _service.LoadAppSettings();
+
+        // Save back to a fresh AppSettings
+        var saved = new AppSettings();
+        _settingsService.Settings.Returns(saved);
+        _service.SaveAppSettings();
+
+        // Verify all values survived the round-trip
+        Assert.Multiple(() =>
+        {
+            Assert.That(saved.WindowWidth, Is.EqualTo(1600));
+            Assert.That(saved.WindowHeight, Is.EqualTo(900));
+            Assert.That(saved.WindowX, Is.EqualTo(200));
+            Assert.That(saved.WindowY, Is.EqualTo(100));
+            Assert.That(saved.WindowMaximized, Is.True);
+            Assert.That(saved.StartFullscreen, Is.True);
+            Assert.That(saved.SvennArrowVisible, Is.True);
+            Assert.That(saved.KeyboardEnabled, Is.True);
+            Assert.That(saved.GridVisible, Is.False);
+            Assert.That(saved.CompassVisible, Is.False);
+            Assert.That(saved.SpeedVisible, Is.False);
+            Assert.That(saved.CameraZoom, Is.EqualTo(50.0));
+            Assert.That(saved.CameraPitch, Is.EqualTo(-30.0));
+            Assert.That(saved.NtripCasterIp, Is.EqualTo("ntrip.test"));
+            Assert.That(saved.NtripCasterPort, Is.EqualTo(9999));
+            Assert.That(saved.NtripMountPoint, Is.EqualTo("MP1"));
+            Assert.That(saved.NtripUsername, Is.EqualTo("u"));
+            Assert.That(saved.NtripPassword, Is.EqualTo("p"));
+            Assert.That(saved.NtripAutoConnect, Is.True);
+            Assert.That(saved.AgShareServer, Is.EqualTo("https://test"));
+            Assert.That(saved.AgShareApiKey, Is.EqualTo("k"));
+            Assert.That(saved.AgShareEnabled, Is.True);
+            Assert.That(saved.GpsUpdateRate, Is.EqualTo(5));
+            Assert.That(saved.UseRtk, Is.False);
+            Assert.That(saved.SimulatorEnabled, Is.False);
+            Assert.That(saved.SimulatorLatitude, Is.EqualTo(48.8566));
+            Assert.That(saved.SimulatorLongitude, Is.EqualTo(2.3522));
+            Assert.That(saved.SimulatorSpeed, Is.EqualTo(12.0));
+            Assert.That(saved.SimulatorSteerAngle, Is.EqualTo(-5.0));
+        });
+    }
+
+    // =====================================================================
+    // Completeness check: detect unmapped properties
+    // =====================================================================
+
+    [Test]
+    public void Completeness_AllPersistableProperties_AreMapped()
+    {
+        // Properties that are intentionally NOT mapped through ConfigurationStore
+        // (they are used directly from AppSettings or managed elsewhere)
+        var excluded = new HashSet<string>
+        {
+            "FieldsDirectory",       // Used directly by FieldService
+            "CurrentFieldName",      // Managed by FieldService
+            "LastOpenedField",       // Managed by FieldService
+            "IsFirstRun",           // Checked directly at startup
+            "LastRunDate",          // Checked directly at startup
+            "LastUsedVehicleProfile", // Mapped via ActiveProfileName (different name)
+            "HotkeyBindings",       // Mapped via Hotkeys.LoadFromDictionary (special handling)
+            // Panel positions with NaN defaults - mapped but tested separately
+            "LeftNavPanelX", "LeftNavPanelY",
+            "RightNavPanelX", "RightNavPanelY",
+            "BottomNavPanelX", "BottomNavPanelY",
+            "SectionPanelX", "SectionPanelY",
+        };
+
+        // Set every non-excluded property to a non-default value
+        _settings.WindowWidth = 9999;
+        _settings.WindowHeight = 9999;
+        _settings.WindowX = 9999;
+        _settings.WindowY = 9999;
+        _settings.WindowMaximized = true;
+        _settings.StartFullscreen = true;
+        _settings.SvennArrowVisible = true;
+        _settings.KeyboardEnabled = true;
+        _settings.SimulatorPanelX = 9999;
+        _settings.SimulatorPanelY = 9999;
+        _settings.SimulatorPanelVisible = true;
+        _settings.GridVisible = false;
+        _settings.CompassVisible = false;
+        _settings.SpeedVisible = false;
+        _settings.CameraZoom = 9999;
+        _settings.CameraPitch = -50;
+        _settings.NtripCasterIp = "MAPPED";
+        _settings.NtripCasterPort = 9999;
+        _settings.NtripMountPoint = "MAPPED";
+        _settings.NtripUsername = "MAPPED";
+        _settings.NtripPassword = "MAPPED";
+        _settings.NtripAutoConnect = true;
+        _settings.AgShareServer = "MAPPED";
+        _settings.AgShareApiKey = "MAPPED";
+        _settings.AgShareEnabled = true;
+        _settings.GpsUpdateRate = 9999;
+        _settings.UseRtk = false;
+        _settings.SimulatorEnabled = false;
+        _settings.SimulatorLatitude = 9999;
+        _settings.SimulatorLongitude = 9999;
+        _settings.SimulatorSpeed = 9999;
+        _settings.SimulatorSteerAngle = 9999;
+
+        _service.LoadAppSettings();
+
+        // Save to fresh settings and check nothing reverted to default
+        var saved = new AppSettings();
+        _settingsService.Settings.Returns(saved);
+        _service.SaveAppSettings();
+
+        // Check each mapped property got a non-default value back
+        var props = typeof(AppSettings).GetProperties()
+            .Where(p => !excluded.Contains(p.Name))
+            .ToList();
+
+        var defaults = new AppSettings();
+        var unmapped = new List<string>();
+
+        foreach (var prop in props)
+        {
+            var savedValue = prop.GetValue(saved);
+            var defaultValue = prop.GetValue(defaults);
+
+            if (Equals(savedValue, defaultValue))
+            {
+                unmapped.Add(prop.Name);
+            }
+        }
+
+        Assert.That(unmapped, Is.Empty,
+            $"These AppSettings properties appear unmapped in ConfigurationService: {string.Join(", ", unmapped)}");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/KeyboardEnabledPersistenceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/KeyboardEnabledPersistenceTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Tests that KeyboardEnabled and SvennArrowVisible persist through
+/// JSON serialization and ConfigurationStore round-trips (#114, #115).
+/// </summary>
+[TestFixture]
+public class DisplayTogglePersistenceTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
+    };
+
+    [Test]
+    public void AppSettings_KeyboardEnabled_DefaultIsFalse()
+    {
+        var settings = new AppSettings();
+        Assert.That(settings.KeyboardEnabled, Is.False);
+    }
+
+    [Test]
+    public void AppSettings_SvennArrowVisible_DefaultIsFalse()
+    {
+        var settings = new AppSettings();
+        Assert.That(settings.SvennArrowVisible, Is.False);
+    }
+
+    [Test]
+    public void AppSettings_KeyboardEnabled_SurvivesJsonRoundTrip()
+    {
+        var original = new AppSettings { KeyboardEnabled = true };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions);
+
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized!.KeyboardEnabled, Is.True);
+    }
+
+    [Test]
+    public void AppSettings_SvennArrowVisible_SurvivesJsonRoundTrip()
+    {
+        var original = new AppSettings { SvennArrowVisible = true };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions);
+
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized!.SvennArrowVisible, Is.True);
+    }
+
+    [Test]
+    public void AppSettings_KeyboardEnabled_FalsePreservedInJson()
+    {
+        var original = new AppSettings { KeyboardEnabled = false };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions);
+
+        Assert.That(deserialized!.KeyboardEnabled, Is.False);
+    }
+
+    [Test]
+    public void AppSettings_MissingProperty_DeserializesToDefault()
+    {
+        // Simulate loading old settings file without the new property
+        var json = """{"WindowWidth":1200,"WindowHeight":800}""";
+        var deserialized = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions);
+
+        Assert.That(deserialized, Is.Not.Null);
+        Assert.That(deserialized!.KeyboardEnabled, Is.False);
+        Assert.That(deserialized!.SvennArrowVisible, Is.False);
+    }
+
+    [Test]
+    public void DisplayConfig_KeyboardEnabled_IsReactive()
+    {
+        var display = new DisplayConfig();
+        bool changed = false;
+        display.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(DisplayConfig.KeyboardEnabled))
+                changed = true;
+        };
+
+        display.KeyboardEnabled = true;
+
+        Assert.That(changed, Is.True);
+        Assert.That(display.KeyboardEnabled, Is.True);
+    }
+
+    [Test]
+    public void DisplayConfig_SvennArrowVisible_IsReactive()
+    {
+        var display = new DisplayConfig();
+        bool changed = false;
+        display.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(DisplayConfig.SvennArrowVisible))
+                changed = true;
+        };
+
+        display.SvennArrowVisible = true;
+
+        Assert.That(changed, Is.True);
+        Assert.That(display.SvennArrowVisible, Is.True);
+    }
+}


### PR DESCRIPTION
Closes #114

## Summary
- Persist `KeyboardEnabled` in `AppSettings` + `ConfigurationService` (default: false)
- Expose `Display` config on `MainViewModel` for AXAML binding
- When KeyboardEnabled ON: show on-screen keyboard panels (touch-friendly)
- When KeyboardEnabled OFF: show TextBox inputs for direct typing (desktop-friendly)
- Add 41 ConfigurationService mapping tests (catches missing mappings for any future setting)
- Add 8 DisplayToggle persistence tests (JSON round-trip, backward compat, reactivity)
- Add comprehensive Docs/TESTING.md

### Affected dialogs
- NumericInputDialogPanel: on-screen numpad vs TextBox
- SimCoordsDialogPanel: on-screen numpad vs TextBox for lat/lon
- AgShareSettingsDialogPanel: on-screen alphanumeric keyboard visibility

## Test plan
- [ ] KeyboardEnabled ON: open numeric input, verify on-screen keyboard visible
- [ ] KeyboardEnabled OFF: open numeric input, verify TextBox visible, enter value, confirm
- [ ] Same for SimCoords dialog (lat/lon)
- [ ] Same for AgShare settings dialog
- [ ] Restart app, verify setting persists
- [ ] All 191 service tests pass (41 new ConfigurationService mapping tests)