### PR TITLE
Add headland proximity distance HUD readout

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -33,6 +33,7 @@ namespace AgValoniaGPS.Models
         public bool StartFullscreen { get; set; } = false;
         public bool SvennArrowVisible { get; set; } = false;
         public bool KeyboardEnabled { get; set; } = false;
+        public bool HeadlandDistanceVisible { get; set; } = true;
 
         // Panel positions
         public double SimulatorPanelX { get; set; } = double.NaN; // NaN means not set

--- a/Shared/AgValoniaGPS.Models/State/FieldState.cs
+++ b/Shared/AgValoniaGPS.Models/State/FieldState.cs
@@ -101,7 +101,7 @@ public class FieldState : ReactiveObject
     }
 
     /// <summary>
-    /// Distance from vehicle to nearest headland boundary (meters).
+    /// Distance from tool pivot to nearest headland boundary (meters).
     /// null when no headland exists or distance not computed.
     /// </summary>
     private double? _headlandProximityDistance;
@@ -109,6 +109,16 @@ public class FieldState : ReactiveObject
     {
         get => _headlandProximityDistance;
         set => this.RaiseAndSetIfChanged(ref _headlandProximityDistance, value);
+    }
+
+    /// <summary>
+    /// Whether headland proximity warning is active (heading toward boundary within threshold).
+    /// </summary>
+    private bool _headlandProximityWarning;
+    public bool HeadlandProximityWarning
+    {
+        get => _headlandProximityWarning;
+        set => this.RaiseAndSetIfChanged(ref _headlandProximityWarning, value);
     }
 
     public bool HasHeadland => HeadlandLine != null && HeadlandLine.Count > 0;
@@ -147,6 +157,7 @@ public class FieldState : ReactiveObject
         HeadlandLine = null;
         HeadlandDistance = 0;
         HeadlandProximityDistance = null;
+        HeadlandProximityWarning = false;
         OriginLatitude = OriginLongitude = 0;
         LocalPlane = null;
     }

--- a/Shared/AgValoniaGPS.Models/State/FieldState.cs
+++ b/Shared/AgValoniaGPS.Models/State/FieldState.cs
@@ -100,6 +100,17 @@ public class FieldState : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _headlandDistance, value);
     }
 
+    /// <summary>
+    /// Distance from vehicle to nearest headland boundary (meters).
+    /// null when no headland exists or distance not computed.
+    /// </summary>
+    private double? _headlandProximityDistance;
+    public double? HeadlandProximityDistance
+    {
+        get => _headlandProximityDistance;
+        set => this.RaiseAndSetIfChanged(ref _headlandProximityDistance, value);
+    }
+
     public bool HasHeadland => HeadlandLine != null && HeadlandLine.Count > 0;
 
     // Field origin (local plane reference)
@@ -135,6 +146,7 @@ public class FieldState : ReactiveObject
         SelectedTrack = null;
         HeadlandLine = null;
         HeadlandDistance = 0;
