### PR TITLE
Add GPS Offset Fix dialog

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Services/MapService.cs
+++ b/Platforms/AgValoniaGPS.Android/Services/MapService.cs
@@ -147,6 +147,14 @@ public class MapService : IMapService
         _mapControl?.SetVehiclePosition(easting, northing, headingRadians);
     }
 
+    public void SetAllPositions(double vehicleX, double vehicleY, double vehicleHeading,
+        double toolX, double toolY, double toolHeading, double toolWidth,
+        double hitchX, double hitchY, bool toolReady)
+    {
+        _mapControl?.SetAllPositions(vehicleX, vehicleY, vehicleHeading,
+            toolX, toolY, toolHeading, toolWidth, hitchX, hitchY, toolReady);
+    }
+
     public void SetReversing(bool isReversing) { if (_mapControl != null) _mapControl.IsReversing = isReversing; }
     public void SetGuidancePoints(double goalEasting, double goalNorthing, bool isActive) { _mapControl?.SetGuidancePoints(goalEasting, goalNorthing, isActive); }
 

--- a/Platforms/AgValoniaGPS.Desktop/Services/MapService.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Services/MapService.cs
@@ -99,6 +99,12 @@ public class MapService : IMapService
     public void SetVehiclePosition(double easting, double northing, double headingRadians) =>
         GetMapControl().SetVehiclePosition(easting, northing, headingRadians);
 
+    public void SetAllPositions(double vehicleX, double vehicleY, double vehicleHeading,
+        double toolX, double toolY, double toolHeading, double toolWidth,
+        double hitchX, double hitchY, bool toolReady) =>
+        GetMapControl().SetAllPositions(vehicleX, vehicleY, vehicleHeading,
+            toolX, toolY, toolHeading, toolWidth, hitchX, hitchY, toolReady);
+
     public bool IsGridVisible
     {
         get => _mapControl?.IsGridVisible ?? false;

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -562,7 +562,8 @@ public partial class MainWindow : Window
                     ViewModel.ToolHeadingRadians,
                     ViewModel.ToolWidth,
                     ViewModel.HitchEasting,
-                    ViewModel.HitchNorthing);
+                    ViewModel.HitchNorthing,
+                    ViewModel.IsToolPositionReady);
                 // Also update section states for rendering
                 MapControl.SetSectionStates(
                     ViewModel.GetSectionStates(),

--- a/Platforms/AgValoniaGPS.iOS/Services/MapService.cs
+++ b/Platforms/AgValoniaGPS.iOS/Services/MapService.cs
@@ -147,6 +147,14 @@ public class MapService : IMapService
         _mapControl?.SetVehiclePosition(easting, northing, headingRadians);
     }
 
+    public void SetAllPositions(double vehicleX, double vehicleY, double vehicleHeading,
+        double toolX, double toolY, double toolHeading, double toolWidth,
+        double hitchX, double hitchY, bool toolReady)
+    {
+        _mapControl?.SetAllPositions(vehicleX, vehicleY, vehicleHeading,
+            toolX, toolY, toolHeading, toolWidth, hitchX, hitchY, toolReady);
+    }
+
     public void SetReversing(bool isReversing) { if (_mapControl != null) _mapControl.IsReversing = isReversing; }
     public void SetGuidancePoints(double goalEasting, double goalNorthing, bool isActive) { _mapControl?.SetGuidancePoints(goalEasting, goalNorthing, isActive); }
 

--- a/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
@@ -53,11 +53,11 @@ public class ToolConfig : ReactiveObject
     }
 
     // Hitch configuration
-    private double _hitchLength = -1.8;
+    private double _hitchLength = 1.8;
     public double HitchLength
     {
         get => _hitchLength;
-        set => this.RaiseAndSetIfChanged(ref _hitchLength, value);
+        set => this.RaiseAndSetIfChanged(ref _hitchLength, Math.Max(0, value));
     }
 
     private double _trailingHitchLength = -2.5;

--- a/Shared/AgValoniaGPS.Models/State/FieldState.cs
+++ b/Shared/AgValoniaGPS.Models/State/FieldState.cs
@@ -138,6 +138,21 @@ public class FieldState : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _originLongitude, value);
     }
 
+    // GPS drift compensation (offset fix)
+    private double _driftNorthing;
+    public double DriftNorthing
+    {
+        get => _driftNorthing;
+        set => this.RaiseAndSetIfChanged(ref _driftNorthing, value);
+    }
+
+    private double _driftEasting;
+    public double DriftEasting
+    {
+        get => _driftEasting;
+        set => this.RaiseAndSetIfChanged(ref _driftEasting, value);
+    }
+
     // Local plane for coordinate conversion
     private LocalPlane? _localPlane;
     public LocalPlane? LocalPlane
@@ -158,6 +173,7 @@ public class FieldState : ReactiveObject
         HeadlandDistance = 0;
         HeadlandProximityDistance = null;
         HeadlandProximityWarning = false;
+        DriftNorthing = DriftEasting = 0;
         OriginLatitude = OriginLongitude = 0;
         LocalPlane = null;
     }

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -69,7 +69,6 @@ public class UIState : ReactiveObject
                 this.RaisePropertyChanged(nameof(IsFlagListDialogVisible));
                 this.RaisePropertyChanged(nameof(IsViewSettingsDialogVisible));
                 this.RaisePropertyChanged(nameof(IsImportTracksDialogVisible));
-                this.RaisePropertyChanged(nameof(IsOffsetFixDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -109,7 +108,6 @@ public class UIState : ReactiveObject
     public bool IsFlagListDialogVisible => ActiveDialog == DialogType.FlagList;
     public bool IsViewSettingsDialogVisible => ActiveDialog == DialogType.ViewSettings;
     public bool IsImportTracksDialogVisible => ActiveDialog == DialogType.ImportTracks;
-    public bool IsOffsetFixDialogVisible => ActiveDialog == DialogType.OffsetFix;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -138,6 +136,13 @@ public class UIState : ReactiveObject
     {
         get => _isSectionControlPanelVisible;
         set => this.RaiseAndSetIfChanged(ref _isSectionControlPanelVisible, value);
+    }
+
+    private bool _isOffsetFixPanelVisible;
+    public bool IsOffsetFixPanelVisible
+    {
+        get => _isOffsetFixPanelVisible;
+        set => this.RaiseAndSetIfChanged(ref _isOffsetFixPanelVisible, value);
     }
 
     // Busy overlay state (for blocking operations like file save/load)
@@ -228,8 +233,7 @@ public enum DialogType
     FlagByLatLon,
     FlagList,
     ViewSettings,
-    ImportTracks,
-    OffsetFix
+    ImportTracks
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -69,6 +69,7 @@ public class UIState : ReactiveObject
                 this.RaisePropertyChanged(nameof(IsFlagListDialogVisible));
                 this.RaisePropertyChanged(nameof(IsViewSettingsDialogVisible));
                 this.RaisePropertyChanged(nameof(IsImportTracksDialogVisible));
+                this.RaisePropertyChanged(nameof(IsOffsetFixDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -108,6 +109,7 @@ public class UIState : ReactiveObject
     public bool IsFlagListDialogVisible => ActiveDialog == DialogType.FlagList;
     public bool IsViewSettingsDialogVisible => ActiveDialog == DialogType.ViewSettings;
     public bool IsImportTracksDialogVisible => ActiveDialog == DialogType.ImportTracks;
+    public bool IsOffsetFixDialogVisible => ActiveDialog == DialogType.OffsetFix;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -226,7 +228,8 @@ public enum DialogType
     FlagByLatLon,
     FlagList,
     ViewSettings,
-    ImportTracks
+    ImportTracks,
+    OffsetFix
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -45,6 +45,8 @@ public class AutoSteerService : IAutoSteerService
     // Local coordinate system reference
     private LocalPlane? _localPlane;
     private SharedFieldProperties _sharedFieldProperties;
+    private double _driftEasting;
+    private double _driftNorthing;
 
     // Current track for guidance (set by MainViewModel)
     private TrackModel? _currentTrack;
@@ -230,6 +232,17 @@ public class AutoSteerService : IAutoSteerService
     }
 
     /// <summary>
+    /// Set GPS drift compensation (offset fix). Applied to local coordinates
+    /// before guidance and tool position calculations, so tractor + implement
+    /// move together. Values in meters.
+    /// </summary>
+    public void SetDriftCompensation(double driftEasting, double driftNorthing)
+    {
+        _driftEasting = driftEasting;
+        _driftNorthing = driftNorthing;
+    }
+
+    /// <summary>
     /// Set the current track for guidance.
     /// Called by MainViewModel when active track changes.
     /// </summary>
@@ -263,8 +276,10 @@ public class AutoSteerService : IAutoSteerService
         {
             var geoCoord = _localPlane.ConvertWgs84ToGeoCoord(
                 new Wgs84(_state.Latitude, _state.Longitude));
-            _state.Easting = geoCoord.Easting;
-            _state.Northing = geoCoord.Northing;
+            // Apply GPS drift compensation (offset fix) before any calculations
+            // This shifts tractor + implement together, matching legacy behavior
+            _state.Easting = geoCoord.Easting + _driftEasting;
+            _state.Northing = geoCoord.Northing + _driftNorthing;
         }
 
         // Calculate guidance if we have an active track

--- a/Shared/AgValoniaGPS.Services/DebugDumpService.cs
+++ b/Shared/AgValoniaGPS.Services/DebugDumpService.cs
@@ -231,7 +231,9 @@ public class DebugDumpService
                 TrackCount = state.Field.Tracks.Count,
                 ActiveTrack = state.Field.ActiveTrack?.Name,
                 OriginLat = state.Field.OriginLatitude,
-                OriginLon = state.Field.OriginLongitude
+                OriginLon = state.Field.OriginLongitude,
+                DriftEasting = state.Field.DriftEasting,
+                DriftNorthing = state.Field.DriftNorthing
             },
             Guidance = new
             {

--- a/Shared/AgValoniaGPS.Services/FieldPlaneFileService.cs
+++ b/Shared/AgValoniaGPS.Services/FieldPlaneFileService.cs
@@ -96,23 +96,22 @@ public class FieldPlaneFileService
             var startFixHeader = reader.ReadLine();
             if (startFixHeader != null && startFixHeader.StartsWith("StartFix", StringComparison.OrdinalIgnoreCase))
             {
-                // Line 9: Latitude,Longitude
+                // Line 9: Latitude,Longitude (always InvariantCulture with period decimal)
                 var startFixLine = reader.ReadLine();
                 if (!string.IsNullOrWhiteSpace(startFixLine))
                 {
                     var parts = startFixLine.Split(',');
-                    if (parts.Length >= 2)
+                    if (parts.Length >= 2 &&
+                        double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out double lat) &&
+                        double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double lon) &&
+                        lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180)
                     {
-                        if (double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out double lat) &&
-                            double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double lon))
+                        field.Origin = new Position
                         {
-                            field.Origin = new Position
-                            {
-                                Latitude = lat,
-                                Longitude = lon,
-                                Altitude = 0
-                            };
-                        }
+                            Latitude = lat,
+                            Longitude = lon,
+                            Altitude = 0
+                        };
                     }
                 }
             }

