### PR TITLE
Persist ExtraGuidelines and FieldTexture display settings

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -34,6 +34,9 @@ namespace AgValoniaGPS.Models
         public bool SvennArrowVisible { get; set; } = false;
         public bool KeyboardEnabled { get; set; } = false;
         public bool HeadlandDistanceVisible { get; set; } = true;
+        public bool ExtraGuidelines { get; set; } = false;
+        public int ExtraGuidelinesCount { get; set; } = 10;
+        public bool FieldTextureVisible { get; set; } = false;
 
         // Panel positions
         public double SimulatorPanelX { get; set; } = double.NaN; // NaN means not set

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -301,6 +301,9 @@ public class ConfigurationService(
         store.Display.SvennArrowVisible = settings.SvennArrowVisible;
         store.Display.KeyboardEnabled = settings.KeyboardEnabled;
         store.Display.HeadlandDistanceVisible = settings.HeadlandDistanceVisible;
+        store.Display.ExtraGuidelines = settings.ExtraGuidelines;
+        store.Display.ExtraGuidelinesCount = settings.ExtraGuidelinesCount;
+        store.Display.FieldTextureVisible = settings.FieldTextureVisible;
         store.Display.SimulatorPanelX = settings.SimulatorPanelX;
         store.Display.SimulatorPanelY = settings.SimulatorPanelY;
         store.Display.SimulatorPanelVisible = settings.SimulatorPanelVisible;
@@ -362,6 +365,9 @@ public class ConfigurationService(
         settings.SvennArrowVisible = store.Display.SvennArrowVisible;
         settings.KeyboardEnabled = store.Display.KeyboardEnabled;
         settings.HeadlandDistanceVisible = store.Display.HeadlandDistanceVisible;
+        settings.ExtraGuidelines = store.Display.ExtraGuidelines;
+        settings.ExtraGuidelinesCount = store.Display.ExtraGuidelinesCount;
+        settings.FieldTextureVisible = store.Display.FieldTextureVisible;
         settings.SimulatorPanelX = store.Display.SimulatorPanelX;
         settings.SimulatorPanelY = store.Display.SimulatorPanelY;
         settings.SimulatorPanelVisible = store.Display.SimulatorPanelVisible;

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -611,6 +611,9 @@ public class ConfigurationServiceMappingTests
         _settings.SvennArrowVisible = true;
         _settings.KeyboardEnabled = true;
         _settings.HeadlandDistanceVisible = false;
+        _settings.ExtraGuidelines = true;
+        _settings.ExtraGuidelinesCount = 5;
+        _settings.FieldTextureVisible = true;
         _settings.SimulatorPanelX = 9999;
         _settings.SimulatorPanelY = 9999;
         _settings.SimulatorPanelVisible = true;


### PR DESCRIPTION
Closes #56

## Summary
- Persist `ExtraGuidelines`, `ExtraGuidelinesCount`, and `FieldTextureVisible` in AppSettings + ConfigurationService
- All display options from #56 are now complete:
  - Grid: already persisted
  - Extra Guidelines: now persisted (toggle + count)
  - Field Texture: now persisted
  - Elevation Log: tracked separately in #120 (data pipeline, not a display toggle)

## Test plan
- [ ] Toggle extra guidelines on, set count to 5, restart, verify settings preserved
- [ ] Toggle field texture on, restart, verify preserved
- [x] Completeness test updated and passing (200 tests)