### PR TITLE
Add debug dump button for bug reporting

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -104,5 +104,62 @@ namespace AgValoniaGPS.Models
 
         // Hotkey bindings (empty = use defaults)
         public Dictionary<string, string> HotkeyBindings { get; set; } = new();
+
+        /// <summary>
+        /// Validate and clamp all settings to valid ranges.
+        /// Returns list of fields that were corrected.
+        /// </summary>
+        public List<string> ValidateAndFix()
+        {
+            var defaults = new AppSettings();
+            var fixes = new List<string>();
+
+            // Simulator coordinates
+            if (SimulatorLatitude < -90 || SimulatorLatitude > 90)
+            {
+                fixes.Add($"SimulatorLatitude was {SimulatorLatitude}, reset to {defaults.SimulatorLatitude}");
+                SimulatorLatitude = defaults.SimulatorLatitude;
+            }
+            if (SimulatorLongitude < -180 || SimulatorLongitude > 180)
+            {
+                fixes.Add($"SimulatorLongitude was {SimulatorLongitude}, reset to {defaults.SimulatorLongitude}");
+                SimulatorLongitude = defaults.SimulatorLongitude;
+            }
+
+            // Window dimensions
+            if (WindowWidth < 100 || WindowWidth > 10000)
+            {
+                fixes.Add($"WindowWidth was {WindowWidth}, reset to {defaults.WindowWidth}");
+                WindowWidth = defaults.WindowWidth;
+            }
+            if (WindowHeight < 100 || WindowHeight > 10000)
+            {
+                fixes.Add($"WindowHeight was {WindowHeight}, reset to {defaults.WindowHeight}");
+                WindowHeight = defaults.WindowHeight;
+            }
+
+            // Camera
+            if (CameraZoom < 1 || CameraZoom > 10000)
+            {
+                fixes.Add($"CameraZoom was {CameraZoom}, reset to {defaults.CameraZoom}");
+                CameraZoom = defaults.CameraZoom;
+            }
+
+            // GPS update rate
+            if (GpsUpdateRate < 1 || GpsUpdateRate > 100)
+            {
+                fixes.Add($"GpsUpdateRate was {GpsUpdateRate}, reset to {defaults.GpsUpdateRate}");
+                GpsUpdateRate = defaults.GpsUpdateRate;
+            }
+
+            // NTRIP port
+            if (NtripCasterPort < 1 || NtripCasterPort > 65535)
+            {
+                fixes.Add($"NtripCasterPort was {NtripCasterPort}, reset to {defaults.NtripCasterPort}");
+                NtripCasterPort = defaults.NtripCasterPort;
+            }
+
+            return fixes;
+        }
     }
 }

--- a/Shared/AgValoniaGPS.Models/Configuration/SimulatorConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/SimulatorConfig.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using ReactiveUI;
 
 namespace AgValoniaGPS.Models.Configuration;
@@ -35,14 +36,14 @@ public class SimulatorConfig : ReactiveObject
     public double Latitude
     {
         get => _latitude;
-        set => this.RaiseAndSetIfChanged(ref _latitude, value);
+        set => this.RaiseAndSetIfChanged(ref _latitude, Math.Clamp(value, -90, 90));
     }
 
     private double _longitude = -74.0060;
     public double Longitude
     {
         get => _longitude;
-        set => this.RaiseAndSetIfChanged(ref _longitude, value);
+        set => this.RaiseAndSetIfChanged(ref _longitude, Math.Clamp(value, -180, 180));
     }
 
     private double _heading;