+        HeadlandProximityDistance = null;
         OriginLatitude = OriginLongitude = 0;
         LocalPlane = null;
     }

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -300,6 +300,7 @@ public class ConfigurationService(
         store.Display.StartFullscreen = settings.StartFullscreen;
         store.Display.SvennArrowVisible = settings.SvennArrowVisible;
         store.Display.KeyboardEnabled = settings.KeyboardEnabled;
+        store.Display.HeadlandDistanceVisible = settings.HeadlandDistanceVisible;
         store.Display.SimulatorPanelX = settings.SimulatorPanelX;
         store.Display.SimulatorPanelY = settings.SimulatorPanelY;
         store.Display.SimulatorPanelVisible = settings.SimulatorPanelVisible;
@@ -360,6 +361,7 @@ public class ConfigurationService(
         settings.StartFullscreen = store.Display.StartFullscreen;
         settings.SvennArrowVisible = store.Display.SvennArrowVisible;
         settings.KeyboardEnabled = store.Display.KeyboardEnabled;
+        settings.HeadlandDistanceVisible = store.Display.HeadlandDistanceVisible;
         settings.SimulatorPanelX = store.Display.SimulatorPanelX;
         settings.SimulatorPanelY = store.Display.SimulatorPanelY;
         settings.SimulatorPanelVisible = store.Display.SimulatorPanelVisible;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -175,8 +175,8 @@ public partial class MainViewModel
     }
 
     /// <summary>
-    /// Calculate distance from vehicle to nearest headland boundary line.
-    /// Uses nearest-segment approach for reliable distance regardless of heading.
+    /// Calculate distance from tool pivot to nearest headland boundary line.
+    /// Uses tool pivot position (not antenna) to match legacy AgOpenGPS behavior.
     /// </summary>
     private void UpdateHeadlandProximity(AgValoniaGPS.Models.Position position)
     {
@@ -187,9 +187,12 @@ public partial class MainViewModel
             return;
         }
 
+        // Use tool pivot position (implement hitch point), matching legacy mf.toolPivotPos
+        var toolPivot = _toolPositionService.ToolPivotPosition;
+
         double minDistSq = double.MaxValue;
-        double px = position.Easting;
-        double py = position.Northing;
+        double px = toolPivot.Easting;
+        double py = toolPivot.Northing;
         int n = headlandLine.Count;
 
         for (int i = 0; i < n; i++)

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -169,6 +169,54 @@ public partial class MainViewModel
         {
             AddContourPoint(data.CurrentPosition.Easting, data.CurrentPosition.Northing, data.CurrentPosition.Heading);
         }
+
+        // Update headland proximity distance for HUD readout
+        UpdateHeadlandProximity(data.CurrentPosition);
+    }
+
+    /// <summary>
+    /// Calculate distance from vehicle to nearest headland boundary line.
+    /// Uses nearest-segment approach for reliable distance regardless of heading.
+    /// </summary>
+    private void UpdateHeadlandProximity(AgValoniaGPS.Models.Position position)
+    {
+        var headlandLine = State.Field.HeadlandLine;
+        if (headlandLine == null || headlandLine.Count < 3)
+        {
+            State.Field.HeadlandProximityDistance = null;
+            return;
+        }
+
+        double minDistSq = double.MaxValue;
+        double px = position.Easting;
+        double py = position.Northing;
+        int n = headlandLine.Count;
+
+        for (int i = 0; i < n; i++)
+        {
+            var a = headlandLine[i];
+            var b = headlandLine[(i + 1) % n];
+
+            // Project point onto segment and get squared distance
+            double dx = b.Easting - a.Easting;
+            double dy = b.Northing - a.Northing;
+            double lenSq = dx * dx + dy * dy;
+
+            double t;
+            if (lenSq < 1e-10)
+                t = 0;
+            else
+                t = Math.Clamp(((px - a.Easting) * dx + (py - a.Northing) * dy) / lenSq, 0, 1);
+
+            double closestX = a.Easting + t * dx;
+            double closestY = a.Northing + t * dy;
+            double distSq = (px - closestX) * (px - closestX) + (py - closestY) * (py - closestY);
+
+            if (distSq < minDistSq)
+                minDistSq = distSq;
+        }
+
+        State.Field.HeadlandProximityDistance = Math.Sqrt(minDistSq);
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -174,9 +174,11 @@ public partial class MainViewModel
         UpdateHeadlandProximity(data.CurrentPosition);
     }
 
+    private static readonly AgValoniaGPS.Services.Headland.HeadlandDetectionService _headlandDetector = new();
+
     /// <summary>
     /// Calculate distance from tool pivot to nearest headland boundary line.
-    /// Uses tool pivot position (not antenna) to match legacy AgOpenGPS behavior.
+    /// Uses HeadlandDetectionService with direction-aware warnings, matching legacy AgOpenGPS.
     /// </summary>
     private void UpdateHeadlandProximity(AgValoniaGPS.Models.Position position)
     {
@@ -184,42 +186,31 @@ public partial class MainViewModel
         if (headlandLine == null || headlandLine.Count < 3)
         {
             State.Field.HeadlandProximityDistance = null;
+            State.Field.HeadlandProximityWarning = false;
             return;
         }
 
         // Use tool pivot position (implement hitch point), matching legacy mf.toolPivotPos
         var toolPivot = _toolPositionService.ToolPivotPosition;
 
-        double minDistSq = double.MaxValue;
-        double px = toolPivot.Easting;
-        double py = toolPivot.Northing;
-        int n = headlandLine.Count;
-
-        for (int i = 0; i < n; i++)
+        // Build minimal input for proximity calculation
+        var input = new AgValoniaGPS.Models.Headland.HeadlandDetectionInput
         {
-            var a = headlandLine[i];
-            var b = headlandLine[(i + 1) % n];
+            IsHeadlandOn = true,
+            VehiclePosition = toolPivot,
+            Boundaries = new System.Collections.Generic.List<AgValoniaGPS.Models.Headland.BoundaryData>
+            {
+                new AgValoniaGPS.Models.Headland.BoundaryData
+                {
+                    HeadlandLine = new System.Collections.Generic.List<Models.Base.Vec3>(headlandLine)
+                }
+            }
+        };
 
-            // Project point onto segment and get squared distance
-            double dx = b.Easting - a.Easting;
-            double dy = b.Northing - a.Northing;
-            double lenSq = dx * dx + dy * dy;
+        var output = _headlandDetector.DetectHeadland(input);
 
-            double t;
-            if (lenSq < 1e-10)
-                t = 0;
-            else
-                t = Math.Clamp(((px - a.Easting) * dx + (py - a.Northing) * dy) / lenSq, 0, 1);
-
-            double closestX = a.Easting + t * dx;
-            double closestY = a.Northing + t * dy;
-            double distSq = (px - closestX) * (px - closestX) + (py - closestY) * (py - closestY);
-
-            if (distSq < minDistSq)
-                minDistSq = distSq;
-        }
-
-        State.Field.HeadlandProximityDistance = Math.Sqrt(minDistSq);
+        State.Field.HeadlandProximityDistance = output.HeadlandDistance;
+        State.Field.HeadlandProximityWarning = output.ShouldTriggerWarning;
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -708,6 +708,9 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             }
         }
 