--- a/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
@@ -117,6 +117,12 @@ public interface IAutoSteerService
     /// <param name="angleDegrees">Target steer angle (-40 to +40 degrees)</param>
     void SetFreeDriveAngle(double angleDegrees);
 
+    /// <summary>
+    /// Set GPS drift compensation (offset fix). Applied to local coordinates
+    /// before guidance/tool calculations so tractor + implement move together.
+    /// </summary>
+    void SetDriftCompensation(double driftEasting, double driftNorthing);
+
     // ═══════════════════════════════════════════════════════════════════════
     // Module Feedback (PGN 253, 250)
     // ═══════════════════════════════════════════════════════════════════════

--- a/Shared/AgValoniaGPS.Services/Interfaces/IMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IMapService.cs
@@ -59,6 +59,13 @@ public interface IMapService
     void SetBoundary(Boundary? boundary);
     void SetVehiclePosition(double easting, double northing, double headingRadians);
 
+    /// <summary>
+    /// Atomic update of vehicle + tool + hitch positions in a single call.
+    /// </summary>
+    void SetAllPositions(double vehicleX, double vehicleY, double vehicleHeading,
+        double toolX, double toolY, double toolHeading, double toolWidth,
+        double hitchX, double hitchY, bool toolReady);
+
     // Grid
     bool IsGridVisible { get; set; }
 

--- a/Shared/AgValoniaGPS.Services/Interfaces/IToolPositionService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IToolPositionService.cs
@@ -51,6 +51,11 @@ public interface IToolPositionService
     Vec3 HitchPosition { get; }
 
     /// <summary>
+    /// True when tool heading is based on actual GPS movement, not startup default.
+    /// </summary>
+    bool IsToolPositionReady { get; }
+
+    /// <summary>
     /// Update tool position based on vehicle position.
     /// Should be called every GPS update for smooth trailing behavior.
     /// </summary>

--- a/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
+++ b/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
@@ -43,8 +43,10 @@ public class ToolPositionService : IToolPositionService
     // State for trailing calculations (Torriem algorithm)
     private Vec3 _lastToolPivotPos;
     private Vec3 _lastTankPos;
+    private Vec3 _lastHitchPos;
     private int _startCounter;
     private const int STARTUP_FRAMES = 50;
+    private const double JUMP_THRESHOLD_SQ = 400.0; // 20m squared - snap on GPS jumps
 
     // Jackknife protection threshold (~115 degrees)
     private const double JACKKNIFE_THRESHOLD = 2.0;
@@ -148,14 +150,16 @@ public class ToolPositionService : IToolPositionService
         }
 
         // Detect large position jumps (GPS glitch, RTK reacquire, drift change)
-        // If hitch moved more than 10m in one frame, snap instead of trailing
-        double jumpDx = _hitchPosition.Easting - _lastToolPivotPos.Easting;
-        double jumpDy = _hitchPosition.Northing - _lastToolPivotPos.Northing;
-        if (jumpDx * jumpDx + jumpDy * jumpDy > 100.0) // > 10m
+        // Compare hitch-to-hitch (not hitch-to-toolPivot which includes trailing length)
+        double jumpDx = _hitchPosition.Easting - _lastHitchPos.Easting;
+        double jumpDy = _hitchPosition.Northing - _lastHitchPos.Northing;
+        if (jumpDx * jumpDx + jumpDy * jumpDy > JUMP_THRESHOLD_SQ) // > 20m
         {
             SnapToolBehindVehicle(vehicleHeading, tool);
+            _lastHitchPos = _hitchPosition;
             return;
         }
+        _lastHitchPos = _hitchPosition;
 
         // Torriem's algorithm: calculate heading from movement
         // Tool heading = direction from current position toward hitch
@@ -194,6 +198,7 @@ public class ToolPositionService : IToolPositionService
 
         // Save for next frame
         _lastToolPivotPos = _toolPivotPosition;
+        _lastHitchPos = _hitchPosition;
     }
 
     /// <summary>
@@ -212,13 +217,15 @@ public class ToolPositionService : IToolPositionService
         }
 
         // Detect large position jumps - snap instead of trailing
-        double jumpDx = _hitchPosition.Easting - _lastToolPivotPos.Easting;
-        double jumpDy = _hitchPosition.Northing - _lastToolPivotPos.Northing;
-        if (jumpDx * jumpDx + jumpDy * jumpDy > 100.0) // > 10m
+        double jumpDx = _hitchPosition.Easting - _lastHitchPos.Easting;
+        double jumpDy = _hitchPosition.Northing - _lastHitchPos.Northing;
+        if (jumpDx * jumpDx + jumpDy * jumpDy > JUMP_THRESHOLD_SQ) // > 20m
         {
             SnapTBTBehindVehicle(vehicleHeading, tool);
+            _lastHitchPos = _hitchPosition;
             return;
         }
+        _lastHitchPos = _hitchPosition;
 
         // Stage 1: Tank follows hitch (Torriem's algorithm)
         double tankDx = _hitchPosition.Easting - _lastTankPos.Easting;
@@ -271,6 +278,7 @@ public class ToolPositionService : IToolPositionService
         // Save for next frame
         _lastTankPos = _tankPosition;
         _lastToolPivotPos = _toolPivotPosition;
+        _lastHitchPos = _hitchPosition;
     }
 
     /// <summary>
@@ -304,6 +312,7 @@ public class ToolPositionService : IToolPositionService
 
         _tankPosition = new Vec3(0, 0, 0);
         _lastToolPivotPos = _toolPivotPosition;
+        _lastHitchPos = _hitchPosition;
     }
 
     /// <summary>
@@ -336,6 +345,7 @@ public class ToolPositionService : IToolPositionService
 
         _lastTankPos = _tankPosition;
         _lastToolPivotPos = _toolPivotPosition;
+        _lastHitchPos = _hitchPosition;
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
+++ b/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
@@ -409,14 +409,21 @@ public class ToolPositionService : IToolPositionService
 
     public void ResetTrailingState(Vec3 vehiclePivot, double vehicleHeading)
     {
-        _startCounter = 0;
+        _startCounter = STARTUP_FRAMES - 5; // Brief snap period (5 frames) then resume trailing
 
         var tool = ConfigurationStore.Instance.Tool;
 
-        // Calculate hitch position
+        // Calculate hitch position - must match Update() sign convention:
+        // negative distance for rear/trailing tools (behind vehicle)
+        double hitchDistance = Math.Abs(tool.HitchLength);
+        if (tool.IsToolRearFixed || tool.IsToolTrailing || tool.IsToolTBT)
+        {
+            hitchDistance = -hitchDistance;
+        }
+
         _hitchPosition = new Vec3(
-            vehiclePivot.Easting + Math.Sin(vehicleHeading) * tool.HitchLength,
-            vehiclePivot.Northing + Math.Cos(vehicleHeading) * tool.HitchLength,
+            vehiclePivot.Easting + Math.Sin(vehicleHeading) * hitchDistance,
+            vehiclePivot.Northing + Math.Cos(vehicleHeading) * hitchDistance,
             vehicleHeading
         );
 

--- a/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
+++ b/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
@@ -147,6 +147,16 @@ public class ToolPositionService : IToolPositionService
             return;
         }
 
+        // Detect large position jumps (GPS glitch, RTK reacquire, drift change)
+        // If hitch moved more than 10m in one frame, snap instead of trailing
+        double jumpDx = _hitchPosition.Easting - _lastToolPivotPos.Easting;
+        double jumpDy = _hitchPosition.Northing - _lastToolPivotPos.Northing;
+        if (jumpDx * jumpDx + jumpDy * jumpDy > 100.0) // > 10m
+        {
+            SnapToolBehindVehicle(vehicleHeading, tool);
+            return;
+        }
+
         // Torriem's algorithm: calculate heading from movement
         // Tool heading = direction from current position toward hitch
         double dx = _hitchPosition.Easting - _lastToolPivotPos.Easting;
@@ -196,6 +206,15 @@ public class ToolPositionService : IToolPositionService
 
         // During startup, snap everything behind vehicle
         if (_startCounter < STARTUP_FRAMES)