--- a/Shared/AgValoniaGPS.Services/DebugDumpService.cs
+++ b/Shared/AgValoniaGPS.Services/DebugDumpService.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using AgValoniaGPS.Models;
@@ -141,6 +142,18 @@ public class DebugDumpService
     private static string BuildSystemInfo()
     {
         var sb = new StringBuilder();
+
+        // App version + git hash from AssemblyInformationalVersion
+        var assembly = typeof(DebugDumpService).Assembly;
+        var infoVersion = assembly
+            .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "unknown";
+        var fileVersion = assembly
+            .GetCustomAttribute<System.Reflection.AssemblyFileVersionAttribute>()
+            ?.Version ?? "unknown";
+
+        sb.AppendLine($"App Version: {fileVersion}");
+        sb.AppendLine($"Build Info: {infoVersion}");
         sb.AppendLine($"Timestamp: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine($"OS: {Environment.OSVersion}");
         sb.AppendLine($"Runtime: {Environment.Version}");

--- a/Shared/AgValoniaGPS.Services/DebugDumpService.cs
+++ b/Shared/AgValoniaGPS.Services/DebugDumpService.cs
@@ -1,0 +1,257 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Logging;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Creates a debug dump zip containing logs, settings, field data, and runtime state.
+/// For bug reporting and diagnostics.
+/// </summary>
+public class DebugDumpService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals
+    };
+
+    /// <summary>
+    /// Create a debug dump zip file containing all diagnostic information.
+    /// Returns the path to the created zip file.
+    /// </summary>
+    public static string CreateDump(
+        ISettingsService settingsService,
+        ApplicationState appState,
+        string? additionalNotes = null)
+    {
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        var dumpDir = Path.Combine(Path.GetTempPath(), "AgValoniaGPS", "dumps");
+        Directory.CreateDirectory(dumpDir);
+        var zipPath = Path.Combine(dumpDir, $"debug_dump_{timestamp}.zip");
+
+        using var zipStream = File.Create(zipPath);
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Create);
+
+        // 1. System info
+        AddTextEntry(archive, "system_info.txt", BuildSystemInfo());
+
+        // 2. App settings
+        try
+        {
+            var settingsJson = JsonSerializer.Serialize(settingsService.Settings, JsonOptions);
+            AddTextEntry(archive, "appsettings.json", settingsJson);
+        }
+        catch (Exception ex)
+        {
+            AddTextEntry(archive, "appsettings_error.txt", ex.ToString());
+        }
+
+        // 3. Configuration store snapshot
+        try
+        {
+            var configSnapshot = BuildConfigSnapshot();
+            AddTextEntry(archive, "configuration.json", configSnapshot);
+        }
+        catch (Exception ex)
+        {
+            AddTextEntry(archive, "configuration_error.txt", ex.ToString());
+        }
+
+        // 4. Runtime state snapshot
+        try
+        {
+            var stateSnapshot = BuildStateSnapshot(appState);
+            AddTextEntry(archive, "runtime_state.json", stateSnapshot);
+        }
+        catch (Exception ex)
+        {
+            AddTextEntry(archive, "state_error.txt", ex.ToString());
+        }
+
+        // 5. Log entries
+        try
+        {
+            var logs = BuildLogDump();
+            AddTextEntry(archive, "logs.txt", logs);
+        }
+        catch (Exception ex)
+        {
+            AddTextEntry(archive, "logs_error.txt", ex.ToString());
+        }
+
+        // 6. Current field files (if a field is open)
+        try
+        {
+            var fieldDir = appState.Field.ActiveField?.DirectoryPath;
+            if (!string.IsNullOrEmpty(fieldDir) && Directory.Exists(fieldDir))
+            {
+                foreach (var file in Directory.GetFiles(fieldDir))
+                {
+                    var fileName = Path.GetFileName(file);
+                    // Skip large binary files
+                    var ext = Path.GetExtension(file).ToLowerInvariant();
+                    if (ext == ".bin" && new FileInfo(file).Length > 5_000_000)
+                        continue;
+
+                    var entry = archive.CreateEntry($"field/{fileName}");
+                    using var entryStream = entry.Open();
+                    using var fileStream = File.OpenRead(file);
+                    fileStream.CopyTo(entryStream);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AddTextEntry(archive, "field_error.txt", ex.ToString());
+        }
+
+        // 7. Current vehicle profile
+        try
+        {
+            var profileName = ConfigurationStore.Instance.ActiveProfileName;
+            if (!string.IsNullOrEmpty(profileName))
+            {
+                AddTextEntry(archive, "active_profile_name.txt", profileName);
+            }
+        }
+        catch { }
+
+        // 8. User notes
+        if (!string.IsNullOrEmpty(additionalNotes))
+        {
+            AddTextEntry(archive, "user_notes.txt", additionalNotes);
+        }
+
+        return zipPath;
+    }
+
+    private static string BuildSystemInfo()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Timestamp: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"OS: {Environment.OSVersion}");
+        sb.AppendLine($"Runtime: {Environment.Version}");
+        sb.AppendLine($"64-bit OS: {Environment.Is64BitOperatingSystem}");
+        sb.AppendLine($"64-bit Process: {Environment.Is64BitProcess}");
+        sb.AppendLine($"Machine: {Environment.MachineName}");
+        sb.AppendLine($"Processors: {Environment.ProcessorCount}");
+        sb.AppendLine($"Working Set: {Environment.WorkingSet / 1024 / 1024}MB");
+        return sb.ToString();
+    }
+
+    private static string BuildConfigSnapshot()
+    {
+        var store = ConfigurationStore.Instance;
+        var snapshot = new
+        {
+            Vehicle = new
+            {
+                store.Vehicle.Name,
+                store.Vehicle.Wheelbase,
+                store.Vehicle.TrackWidth,
+                store.Vehicle.AntennaHeight,
+                store.Vehicle.AntennaPivot,
+                store.Vehicle.AntennaOffset,
+                store.Vehicle.MaxSteerAngle
+            },
+            Tool = new
+            {
+                store.Tool.Width,
+                store.Tool.Overlap,
+                store.Tool.Offset,
+                store.Tool.HitchLength,
+                store.Tool.TrailingHitchLength,
+                store.Tool.IsToolTrailing,
+                store.Tool.IsToolRearFixed,
+                store.Tool.IsToolTBT,
+                store.Tool.IsMultiColoredSections
+            },
+            Guidance = new
+            {
+                store.Guidance.GoalPointLookAheadHold,
+                store.Guidance.StanleyHeadingErrorGain,
+                store.Guidance.StanleyDistanceErrorGain,
+                store.Guidance.UTurnRadius
+            },
+            NumSections = store.NumSections,
+            IsMetric = store.IsMetric,
+            ActiveProfile = store.ActiveProfileName
+        };
+        return JsonSerializer.Serialize(snapshot, JsonOptions);
+    }
+
+    private static string BuildStateSnapshot(ApplicationState state)
+    {
+        var snapshot = new
+        {
+            Vehicle = new
+            {
+                state.Vehicle.Latitude,
+                state.Vehicle.Longitude,
+                state.Vehicle.Easting,
+                state.Vehicle.Northing,
+                state.Vehicle.Heading,
+                Speed = state.Vehicle.Speed,
+                state.Vehicle.FixQuality,
+                state.Vehicle.SatelliteCount,
+                state.Vehicle.Hdop
+            },
+            Field = new
+            {
+                ActiveField = state.Field.ActiveField?.Name ?? "None",
+                HasBoundary = state.Field.CurrentBoundary?.IsValid ?? false,
+                HasHeadland = state.Field.HasHeadland,
+                HeadlandDistance = state.Field.HeadlandDistance,
+                TrackCount = state.Field.Tracks.Count,
+                ActiveTrack = state.Field.ActiveTrack?.Name,
+                OriginLat = state.Field.OriginLatitude,
+                OriginLon = state.Field.OriginLongitude
+            },
+            Guidance = new
+            {
+                state.Guidance.CrossTrackError,
+                state.Guidance.SteerAngle,
+                state.Guidance.HeadingError
+            },
+            UI = new
+            {
+                ActiveDialog = state.UI.ActiveDialog.ToString(),
+                state.UI.IsSimulatorPanelVisible,
+                state.UI.IsBoundaryPanelVisible
+            }
+        };
+        return JsonSerializer.Serialize(snapshot, JsonOptions);
+    }
+
+    private static string BuildLogDump()
+    {
+        var sb = new StringBuilder();
+        var entries = LogStore.Instance.GetSnapshot();
+        foreach (var entry in entries)
+        {
+            sb.AppendLine($"[{entry.Timestamp:HH:mm:ss.fff}] [{entry.Level}] {entry.Category}: {entry.Message}");
+        }
+        return sb.ToString();
+    }
+
+    private static void AddTextEntry(ZipArchive archive, string name, string content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var stream = entry.Open();
+        using var writer = new StreamWriter(stream, Encoding.UTF8);
+        writer.Write(content);
+    }
+}

