### PR TITLE
File Modernization: auto-convert legacy fields and cleanup

### DIFF
--- a/Shared/AgValoniaGPS.Models/Field.cs
+++ b/Shared/AgValoniaGPS.Models/Field.cs
@@ -65,8 +65,6 @@ public class Field
     /// </summary>
     public BackgroundImage? BackgroundImage { get; set; }
 
-    public List<ABLine> ABLines { get; set; } = new();
-
     /// <summary>
     /// Total area in hectares (calculated from boundary)
     /// </summary>

--- a/Shared/AgValoniaGPS.Services/FieldService.cs
+++ b/Shared/AgValoniaGPS.Services/FieldService.cs
@@ -100,6 +100,20 @@ public class FieldService : IFieldService
         var legacyField = _fieldPlaneService.LoadField(fieldDirectory);
         legacyField.Boundary = _boundaryService.LoadBoundary(fieldDirectory);
         legacyField.BackgroundImage = _backgroundImageService.LoadBackgroundImage(fieldDirectory);
+
+        // Auto-convert: save as GeoJSON so future loads use the modern format
+        try
+        {
+            GeoJsonFieldService.Save(legacyField, tracks: null);
+            System.Diagnostics.Debug.WriteLine(
+                $"[FieldService] Auto-converted legacy field to GeoJSON: '{fieldDirectory}'");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[FieldService] Auto-conversion to GeoJSON failed: {ex.Message}");
+        }
+
         return legacyField;
     }
 

--- a/Tests/AgValoniaGPS.Services.Tests/GeoJsonCorruptFallbackTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/GeoJsonCorruptFallbackTests.cs
@@ -108,14 +108,14 @@ public class GeoJsonCorruptFallbackTests
 
         _service.LoadField(_fieldDir);
 
-        // Original should be renamed
-        Assert.That(File.Exists(Path.Combine(_fieldDir, "field.geojson")), Is.False,
-            "Corrupt file should be renamed");
-
         // Backup should exist with .corrupt. prefix
         var backups = Directory.GetFiles(_fieldDir, "field.geojson.corrupt.*");
         Assert.That(backups, Has.Length.EqualTo(1),
             "Should create exactly one backup of corrupt file");
+
+        // A fresh field.geojson should be created from auto-conversion of legacy
+        Assert.That(File.Exists(Path.Combine(_fieldDir, "field.geojson")), Is.True,
+            "Fresh GeoJSON should be auto-created from legacy after corrupt rename");
     }
 
     [Test]