+        {
+            SnapTBTBehindVehicle(vehicleHeading, tool);
+            return;
+        }
+
+        // Detect large position jumps - snap instead of trailing
+        double jumpDx = _hitchPosition.Easting - _lastToolPivotPos.Easting;
+        double jumpDy = _hitchPosition.Northing - _lastToolPivotPos.Northing;
+        if (jumpDx * jumpDx + jumpDy * jumpDy > 100.0) // > 10m
         {
             SnapTBTBehindVehicle(vehicleHeading, tool);
             return;

--- a/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
+++ b/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
@@ -55,6 +55,12 @@ public class ToolPositionService : IToolPositionService
     public Vec3 TankPosition => _tankPosition;
     public Vec3 HitchPosition => _hitchPosition;
 
+    /// <summary>
+    /// True when tool position is based on actual movement, not startup snap.
+    /// During startup, the tool heading may be unreliable (GPS heading = 0 when stationary).
+    /// </summary>
+    public bool IsToolPositionReady => _startCounter >= STARTUP_FRAMES;
+
     public event EventHandler<ToolPositionUpdatedEventArgs>? PositionUpdated;
 
     public void Update(Vec3 vehiclePivot, double vehicleHeading)
@@ -132,7 +138,9 @@ public class ToolPositionService : IToolPositionService
     {
         _startCounter++;
 
-        // During startup, snap tool behind vehicle to prevent jackknife
+        // Always snap until we have enough movement for a reliable heading.
+        // This prevents the tool from drifting during startup when heading
+        // defaults to 0 (north) because GPS hasn't computed heading from movement yet.
         if (_startCounter < STARTUP_FRAMES)
         {
             SnapToolBehindVehicle(vehicleHeading, tool);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -160,34 +160,26 @@ public partial class MainViewModel
             State.UI.IsOffsetFixPanelVisible = false;
         });
 
-        OffsetFixNorthCommand = ReactiveCommand.Create(() =>
-        {
-            State.Field.DriftNorthing += OFFSET_STEP;
-        });
-
-        OffsetFixSouthCommand = ReactiveCommand.Create(() =>
-        {
-            State.Field.DriftNorthing -= OFFSET_STEP;
-        });
-
-        OffsetFixEastCommand = ReactiveCommand.Create(() =>
-        {
-            State.Field.DriftEasting += OFFSET_STEP;
-        });
-
-        OffsetFixWestCommand = ReactiveCommand.Create(() =>
-        {
-            State.Field.DriftEasting -= OFFSET_STEP;
-        });
-
+        OffsetFixNorthCommand = ReactiveCommand.Create(() => ApplyDrift(0, OFFSET_STEP));
+        OffsetFixSouthCommand = ReactiveCommand.Create(() => ApplyDrift(0, -OFFSET_STEP));
+        OffsetFixEastCommand = ReactiveCommand.Create(() => ApplyDrift(OFFSET_STEP, 0));
+        OffsetFixWestCommand = ReactiveCommand.Create(() => ApplyDrift(-OFFSET_STEP, 0));
         OffsetFixZeroCommand = ReactiveCommand.Create(() =>
         {
-            State.Field.DriftNorthing = 0;
             State.Field.DriftEasting = 0;
+            State.Field.DriftNorthing = 0;
+            _autoSteerService.SetDriftCompensation(0, 0);
         });
     }
 
     public ICommand? CreateDebugDumpCommand { get; private set; }
+
+    private void ApplyDrift(double deltaEasting, double deltaNorthing)
+    {
+        State.Field.DriftEasting += deltaEasting;
+        State.Field.DriftNorthing += deltaNorthing;
+        _autoSteerService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
+    }
 
     private void RefreshAppDirectories()
     {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -169,6 +169,9 @@ public partial class MainViewModel
             State.Field.DriftEasting = 0;
             State.Field.DriftNorthing = 0;
             _autoSteerService.SetDriftCompensation(0, 0);
+            double headingRad = Heading * Math.PI / 180.0;
+            _toolPositionService.ResetTrailingState(
+                new Models.Base.Vec3(Easting, Northing, headingRad), headingRad);
         });
     }
 
@@ -179,6 +182,11 @@ public partial class MainViewModel
         State.Field.DriftEasting += deltaEasting;
         State.Field.DriftNorthing += deltaNorthing;
         _autoSteerService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
+
+        // Reset trailing tool so it snaps to new position instead of trailing from old one
+        double headingRad = Heading * Math.PI / 180.0;
+        var driftedPos = new Models.Base.Vec3(Easting, Northing, headingRad);
+        _toolPositionService.ResetTrailingState(driftedPos, headingRad);
     }
 
     private void RefreshAppDirectories()

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -183,9 +183,13 @@ public partial class MainViewModel
         State.Field.DriftNorthing += deltaNorthing;
         _autoSteerService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
 
-        // Reset trailing tool so it snaps to new position instead of trailing from old one
+        // Reset trailing tool at the NEW drifted position.
+        // Easting/Northing still reflect the OLD drift (pre-delta), so add the delta.
         double headingRad = Heading * Math.PI / 180.0;
-        var driftedPos = new Models.Base.Vec3(Easting, Northing, headingRad);
+        var driftedPos = new Models.Base.Vec3(
+            Easting + deltaEasting,
+            Northing + deltaNorthing,
+            headingRad);
         _toolPositionService.ResetTrailingState(driftedPos, headingRad);
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -152,12 +152,12 @@ public partial class MainViewModel
 
         ShowOffsetFixDialogCommand = ReactiveCommand.Create(() =>
         {
-            State.UI.ShowDialog(Models.State.DialogType.OffsetFix);
+            State.UI.IsOffsetFixPanelVisible = !State.UI.IsOffsetFixPanelVisible;
         });
 
         CloseOffsetFixDialogCommand = ReactiveCommand.Create(() =>
         {
-            State.UI.CloseDialog();
+            State.UI.IsOffsetFixPanelVisible = false;
         });
 
         OffsetFixNorthCommand = ReactiveCommand.Create(() =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -146,6 +146,45 @@ public partial class MainViewModel
                 _logger.LogError(ex, "Debug dump failed");
             }
         });
+
+        // Offset Fix (#36) - GPS drift compensation
+        const double OFFSET_STEP = 0.01; // 1cm per click
+
+        ShowOffsetFixDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.ShowDialog(Models.State.DialogType.OffsetFix);
+        });
+
+        CloseOffsetFixDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.CloseDialog();
+        });
+
+        OffsetFixNorthCommand = ReactiveCommand.Create(() =>
+        {
+            State.Field.DriftNorthing += OFFSET_STEP;
+        });
+
+        OffsetFixSouthCommand = ReactiveCommand.Create(() =>
+        {
+            State.Field.DriftNorthing -= OFFSET_STEP;
+        });
+
+        OffsetFixEastCommand = ReactiveCommand.Create(() =>
+        {
+            State.Field.DriftEasting += OFFSET_STEP;
+        });
+
+        OffsetFixWestCommand = ReactiveCommand.Create(() =>
+        {
+            State.Field.DriftEasting -= OFFSET_STEP;
+        });
+
+        OffsetFixZeroCommand = ReactiveCommand.Create(() =>
+        {
+            State.Field.DriftNorthing = 0;
+            State.Field.DriftEasting = 0;
+        });
     }
 
     public ICommand? CreateDebugDumpCommand { get; private set; }
@@ -198,6 +237,15 @@ public partial class MainViewModel
     public ICommand? CloseLogViewerDialogCommand { get; private set; }
     public ICommand? ClearLogEntriesCommand { get; private set; }
     public ICommand? SetLogFilterCommand { get; private set; }
+
+    // Offset Fix (#36)
+    public ICommand? ShowOffsetFixDialogCommand { get; private set; }
+    public ICommand? CloseOffsetFixDialogCommand { get; private set; }
+    public ICommand? OffsetFixNorthCommand { get; private set; }
+    public ICommand? OffsetFixSouthCommand { get; private set; }
+    public ICommand? OffsetFixEastCommand { get; private set; }
+    public ICommand? OffsetFixWestCommand { get; private set; }
+    public ICommand? OffsetFixZeroCommand { get; private set; }
 }
 
 // --- Flag By Lat/Lon (#23) ---

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -152,9 +152,13 @@ public partial class MainViewModel
             _previousFixQuality = data.FixQuality;
         }
 
+        // Apply GPS drift compensation (offset fix #36)
+        double driftE = State.Field.DriftEasting;
+        double driftN = State.Field.DriftNorthing;
+
         // Update UTM coordinates and heading for map rendering
-        Easting = data.CurrentPosition.Easting;
-        Northing = data.CurrentPosition.Northing;
+        Easting = data.CurrentPosition.Easting + driftE;
+        Northing = data.CurrentPosition.Northing + driftN;
         Heading = data.CurrentPosition.Heading;
 
         // Update reverse indicator on map

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -155,9 +155,18 @@ public partial class MainViewModel
         // Update UTM coordinates and heading for map rendering
         // Apply GPS drift compensation for display (same drift as AutoSteerService applies
         // for guidance/tool calculations - both paths must be consistent)
-        Easting = data.CurrentPosition.Easting + State.Field.DriftEasting;
-        Northing = data.CurrentPosition.Northing + State.Field.DriftNorthing;
+        double driftedEasting = data.CurrentPosition.Easting + State.Field.DriftEasting;
+        double driftedNorthing = data.CurrentPosition.Northing + State.Field.DriftNorthing;
+        Easting = driftedEasting;
+        Northing = driftedNorthing;
         Heading = data.CurrentPosition.Heading;
+
+        // Update tool/implement position from drifted vehicle position
+        // Tool is always computed relative to the tractor, so drift propagates naturally
+        double headingRad = data.CurrentPosition.Heading * Math.PI / 180.0;
+        _toolPositionService.Update(
+            new Models.Base.Vec3(driftedEasting, driftedNorthing, headingRad),
+            headingRad);
 
         // Update reverse indicator on map
         _mapService.SetReversing(IsReversing);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -153,10 +153,10 @@ public partial class MainViewModel
         }
 
         // Update UTM coordinates and heading for map rendering