--- a/Shared/AgValoniaGPS.Services/SettingsService.cs
+++ b/Shared/AgValoniaGPS.Services/SettingsService.cs
@@ -89,6 +89,14 @@ namespace AgValoniaGPS.Services
                 if (loadedSettings != null)
                 {
                     Settings = loadedSettings;
+
+                    // Validate loaded settings and fix out-of-range values
+                    var fixes = Settings.ValidateAndFix();
+                    foreach (var fix in fixes)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"[Settings] Validation fix: {fix}");
+                    }
+
                     Settings.IsFirstRun = false;
                     Settings.LastRunDate = DateTime.Now;
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -130,7 +130,25 @@ public partial class MainViewModel
         {
             State.UI.CloseDialog();
         });
+
+        // Debug Dump (#127)
+        CreateDebugDumpCommand = ReactiveCommand.Create(() =>
+        {
+            try
+            {
+                var zipPath = Services.DebugDumpService.CreateDump(_settingsService, _appState);
+                StatusMessage = $"Debug dump saved: {zipPath}";
+                _logger.LogInformation($"Debug dump created: {zipPath}");
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = $"Debug dump failed: {ex.Message}";
+                _logger.LogError(ex, "Debug dump failed");
+            }
+        });
     }
+
+    public ICommand? CreateDebugDumpCommand { get; private set; }
 
     private void RefreshAppDirectories()
     {

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -100,6 +100,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Button Classes="ModernButton" Content="Help" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
             <Button Classes="ModernButton" Content="About" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAboutDialogCommand}"/>
+            <Button Classes="ModernButton" Content="Bug Report Dump" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding CreateDebugDumpCommand}"/>
         </StackPanel>
     </Border>
 </UserControl>

