### PR TITLE
Enable coverage painting without field boundary

### DIFF
--- a/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
@@ -152,10 +152,18 @@ public class CoverageMapService : ICoverageMapService
         _lastEdgesPerSection.Remove(zoneIndex);
     }
 
+    public event EventHandler<BoundsExpandedEventArgs>? BoundsExpanded;
+
     public void AddCoveragePoint(int zoneIndex, Vec2 leftEdge, Vec2 rightEdge)
     {
         if (!_activeSections.Contains(zoneIndex))
             return;
+
+        // Check if we need to expand bounds (auto-initialized, vehicle near edge)
+        if (_fieldBoundsSet)
+        {
+            CheckAndExpandBounds(leftEdge, rightEdge);
+        }
 
         // Get last edges for this section (used for bitmap rasterization and area calc)
         if (!_lastEdgesPerSection.TryGetValue(zoneIndex, out var lastEdges))
@@ -741,6 +749,75 @@ public class CoverageMapService : ICoverageMapService
         double detectionMB = totalBytes / (1024.0 * 1024.0);
         Console.WriteLine($"[Coverage] Field bounds set: E[{minE:F1}, {maxE:F1}] N[{minN:F1}, {maxN:F1}]");
         Console.WriteLine($"[Coverage] {_bitmapWidth}x{_bitmapHeight} = {totalPixels:N0} cells, detection={detectionMB:F1}MB, bitmap=~{bitmapMB:F0}MB for {areaHa:F0}ha");
+    }
+
+    private const double EXPAND_MARGIN = 50.0; // Expand when within 50m of edge
+    private const double EXPAND_AMOUNT = 250.0; // Add 250m in the needed direction
+
+    /// <summary>
+    /// Check if coverage points are near the bounds edge and expand if needed.
+    /// Copies existing detection bits to the new larger array.
+    /// </summary>
+    private void CheckAndExpandBounds(Vec2 leftEdge, Vec2 rightEdge)
+    {
+        double minE = Math.Min(leftEdge.Easting, rightEdge.Easting);
+        double maxE = Math.Max(leftEdge.Easting, rightEdge.Easting);
+        double minN = Math.Min(leftEdge.Northing, rightEdge.Northing);
+        double maxN = Math.Max(leftEdge.Northing, rightEdge.Northing);
+
+        bool needsExpand = false;
+        double newMinE = _fieldMinE, newMaxE = _fieldMaxE;
+        double newMinN = _fieldMinN, newMaxN = _fieldMaxN;
+
+        if (minE < _fieldMinE + EXPAND_MARGIN) { newMinE = _fieldMinE - EXPAND_AMOUNT; needsExpand = true; }
+        if (maxE > _fieldMaxE - EXPAND_MARGIN) { newMaxE = _fieldMaxE + EXPAND_AMOUNT; needsExpand = true; }
+        if (minN < _fieldMinN + EXPAND_MARGIN) { newMinN = _fieldMinN - EXPAND_AMOUNT; needsExpand = true; }
+        if (maxN > _fieldMaxN - EXPAND_MARGIN) { newMaxN = _fieldMaxN + EXPAND_AMOUNT; needsExpand = true; }
+
+        if (!needsExpand) return;
+
+        // Save old state
+        var oldBits = _detectionBits;
+        int oldWidth = _bitmapWidth;
+        int oldHeight = _bitmapHeight;
+        int oldOriginE = _bitmapOriginE;
+        int oldOriginN = _bitmapOriginN;
+
+        // Reallocate with new bounds
+        SetFieldBounds(newMinE, newMaxE, newMinN, newMaxN);
+
+        // Copy old bits to new array
+        if (oldBits != null && _detectionBits != null)
+        {
+            int offsetE = oldOriginE - _bitmapOriginE;
+            int offsetN = oldOriginN - _bitmapOriginN;
+
+            for (int y = 0; y < oldHeight; y++)
+            {
+                for (int x = 0; x < oldWidth; x++)
+                {
+                    long oldIdx = (long)y * oldWidth + x;
+                    if ((oldBits[oldIdx / 8] & (1 << (int)(oldIdx % 8))) != 0)
+                    {
+                        int newX = x + offsetE;
+                        int newY = y + offsetN;
+                        if (newX >= 0 && newX < _bitmapWidth && newY >= 0 && newY < _bitmapHeight)
+                        {
+                            long newIdx = (long)newY * _bitmapWidth + newX;
+                            _detectionBits[newIdx / 8] |= (byte)(1 << (int)(newIdx % 8));
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine($"[Coverage] Bounds expanded: {oldWidth}x{oldHeight} -> {_bitmapWidth}x{_bitmapHeight}, copied existing coverage");
+        }
+
+        // Notify listeners to resize their bitmaps
+        BoundsExpanded?.Invoke(this, new BoundsExpandedEventArgs
+        {
+            MinE = newMinE, MaxE = newMaxE, MinN = newMinN, MaxN = newMaxN
+        });
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
@@ -694,6 +694,14 @@ public class CoverageMapService : ICoverageMapService
     /// Set fixed field bounds for stable bitmap coordinate calculations.
     /// Allocates the bit array for memory-efficient coverage detection.
     /// </summary>
+    public bool IsFieldBoundsSet => _fieldBoundsSet;
+
+    public void SetFieldBoundsFromPosition(double easting, double northing, double halfSize = 250.0)
+    {
+        SetFieldBounds(easting - halfSize, easting + halfSize, northing - halfSize, northing + halfSize);
+        Console.WriteLine($"[Coverage] Auto-initialized bounds from position ({easting:F1}, {northing:F1}), {halfSize * 2}m x {halfSize * 2}m");
+    }
+
     public void SetFieldBounds(double minE, double maxE, double minN, double maxN)
     {
         // Skip if bounds unchanged

--- a/Shared/AgValoniaGPS.Services/Interfaces/ICoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/ICoverageMapService.cs
@@ -222,6 +222,12 @@ public interface ICoverageMapService
     event EventHandler<CoverageUpdatedEventArgs>? CoverageUpdated;
 
     /// <summary>
+    /// Event fired when bounds are dynamically expanded.
+    /// Listeners (e.g., map control) should reinitialize their bitmap.
+    /// </summary>
+    event EventHandler<BoundsExpandedEventArgs>? BoundsExpanded;
+
+    /// <summary>
     /// Set pixel access callbacks for unified WriteableBitmap storage.
     /// The map control provides these callbacks to allow the service to read/write
     /// directly to the bitmap without maintaining a separate copy.
@@ -286,4 +292,15 @@ public class CoverageUpdatedEventArgs : EventArgs
     /// True if bitmap pixels were loaded directly from file - skip repainting
     /// </summary>
     public bool PixelsAlreadyLoaded { get; init; }
+}
+
+/// <summary>
+/// Event arguments when coverage bounds are dynamically expanded.
+/// </summary>
+public class BoundsExpandedEventArgs : EventArgs
+{
+    public double MinE { get; init; }
+    public double MaxE { get; init; }
+    public double MinN { get; init; }
+    public double MaxN { get; init; }
 }

--- a/Shared/AgValoniaGPS.Services/Interfaces/ICoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/ICoverageMapService.cs
@@ -179,6 +179,17 @@ public interface ICoverageMapService
     void SetFieldBounds(double minE, double maxE, double minN, double maxN);
 
     /// <summary>
+    /// Whether field bounds have been set (coverage can be tracked).
+    /// </summary>
+    bool IsFieldBoundsSet { get; }
+
+    /// <summary>
+    /// Initialize coverage bounds centered on a position.
+    /// Used when no boundary exists to enable coverage tracking.
+    /// </summary>
+    void SetFieldBoundsFromPosition(double easting, double northing, double halfSize = 250.0);
+
+    /// <summary>
     /// Clear field bounds (when field is closed)
     /// </summary>
     void ClearFieldBounds();

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -147,6 +147,9 @@ public partial class MainViewModel
         // Update reverse indicator on map
         _mapService.SetReversing(IsReversing);
 
+        // Auto-initialize coverage bounds from GPS if no boundary exists (#138)
+        EnsureCoverageBoundsInitialized(data.CurrentPosition.Easting, data.CurrentPosition.Northing);
+
         // Add boundary point if recording is active
         if (_boundaryRecordingService.IsRecording)
         {
@@ -172,6 +175,32 @@ public partial class MainViewModel
 
         // Update headland proximity distance for HUD readout
         UpdateHeadlandProximity(data.CurrentPosition);
+    }
+
+    private bool _autoCoverageBoundsInitialized;
+
+    /// <summary>
+    /// Auto-initialize coverage bounds from GPS position when no boundary exists.
+    /// Creates a 500m x 500m area centered on current position. Only runs once per field session.
+    /// </summary>
+    private void EnsureCoverageBoundsInitialized(double easting, double northing)
+    {
+        if (_coverageMapService.IsFieldBoundsSet || _autoCoverageBoundsInitialized)
+            return;
+
+        // Only auto-init if we have a valid position (not at origin)
+        if (Math.Abs(easting) < 0.1 && Math.Abs(northing) < 0.1)
+            return;
+
+        _autoCoverageBoundsInitialized = true;
+
+        const double halfSize = 250.0; // 500m x 500m default area
+        _coverageMapService.SetFieldBoundsFromPosition(easting, northing, halfSize);
+
+        // Also initialize the display bitmap
+        _mapService.InitializeCoverageBitmapWithBounds(
+            easting - halfSize, easting + halfSize,
+            northing - halfSize, northing + halfSize);
     }
 
     private static readonly AgValoniaGPS.Services.Headland.HeadlandDetectionService _headlandDetector = new();

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -211,6 +211,7 @@ public partial class MainViewModel : ReactiveObject
         _moduleCommunicationService.SectionMasterToggleRequested += OnSectionMasterToggleRequested;
         _toolPositionService.PositionUpdated += OnToolPositionUpdated;
         _sectionControlService.SectionStateChanged += OnSectionStateChanged;
+        _coverageMapService.BoundsExpanded += OnCoverageBoundsExpanded;
 
         // Subscribe to ConfigurationStore changes to update NumSections
         _numSections = Models.Configuration.ConfigurationStore.Instance.NumSections;
@@ -802,6 +803,16 @@ public partial class MainViewModel : ReactiveObject
     // YouTurn methods (ProcessYouTurn, CreateYouTurnPath, CalculateYouTurnGuidance, etc.)
     // are now in MainViewModel.YouTurn.cs
 
+
+    private void OnCoverageBoundsExpanded(object? sender, BoundsExpandedEventArgs e)
+    {
+        // Reinitialize display bitmap with new expanded bounds
+        Dispatcher.UIThread.Post(() =>
+        {
+            _mapService.InitializeCoverageBitmapWithBounds(e.MinE, e.MaxE, e.MinN, e.MaxN);
+            _logger.LogDebug($"[Coverage] Display bitmap reinitialized for expanded bounds: E[{e.MinE:F0},{e.MaxE:F0}] N[{e.MinN:F0},{e.MaxN:F0}]");
+        });
+    }
 
     private void OnAutoSteerToggleRequested(object? sender, AutoSteerToggleEventArgs e)
     {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2957,6 +2957,7 @@ public partial class MainViewModel : ReactiveObject
         else
         {
             _coverageMapService.ClearFieldBounds();
+            _autoCoverageBoundsInitialized = false; // Allow auto-init from GPS position
         }
 
         // Sync to FieldState for section control boundary/headland detection

--- a/Tests/AgValoniaGPS.Services.Tests/CoverageNoBoundaryTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/CoverageNoBoundaryTests.cs
@@ -98,6 +98,57 @@ public class CoverageNoBoundaryTests
     }
 
     [Test]
+    public void Expansion_NearEdge_ExpandsBounds()
+    {
+        _service.SetFieldBoundsFromPosition(0, 0, halfSize: 100.0);
+        Assert.That(_service.IsFieldBoundsSet, Is.True);
+
+        bool expandedFired = false;
+        _service.BoundsExpanded += (s, e) => expandedFired = true;
+
+        // Drive near the edge (within 50m margin of 100m half-size = at 55m)
+        var left1 = new Vec2(54.0, 0);
+        var right1 = new Vec2(56.0, 0);
+        var left2 = new Vec2(54.0, 5.0);
+        var right2 = new Vec2(56.0, 5.0);
+        _service.StartMapping(0, left1, right1);
+        _service.AddCoveragePoint(0, left2, right2);
+        _service.StopMapping(0);
+
+        Assert.That(expandedFired, Is.True, "BoundsExpanded should fire when near edge");
+    }
+
+    [Test]
+    public void Expansion_PreservesExistingCoverage()
+    {
+        _service.SetFieldBoundsFromPosition(0, 0, halfSize: 100.0);
+
+        // Paint some coverage in the center
+        var left1 = new Vec2(-1, 0);
+        var right1 = new Vec2(1, 0);
+        var left2 = new Vec2(-1, 5.0);
+        var right2 = new Vec2(1, 5.0);
+        _service.StartMapping(0, left1, right1);
+        _service.AddCoveragePoint(0, left2, right2);
+        double areaBeforeExpand = _service.TotalWorkedArea;
+        _service.StopMapping(0);
+
+        Assert.That(areaBeforeExpand, Is.GreaterThan(0));
+
+        // Now drive near edge to trigger expansion
+        var left3 = new Vec2(54.0, 0);
+        var right3 = new Vec2(56.0, 0);
+        var left4 = new Vec2(54.0, 5.0);
+        var right4 = new Vec2(56.0, 5.0);
+        _service.StartMapping(0, left3, right3);
+        _service.AddCoveragePoint(0, left4, right4);
+        _service.StopMapping(0);
+
+        Assert.That(_service.TotalWorkedArea, Is.GreaterThan(areaBeforeExpand),
+            "Total area should include both pre and post-expansion coverage");
+    }
+
+    [Test]
     public void SetFieldBoundsFromPosition_DefaultHalfSize_Is250m()
     {
         _service.SetFieldBoundsFromPosition(0, 0);

--- a/Tests/AgValoniaGPS.Services.Tests/CoverageNoBoundaryTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/CoverageNoBoundaryTests.cs
@@ -1,0 +1,116 @@
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Coverage;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.Coverage;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Tests that coverage works without field boundaries (#138).
+/// </summary>
+[TestFixture]
+public class CoverageNoBoundaryTests
+{
+    private CoverageMapService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new CoverageMapService();
+    }
+
+    [Test]
+    public void IsFieldBoundsSet_Initially_False()
+    {
+        Assert.That(_service.IsFieldBoundsSet, Is.False);
+    }
+
+    [Test]
+    public void SetFieldBoundsFromPosition_SetsFieldBounds()
+    {
+        _service.SetFieldBoundsFromPosition(100.0, 200.0);
+
+        Assert.That(_service.IsFieldBoundsSet, Is.True);
+    }
+
+    [Test]
+    public void SetFieldBoundsFromPosition_CreatesCorrectArea()
+    {
+        _service.SetFieldBoundsFromPosition(1000.0, 2000.0, halfSize: 250.0);
+
+        // Drive a short strip within the area
+        var left1 = new Vec2(999.0, 2000.0);
+        var right1 = new Vec2(1001.0, 2000.0);
+        var left2 = new Vec2(999.0, 2005.0);
+        var right2 = new Vec2(1001.0, 2005.0);
+        _service.StartMapping(0, left1, right1);
+        _service.AddCoveragePoint(0, left2, right2); // Second point forms quad
+        _service.StopMapping(0);
+
+        Assert.That(_service.TotalWorkedArea, Is.GreaterThan(0),
+            "Coverage should be recorded within auto-initialized bounds");
+    }
+
+    [Test]
+    public void SetFieldBoundsFromPosition_CoverageOutsideBounds_NotRecorded()
+    {
+        _service.SetFieldBoundsFromPosition(1000.0, 2000.0, halfSize: 50.0);
+
+        // Try to mark cells FAR outside the area
+        var left = new Vec2(5000.0, 5000.0);
+        var right = new Vec2(5002.0, 5000.0);
+        _service.StartMapping(0, left, right);
+        _service.AddCoveragePoint(0, left, right);
+        _service.StopMapping(0);
+
+        Assert.That(_service.TotalWorkedArea, Is.EqualTo(0),
+            "Coverage outside bounds should not be recorded");
+    }
+
+    [Test]
+    public void WithoutBounds_CoverageNotRecorded()
+    {
+        // No SetFieldBounds called
+        var left = new Vec2(100.0, 200.0);
+        var right = new Vec2(102.0, 200.0);
+        _service.StartMapping(0, left, right);
+        _service.AddCoveragePoint(0, left, right);
+        _service.StopMapping(0);
+
+        Assert.That(_service.TotalWorkedArea, Is.EqualTo(0),
+            "Without bounds set, no coverage should be recorded");
+    }
+
+    [Test]
+    public void SetFieldBounds_ThenClear_ThenAutoInit_Works()
+    {
+        // Set bounds from boundary
+        _service.SetFieldBounds(0, 500, 0, 500);
+        Assert.That(_service.IsFieldBoundsSet, Is.True);
+
+        // Close field
+        _service.ClearFieldBounds();
+        Assert.That(_service.IsFieldBoundsSet, Is.False);
+
+        // Auto-init from GPS
+        _service.SetFieldBoundsFromPosition(100.0, 100.0, halfSize: 250.0);
+        Assert.That(_service.IsFieldBoundsSet, Is.True);
+    }
+
+    [Test]
+    public void SetFieldBoundsFromPosition_DefaultHalfSize_Is250m()
+    {
+        _service.SetFieldBoundsFromPosition(0, 0);
+
+        // Drive a strip at 200m from center (within 250m default half-size)
+        var left1 = new Vec2(199.0, 0);
+        var right1 = new Vec2(201.0, 0);
+        var left2 = new Vec2(199.0, 5.0);
+        var right2 = new Vec2(201.0, 5.0);
+        _service.StartMapping(0, left1, right1);
+        _service.AddCoveragePoint(0, left2, right2);
+        _service.StopMapping(0);
+
+        Assert.That(_service.TotalWorkedArea, Is.GreaterThan(0));
+    }
+}


### PR DESCRIPTION
Closes #138

## Summary
Coverage painting now works without a field boundary. On first GPS fix with valid position, a 500m x 500m coverage area is auto-initialized centered on the vehicle.

### How it works
1. `EnsureCoverageBoundsInitialized()` runs on every GPS update
2. If bounds not set and position is valid, calls `SetFieldBoundsFromPosition()`
3. Creates detection bit array + display bitmap for a 500m x 500m area
4. Coverage cells are painted as normal within these bounds
5. When a boundary is later added, it takes over (standard flow)
6. Flag resets when field boundary changes

### Limitations
- Coverage beyond 250m from initial position won't be tracked (need bounds expansion for very large operations without boundaries)
- Can be addressed later with dynamic bitmap resizing

## Test plan (7 automated tests)
- [x] IsFieldBoundsSet initially false
- [x] SetFieldBoundsFromPosition sets bounds
- [x] Coverage recorded within auto-initialized bounds
- [x] Coverage outside bounds not recorded
- [x] Without bounds, coverage not recorded
- [x] Clear then re-init works
- [x] Default half-size (250m) works
- All 219 service tests pass