-        // Note: GPS drift (offset fix) is applied in AutoSteerService.ProcessGpsBuffer()
-        // before guidance/tool calculations, so position here already includes drift
-        Easting = data.CurrentPosition.Easting;
-        Northing = data.CurrentPosition.Northing;
+        // Apply GPS drift compensation for display (same drift as AutoSteerService applies
+        // for guidance/tool calculations - both paths must be consistent)
+        Easting = data.CurrentPosition.Easting + State.Field.DriftEasting;
+        Northing = data.CurrentPosition.Northing + State.Field.DriftNorthing;
         Heading = data.CurrentPosition.Heading;
 
         // Update reverse indicator on map

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -152,11 +152,28 @@ public partial class MainViewModel
             _previousFixQuality = data.FixQuality;
         }
 
-        // Update UTM coordinates and heading for map rendering
-        // Apply GPS drift compensation for display (same drift as AutoSteerService applies
-        // for guidance/tool calculations - both paths must be consistent)
-        double driftedEasting = data.CurrentPosition.Easting + State.Field.DriftEasting;
-        double driftedNorthing = data.CurrentPosition.Northing + State.Field.DriftNorthing;
+        // Convert WGS84 to local coordinates for display
+        // In simulator mode, this is already done. In real GPS mode, GpsData only has lat/lon.
+        double posEasting = data.CurrentPosition.Easting;
+        double posNorthing = data.CurrentPosition.Northing;
+
+        // If easting/northing are zero (real GPS path), convert from lat/lon
+        if (Math.Abs(posEasting) < 0.001 && Math.Abs(posNorthing) < 0.001
+            && Math.Abs(data.CurrentPosition.Latitude) > 0.001)
+        {
+            var localPlane = State.Field.LocalPlane;
+            if (localPlane != null)
+            {
+                var geoCoord = localPlane.ConvertWgs84ToGeoCoord(
+                    new Models.Wgs84(data.CurrentPosition.Latitude, data.CurrentPosition.Longitude));
+                posEasting = geoCoord.Easting;
+                posNorthing = geoCoord.Northing;
+            }
+        }
+
+        // Apply GPS drift compensation
+        double driftedEasting = posEasting + State.Field.DriftEasting;
+        double driftedNorthing = posNorthing + State.Field.DriftNorthing;
         Easting = driftedEasting;
         Northing = driftedNorthing;
         Heading = data.CurrentPosition.Heading;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -152,13 +152,11 @@ public partial class MainViewModel
             _previousFixQuality = data.FixQuality;
         }
 
-        // Apply GPS drift compensation (offset fix #36)
-        double driftE = State.Field.DriftEasting;
-        double driftN = State.Field.DriftNorthing;
-
         // Update UTM coordinates and heading for map rendering
-        Easting = data.CurrentPosition.Easting + driftE;
-        Northing = data.CurrentPosition.Northing + driftN;
+        // Note: GPS drift (offset fix) is applied in AutoSteerService.ProcessGpsBuffer()
+        // before guidance/tool calculations, so position here already includes drift
+        Easting = data.CurrentPosition.Easting;
+        Northing = data.CurrentPosition.Northing;
         Heading = data.CurrentPosition.Heading;
 
         // Update reverse indicator on map

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -174,16 +174,27 @@ public partial class MainViewModel
         // Apply GPS drift compensation
         double driftedEasting = posEasting + State.Field.DriftEasting;
         double driftedNorthing = posNorthing + State.Field.DriftNorthing;
-        Easting = driftedEasting;
-        Northing = driftedNorthing;
-        Heading = data.CurrentPosition.Heading;
+        double headingRad = data.CurrentPosition.Heading * Math.PI / 180.0;
 
         // Update tool/implement position from drifted vehicle position
-        // Tool is always computed relative to the tractor, so drift propagates naturally
-        double headingRad = data.CurrentPosition.Heading * Math.PI / 180.0;
         _toolPositionService.Update(
             new Models.Base.Vec3(driftedEasting, driftedNorthing, headingRad),
             headingRad);
+
+        // Atomic map update: vehicle + tool + hitch in one call
+        // Prevents rendering mismatches between vehicle and tool positions
+        var hitchPos = _toolPositionService.HitchPosition;
+        var toolPos = _toolPositionService.ToolPosition;
+        _mapService.SetAllPositions(
+            driftedEasting, driftedNorthing, headingRad,
+            toolPos.Easting, toolPos.Northing, _toolPositionService.ToolHeading,
+            ToolWidth, hitchPos.Easting, hitchPos.Northing,
+            _toolPositionService.IsToolPositionReady);
+
+        // Update properties for bindings (but map already updated atomically above)
+        Easting = driftedEasting;
+        Northing = driftedNorthing;
+        Heading = data.CurrentPosition.Heading;
 
         // Update reverse indicator on map
         _mapService.SetReversing(IsReversing);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
@@ -112,14 +112,10 @@ public partial class MainViewModel
         // Use the TRANSFORMED position (pivot/tractor center) for all guidance calculations
         var transformedPosition = gpsData.CurrentPosition;
 
-        // Update tool position based on vehicle pivot position
-        // Tool position service handles fixed, trailing, and TBT configurations
-        var vehiclePivot = new Vec3(
-            transformedPosition.Easting,
-            transformedPosition.Northing,
-            transformedPosition.Heading * Math.PI / 180.0  // Convert to radians
-        );
-        _toolPositionService.Update(vehiclePivot, transformedPosition.Heading * Math.PI / 180.0);
+        // NOTE: _toolPositionService.Update() is NOT called here.
+        // GpsHandling.UpdateGpsProperties (triggered by _gpsService.UpdateGpsData above)
+        // already calls it with drift-compensated coordinates. Calling it again here
+        // with undrifted coords would overwrite the correct drifted tool position.
 
         // Process through AutoSteer pipeline for latency measurement
         _autoSteerService.ProcessSimulatedPosition(

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -681,6 +681,8 @@ public partial class MainViewModel : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _hitchNorthing, value);
     }
 
+    public bool IsToolPositionReady => _toolPositionService.IsToolPositionReady;
+
     // OnAutoSteerStateUpdated is now in MainViewModel.Guidance.cs
 
     private void OnToolPositionUpdated(object? sender, Services.Interfaces.ToolPositionUpdatedEventArgs e)

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -216,6 +216,15 @@ public partial class MainViewModel : ReactiveObject
         _sectionControlService.SectionStateChanged += OnSectionStateChanged;
         _coverageMapService.BoundsExpanded += OnCoverageBoundsExpanded;
 
+        // Sync drift compensation to AutoSteerService when edited via TextBox
+        State.Field.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName is nameof(State.Field.DriftEasting) or nameof(State.Field.DriftNorthing))
+            {
+                _autoSteerService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
+            }
+        };
+
         // Subscribe to ConfigurationStore changes to update NumSections
         _numSections = Models.Configuration.ConfigurationStore.Instance.NumSections;
         Models.Configuration.ConfigurationStore.Instance.PropertyChanged += (s, e) =>

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -61,6 +61,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:FlagByLatLonDialogPanel/>
         <dialogs:FlagListDialogPanel/>
         <dialogs:ViewSettingsDialogPanel/>
+        <dialogs:OffsetFixDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
@@ -1,0 +1,90 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.OffsetFixDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsOffsetFixDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsOffsetFixDialogVisible}">
+
+    <Grid>
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="12" Padding="24"
+                Width="320" Height="380"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+            <Grid RowDefinitions="Auto,*,Auto,Auto">
+                <TextBlock Text="GPS Offset Fix" FontSize="20" FontWeight="Bold"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                           HorizontalAlignment="Center" Margin="0,0,0,16"/>
+
+                <!-- D-pad layout -->
+                <Grid Grid.Row="1" RowDefinitions="*,*,*" ColumnDefinitions="*,*,*"
+                      HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <!-- North -->
+                    <Button Grid.Row="0" Grid.Column="1" Width="70" Height="70"
+                            Command="{Binding OffsetFixNorthCommand}"
+                            Background="#2E7D32" Foreground="White" FontSize="16" FontWeight="Bold"
+                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                        <TextBlock Text="N" FontSize="20" FontWeight="Bold"/>
+                    </Button>
+                    <!-- West -->
+                    <Button Grid.Row="1" Grid.Column="0" Width="70" Height="70"
+                            Command="{Binding OffsetFixWestCommand}"
+                            Background="#1565C0" Foreground="White" FontSize="16" FontWeight="Bold"
+                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                        <TextBlock Text="W" FontSize="20" FontWeight="Bold"/>
+                    </Button>
+                    <!-- Center: Zero -->
+                    <Button Grid.Row="1" Grid.Column="1" Width="70" Height="70"
+                            Command="{Binding OffsetFixZeroCommand}"
+                            Background="#C62828" Foreground="White" FontSize="14" FontWeight="Bold"
+                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                        <TextBlock Text="Zero" FontSize="16" FontWeight="Bold"/>
+                    </Button>
+                    <!-- East -->
+                    <Button Grid.Row="1" Grid.Column="2" Width="70" Height="70"
+                            Command="{Binding OffsetFixEastCommand}"
+                            Background="#1565C0" Foreground="White" FontSize="16" FontWeight="Bold"
+                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                        <TextBlock Text="E" FontSize="20" FontWeight="Bold"/>
+                    </Button>
+                    <!-- South -->
+                    <Button Grid.Row="2" Grid.Column="1" Width="70" Height="70"
+                            Command="{Binding OffsetFixSouthCommand}"
+                            Background="#2E7D32" Foreground="White" FontSize="16" FontWeight="Bold"
+                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                        <TextBlock Text="S" FontSize="20" FontWeight="Bold"/>
+                    </Button>
+                </Grid>
+
+                <!-- Current offset display -->
+                <StackPanel Grid.Row="2" HorizontalAlignment="Center" Margin="0,12,0,12">
+                    <TextBlock HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"
+                               Text="Current Offset (cm)"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="20">
+                        <StackPanel>
+                            <TextBlock Text="N/S" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
+                            <TextBlock Text="{Binding State.Field.DriftNorthing, StringFormat='{}{0:F2} m'}"
+                                       FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                        </StackPanel>
+                        <StackPanel>
+                            <TextBlock Text="E/W" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
+                            <TextBlock Text="{Binding State.Field.DriftEasting, StringFormat='{}{0:F2} m'}"
+                                       FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- Close button -->
+                <Button Grid.Row="3" Content="Close" HorizontalAlignment="Stretch" Height="44"
+                        Command="{Binding CloseOffsetFixDialogCommand}"
+                        Background="#4A9A7E" Foreground="White" FontSize="16" FontWeight="Bold"
+                        CornerRadius="8" HorizontalContentAlignment="Center"/>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
@@ -3,88 +3,80 @@
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.OffsetFixDialogPanel"
              x:DataType="vm:MainViewModel"