--- a/Tests/AgValoniaGPS.Services.Tests/SettingsValidationTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SettingsValidationTests.cs
@@ -1,0 +1,104 @@
+using AgValoniaGPS.Models;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Tests that AppSettings validation catches and fixes corrupt values.
+/// </summary>
+[TestFixture]
+public class SettingsValidationTests
+{
+    [Test]
+    public void ValidateAndFix_ValidSettings_NoFixes()
+    {
+        var settings = new AppSettings();
+        var fixes = settings.ValidateAndFix();
+        Assert.That(fixes, Is.Empty);
+    }
+
+    [Test]
+    public void ValidateAndFix_CorruptLongitude_ResetsToDefault()
+    {
+        var settings = new AppSettings { SimulatorLongitude = 71280000 };
+        var fixes = settings.ValidateAndFix();
+
+        Assert.That(fixes, Has.Count.GreaterThan(0));
+        Assert.That(settings.SimulatorLongitude, Is.EqualTo(-74.006).Within(0.001));
+    }
+
+    [Test]
+    public void ValidateAndFix_CorruptLatitude_ResetsToDefault()
+    {
+        var settings = new AppSettings { SimulatorLatitude = -100 };
+        var fixes = settings.ValidateAndFix();
+
+        Assert.That(fixes, Has.Count.GreaterThan(0));
+        Assert.That(settings.SimulatorLatitude, Is.EqualTo(40.7128).Within(0.001));
+    }
+
+    [Test]
+    public void ValidateAndFix_ValidCoordinates_Preserved()
+    {
+        var settings = new AppSettings
+        {
+            SimulatorLatitude = 51.5074,
+            SimulatorLongitude = -0.1278
+        };
+        var fixes = settings.ValidateAndFix();
+
+        Assert.That(fixes, Is.Empty);
+        Assert.That(settings.SimulatorLatitude, Is.EqualTo(51.5074));
+        Assert.That(settings.SimulatorLongitude, Is.EqualTo(-0.1278));
+    }
+
+    [Test]
+    public void ValidateAndFix_ZeroWindowSize_ResetsToDefault()
+    {
+        var settings = new AppSettings { WindowWidth = 0, WindowHeight = 50 };
+        var fixes = settings.ValidateAndFix();
+
+        Assert.That(fixes, Has.Count.EqualTo(2));
+        Assert.That(settings.WindowWidth, Is.EqualTo(1200));
+        Assert.That(settings.WindowHeight, Is.EqualTo(800));
+    }
+
+    [Test]
+    public void ValidateAndFix_NegativeGpsRate_ResetsToDefault()
+    {
+        var settings = new AppSettings { GpsUpdateRate = -5 };
+        var fixes = settings.ValidateAndFix();
+
+        Assert.That(settings.GpsUpdateRate, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void ValidateAndFix_InvalidPort_ResetsToDefault()
+    {
+        var settings = new AppSettings { NtripCasterPort = 999999 };
+        var fixes = settings.ValidateAndFix();
+
+        Assert.That(settings.NtripCasterPort, Is.EqualTo(2101));
+    }
+
+    [Test]
+    public void SimulatorConfig_ClampLatitude()
+    {
+        var config = new AgValoniaGPS.Models.Configuration.SimulatorConfig();
+        config.Latitude = 100;
+        Assert.That(config.Latitude, Is.EqualTo(90));
+
+        config.Latitude = -100;
+        Assert.That(config.Latitude, Is.EqualTo(-90));
+    }
+
+    [Test]
+    public void SimulatorConfig_ClampLongitude()
+    {
+        var config = new AgValoniaGPS.Models.Configuration.SimulatorConfig();
+        config.Longitude = 71280000;
+        Assert.That(config.Longitude, Is.EqualTo(180));
+
+        config.Longitude = -200;
+        Assert.That(config.Longitude, Is.EqualTo(-180));
+    }
+}


### PR DESCRIPTION
Refs #127

## Summary
"Bug Report Dump" button in File menu creates a zip file with all diagnostic data:

**Contents:**
- `system_info.txt` - OS, runtime, memory, CPU count
- `appsettings.json` - all persisted settings
- `configuration.json` - vehicle, tool, guidance config snapshot
- `runtime_state.json` - GPS position, field, guidance, UI state
- `logs.txt` - in-memory log entries
- `field/` - all files from current field directory (geojson, boundary, tracks)
- `active_profile_name.txt`

Zip saved to `{temp}/AgValoniaGPS/dumps/debug_dump_{timestamp}.zip`

This is the quick dump version. Full bug report form with user input fields (#127) can be added later.

## Test plan
- [ ] Click "Bug Report Dump" in File menu
- [ ] Verify zip created at path shown in status message
- [ ] Open zip, verify all sections populated
- [ ] Verify field files included when field is open