### PR TITLE
Add auto track selection with heading alignment

### DIFF
--- a/Shared/AgValoniaGPS.Services/Track/AutoTrackSelectionService.cs
+++ b/Shared/AgValoniaGPS.Services/Track/AutoTrackSelectionService.cs
@@ -1,0 +1,128 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+using TrackModel = AgValoniaGPS.Models.Track.Track;
+
+namespace AgValoniaGPS.Services.Track;
+
+/// <summary>
+/// Finds the closest guidance track to the vehicle position.
+/// Matches legacy AgOpenGPS CTrack.FindClosestRefTrack() behavior.
+/// </summary>
+public static class AutoTrackSelectionService
+{
+    private const double MAX_HEADING_DIFF = 1.0; // ~57 degrees in radians
+    private const double MIN_HEADING_DIFF = 2.14; // ~123 degrees (allows opposite direction)
+
+    /// <summary>
+    /// Find the closest visible, heading-aligned track to the vehicle.
+    /// </summary>
+    /// <param name="tracks">Available tracks</param>
+    /// <param name="position">Vehicle position (easting, northing)</param>
+    /// <param name="headingRadians">Vehicle heading in radians</param>
+    /// <returns>The closest track, or null if none is aligned</returns>
+    public static TrackModel? FindClosestTrack(
+        IReadOnlyList<TrackModel> tracks,
+        Vec2 position,
+        double headingRadians)
+    {
+        if (tracks.Count == 0) return null;
+
+        TrackModel? closest = null;
+        double minDistance = double.MaxValue;
+
+        for (int i = 0; i < tracks.Count; i++)
+        {
+            var track = tracks[i];
+            if (!track.IsVisible || track.Points.Count < 2)
+                continue;
+
+            // Heading alignment check for AB lines (curves skip this)
+            if (track.IsABLine)
+            {
+                double trackHeading = Math.Atan2(
+                    track.Points[1].Easting - track.Points[0].Easting,
+                    track.Points[1].Northing - track.Points[0].Northing);
+
+                double diff = Math.Abs(headingRadians - trackHeading);
+                // Normalize to [0, PI]
+                while (diff > Math.PI) diff -= Math.PI * 2;
+                diff = Math.Abs(diff);
+
+                // Must be within ~57 degrees or within ~57 degrees of opposite
+                if (diff > MAX_HEADING_DIFF && diff < MIN_HEADING_DIFF)
+                    continue;
+            }
+
+            double distance = CalculateDistanceToTrack(track, position);
+            if (distance < minDistance)
+            {
+                minDistance = distance;
+                closest = track;
+            }
+        }
+
+        return closest;
+    }
+
+    /// <summary>
+    /// Calculate perpendicular distance from position to track.
+    /// AB lines: distance to infinite line through A and B.
+    /// Curves: minimum distance to any segment.
+    /// </summary>
+    private static double CalculateDistanceToTrack(TrackModel track, Vec2 position)
+    {
+        if (track.IsABLine && track.Points.Count == 2)
+        {
+            return PerpendicularDistanceToLine(
+                position,
+                track.Points[0].Easting, track.Points[0].Northing,
+                track.Points[1].Easting, track.Points[1].Northing);
+        }
+
+        // Curve: find minimum distance to any segment
+        double minDist = double.MaxValue;
+        for (int i = 0; i < track.Points.Count - 1; i++)
+        {
+            double dist = DistanceToSegment(
+                position,
+                track.Points[i].Easting, track.Points[i].Northing,
+                track.Points[i + 1].Easting, track.Points[i + 1].Northing);
+            if (dist < minDist) minDist = dist;
+        }
+        return minDist;
+    }
+
+    private static double PerpendicularDistanceToLine(
+        Vec2 point, double ax, double ay, double bx, double by)
+    {
+        double dx = bx - ax;
+        double dy = by - ay;
+        double lenSq = dx * dx + dy * dy;
+        if (lenSq < 1e-10) return GeometryMath.Distance(point, new Vec2(ax, ay));
+
+        // Perpendicular distance to infinite line
+        return Math.Abs(dy * point.Easting - dx * point.Northing + bx * ay - by * ax) / Math.Sqrt(lenSq);
+    }
+
+    private static double DistanceToSegment(
+        Vec2 point, double ax, double ay, double bx, double by)
+    {
+        double dx = bx - ax;
+        double dy = by - ay;
+        double lenSq = dx * dx + dy * dy;
+        if (lenSq < 1e-10) return GeometryMath.Distance(point, new Vec2(ax, ay));
+
+        double t = Math.Clamp(((point.Easting - ax) * dx + (point.Northing - ay) * dy) / lenSq, 0, 1);
+        double closestX = ax + t * dx;
+        double closestY = ay + t * dy;
+        double ddx = point.Easting - closestX;
+        double ddy = point.Northing - closestY;
+        return Math.Sqrt(ddx * ddx + ddy * ddy);
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -188,6 +188,50 @@ public partial class MainViewModel
 
         // Update headland proximity distance for HUD readout
         UpdateHeadlandProximity(data.CurrentPosition);
+
+        // Auto-select closest track when autosteer is not engaged (#143)
+        UpdateAutoTrackSelection(data.CurrentPosition);
+    }
+
+    private bool _isAutoTrackEnabled = true;
+    public bool IsAutoTrackEnabled
+    {
+        get => _isAutoTrackEnabled;
+        set => this.RaiseAndSetIfChanged(ref _isAutoTrackEnabled, value);
+    }
+
+    private DateTime _lastAutoTrackTime = DateTime.MinValue;
+    private const double AUTO_TRACK_INTERVAL_SECONDS = 3.0;
+
+    /// <summary>
+    /// Auto-select closest track when autosteer is not engaged.
+    /// Matches legacy: 3-second debounce, heading alignment, visibility filter.
+    /// </summary>
+    private void UpdateAutoTrackSelection(AgValoniaGPS.Models.Position position)
+    {
+        if (!_isAutoTrackEnabled || IsAutoSteerEngaged)
+            return;
+
+        var tracks = State.Field.Tracks;
+        if (tracks.Count == 0)
+            return;
+
+        // 3-second debounce
+        var now = DateTime.UtcNow;
+        if ((now - _lastAutoTrackTime).TotalSeconds < AUTO_TRACK_INTERVAL_SECONDS)
+            return;
+        _lastAutoTrackTime = now;
+
+        double headingRadians = position.Heading * Math.PI / 180.0;
+        var vehiclePos = new Models.Base.Vec2(position.Easting, position.Northing);
+
+        var closest = Services.Track.AutoTrackSelectionService.FindClosestTrack(
+            tracks, vehiclePos, headingRadians);
+
+        if (closest != null && closest != SelectedTrack)
+        {
+            SelectedTrack = closest;
+        }
     }
 
     private bool _autoCoverageBoundsInitialized;

--- a/Tests/AgValoniaGPS.Services.Tests/AutoTrackSelectionTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoTrackSelectionTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Services.Track;
+using TrackModel = AgValoniaGPS.Models.Track.Track;
+using TrackType = AgValoniaGPS.Models.Track.TrackType;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Tests for auto track selection algorithm (#143).
+/// Matches legacy AgOpenGPS CTrack.FindClosestRefTrack() behavior.
+/// </summary>
+[TestFixture]
+public class AutoTrackSelectionTests
+{
+    private static TrackModel MakeABLine(string name, double ax, double ay, double bx, double by, bool visible = true)
+    {
+        return new TrackModel
+        {
+            Name = name,
+            Type = TrackType.ABLine,
+            IsVisible = visible,
+            Points = new List<Vec3>
+            {
+                new Vec3(ax, ay, 0),
+                new Vec3(bx, by, 0)
+            }
+        };
+    }
+
+    private static TrackModel MakeCurve(string name, List<Vec3> points, bool visible = true)
+    {
+        return new TrackModel
+        {
+            Name = name,
+            Type = TrackType.Curve,
+            IsVisible = visible,
+            Points = points
+        };
+    }
+
+    [Test]
+    public void FindClosestTrack_SingleABLine_ReturnsIt()
+    {
+        var tracks = new List<TrackModel> { MakeABLine("AB1", 0, 0, 0, 100) };
+        var pos = new Vec2(5, 50); // 5m east of line
+        double heading = 0; // Heading north, same as line
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Name, Is.EqualTo("AB1"));
+    }
+
+    [Test]
+    public void FindClosestTrack_MultipleABLines_ReturnsClosest()
+    {
+        var tracks = new List<TrackModel>
+        {
+            MakeABLine("AB1", 0, 0, 0, 100),   // Along Y axis at X=0
+            MakeABLine("AB2", 10, 0, 10, 100),  // Along Y axis at X=10
+        };
+        var pos = new Vec2(8, 50); // Closer to AB2 (2m vs 8m)
+        double heading = 0;
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result!.Name, Is.EqualTo("AB2"));
+    }
+
+    [Test]
+    public void FindClosestTrack_HeadingAligned_Selected()
+    {
+        // Track runs north (heading 0). Vehicle heading ~30 degrees (within 57 degree limit)
+        var tracks = new List<TrackModel> { MakeABLine("AB1", 0, 0, 0, 100) };
+        var pos = new Vec2(5, 50);
+        double heading = 0.5; // ~29 degrees
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result, Is.Not.Null);
+    }
+
+    [Test]
+    public void FindClosestTrack_HeadingPerpendicular_Rejected()
+    {
+        // Track runs north. Vehicle heading east (~90 degrees = PI/2)
+        var tracks = new List<TrackModel> { MakeABLine("AB1", 0, 0, 0, 100) };
+        var pos = new Vec2(5, 50);
+        double heading = Math.PI / 2; // 90 degrees - perpendicular
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result, Is.Null, "Perpendicular heading should reject the track");
+    }
+
+    [Test]
+    public void FindClosestTrack_OppositeHeading_Selected()
+    {
+        // Track runs north. Vehicle heading south (PI radians) - valid for return pass
+        var tracks = new List<TrackModel> { MakeABLine("AB1", 0, 0, 0, 100) };
+        var pos = new Vec2(5, 50);
+        double heading = Math.PI; // 180 degrees - opposite
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result, Is.Not.Null, "Opposite heading should be accepted (return pass)");
+    }
+
+    [Test]
+    public void FindClosestTrack_InvisibleTrack_Skipped()
+    {
+        var tracks = new List<TrackModel>
+        {
+            MakeABLine("Hidden", 0, 0, 0, 100, visible: false),
+            MakeABLine("Visible", 20, 0, 20, 100, visible: true),
+        };
+        var pos = new Vec2(1, 50); // Much closer to hidden track
+        double heading = 0;
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result!.Name, Is.EqualTo("Visible"), "Should skip invisible track");
+    }
+
+    [Test]
+    public void FindClosestTrack_CurveTrack_NoHeadingFilter()
+    {
+        // Curve at any heading should be considered
+        var curve = MakeCurve("Curve1", new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(5, 10, 0),
+            new Vec3(10, 20, 0),
+            new Vec3(15, 30, 0),
+        });
+        var tracks = new List<TrackModel> { curve };
+        var pos = new Vec2(2, 15); // Near curve
+        double heading = Math.PI / 2; // 90 degrees - would reject AB line
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result, Is.Not.Null, "Curves should not be filtered by heading");
+    }
+
+    [Test]
+    public void FindClosestTrack_NoTracks_ReturnsNull()
+    {
+        var tracks = new List<TrackModel>();
+        var pos = new Vec2(0, 0);
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, 0);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void FindClosestTrack_MixedABAndCurve_ReturnsClosest()
+    {
+        var ab = MakeABLine("AB1", 20, 0, 20, 100); // At X=20
+        var curve = MakeCurve("Curve1", new List<Vec3>
+        {
+            new Vec3(5, 0, 0),
+            new Vec3(5, 50, 0),
+            new Vec3(5, 100, 0),
+        }); // At X=5
+
+        var tracks = new List<TrackModel> { ab, curve };
+        var pos = new Vec2(3, 50); // Closer to curve (2m vs 17m)
+        double heading = 0;
+
+        var result = AutoTrackSelectionService.FindClosestTrack(tracks, pos, heading);
+
+        Assert.That(result!.Name, Is.EqualTo("Curve1"));
+    }
+}


### PR DESCRIPTION
Closes #143

## Summary
Automatically selects the closest visible, heading-aligned guidance track every 3 seconds when autosteer is not engaged. Matches legacy AgOpenGPS `CTrack.FindClosestRefTrack()`.

### Algorithm
- AB lines: perpendicular distance to infinite line, heading within ~57 degrees or opposite (return pass)
- Curves: minimum distance to any segment, no heading filter
- Invisible tracks skipped
- 3-second debounce timer
- Disabled when autosteer is engaged
- `IsAutoTrackEnabled` property (default: true)

## Test plan (9 automated tests)
- [x] Single AB line -> returns it
- [x] Multiple AB lines -> returns closest
- [x] Heading aligned (~30 deg) -> selected
- [x] Heading perpendicular (90 deg) -> rejected
- [x] Opposite heading (180 deg) -> selected (return pass)
- [x] Invisible track -> skipped
- [x] Curve track -> no heading filter
- [x] No tracks -> returns null
- [x] Mixed AB + curve -> returns closest
- All 230 service tests pass