### PR TITLE
Send PGN 239 (Machine Data) every GPS cycle

### DIFF
--- a/Shared/AgValoniaGPS.Models/VehicleState.cs
+++ b/Shared/AgValoniaGPS.Models/VehicleState.cs
@@ -123,6 +123,22 @@ public struct VehicleState
     public bool MasterSectionOn;
 
     // ═══════════════════════════════════════════════════════════════════════
+    // Machine Control (PGN 239 output)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// <summary>U-turn active state (sent to machine module)</summary>
+    public bool IsInUTurn;
+
+    /// <summary>Hydraulic lift state: 0=down, 1=up, 2=transitioning</summary>
+    public byte HydLiftState;
+
+    /// <summary>Tramline control byte</summary>
+    public byte TramState;
+
+    /// <summary>Geo-fence stop: 0=ok, 1=out of bounds</summary>
+    public byte GeoStopState;
+
+    // ═══════════════════════════════════════════════════════════════════════
     // Switch States (received from hardware via PGN)
     // ═══════════════════════════════════════════════════════════════════════
 

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -242,6 +242,12 @@ public class AutoSteerService : IAutoSteerService
         _driftNorthing = driftNorthing;
     }
 
+    public void SetMachineState(ushort sectionBits, bool isInUTurn)
+    {
+        _state.SectionStates = sectionBits;
+        _state.IsInUTurn = isInUTurn;
+    }
+
     /// <summary>
     /// Set the current track for guidance.
     /// Called by MainViewModel when active track changes.

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -375,6 +375,15 @@ public class AutoSteerService : IAutoSteerService
         // This keeps the module informed of current position/speed even when not engaged
         var pgn = PgnBuilder.BuildAutoSteerPgn(ref _state);
         _udpService.SendToModules(pgn);
+
+        // Send PGN 239 (Machine Data) - section control, speed, tramline state
+        // Sent every GPS cycle so machine module has current section/speed info
+        var machinePgn = PgnBuilder.BuildMachinePgn(ref _state,
+            uturn: _state.IsInUTurn ? (byte)1 : (byte)0,
+            hydLift: _state.HydLiftState,
+            tram: _state.TramState,
+            geoStop: _state.GeoStopState);
+        _udpService.SendToModules(machinePgn);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
@@ -123,6 +123,12 @@ public interface IAutoSteerService
     /// </summary>
     void SetDriftCompensation(double driftEasting, double driftNorthing);
 
+    /// <summary>
+    /// Update machine control state sent via PGN 239.
+    /// Called by ViewModel after section control updates.
+    /// </summary>
+    void SetMachineState(ushort sectionBits, bool isInUTurn);
+
     // ═══════════════════════════════════════════════════════════════════════
     // Module Feedback (PGN 253, 250)
     // ═══════════════════════════════════════════════════════════════════════

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -737,6 +737,9 @@ public partial class MainViewModel : ReactiveObject
         _sectionControlService.Update(e.ToolPosition, e.ToolHeading, e.VehicleHeading, Speed);
         _lastSectionControlMs = _updateSw.Elapsed.TotalMilliseconds;
 
+        // Push section bits + u-turn state to AutoSteerService for PGN 239
+        _autoSteerService.SetMachineState(_sectionControlService.GetSectionBits(), _isInYouTurn);
+
         // Update coverage painting - paint when sections are active and moving
         _updateSw.Restart();
         UpdateCoveragePainting(e.ToolPosition, e.ToolHeading);


### PR DESCRIPTION
Closes #53

## Summary
- PGN 239 (Machine Data) sent alongside PGN 254 on every GPS cycle (~10Hz)
- Section bitmask wired from SectionControlService into PGN bytes 11-12
- U-turn state wired from YouTurn into PGN byte 5
- Speed sent as byte 6 (speed * 10)
- HydLift, Tram, GeoStop stubbed at 0 (features not yet implemented)

## Test plan
- [ ] Connect machine module, verify PGN 239 received (UDP sniffer)
- [ ] Toggle sections, verify bitmask updates in PGN 239 bytes 11-12
- [ ] Drive at known speed, verify byte 6 = speed * 10
- [x] 323 tests pass (72 model + 251 service)

Generated with [Claude Code](https://claude.com/claude-code)