### PR TITLE
Implement section mapping color cycling button

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -615,10 +615,35 @@ public partial class MainViewModel
             NudgeTrack(ConfigStore.AutoSteer.NudgeDistance * 0.0025); // 1/4 of standard nudge, right
         });
 
-        // Bottom Strip Commands
+        // Bottom Strip Commands - cycle through preset coverage colors
         ChangeMappingColorCommand = ReactiveCommand.Create(() =>
         {
-            StatusMessage = "Section Mapping Color - not yet implemented";
+            uint[] presets = new uint[]
+            {
+                0x98FB98, // Pale green (default)
+                0x00CED1, // Dark turquoise
+                0xFFD700, // Gold
+                0xFF8C00, // Dark orange
+                0xFF69B4, // Hot pink
+                0x87CEEB, // Sky blue
+                0xDDA0DD, // Plum
+                0xF0E68C, // Khaki
+            };
+
+            var tool = ConfigStore.Tool;
+            uint current = tool.SingleCoverageColor;
+
+            // Find current index and cycle to next
+            int idx = Array.IndexOf(presets, current);
+            int next = (idx + 1) % presets.Length;
+            tool.SingleCoverageColor = presets[next];
+
+            // Extract RGB for status message
+            byte r = (byte)((presets[next] >> 16) & 0xFF);
+            byte g = (byte)((presets[next] >> 8) & 0xFF);
+            byte b = (byte)(presets[next] & 0xFF);
+            string[] names = { "Green", "Turquoise", "Gold", "Orange", "Pink", "Blue", "Plum", "Khaki" };
+            StatusMessage = $"Coverage color: {names[next]}";
         });
 
         SnapToPivotCommand = ReactiveCommand.Create(() =>


### PR DESCRIPTION
Closes #41

## Summary
Bottom panel "Section Mapping Color" button now cycles through 8 preset coverage colors on each press: green (default), turquoise, gold, orange, pink, blue, plum, khaki.

Color change takes effect immediately for new coverage cells - CoverageMapService reads `SingleCoverageColor` from ConfigurationStore on each paint call. Status message shows the active color name.

Note: This is the quick-access field behavior. Full color customization (per-section colors, custom RGB) is available in the Configuration dialog's section colors tab.

## Test plan
- [ ] Press button, verify status message shows new color name
- [ ] Drive with coverage, verify new patches use the new color
- [ ] Press 8 times, verify it cycles back to green
- [ ] Existing coverage retains its original color