### PR TITLE
Replace AutoDayNight configurable hours with GPS-based Sun Calc

### DIFF
--- a/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
@@ -230,7 +230,7 @@ public class DisplayConfig : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _headlandDistanceVisible, value);
     }
 
-    private bool _autoDayNight;
+    private bool _autoDayNight = true;
     public bool AutoDayNight
     {
         get => _autoDayNight;

--- a/Shared/AgValoniaGPS.Services/SolarCalculator.cs
+++ b/Shared/AgValoniaGPS.Services/SolarCalculator.cs
@@ -26,6 +26,7 @@ public static class SolarCalculator
 {
     /// <summary>
     /// Returns true if the sun is up at the given lat/lon/time.
+    /// dateTime should be in UTC not local time
     /// </summary>
     public static bool IsDay(double latitude, double longitude, DateTime dateTime)
     {

--- a/Shared/AgValoniaGPS.Services/SolarCalculator.cs
+++ b/Shared/AgValoniaGPS.Services/SolarCalculator.cs
@@ -1,0 +1,109 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Computes sunrise and sunset times from GPS latitude/longitude and current date.
+/// Based on NOAA simplified solar position algorithms.
+/// </summary>
+public static class SolarCalculator
+{
+    /// <summary>
+    /// Returns true if the sun is up at the given lat/lon/time.
+    /// </summary>
+    public static bool IsDay(double latitude, double longitude, DateTime dateTime)
+    {
+        var (sunrise, sunset) = GetSunTimes(latitude, longitude, dateTime.Date);
+        return dateTime >= sunrise && dateTime <= sunset;
+    }
+
+    /// <summary>
+    /// Returns sunrise and sunset in local time for a given date.
+    /// </summary>
+    /// <returns>
+    /// DateTime.MaxValue for both if sun never rises (polar night).
+    /// DateTime.MinValue for both if sun never sets (midnight sun).
+    /// </returns>
+    public static (DateTime sunriseUtc, DateTime sunsetUtc) GetSunTimes(double latitude, double longitude, DateTime dateUtc)
+    {
+        double lngHour = longitude / 15.0;
+        int day = dateUtc.Day;
+        int month = dateUtc.Month;
+        int year = dateUtc.Year;
+
+        int N1 = (int)Math.Floor(275 * month / 9.0);
+        int N2 = (int)Math.Floor((month + 9) / 12.0);
+        int N3 = 1 + (int)Math.Floor((year - 4 * Math.Floor(year / 4.0) + 2) / 3.0);
+        int N = N1 - (N2 * N3) + day - 30;
+
+        double tRise = N + ((6 - lngHour) / 24.0);
+        double tSet  = N + ((18 - lngHour) / 24.0);
+
+        double MRise = (0.9856 * tRise) - 3.289;
+        double MSet  = (0.9856 * tSet)  - 3.289;
+
+        double LRise = MRise + 1.916 * Math.Sin(DegToRad(MRise)) + 0.020 * Math.Sin(DegToRad(2 * MRise)) + 282.634;
+        double LSet  = MSet  + 1.916 * Math.Sin(DegToRad(MSet))  + 0.020 * Math.Sin(DegToRad(2 * MSet))  + 282.634;
+        LRise = NormalizeAngle(LRise);
+        LSet  = NormalizeAngle(LSet);
+
+        double RARise = RadToDeg(Math.Atan(0.91764 * Math.Tan(DegToRad(LRise))));
+        double RASet  = RadToDeg(Math.Atan(0.91764 * Math.Tan(DegToRad(LSet))));
+        RARise = NormalizeAngle(RARise);
+        RASet  = NormalizeAngle(RASet);
+
+        RARise += Math.Floor(LRise / 90.0) * 90.0 - Math.Floor(RARise / 90.0) * 90.0;
+        RASet  += Math.Floor(LSet / 90.0)  * 90.0 - Math.Floor(RASet / 90.0)  * 90.0;
+
+        RARise /= 15.0;
+        RASet  /= 15.0;
+
+        double sinDecRise = 0.39782 * Math.Sin(DegToRad(LRise));
+        double cosDecRise = Math.Cos(Math.Asin(sinDecRise));
+        double sinDecSet  = 0.39782 * Math.Sin(DegToRad(LSet));
+        double cosDecSet  = Math.Cos(Math.Asin(sinDecSet));
+
+        double cosHRise = (Math.Cos(DegToRad(90.833)) - (sinDecRise * Math.Sin(DegToRad(latitude)))) / (cosDecRise * Math.Cos(DegToRad(latitude)));
+        double cosHSet  = (Math.Cos(DegToRad(90.833)) - (sinDecSet  * Math.Sin(DegToRad(latitude)))) / (cosDecSet  * Math.Cos(DegToRad(latitude)));
+        
+        if (cosHRise > 1) return (DateTime.MaxValue, DateTime.MinValue); // sun never rises
+        if (cosHSet < -1) return (DateTime.MinValue, DateTime.MaxValue);  // sun never sets
+        
+        double HRise = 360 - RadToDeg(Math.Acos(cosHRise));
+        double HSet  = RadToDeg(Math.Acos(cosHSet));
+        HRise /= 15.0;
+        HSet  /= 15.0;
+
+        double TRise = HRise + RARise - (0.06571 * tRise) - 6.622;
+        double TSet  = HSet  + RASet  - (0.06571 * tSet)  - 6.622;
+
+        double UTCRise = NormalizeTime(TRise - lngHour);
+        double UTCSet  = NormalizeTime(TSet  - lngHour);
+
+        DateTime sunriseUtc = DateTime.SpecifyKind(new DateTime(dateUtc.Year, dateUtc.Month, dateUtc.Day), DateTimeKind.Utc).AddHours(UTCRise);
+        DateTime sunsetUtc  = DateTime.SpecifyKind(new DateTime(dateUtc.Year, dateUtc.Month, dateUtc.Day), DateTimeKind.Utc).AddHours(UTCSet);
+
+        return (sunriseUtc, sunsetUtc);
+    }
+
+    private static double DegToRad(double angle) => angle * Math.PI / 180.0;
+    private static double RadToDeg(double angle) => angle * 180.0 / Math.PI;
+    private static double NormalizeAngle(double angle) => (angle % 360 + 360) % 360;
+    private static double NormalizeTime(double t) => (t % 24 + 24) % 24;
+}

--- a/Shared/AgValoniaGPS.Services/SolarCalculator.cs
+++ b/Shared/AgValoniaGPS.Services/SolarCalculator.cs
@@ -43,20 +43,13 @@ public static class SolarCalculator
     public static (DateTime sunriseUtc, DateTime sunsetUtc) GetSunTimes(double latitude, double longitude, DateTime dateUtc)
     {
         double lngHour = longitude / 15.0;
-        int day = dateUtc.Day;
-        int month = dateUtc.Month;
-        int year = dateUtc.Year;
-
-        int N1 = (int)Math.Floor(275 * month / 9.0);
-        int N2 = (int)Math.Floor((month + 9) / 12.0);
-        int N3 = 1 + (int)Math.Floor((year - 4 * Math.Floor(year / 4.0) + 2) / 3.0);
-        int N = N1 - (N2 * N3) + day - 30;
+        int N = dateUtc.DayOfYear;
 
         double tRise = N + ((6 - lngHour) / 24.0);
-        double tSet  = N + ((18 - lngHour) / 24.0);
+        double tSet  = tRise + 0.5;
 
         double MRise = (0.9856 * tRise) - 3.289;
-        double MSet  = (0.9856 * tSet)  - 3.289;
+        double MSet  = MRise + 0.4928;
 
         double LRise = MRise + 1.916 * Math.Sin(DegToRad(MRise)) + 0.020 * Math.Sin(DegToRad(2 * MRise)) + 282.634;
         double LSet  = MSet  + 1.916 * Math.Sin(DegToRad(MSet))  + 0.020 * Math.Sin(DegToRad(2 * MSet))  + 282.634;
@@ -75,12 +68,15 @@ public static class SolarCalculator
         RASet  /= 15.0;
 
         double sinDecRise = 0.39782 * Math.Sin(DegToRad(LRise));
-        double cosDecRise = Math.Cos(Math.Asin(sinDecRise));
+        double cosDecRise = Math.Sqrt(1.0 - sinDecRise * sinDecRise);
         double sinDecSet  = 0.39782 * Math.Sin(DegToRad(LSet));
-        double cosDecSet  = Math.Cos(Math.Asin(sinDecSet));
+        double cosDecSet  = Math.Sqrt(1.0 - sinDecSet * sinDecSet);
+        
+        double sinLat = Math.Sin(DegToRad(latitude));
+        double cosLat = Math.Cos(DegToRad(latitude));
 
-        double cosHRise = (Math.Cos(DegToRad(90.833)) - (sinDecRise * Math.Sin(DegToRad(latitude)))) / (cosDecRise * Math.Cos(DegToRad(latitude)));
-        double cosHSet  = (Math.Cos(DegToRad(90.833)) - (sinDecSet  * Math.Sin(DegToRad(latitude)))) / (cosDecSet  * Math.Cos(DegToRad(latitude)));
+        double cosHRise = (-0.01453808 - (sinDecRise * sinLat)) / (cosDecRise * cosLat);
+        double cosHSet  = (-0.01453808 - (sinDecSet  * sinLat)) / (cosDecSet  * cosLat);
         
         if (cosHRise > 1) return (DateTime.MaxValue, DateTime.MinValue); // sun never rises
         if (cosHSet < -1) return (DateTime.MinValue, DateTime.MaxValue);  // sun never sets

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -289,7 +289,8 @@ public partial class MainViewModel
     private void CheckAutoDayNight()
     {
         var display = ConfigurationStore.Instance.Display;
-
+        if (!display.AutoDayNight) return;
+        
         bool shouldBeDay = false;
         // Try GPS-based solar calculation when we have a valid position
         if (_gpsService.IsGpsDataOk() && display.AutoDayNight)

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -17,6 +17,7 @@
 using System;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services;
 using Avalonia.Threading;
 using ReactiveUI;
 
@@ -212,6 +213,8 @@ public partial class MainViewModel
         {
             _displaySettings.IsDayMode = value;
             this.RaisePropertyChanged();
+            _mapService.SetDayMode(value);
+            ApplyThemeVariant(value);
         }
     }
 
@@ -278,26 +281,33 @@ public partial class MainViewModel
     }
 
     /// <summary>
-    /// Switch day/night mode automatically based on local time.
-    /// Uses configurable DayStartHour and NightStartHour from DisplayConfig.
-    /// Only applies when AutoDayNight is enabled in DisplayConfig.
+    /// Switch day/night mode automatically based on solar position.
+    /// Uses GPS-based sunrise/sunset when available, falls back to configured hours.
+    /// GPS-based only when AutoDayNight is enabled.
     /// </summary>
     private void CheckAutoDayNight()
     {
         var display = ConfigurationStore.Instance.Display;
-        if (!display.AutoDayNight) return;
 
-        int hour = DateTime.Now.Hour;
-        int dayStart = display.DayStartHour;
-        int nightStart = display.NightStartHour;
-
-        bool shouldBeDay;
-        if (dayStart < nightStart)
-            shouldBeDay = hour >= dayStart && hour < nightStart;
+        bool shouldBeDay = false;
+        // Try GPS-based solar calculation when we have a valid position
+        if (Math.Abs(Latitude) > 0.001 && Math.Abs(Longitude) > 0.001 && display.AutoDayNight)
+        {
+            shouldBeDay = SolarCalculator.IsDay(Latitude, Longitude, DateTime.UtcNow);
+        }
         else
-            // Handles wrap-around (e.g. day=22, night=6 for night-shift work)
-            shouldBeDay = hour >= dayStart || hour < nightStart;
+        {
+            // Fallback to configurable hours
+            int hour = DateTime.Now.Hour;
+            int dayStart = display.DayStartHour;
+            int nightStart = display.NightStartHour;
 
+            if (dayStart < nightStart)
+                shouldBeDay = hour >= dayStart && hour < nightStart;
+            else
+                // Handles wrap-around (e.g. day=22, night=6 for night-shift work)
+                shouldBeDay = hour >= dayStart || hour < nightStart;
+        }
         if (IsDayMode != shouldBeDay)
         {
             IsDayMode = shouldBeDay;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -291,7 +291,7 @@ public partial class MainViewModel
 
         bool shouldBeDay = false;
         // Try GPS-based solar calculation when we have a valid position
-        if (Math.Abs(Latitude) > 0.001 && Math.Abs(Longitude) > 0.001 && display.AutoDayNight)
+        if (_gpsService.IsGpsDataOk() && display.AutoDayNight)
         {
             shouldBeDay = SolarCalculator.IsDay(Latitude, Longitude, DateTime.UtcNow);
         }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -272,6 +272,7 @@ public partial class MainViewModel
 
     private void InitializeAutoDayNight()
     {
+        CheckAutoDayNight();
         _autoDayNightTimer = new DispatcherTimer
         {
             Interval = TimeSpan.FromSeconds(60)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -140,7 +140,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             </Button>
                             <TextBlock Text="Auto Day/Night" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center"
-                                        IsVisible="{Binding Display.AutoDayNight}">
+                                        IsVisible="{Binding !Display.AutoDayNight}">
                                 <TextBlock Text="Day" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="9" VerticalAlignment="Center"/>
                                 <NumericUpDown Value="{Binding Display.DayStartHour}" Minimum="0" Maximum="23"
                                                Width="55" FontSize="10" Height="24" FormatString="0"/>


### PR DESCRIPTION
## What changed
Created SolarCalculator.cs which finds sunrise and sunset for a given gps value and date, and finds isDay with this information
Modified behavior of CheckAutoDayNight to allign with these changes

## Related issue

Closes https://github.com/AgOpenGPS-Official/AgValoniaGPS/issues/90

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes
- [x] Tested on: Linux, Windows