-             IsVisible="{Binding State.UI.IsOffsetFixDialogVisible}"
-             IsHitTestVisible="{Binding State.UI.IsOffsetFixDialogVisible}">
+             IsVisible="{Binding State.UI.IsOffsetFixPanelVisible}"
+             IsHitTestVisible="{Binding State.UI.IsOffsetFixPanelVisible}">
 
-    <Grid>
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
-
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="12" Padding="24"
-                Width="320" Height="380"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
-            <Grid RowDefinitions="Auto,*,Auto,Auto">
-                <TextBlock Text="GPS Offset Fix" FontSize="20" FontWeight="Bold"
-                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                           HorizontalAlignment="Center" Margin="0,0,0,16"/>
-
-                <!-- D-pad layout -->
-                <Grid Grid.Row="1" RowDefinitions="*,*,*" ColumnDefinitions="*,*,*"
-                      HorizontalAlignment="Center" VerticalAlignment="Center">
-                    <!-- North -->
-                    <Button Grid.Row="0" Grid.Column="1" Width="70" Height="70"
-                            Command="{Binding OffsetFixNorthCommand}"
-                            Background="#2E7D32" Foreground="White" FontSize="16" FontWeight="Bold"
-                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
-                        <TextBlock Text="N" FontSize="20" FontWeight="Bold"/>
-                    </Button>
-                    <!-- West -->
-                    <Button Grid.Row="1" Grid.Column="0" Width="70" Height="70"
-                            Command="{Binding OffsetFixWestCommand}"
-                            Background="#1565C0" Foreground="White" FontSize="16" FontWeight="Bold"
-                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
-                        <TextBlock Text="W" FontSize="20" FontWeight="Bold"/>
-                    </Button>
-                    <!-- Center: Zero -->
-                    <Button Grid.Row="1" Grid.Column="1" Width="70" Height="70"
-                            Command="{Binding OffsetFixZeroCommand}"
-                            Background="#C62828" Foreground="White" FontSize="14" FontWeight="Bold"
-                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
-                        <TextBlock Text="Zero" FontSize="16" FontWeight="Bold"/>
-                    </Button>
-                    <!-- East -->
-                    <Button Grid.Row="1" Grid.Column="2" Width="70" Height="70"
-                            Command="{Binding OffsetFixEastCommand}"
-                            Background="#1565C0" Foreground="White" FontSize="16" FontWeight="Bold"
-                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
-                        <TextBlock Text="E" FontSize="20" FontWeight="Bold"/>
-                    </Button>
-                    <!-- South -->
-                    <Button Grid.Row="2" Grid.Column="1" Width="70" Height="70"
-                            Command="{Binding OffsetFixSouthCommand}"
-                            Background="#2E7D32" Foreground="White" FontSize="16" FontWeight="Bold"
-                            CornerRadius="8" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
-                        <TextBlock Text="S" FontSize="20" FontWeight="Bold"/>
-                    </Button>
-                </Grid>
-
-                <!-- Current offset display -->
-                <StackPanel Grid.Row="2" HorizontalAlignment="Center" Margin="0,12,0,12">
-                    <TextBlock HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"
-                               Text="Current Offset (cm)"/>
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="20">
-                        <StackPanel>
-                            <TextBlock Text="N/S" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
-                            <TextBlock Text="{Binding State.Field.DriftNorthing, StringFormat='{}{0:F2} m'}"
-                                       FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                        </StackPanel>
-                        <StackPanel>
-                            <TextBlock Text="E/W" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
-                            <TextBlock Text="{Binding State.Field.DriftEasting, StringFormat='{}{0:F2} m'}"
-                                       FontSize="18" FontWeight="Bold" HorizontalAlignment="Center"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-
-                <!-- Close button -->
-                <Button Grid.Row="3" Content="Close" HorizontalAlignment="Stretch" Height="44"
+    <!-- Floating non-modal panel - user can interact with map behind it -->
+    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+            CornerRadius="12" Padding="16"
+            Width="280"
+            HorizontalAlignment="Right" VerticalAlignment="Top"
+            Margin="0,60,16,0"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+        <StackPanel Spacing="8">
+            <!-- Header with close button -->
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Text="GPS Offset Fix" FontSize="16" FontWeight="Bold"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                <Button Grid.Column="1" Content="X" Width="28" Height="28"
                         Command="{Binding CloseOffsetFixDialogCommand}"
-                        Background="#4A9A7E" Foreground="White" FontSize="16" FontWeight="Bold"
-                        CornerRadius="8" HorizontalContentAlignment="Center"/>
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                        FontSize="14" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        Padding="0" CornerRadius="4"/>
             </Grid>
-        </Border>
-    </Grid>
+
+            <!-- D-pad layout (compact) -->
+            <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,*,*"
+                  HorizontalAlignment="Center" Margin="0,4">
+                <Button Grid.Row="0" Grid.Column="1" Width="60" Height="50"
+                        Command="{Binding OffsetFixNorthCommand}"
+                        Background="#2E7D32" Foreground="White" CornerRadius="6"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="N" FontSize="18" FontWeight="Bold"/>
+                </Button>
+                <Button Grid.Row="1" Grid.Column="0" Width="60" Height="50"
+                        Command="{Binding OffsetFixWestCommand}"
+                        Background="#1565C0" Foreground="White" CornerRadius="6"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="W" FontSize="18" FontWeight="Bold"/>
+                </Button>
+                <Button Grid.Row="1" Grid.Column="1" Width="60" Height="50"
+                        Command="{Binding OffsetFixZeroCommand}"
+                        Background="#C62828" Foreground="White" CornerRadius="6"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="0" FontSize="18" FontWeight="Bold"/>
+                </Button>
+                <Button Grid.Row="1" Grid.Column="2" Width="60" Height="50"
+                        Command="{Binding OffsetFixEastCommand}"
+                        Background="#1565C0" Foreground="White" CornerRadius="6"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="E" FontSize="18" FontWeight="Bold"/>
+                </Button>
+                <Button Grid.Row="2" Grid.Column="1" Width="60" Height="50"
+                        Command="{Binding OffsetFixSouthCommand}"
+                        Background="#2E7D32" Foreground="White" CornerRadius="6"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="S" FontSize="18" FontWeight="Bold"/>
+                </Button>
+            </Grid>
+
+            <!-- Manual offset input -->
+            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="4">
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="N/S (m)" FontSize="11"
+                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
+                <TextBlock Grid.Row="0" Grid.Column="1" Text="E/W (m)" FontSize="11"
+                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
+                <TextBox Grid.Row="1" Grid.Column="0" x:Name="NorthingInput"
+                         Text="{Binding State.Field.DriftNorthing, StringFormat='{}{0:F3}', Mode=TwoWay}"
+                         FontSize="16" FontWeight="Bold" HorizontalContentAlignment="Center"/>
+                <TextBox Grid.Row="1" Grid.Column="1" x:Name="EastingInput"
+                         Text="{Binding State.Field.DriftEasting, StringFormat='{}{0:F3}', Mode=TwoWay}"
+                         FontSize="16" FontWeight="Bold" HorizontalContentAlignment="Center"/>
+            </Grid>
+
+            <TextBlock Text="1 cm per click" FontSize="10"
+                       Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+    </Border>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Input;
 
 namespace AgValoniaGPS.Views.Controls.Dialogs;
 
@@ -8,13 +7,5 @@ public partial class OffsetFixDialogPanel : UserControl
     public OffsetFixDialogPanel()
     {
         InitializeComponent();
-    }
-
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
-        {
-            vm.CloseOffsetFixDialogCommand?.Execute(null);
-        }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class OffsetFixDialogPanel : UserControl
+{
+    public OffsetFixDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CloseOffsetFixDialogCommand?.Execute(null);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -693,8 +693,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             }
 
             // Draw tool BEFORE vehicle (so vehicle appears on top)
-            // Skip during startup when heading is unreliable (GPS heading = 0 when stationary)
-            if (ShowVehicle && _toolWidth > 0.1 && _toolPositionReady)
+            if (ShowVehicle && _toolWidth > 0.1)
             {
                 DrawTool(context);
             }

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -66,7 +66,7 @@ public interface ISharedMapControl
     // Content
     void SetBoundary(Boundary? boundary);
     void SetVehiclePosition(double x, double y, double heading);
-    void SetToolPosition(double x, double y, double heading, double width, double hitchX, double hitchY);
+    void SetToolPosition(double x, double y, double heading, double width, double hitchX, double hitchY, bool isReady = true);
     void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections, int[]? buttonStates = null);
     void SetGridVisible(bool visible);
     void SetNorthUp(bool isNorthUp);
@@ -246,6 +246,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
     private double _toolWidth = 0.0;
     private double _hitchX = 0.0;
     private double _hitchY = 0.0;
+    private bool _toolPositionReady;
 
     // Section state for individual section rendering
     private bool[] _sectionOn = new bool[16];
@@ -692,7 +693,8 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             }
 
             // Draw tool BEFORE vehicle (so vehicle appears on top)
