### PR TITLE
Persist sound toggle settings across restarts

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -37,6 +37,10 @@ namespace AgValoniaGPS.Models
         public bool ExtraGuidelines { get; set; } = false;
         public int ExtraGuidelinesCount { get; set; } = 10;
         public bool FieldTextureVisible { get; set; } = false;
+        public bool AutoSteerSound { get; set; } = true;
+        public bool UTurnSound { get; set; } = true;
+        public bool HydraulicSound { get; set; } = true;
+        public bool SectionsSound { get; set; } = true;
 
         // Panel positions
         public double SimulatorPanelX { get; set; } = double.NaN; // NaN means not set

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -304,6 +304,10 @@ public class ConfigurationService(
         store.Display.ExtraGuidelines = settings.ExtraGuidelines;
         store.Display.ExtraGuidelinesCount = settings.ExtraGuidelinesCount;
         store.Display.FieldTextureVisible = settings.FieldTextureVisible;
+        store.Display.AutoSteerSound = settings.AutoSteerSound;
+        store.Display.UTurnSound = settings.UTurnSound;
+        store.Display.HydraulicSound = settings.HydraulicSound;
+        store.Display.SectionsSound = settings.SectionsSound;
         store.Display.SimulatorPanelX = settings.SimulatorPanelX;
         store.Display.SimulatorPanelY = settings.SimulatorPanelY;
         store.Display.SimulatorPanelVisible = settings.SimulatorPanelVisible;
@@ -368,6 +372,10 @@ public class ConfigurationService(
         settings.ExtraGuidelines = store.Display.ExtraGuidelines;
         settings.ExtraGuidelinesCount = store.Display.ExtraGuidelinesCount;
         settings.FieldTextureVisible = store.Display.FieldTextureVisible;
+        settings.AutoSteerSound = store.Display.AutoSteerSound;
+        settings.UTurnSound = store.Display.UTurnSound;
+        settings.HydraulicSound = store.Display.HydraulicSound;
+        settings.SectionsSound = store.Display.SectionsSound;
         settings.SimulatorPanelX = store.Display.SimulatorPanelX;
         settings.SimulatorPanelY = store.Display.SimulatorPanelY;
         settings.SimulatorPanelVisible = store.Display.SimulatorPanelVisible;

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -614,6 +614,10 @@ public class ConfigurationServiceMappingTests
         _settings.ExtraGuidelines = true;
         _settings.ExtraGuidelinesCount = 5;
         _settings.FieldTextureVisible = true;
+        _settings.AutoSteerSound = false;
+        _settings.UTurnSound = false;
+        _settings.HydraulicSound = false;
+        _settings.SectionsSound = false;
         _settings.SimulatorPanelX = 9999;
         _settings.SimulatorPanelY = 9999;
         _settings.SimulatorPanelVisible = true;


### PR DESCRIPTION
Closes #122

## Summary
Sound toggle buttons already exist in AdditionalOptionsConfigTab (tab 8). This PR adds persistence so the toggles survive app restart:
- `AutoSteerSound`, `UTurnSound`, `HydraulicSound`, `SectionsSound` added to AppSettings
- Bidirectional mapping in ConfigurationService
- Completeness test updated

## Test plan
- [ ] Toggle each sound off in Additional Options tab, restart, verify still off
- [ ] Toggle back on, restart, verify still on
- [x] 221 service tests pass