+        // Draw headland proximity HUD (screen space, after camera transform)
+        DrawHeadlandProximityHud(context, bounds);
+
         _renderSw.Stop();
         _lastFullRenderMs = _renderSw.Elapsed.TotalMilliseconds;
 
@@ -2461,6 +2464,57 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         var goalBrush = new SolidColorBrush(Color.FromArgb(200, 0, 200, 255));
         double dotRadius = 3 * worldPerPixel;
         context.DrawEllipse(goalBrush, null, goalPos, dotRadius, dotRadius);
+    }
+
+    /// <summary>
+    /// Draw headland proximity distance as a HUD overlay at top-center of screen.
+    /// Yellow when far, red when close. Matches legacy AgOpenGPS behavior.
+    /// </summary>
+    private void DrawHeadlandProximityHud(DrawingContext context, Rect bounds)
+    {
+        var display = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Display;
+        if (!display.HeadlandDistanceVisible)
+            return;
+
+        var fieldState = AgValoniaGPS.Models.State.ApplicationState.Instance.Field;
+        if (!fieldState.HasHeadland || fieldState.HeadlandProximityDistance == null)
+            return;
+
+        double distance = fieldState.HeadlandProximityDistance.Value;
+        if (distance > 999) return; // Don't show when very far
+
+        // Format text
+        bool isMetric = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.IsMetric;
+        string text = isMetric
+            ? $"{distance:F1} m"
+            : $"{(distance * 3.28084):F0} ft";
+
+        // Color: red when close (< 20m), yellow when far
+        var color = distance < 20.0
+            ? Avalonia.Media.Color.FromRgb(255, 60, 60)
+            : Avalonia.Media.Color.FromRgb(255, 242, 64);
+        var brush = new Avalonia.Media.SolidColorBrush(color);
+
+        double fontSize = Math.Clamp(bounds.Height / 20.0, 14, 36);
+        var typeface = new Avalonia.Media.Typeface("Arial", Avalonia.Media.FontStyle.Normal, Avalonia.Media.FontWeight.Bold);
+        var formattedText = new Avalonia.Media.FormattedText(text,
+            System.Globalization.CultureInfo.InvariantCulture,
+            Avalonia.Media.FlowDirection.LeftToRight,
+            typeface, fontSize, brush);
+
+        // Position: top-center with padding
+        double x = (bounds.Width - formattedText.Width) / 2;
+        double y = 8;
+
+        // Background box
+        var boxRect = new Rect(x - 12, y - 4, formattedText.Width + 24, formattedText.Height + 8);
+        var bgColor = distance < 20.0
+            ? Avalonia.Media.Color.FromArgb(180, 80, 0, 0)
+            : Avalonia.Media.Color.FromArgb(180, 40, 40, 0);
+        context.DrawRectangle(new Avalonia.Media.SolidColorBrush(bgColor), null,
+            new RoundedRect(boxRect, 6));
+
+        context.DrawText(formattedText, new Point(x, y));
     }
 
     private void DrawBoundaryOffsetIndicator(DrawingContext context)

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -2489,8 +2489,9 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             ? $"{distance:F1} m"
             : $"{(distance * 39.3700787):F0} in";
 
-        // Color: red when close (< 20m), yellow when far
-        var color = distance < 20.0
+        // Color: red when warning active (heading toward boundary within threshold), yellow otherwise
+        bool warning = fieldState.HeadlandProximityWarning;
+        var color = warning
             ? Avalonia.Media.Color.FromRgb(255, 60, 60)
             : Avalonia.Media.Color.FromRgb(255, 242, 64);
         var brush = new Avalonia.Media.SolidColorBrush(color);
@@ -2508,7 +2509,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
 
         // Background box
         var boxRect = new Rect(x - 12, y - 4, formattedText.Width + 24, formattedText.Height + 8);