-            if (ShowVehicle && _toolWidth > 0.1)
+            // Skip during startup when heading is unreliable (GPS heading = 0 when stationary)
+            if (ShowVehicle && _toolWidth > 0.1 && _toolPositionReady)
             {
                 DrawTool(context);
             }
@@ -3345,7 +3347,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         }
     }
 
-    public void SetToolPosition(double x, double y, double heading, double width, double hitchX, double hitchY)
+    public void SetToolPosition(double x, double y, double heading, double width, double hitchX, double hitchY, bool isReady = true)
     {
         _toolX = x;
         _toolY = y;
@@ -3353,6 +3355,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         _toolWidth = width;
         _hitchX = hitchX;
         _hitchY = hitchY;
+        _toolPositionReady = isReady;
     }
 
     public void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections, int[]? buttonStates = null)

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -2232,9 +2232,13 @@ public class DrawingContextMapControl : Control, ISharedMapControl
 
         double toolDepth = 2.0; // Tool depth in meters (front to back)
 
-        // Draw tractor-side hitch bar (from rear of tractor to hitch point)
+        // Draw tractor-side hitch bar from hitch point toward vehicle
+        // Use tool-relative positions to avoid frame sync issues between vehicle and tool updates
+        var hitchLength = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Tool.HitchLength;
+        double barEndX = _hitchX + Math.Sin(_vehicleHeading) * hitchLength;
+        double barEndY = _hitchY + Math.Cos(_vehicleHeading) * hitchLength;
         var rearPen = new Pen(Brushes.Black, 0.3);
-        context.DrawLine(rearPen, new Point(_vehicleX, _vehicleY), new Point(_hitchX, _hitchY));
+        context.DrawLine(rearPen, new Point(barEndX, barEndY), new Point(_hitchX, _hitchY));
 
         // Draw V-shape hitch triangle: apex at fixed drawbar position relative to tool
         double hitchHalfW = _toolWidth / 2.0;

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -67,6 +67,14 @@ public interface ISharedMapControl
     void SetBoundary(Boundary? boundary);
     void SetVehiclePosition(double x, double y, double heading);
     void SetToolPosition(double x, double y, double heading, double width, double hitchX, double hitchY, bool isReady = true);
+
+    /// <summary>
+    /// Atomic update of vehicle + tool positions in a single call.
+    /// Prevents rendering mismatches between vehicle and tool.
+    /// </summary>
+    void SetAllPositions(double vehicleX, double vehicleY, double vehicleHeading,
+        double toolX, double toolY, double toolHeading, double toolWidth,
+        double hitchX, double hitchY, bool toolReady);
     void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections, int[]? buttonStates = null);
     void SetGridVisible(bool visible);
     void SetNorthUp(bool isNorthUp);
@@ -3348,6 +3356,22 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             case 2: // Free: don't move camera at all
                 break;
         }
+    }
+
+    public void SetAllPositions(double vehicleX, double vehicleY, double vehicleHeading,
+        double toolX, double toolY, double toolHeading, double toolWidth,
+        double hitchX, double hitchY, bool toolReady)
+    {
+        _vehicleX = vehicleX;
+        _vehicleY = vehicleY;
+        _vehicleHeading = vehicleHeading;
+        _toolX = toolX;
+        _toolY = toolY;
+        _toolHeading = toolHeading;
+        _toolWidth = toolWidth;
+        _hitchX = hitchX;
+        _hitchY = hitchY;
+        _toolPositionReady = toolReady;
     }
 
     public void SetToolPosition(double x, double y, double heading, double width, double hitchX, double hitchY, bool isReady = true)

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
@@ -148,7 +148,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Row 5: Offset Fix -->
                 <Button Grid.Column="0" Grid.Row="5" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press">
+                        ClickMode="Press" Command="{Binding ShowOffsetFixDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/YouTurnReverse.png" Width="28" Height="28"/>
                         <TextBlock Text="Offset Fix" VerticalAlignment="Center" FontSize="12"/>

--- a/Tests/AgValoniaGPS.Services.Tests/LegacyAutoImportTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/LegacyAutoImportTests.cs
@@ -217,4 +217,41 @@ public class LegacyAutoImportTests
     {
         Assert.That(_service.FieldExists(_fieldDir), Is.False);
     }
+
+    [Test]
+    public void LoadField_LocaleCorruptedCoordinates_RejectsInvalidValues()
+    {
+        // Locale-corrupted file: commas as decimal separators produce invalid values
+        // Parser rejects them (out of range), origin stays at default (0,0)
+        File.WriteAllLines(Path.Combine(_fieldDir, "Field.txt"), new[]
+        {
+            "2026-03-27 10:12:22",
+            "$FieldDir",
+            "test2",
+            "$Offsets",
+            "0,0",
+            "Convergence",
+            "0",
+            "StartFix",
+            "40,71280000,-74,00600000"
+        });
+
+        var field = _service.LoadField(_fieldDir);
+
+        // Corrupted values (71280000) are out of range and rejected
+        // Origin stays at default (0,0) rather than accepting garbage
+        Assert.That(field.Origin.Latitude, Is.EqualTo(0).Within(0.001),
+            "Corrupted coordinates should be rejected, origin stays at default");
+    }
+
+    [Test]
+    public void LoadField_StandardCoordinates_ParsesCorrectly()
+    {
+        WriteLegacyFieldTxt(lat: 51.5074, lon: -0.1278);
+
+        var field = _service.LoadField(_fieldDir);
+
+        Assert.That(field.Origin.Latitude, Is.EqualTo(51.5074).Within(0.0001));
+        Assert.That(field.Origin.Longitude, Is.EqualTo(-0.1278).Within(0.0001));
+    }
 }

--- a/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
@@ -1,0 +1,118 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Tests for GPS offset fix (#36).
+/// Verifies that drift compensation shifts the vehicle position
+/// relative to field geometry (boundary, tracks, coverage).
+/// </summary>
+[TestFixture]
+public class OffsetFixTests
+{
+    [Test]
+    public void DriftApplied_ShiftsDisplayPosition()
+    {
+        // Simulate: vehicle at (100, 200), apply 10m south drift
+        var fieldState = new FieldState();
+        double rawEasting = 100.0;
+        double rawNorthing = 200.0;
+
+        // No drift - display matches raw
+        Assert.That(rawEasting + fieldState.DriftEasting, Is.EqualTo(100.0));
+        Assert.That(rawNorthing + fieldState.DriftNorthing, Is.EqualTo(200.0));
+
+        // Apply 10m south drift
+        fieldState.DriftNorthing = -10.0;
+
+        double displayEasting = rawEasting + fieldState.DriftEasting;
+        double displayNorthing = rawNorthing + fieldState.DriftNorthing;
+
+        Assert.That(displayEasting, Is.EqualTo(100.0), "Easting should not change");
+        Assert.That(displayNorthing, Is.EqualTo(190.0), "Northing should shift 10m south");
+    }
+
+    [Test]
+    public void DriftApplied_VehicleMovesToFieldEdge()
+    {
+        // Scenario from user:
+        // 1. Vehicle at center of 20m field (boundary extends 10m in each direction)
+        // 2. Apply 10m south offset
+        // 3. Vehicle should appear at south edge of field
+
+        double fieldCenterN = 200.0;
+        double fieldHalfSize = 10.0; // 20m field = 10m each way
+        double boundarySouthEdge = fieldCenterN - fieldHalfSize; // 190.0
+
+        // Vehicle at field center
+        double vehicleNorthing = fieldCenterN; // 200.0
+
+        // Apply 10m south drift
+        var fieldState = new FieldState();
+        fieldState.DriftNorthing = -10.0;
+
+        // Display position
+        double displayNorthing = vehicleNorthing + fieldState.DriftNorthing;
+
+        Assert.That(displayNorthing, Is.EqualTo(boundarySouthEdge).Within(0.001),
+            "Vehicle should appear at south edge of 20m field after 10m south offset");
+    }
+
+    [Test]
+    public void DriftReset_RestoresOriginalPosition()
+    {
+        var fieldState = new FieldState();
+        double rawNorthing = 200.0;
+
+        fieldState.DriftNorthing = -10.0;
+        Assert.That(rawNorthing + fieldState.DriftNorthing, Is.EqualTo(190.0));
+
+        // Reset
+        fieldState.DriftNorthing = 0;
+        fieldState.DriftEasting = 0;
+        Assert.That(rawNorthing + fieldState.DriftNorthing, Is.EqualTo(200.0));
+    }
+
+    [Test]
+    public void DriftDoesNotMoveBoundary()
+    {
+        // Boundary coordinates are fixed in local plane space
+        // Only the vehicle display position shifts
+        double boundaryPointNorthing = 210.0;
+        var fieldState = new FieldState();
+
+        fieldState.DriftNorthing = -10.0;
+
+        // Boundary point should NOT change
+        Assert.That(boundaryPointNorthing, Is.EqualTo(210.0),
+            "Boundary coordinates must not be affected by drift");
+
+        // Vehicle should shift
+        double vehicleDisplay = 200.0 + fieldState.DriftNorthing;
+        Assert.That(vehicleDisplay, Is.EqualTo(190.0));
+
+        // Distance from vehicle to boundary changes
+        double distanceBefore = boundaryPointNorthing - 200.0; // 10m
+        double distanceAfter = boundaryPointNorthing - vehicleDisplay; // 20m
+        Assert.That(distanceAfter, Is.EqualTo(20.0),
+            "Vehicle should appear 20m from north boundary after 10m south offset");
+    }
+
+    [Test]
+    public void AutoSteerService_DriftAppliedToLocalCoordinates()
+    {
+        // Verify drift is applied in the zero-copy pipeline
+        var autoSteer = new AgValoniaGPS.Services.AutoSteer.AutoSteerService(
+            Substitute.For<ITrackGuidanceService>(),
+            Substitute.For<IUdpCommunicationService>());
+
+        autoSteer.SetDriftCompensation(5.0, -10.0);
+
+        // The drift values should be stored (we can't easily test the full pipeline
+        // without a LocalPlane, but we can verify the method doesn't throw)
+        Assert.DoesNotThrow(() => autoSteer.SetDriftCompensation(0, 0));
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
@@ -188,4 +188,46 @@ public class OffsetFixTests
         Assert.That(Math.Abs(hitchAfterReset - 330), Is.LessThan(5),
             $"After reset, hitch should snap near vehicle. Got {hitchAfterReset:F1}, expected ~328");
     }
+
+    [Test]
+    public void ToolPositionService_TrailingStillWorksAtNormalSpeed()
+    {
+        // Bug: jump detection was comparing hitch to toolPivot (always ~15m apart)
+        // causing the tool to snap rigid every frame instead of trailing
+        var config = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        config.Tool.HitchLength = 2.0;
+        config.Tool.TrailingHitchLength = 15.0; // Large trailing distance
+        config.Tool.IsToolTrailing = true;
+        config.Tool.IsToolRearFixed = false;
+        config.Tool.IsToolFrontFixed = false;
+        config.Tool.IsToolTBT = false;
+
+        var toolService = new AgValoniaGPS.Services.Tool.ToolPositionService();
+
+        // Drive straight north for 60 frames at 1m/frame (36 km/h at 10Hz)
+        for (int i = 0; i < 60; i++)
+        {
+            var pos = new AgValoniaGPS.Models.Base.Vec3(0, i * 1.0, 0);
+            toolService.Update(pos, 0);
+        }
+
+        // Now turn east - trailing implement should lag behind (not snap rigid)
+        double lastToolHeading = toolService.ToolHeading;
+
+        for (int i = 0; i < 20; i++)
+        {
+            var pos = new AgValoniaGPS.Models.Base.Vec3(i * 1.0, 60, Math.PI / 2); // Heading east
+            toolService.Update(pos, Math.PI / 2);
+        }
+
+        double toolHeadingAfterTurn = toolService.ToolHeading;
+
+        // Tool heading should have moved from north (0) toward east (PI/2)
+        // but NOT match vehicle heading exactly - trailing means it lags
+        Assert.That(toolHeadingAfterTurn, Is.GreaterThan(0.1),
+            "Tool heading should have moved away from north");
+        Assert.That(toolHeadingAfterTurn, Is.LessThan(Math.PI / 2 - 0.05),
+            $"Tool should lag behind vehicle (trailing, not rigid). " +
+            $"Vehicle={Math.PI / 2:F2}, Tool={toolHeadingAfterTurn:F2}");
+    }
 }

--- a/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
@@ -144,4 +144,48 @@ public class OffsetFixTests
         Assert.That(toolService.HitchPosition.Northing, Is.EqualTo(188.0).Within(0.1),
             "Hitch must follow drifted vehicle position");
     }