--- a/Tests/AgValoniaGPS.Services.Tests/LegacyAutoImportTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/LegacyAutoImportTests.cs
@@ -1,0 +1,220 @@
+using System.Globalization;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.GeoJson;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Tests that legacy AgOpenGPS field files are automatically converted
+/// to GeoJSON on first load (#66).
+/// </summary>
+[TestFixture]
+public class LegacyAutoImportTests
+{
+    private string _testDir = null!;
+    private string _fieldDir = null!;
+    private FieldService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"AgValoniaGPS_Test_{Guid.NewGuid():N}");
+        _fieldDir = Path.Combine(_testDir, "TestField");
+        Directory.CreateDirectory(_fieldDir);
+        _service = new FieldService();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_testDir, true); } catch { }
+    }
+
+    private void WriteLegacyFieldTxt(double lat = 47.1234567, double lon = -93.9876543, double convergence = 0.5)
+    {
+        File.WriteAllLines(Path.Combine(_fieldDir, "Field.txt"), new[]
+        {
+            "2025-06-15 10:30:00",           // Timestamp
+            "$FieldDir",                      // Header
+            "TestField",                      // Field name
+            "$Offsets",                       // Header
+            "0,0",                            // Offsets X,Y
+            "Convergence",                    // Header
+            convergence.ToString(CultureInfo.InvariantCulture),
+            "StartFix",                       // Header
+            $"{lat.ToString(CultureInfo.InvariantCulture)},{lon.ToString(CultureInfo.InvariantCulture)}"
+        });
+    }
+
+    private void WriteLegacyBoundary(double centerE = 100, double centerN = 200, double size = 50)
+    {
+        // Write a simple square boundary in legacy format
+        var lines = new List<string>
+        {
+            "$Boundary",
+            "False",  // isDriveThru
+            "4",      // point count
+            $"{centerE - size},{centerN - size},0",
+            $"{centerE + size},{centerN - size},0",
+            $"{centerE + size},{centerN + size},0",
+            $"{centerE - size},{centerN + size},0"
+        };
+        File.WriteAllLines(Path.Combine(_fieldDir, "Boundary.txt"), lines);
+    }
+
+    [Test]
+    public void LoadField_LegacyOnly_CreatesGeoJson()
+    {
+        WriteLegacyFieldTxt();
+
+        _service.LoadField(_fieldDir);
+
+        Assert.That(File.Exists(Path.Combine(_fieldDir, "field.geojson")), Is.True,
+            "GeoJSON file should be created after loading legacy field");
+    }
+
+    [Test]
+    public void LoadField_LegacyOnly_PreservesOrigin()
+    {
+        WriteLegacyFieldTxt(lat: 47.5, lon: -93.2);
+
+        var field = _service.LoadField(_fieldDir);
+
+        Assert.That(field.Origin.Latitude, Is.EqualTo(47.5).Within(0.0001));
+        Assert.That(field.Origin.Longitude, Is.EqualTo(-93.2).Within(0.0001));
+    }
+
+    [Test]
+    public void LoadField_LegacyOnly_PreservesConvergence()
+    {
+        WriteLegacyFieldTxt(convergence: 1.23);
+
+        var field = _service.LoadField(_fieldDir);
+
+        Assert.That(field.Convergence, Is.EqualTo(1.23).Within(0.01));
+    }
+
+    [Test]
+    public void LoadField_LegacyWithBoundary_PreservesBoundaryInGeoJson()
+    {
+        WriteLegacyFieldTxt();
+        WriteLegacyBoundary();
+
+        _service.LoadField(_fieldDir);
+
+        // Verify GeoJSON was created
+        Assert.That(GeoJsonFieldService.Exists(_fieldDir), Is.True);
+
+        // Load from GeoJSON and verify boundary survived
+        var (geoField, _) = GeoJsonFieldService.Load(_fieldDir);
+        Assert.That(geoField.Boundary, Is.Not.Null);
+        Assert.That(geoField.Boundary!.OuterBoundary, Is.Not.Null);
+        Assert.That(geoField.Boundary.OuterBoundary!.Points.Count, Is.GreaterThanOrEqualTo(4));
+    }
+
+    [Test]
+    public void LoadField_SecondLoad_UsesGeoJson()
+    {
+        WriteLegacyFieldTxt(lat: 47.0, lon: -93.0);
+
+        // First load: reads legacy, creates GeoJSON
+        _service.LoadField(_fieldDir);
+        Assert.That(GeoJsonFieldService.Exists(_fieldDir), Is.True);
+
+        // Modify the legacy file to have different coordinates
+        WriteLegacyFieldTxt(lat: 99.0, lon: -99.0);
+
+        // Second load: should use GeoJSON (not the modified legacy)
+        var field = _service.LoadField(_fieldDir);
+        Assert.That(field.Origin.Latitude, Is.EqualTo(47.0).Within(0.001),
+            "Second load should use GeoJSON, not the modified legacy file");
+    }
+
+    [Test]
+    public void LoadField_GeoJsonAlreadyExists_DoesNotReConvert()
+    {
+        WriteLegacyFieldTxt(lat: 47.0, lon: -93.0);
+
+        // Create GeoJSON with different origin
+        var geoField = new Field
+        {
+            Name = "TestField",
+            DirectoryPath = _fieldDir,
+            Origin = new Position { Latitude = 48.0, Longitude = -94.0 },
+        };
+        GeoJsonFieldService.Save(geoField, new List<AgValoniaGPS.Models.Track.Track>());
+
+        // Load should use existing GeoJSON, not re-convert from legacy
+        var field = _service.LoadField(_fieldDir);
+        Assert.That(field.Origin.Latitude, Is.EqualTo(48.0).Within(0.001),
+            "Should load from existing GeoJSON, not re-convert from legacy");
+    }
+
+    [Test]
+    public void LoadField_LegacyOnly_OriginalFilesUntouched()
+    {
+        WriteLegacyFieldTxt();
+        var originalContent = File.ReadAllText(Path.Combine(_fieldDir, "Field.txt"));
+
+        _service.LoadField(_fieldDir);
+
+        var afterContent = File.ReadAllText(Path.Combine(_fieldDir, "Field.txt"));
+        Assert.That(afterContent, Is.EqualTo(originalContent),
+            "Legacy files should not be modified during auto-conversion");
+    }
+
+    [Test]
+    public void LoadField_EmptyFieldDir_Throws()
+    {
+        // No Field.txt, no field.geojson
+        Assert.Throws<FileNotFoundException>(() => _service.LoadField(_fieldDir));
+    }
+
+    [Test]
+    public void LoadField_GeoJsonRoundTrip_PreservesOriginAccuracy()
+    {
+        double lat = 47.1234567;
+        double lon = -93.9876543;
+        WriteLegacyFieldTxt(lat: lat, lon: lon);
+
+        // First load: legacy -> auto-convert to GeoJSON
+        _service.LoadField(_fieldDir);
+
+        // Second load: from GeoJSON
+        var field = _service.LoadField(_fieldDir);
+
+        Assert.That(field.Origin.Latitude, Is.EqualTo(lat).Within(0.0000001),
+            "Origin latitude should survive legacy->GeoJSON round-trip with 7dp accuracy");
+        Assert.That(field.Origin.Longitude, Is.EqualTo(lon).Within(0.0000001),
+            "Origin longitude should survive legacy->GeoJSON round-trip with 7dp accuracy");
+    }
+
+    [Test]
+    public void FieldExists_LegacyOnly_ReturnsTrue()
+    {
+        WriteLegacyFieldTxt();
+
+        Assert.That(_service.FieldExists(_fieldDir), Is.True);
+    }
+
+    [Test]
+    public void FieldExists_GeoJsonOnly_ReturnsTrue()
+    {
+        var field = new Field
+        {
+            Name = "TestField",
+            DirectoryPath = _fieldDir,
+            Origin = new Position { Latitude = 47.0, Longitude = -93.0 },
+        };
+        GeoJsonFieldService.Save(field, new List<AgValoniaGPS.Models.Track.Track>());
+
+        Assert.That(_service.FieldExists(_fieldDir), Is.True);
+    }
+
+    [Test]
+    public void FieldExists_EmptyDir_ReturnsFalse()
+    {
+        Assert.That(_service.FieldExists(_fieldDir), Is.False);
+    }
+}


### PR DESCRIPTION
Closes #66
Refs #68, #69

## Summary

### #66 - Auto-detect and import legacy formats
When `LoadField()` falls back to legacy format (Field.txt + Boundary.txt), it automatically saves as `field.geojson` after successful load. Future loads use GeoJSON directly. Legacy files left untouched.

### #69 - Export to AgOpenGPS legacy format
Closed as already implemented: `SaveField()` writes both GeoJSON and legacy formats on every save (dual-write). No separate export action needed.

### #68 - Remove obsolete models (partial)
Removed unused `Field.ABLines` property. ABLine class itself retained for TrackFilesService legacy reading. VehicleProfile models retained for XML I/O (separate concern).

## Test plan (12 new + 1 updated)
- [x] Legacy-only field creates field.geojson on load
- [x] Origin/convergence/boundary preserved through conversion
- [x] Second load uses GeoJSON (not legacy)
- [x] Existing GeoJSON not re-converted
- [x] Legacy files untouched after conversion
- [x] Round-trip origin accuracy (7dp)
- [x] All 212 service tests pass