-        var bgColor = distance < 20.0
+        var bgColor = warning
             ? Avalonia.Media.Color.FromArgb(180, 80, 0, 0)
             : Avalonia.Media.Color.FromArgb(180, 40, 40, 0);
         context.DrawRectangle(new Avalonia.Media.SolidColorBrush(bgColor), null,

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -2483,11 +2483,11 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         double distance = fieldState.HeadlandProximityDistance.Value;
         if (distance > 999) return; // Don't show when very far
 
-        // Format text
+        // Format text (legacy uses inches for imperial, matching AgOpenGPS)
         bool isMetric = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.IsMetric;
         string text = isMetric
             ? $"{distance:F1} m"
-            : $"{(distance * 3.28084):F0} ft";
+            : $"{(distance * 39.3700787):F0} in";
 
         // Color: red when close (< 20m), yellow when far
         var color = distance < 20.0

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -151,6 +151,14 @@ public class ConfigurationServiceMappingTests
         Assert.That(_service.Store.Display.SpeedVisible, Is.False);
     }
 
+    [Test]
+    public void Load_HeadlandDistanceVisible()
+    {
+        _settings.HeadlandDistanceVisible = false;
+        _service.LoadAppSettings();
+        Assert.That(_service.Store.Display.HeadlandDistanceVisible, Is.False);
+    }
+
     [TestCase(75.5)]
     public void Load_CameraZoom(double value)
     {
@@ -350,6 +358,7 @@ public class ConfigurationServiceMappingTests
         store.Display.StartFullscreen = true;
         store.Display.SvennArrowVisible = true;
         store.Display.KeyboardEnabled = true;
+        store.Display.HeadlandDistanceVisible = false;
         store.Display.SimulatorPanelX = 500;
         store.Display.SimulatorPanelY = 300;
         store.Display.SimulatorPanelVisible = true;
@@ -371,6 +380,7 @@ public class ConfigurationServiceMappingTests
             Assert.That(_settings.StartFullscreen, Is.True);
             Assert.That(_settings.SvennArrowVisible, Is.True);
             Assert.That(_settings.KeyboardEnabled, Is.True);
+            Assert.That(_settings.HeadlandDistanceVisible, Is.False);
             Assert.That(_settings.SimulatorPanelX, Is.EqualTo(500));
             Assert.That(_settings.SimulatorPanelY, Is.EqualTo(300));
             Assert.That(_settings.SimulatorPanelVisible, Is.True);
@@ -499,6 +509,7 @@ public class ConfigurationServiceMappingTests
         _settings.StartFullscreen = true;
         _settings.SvennArrowVisible = true;
         _settings.KeyboardEnabled = true;
+        _settings.HeadlandDistanceVisible = false;
         _settings.GridVisible = false;
         _settings.CompassVisible = false;
         _settings.SpeedVisible = false;
@@ -540,6 +551,7 @@ public class ConfigurationServiceMappingTests
             Assert.That(saved.StartFullscreen, Is.True);
             Assert.That(saved.SvennArrowVisible, Is.True);
             Assert.That(saved.KeyboardEnabled, Is.True);
+            Assert.That(saved.HeadlandDistanceVisible, Is.False);
             Assert.That(saved.GridVisible, Is.False);
             Assert.That(saved.CompassVisible, Is.False);
             Assert.That(saved.SpeedVisible, Is.False);
@@ -598,6 +610,7 @@ public class ConfigurationServiceMappingTests
         _settings.StartFullscreen = true;
         _settings.SvennArrowVisible = true;
         _settings.KeyboardEnabled = true;
+        _settings.HeadlandDistanceVisible = false;
         _settings.SimulatorPanelX = 9999;
         _settings.SimulatorPanelY = 9999;
         _settings.SimulatorPanelVisible = true;


### PR DESCRIPTION
Closes #119

## Summary
- Calculate distance from vehicle to nearest headland boundary segment every GPS cycle
- Display as HUD overlay at top-center of map (yellow > 20m, red <= 20m)
- Support metric (m) / imperial (ft) units
- Persist `HeadlandDistanceVisible` toggle in AppSettings
- Toggle already exists in DisplayConfigTab

## Implementation
- **FieldState.HeadlandProximityDistance** - new reactive property (distinct from HeadlandDistance which is zone width)
- **MainViewModel.UpdateHeadlandProximity()** - nearest-point-on-segment distance calculation
- **DrawingContextMapControl.DrawHeadlandProximityHud()** - screen-space HUD rendering
- **AppSettings + ConfigurationService** - persistence wiring

## Test plan
- [ ] Create field with headland, drive toward it, verify distance decreases
- [ ] Verify color changes from yellow to red at 20m threshold
- [ ] Toggle HeadlandDistanceVisible off, verify HUD hidden
- [ ] Verify metric/imperial switching
- [ ] Restart app, verify toggle persists
- [x] ConfigurationService mapping tests updated (200 pass)