+
+    [Test]
+    public void ToolPositionService_ResetAfterLargeJump_SnapsImmediately()
+    {
+        var config = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        config.Tool.HitchLength = 2.0;
+        config.Tool.TrailingHitchLength = 3.0;
+        config.Tool.IsToolTrailing = true;
+        config.Tool.IsToolRearFixed = false;
+        config.Tool.IsToolFrontFixed = false;
+        config.Tool.IsToolTBT = false;
+
+        var toolService = new AgValoniaGPS.Services.Tool.ToolPositionService();
+
+        // Drive normally for 60 frames to establish trailing
+        for (int i = 0; i < 60; i++)
+        {
+            var pos = new AgValoniaGPS.Models.Base.Vec3(100, 200 + i * 0.5, 0);
+            toolService.Update(pos, 0);
+        }
+
+        // Vehicle at (100, 230) after driving
+        double preJumpHitch = toolService.HitchPosition.Northing;
+        Assert.That(Math.Abs(preJumpHitch - 230), Is.LessThan(5),
+            "Hitch should be near vehicle before jump");
+
+        // Simulate large drift: vehicle jumps 100m north
+        var jumpedPos = new AgValoniaGPS.Models.Base.Vec3(100, 330, 0);
+
+        // WITHOUT reset - hitch would be 100m behind
+        toolService.Update(jumpedPos, 0);
+        double hitchAfterJump = toolService.HitchPosition.Northing;
+
+        // With trailing, the tool is still near old position (huge gap)
+        // This is the bug - hitch bar stretched to ~100m
+
+        // Now reset and update again
+        toolService.ResetTrailingState(jumpedPos, 0);
+        toolService.Update(jumpedPos, 0);
+        double hitchAfterReset = toolService.HitchPosition.Northing;
+
+        Assert.That(Math.Abs(hitchAfterReset - 330), Is.LessThan(5),
+            $"After reset, hitch should snap near vehicle. Got {hitchAfterReset:F1}, expected ~328");
+    }
 }

--- a/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
@@ -115,4 +115,33 @@ public class OffsetFixTests
         // without a LocalPlane, but we can verify the method doesn't throw)
         Assert.DoesNotThrow(() => autoSteer.SetDriftCompensation(0, 0));
     }
+
+    [Test]
+    public void ToolPositionService_FollowsVehicle()
+    {
+        // Verify that tool position is relative to vehicle
+        var toolService = new AgValoniaGPS.Services.Tool.ToolPositionService();
+
+        // Configure a rear-fixed hitch at 2m behind
+        var config = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        config.Tool.HitchLength = 2.0;
+        config.Tool.IsToolRearFixed = true;
+
+        // Vehicle at (100, 200) heading north (0 radians)
+        var vehiclePos = new AgValoniaGPS.Models.Base.Vec3(100, 200, 0);
+        toolService.Update(vehiclePos, 0);
+
+        // Hitch should be 2m south of vehicle
+        Assert.That(toolService.HitchPosition.Easting, Is.EqualTo(100.0).Within(0.1));
+        Assert.That(toolService.HitchPosition.Northing, Is.EqualTo(198.0).Within(0.1));
+
+        // Now "drift" by feeding shifted position
+        var driftedPos = new AgValoniaGPS.Models.Base.Vec3(100, 190, 0); // 10m south
+        toolService.Update(driftedPos, 0);
+
+        // Hitch should follow: 190 - 2 = 188
+        Assert.That(toolService.HitchPosition.Easting, Is.EqualTo(100.0).Within(0.1));
+        Assert.That(toolService.HitchPosition.Northing, Is.EqualTo(188.0).Within(0.1),
+            "Hitch must follow drifted vehicle position");
+    }
 }

--- a/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/OffsetFixTests.cs
@@ -190,6 +190,73 @@ public class OffsetFixTests
     }
 
     [Test]
+    public void ToolPositionService_ResetPlacesHitchBehindVehicle()
+    {
+        // Bug: ResetTrailingState used +HitchLength (ahead) instead of -HitchLength (behind)
+        var config = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        config.Tool.HitchLength = 5.0;
+        config.Tool.TrailingHitchLength = 15.0;
+        config.Tool.IsToolTrailing = true;
+        config.Tool.IsToolRearFixed = false;
+        config.Tool.IsToolFrontFixed = false;
+        config.Tool.IsToolTBT = false;
+
+        var toolService = new AgValoniaGPS.Services.Tool.ToolPositionService();
+
+        // Vehicle at origin heading north (0 rad)
+        var pos = new AgValoniaGPS.Models.Base.Vec3(100, 200, 0);
+        toolService.ResetTrailingState(pos, 0);
+
+        // Hitch should be 5m BEHIND (south of) vehicle, not 5m ahead
+        Assert.That(toolService.HitchPosition.Northing, Is.LessThan(200.0),
+            $"Hitch should be south of vehicle (behind when heading north). Got N={toolService.HitchPosition.Northing:F1}");
+        Assert.That(toolService.HitchPosition.Northing, Is.EqualTo(195.0).Within(0.1),
+            "Hitch should be exactly 5m behind vehicle");
+        Assert.That(toolService.HitchPosition.Easting, Is.EqualTo(100.0).Within(0.1),
+            "Hitch easting should match vehicle");
+
+        // Tool should be further behind (5m hitch + 15m trailing = 20m total)
+        Assert.That(toolService.ToolPosition.Northing, Is.LessThan(195.0),
+            "Tool should be behind hitch point");
+    }
+
+    [Test]
+    public void ToolPositionService_ResetThenUpdateProducesConsistentPositions()
+    {
+        // After reset + one Update frame, tool should be near vehicle
+        var config = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        config.Tool.HitchLength = 5.0;
+        config.Tool.TrailingHitchLength = 15.0;
+        config.Tool.IsToolTrailing = true;
+        config.Tool.IsToolRearFixed = false;
+        config.Tool.IsToolFrontFixed = false;
+        config.Tool.IsToolTBT = false;
+
+        var toolService = new AgValoniaGPS.Services.Tool.ToolPositionService();
+
+        // Drive north to establish trailing
+        for (int i = 0; i < 60; i++)
+            toolService.Update(new AgValoniaGPS.Models.Base.Vec3(0, i * 0.5, 0), 0);
+
+        // Apply offset by resetting to a shifted position (simulate 10m north drift)
+        var newPos = new AgValoniaGPS.Models.Base.Vec3(0, 40, 0);
+        toolService.ResetTrailingState(newPos, 0);
+
+        // Immediately update at the new position
+        toolService.Update(newPos, 0);
+
+        // Hitch should be near vehicle (5m behind at most)
+        double hitchDist = Math.Abs(toolService.HitchPosition.Northing - 40);
+        Assert.That(hitchDist, Is.LessThan(6.0),
+            $"Hitch should be within 6m of vehicle after reset+update. Got {toolService.HitchPosition.Northing:F1}");
+
+        // Tool should be within total hitch+trailing distance
+        double toolDist = Math.Abs(toolService.ToolPosition.Northing - 40);
+        Assert.That(toolDist, Is.LessThan(21.0),
+            $"Tool should be within 21m of vehicle. Got {toolService.ToolPosition.Northing:F1}");
+    }
+
+    [Test]
     public void ToolPositionService_TrailingStillWorksAtNormalSpeed()
     {
         // Bug: jump detection was comparing hitch to toolPivot (always ~15m apart)

--- a/Tests/AgValoniaGPS.UI.Tests/OffsetFixScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/OffsetFixScreenshotTests.cs
@@ -1,0 +1,148 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Coverage;
+using AgValoniaGPS.Views.Controls;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Visual verification of GPS offset fix (#36).
+/// Captures before/after screenshots showing vehicle position
+/// relative to a field boundary.
+/// </summary>
+[TestFixture]
+public class OffsetFixScreenshotTests
+{
+    private static string ScreenshotDir
+    {
+        get
+        {
+            var dir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "screenshots", "offset_fix");
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+    }
+
+    [AvaloniaTest]
+    public void OffsetFix_TrailingImplementFollowsVehicle()
+    {
+        // Configure trailing implement
+        var config = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        config.Tool.HitchLength = 2.0;
+        config.Tool.TrailingHitchLength = 3.0;
+        config.Tool.IsToolTrailing = true;
+        config.Tool.IsToolRearFixed = false;
+        config.Tool.IsToolFrontFixed = false;
+        config.Tool.IsToolTBT = false;
+        config.Tool.Width = 6.0;
+
+        var toolService = new AgValoniaGPS.Services.Tool.ToolPositionService();
+
+        var mapControl = new DrawingContextMapControl
+        {
+            Width = 600,
+            Height = 600,
+            IsGridVisible = true
+        };
+
+        // Set boundary: 40m square centered at (0, 0)
+        var outerPoly = new AgValoniaGPS.Models.BoundaryPolygon();
+        outerPoly.Points.Add(new AgValoniaGPS.Models.BoundaryPoint { Easting = -20, Northing = -20 });
+        outerPoly.Points.Add(new AgValoniaGPS.Models.BoundaryPoint { Easting = 20, Northing = -20 });
+        outerPoly.Points.Add(new AgValoniaGPS.Models.BoundaryPoint { Easting = 20, Northing = 20 });
+        outerPoly.Points.Add(new AgValoniaGPS.Models.BoundaryPoint { Easting = -20, Northing = 20 });
+        var boundary = new AgValoniaGPS.Models.Boundary { OuterBoundary = outerPoly };
+        mapControl.SetBoundary(boundary);
+
+        // Zoom in 8x
+        for (int i = 0; i < 8; i++) mapControl.Zoom(1.2);
+
+        var window = new Window
+        {
+            Content = mapControl,
+            Width = 600,
+            Height = 600,
+            SizeToContent = SizeToContent.Manual,
+            Background = Brushes.Black
+        };
+        window.Show();
+
+        // Drive north a few frames to establish trailing heading
+        for (int i = 0; i < 60; i++)
+        {
+            double n = -10 + i * 0.5; // Drive from -10 to +20
+            var pos = new Vec3(0, n, 0); // Heading north
+            toolService.Update(pos, 0);
+        }
+
+        // Screenshot 1: Vehicle at center, trailing implement behind
+        double vehicleN = 20;
+        var vehiclePos = new Vec3(0, vehicleN, 0);
+        toolService.Update(vehiclePos, 0);
+        mapControl.SetVehiclePosition(0, vehicleN, 0);
+        mapControl.SetToolPosition(
+            toolService.ToolPosition.Easting, toolService.ToolPosition.Northing,
+            toolService.ToolHeading, 6,
+            toolService.HitchPosition.Easting, toolService.HitchPosition.Northing);
+
+        CaptureScreenshot(window, 600, 600,
+            Path.Combine(ScreenshotDir, "01_trailing_no_offset.png"));
+
+        // Screenshot 2: Apply 10m south offset - both tractor and implement shift
+        double driftN = -10;
+        var driftedPos = new Vec3(0, vehicleN + driftN, 0);
+        toolService.Update(driftedPos, 0);
+        mapControl.SetVehiclePosition(0, vehicleN + driftN, 0);
+        mapControl.SetToolPosition(
+            toolService.ToolPosition.Easting, toolService.ToolPosition.Northing,
+            toolService.ToolHeading, 6,
+            toolService.HitchPosition.Easting, toolService.HitchPosition.Northing);
+
+        CaptureScreenshot(window, 600, 600,
+            Path.Combine(ScreenshotDir, "02_trailing_offset_10m_south.png"));
+
+        // Verify: hitch is still close to vehicle (not 100m away)
+        double hitchToVehicle = Math.Abs(toolService.HitchPosition.Northing - (vehicleN + driftN));
+        Assert.That(hitchToVehicle, Is.LessThan(5.0),
+            $"Hitch should be within 5m of vehicle, got {hitchToVehicle:F1}m");
+
+        // Verify screenshots
+        Assert.That(File.Exists(Path.Combine(ScreenshotDir, "01_trailing_no_offset.png")), Is.True);
+        Assert.That(File.Exists(Path.Combine(ScreenshotDir, "02_trailing_offset_10m_south.png")), Is.True);
+
+        TestContext.Out.WriteLine($"Screenshots saved to: {ScreenshotDir}");
+        TestContext.Out.WriteLine($"Hitch distance from vehicle: {hitchToVehicle:F2}m");
+
+        // Screenshot 3: Simulate the bug - vehicle jumps but tool NOT updated yet
+        // This is what happens when PropertyChanged fires for Easting before ToolEasting
+        mapControl.SetVehiclePosition(0, vehicleN + driftN + 100, 0);
+        // Tool position NOT updated - still at old location
+        CaptureScreenshot(window, 600, 600,
+            Path.Combine(ScreenshotDir, "03_BUG_vehicle_jumped_tool_stale.png"));
+
+        // Screenshot 4: After tool catches up (both updated)
+        var jumpedPos = new Vec3(0, vehicleN + driftN + 100, 0);
+        toolService.ResetTrailingState(jumpedPos, 0);
+        toolService.Update(jumpedPos, 0);
+        mapControl.SetVehiclePosition(0, vehicleN + driftN + 100, 0);
+        mapControl.SetToolPosition(
+            toolService.ToolPosition.Easting, toolService.ToolPosition.Northing,
+            toolService.ToolHeading, 6,
+            toolService.HitchPosition.Easting, toolService.HitchPosition.Northing);
+        CaptureScreenshot(window, 600, 600,
+            Path.Combine(ScreenshotDir, "04_FIXED_both_updated.png"));
+    }
+
+    private static void CaptureScreenshot(Window window, int width, int height, string filePath)
+    {
+        window.UpdateLayout();
+        var renderTarget = new RenderTargetBitmap(new PixelSize(width, height), new Vector(96, 96));
+        renderTarget.Render(window);
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        renderTarget.Save(filePath);
+    }
+}

--- a/Tools/unpack-dump.sh
+++ b/Tools/unpack-dump.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Unpack and display AgValoniaGPS debug dump
+# Usage: ./unpack-dump.sh <dump.zip> [output_dir]
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <debug_dump.zip> [output_dir]"
+    exit 1
+fi
+
+ZIP="$1"
+OUTDIR="${2:-$(mktemp -d /tmp/agvdump.XXXXXX)}"
+
+mkdir -p "$OUTDIR"
+unzip -o -q "$ZIP" -d "$OUTDIR"
+
+echo "=== System Info ==="
+cat "$OUTDIR/system_info.txt" 2>/dev/null || echo "(not found)"
+
+echo ""
+echo "=== Active Profile ==="
+cat "$OUTDIR/active_profile_name.txt" 2>/dev/null || echo "(not found)"
+
+echo ""
+echo "=== Configuration ==="
+cat "$OUTDIR/configuration.json" 2>/dev/null | python3 -m json.tool 2>/dev/null || cat "$OUTDIR/configuration.json" 2>/dev/null || echo "(not found)"
+
+echo ""
+echo "=== Runtime State ==="
+cat "$OUTDIR/runtime_state.json" 2>/dev/null | python3 -m json.tool 2>/dev/null || cat "$OUTDIR/runtime_state.json" 2>/dev/null || echo "(not found)"
+
+echo ""
+echo "=== App Settings ==="
+cat "$OUTDIR/appsettings.json" 2>/dev/null | python3 -m json.tool 2>/dev/null || cat "$OUTDIR/appsettings.json" 2>/dev/null || echo "(not found)"
+
+echo ""
+echo "=== Logs ==="
+cat "$OUTDIR/logs.txt" 2>/dev/null || echo "(not found)"
+
+# List any field files
+FIELD_FILES=$(find "$OUTDIR" -name "field_*" -o -name "*.geojson" -o -name "Boundary.txt" -o -name "Field.txt" 2>/dev/null)
+if [ -n "$FIELD_FILES" ]; then
+    echo ""
+    echo "=== Field Files ==="
+    for f in $FIELD_FILES; do
+        echo "--- $(basename "$f") ---"
+        cat "$f"
+        echo ""
+    done
+fi
+
+echo ""
+echo "Unpacked to: $OUTDIR"


### PR DESCRIPTION
Closes #36

## Summary
D-pad style dialog for GPS drift compensation, matching legacy FormShiftPos. Accessible from Job Menu > Offset Fix.

- N/S/E/W buttons nudge GPS position by 1cm per click
- Zero button resets offset to origin
- Current offset displayed in meters (2dp)
- Offset applied to all GPS coordinates in update loop
- Resets on field close

## Test plan
- [ ] Open Job Menu, click Offset Fix, verify dialog appears
- [ ] Click N multiple times, verify vehicle position shifts north on map
- [ ] Click Zero, verify position returns to GPS actual
- [ ] Close and reopen field, verify offset resets