### PR TITLE
Add virtual UDP modules for integration testing

### DIFF
--- a/Shared/AgValoniaGPS.Models/VehicleState.cs
+++ b/Shared/AgValoniaGPS.Models/VehicleState.cs
@@ -123,6 +123,22 @@ public struct VehicleState
     public bool MasterSectionOn;
 
     // ═══════════════════════════════════════════════════════════════════════
+    // Machine Control (PGN 239 output)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// <summary>U-turn active state (sent to machine module)</summary>
+    public bool IsInUTurn;
+
+    /// <summary>Hydraulic lift state: 0=down, 1=up, 2=transitioning</summary>
+    public byte HydLiftState;
+
+    /// <summary>Tramline control byte</summary>
+    public byte TramState;
+
+    /// <summary>Geo-fence stop: 0=ok, 1=out of bounds</summary>
+    public byte GeoStopState;
+
+    // ═══════════════════════════════════════════════════════════════════════
     // Switch States (received from hardware via PGN)
     // ═══════════════════════════════════════════════════════════════════════
 

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -242,6 +242,12 @@ public class AutoSteerService : IAutoSteerService
         _driftNorthing = driftNorthing;
     }
 
+    public void SetMachineState(ushort sectionBits, bool isInUTurn)
+    {
+        _state.SectionStates = sectionBits;
+        _state.IsInUTurn = isInUTurn;
+    }
+
     /// <summary>
     /// Set the current track for guidance.
     /// Called by MainViewModel when active track changes.

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -375,6 +375,15 @@ public class AutoSteerService : IAutoSteerService
         // This keeps the module informed of current position/speed even when not engaged
         var pgn = PgnBuilder.BuildAutoSteerPgn(ref _state);
         _udpService.SendToModules(pgn);
+
+        // Send PGN 239 (Machine Data) - section control, speed, tramline state
+        // Sent every GPS cycle so machine module has current section/speed info
+        var machinePgn = PgnBuilder.BuildMachinePgn(ref _state,
+            uturn: _state.IsInUTurn ? (byte)1 : (byte)0,
+            hydLift: _state.HydLiftState,
+            tram: _state.TramState,
+            geoStop: _state.GeoStopState);
+        _udpService.SendToModules(machinePgn);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
@@ -123,6 +123,12 @@ public interface IAutoSteerService
     /// </summary>
     void SetDriftCompensation(double driftEasting, double driftNorthing);
 
+    /// <summary>
+    /// Update machine control state sent via PGN 239.
+    /// Called by ViewModel after section control updates.
+    /// </summary>
+    void SetMachineState(ushort sectionBits, bool isInUTurn);
+
     // ═══════════════════════════════════════════════════════════════════════
     // Module Feedback (PGN 253, 250)
     // ═══════════════════════════════════════════════════════════════════════

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -737,6 +737,9 @@ public partial class MainViewModel : ReactiveObject
         _sectionControlService.Update(e.ToolPosition, e.ToolHeading, e.VehicleHeading, Speed);
         _lastSectionControlMs = _updateSw.Elapsed.TotalMilliseconds;
 
+        // Push section bits + u-turn state to AutoSteerService for PGN 239
+        _autoSteerService.SetMachineState(_sectionControlService.GetSectionBits(), _isInYouTurn);
+
         // Update coverage painting - paint when sections are active and moving
         _updateSw.Restart();
         UpdateCoveragePainting(e.ToolPosition, e.ToolHeading);

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/PgnProtocol.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/PgnProtocol.cs
@@ -1,0 +1,159 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+
+namespace AgValoniaGPS.IntegrationTests.VirtualModules;
+
+/// <summary>
+/// Shared PGN protocol constants and helpers for virtual modules.
+/// Matches AgOpenGPS/AgValoniaGPS wire format.
+/// </summary>
+public static class PgnProtocol
+{
+    public const byte HEADER1 = 0x80;
+    public const byte HEADER2 = 0x81;
+    public const byte SOURCE_HOST = 0x7F;   // From AgOpenGPS/AgIO
+    public const byte SOURCE_MODULE = 0x7F; // From module (same source byte)
+
+    // PGN numbers - Host to Module
+    public const byte PGN_AUTOSTEER_TO_MODULE = 0xFE;  // 254
+    public const byte PGN_MACHINE_TO_MODULE = 0xEF;     // 239
+    public const byte PGN_STEER_SETTINGS = 0xFC;        // 252
+    public const byte PGN_STEER_CONFIG = 0xFB;          // 251
+    public const byte PGN_MACHINE_CONFIG = 0xEE;        // 238
+    public const byte PGN_HELLO_FROM_HOST = 0xC8;       // 200
+    public const byte PGN_SCAN = 0xCA;                  // 202
+    public const byte PGN_IP_CONFIG = 0xC9;             // 201
+
+    // PGN numbers - Module to Host
+    public const byte PGN_STEER_DATA = 0xFD;            // 253
+    public const byte PGN_SENSOR_DATA = 0xFA;           // 250
+    public const byte PGN_HELLO_AUTOSTEER = 0x7E;       // 126
+    public const byte PGN_HELLO_MACHINE = 0x7B;         // 123
+    public const byte PGN_HELLO_IMU = 0x79;             // 121
+    public const byte PGN_SCAN_REPLY = 0xCB;            // 203
+
+    /// <summary>
+    /// Build a complete PGN packet with header and CRC.
+    /// </summary>
+    public static byte[] BuildPacket(byte pgn, byte[] data)
+    {
+        var packet = new byte[5 + data.Length + 1]; // header(5) + data + crc(1)
+        packet[0] = HEADER1;
+        packet[1] = HEADER2;
+        packet[2] = SOURCE_MODULE;
+        packet[3] = pgn;
+        packet[4] = (byte)data.Length;
+        Array.Copy(data, 0, packet, 5, data.Length);
+        packet[^1] = CalculateCrc(packet);
+        return packet;
+    }
+
+    /// <summary>
+    /// Build a hello response packet for a module type.
+    /// </summary>
+    public static byte[] BuildHelloPacket(byte helloPgn)
+    {
+        return BuildPacket(helloPgn, new byte[] { helloPgn, helloPgn, 0x05 });
+    }
+
+    /// <summary>
+    /// Calculate CRC: sum of bytes 2 through N-1.
+    /// </summary>
+    public static byte CalculateCrc(byte[] packet)
+    {
+        byte crc = 0;
+        for (int i = 2; i < packet.Length - 1; i++)
+            crc += packet[i];
+        return crc;
+    }
+
+    /// <summary>
+    /// Validate packet header and CRC.
+    /// </summary>
+    public static bool IsValidPacket(byte[] data, int length)
+    {
+        if (length < 6) return false;
+        if (data[0] != HEADER1 || data[1] != HEADER2) return false;
+
+        byte crc = 0;
+        for (int i = 2; i < length - 1; i++)
+            crc += data[i];
+        return crc == data[length - 1];
+    }
+
+    /// <summary>
+    /// Extract PGN number from a valid packet.
+    /// </summary>
+    public static byte GetPgn(byte[] data) => data[3];
+
+    /// <summary>
+    /// Extract data length from a valid packet.
+    /// </summary>
+    public static byte GetDataLength(byte[] data) => data[4];
+
+    /// <summary>
+    /// Parse PGN 254 (AutoSteer data from host).
+    /// </summary>
+    public static AutoSteerCommand ParseAutoSteerCommand(byte[] data)
+    {
+        return new AutoSteerCommand
+        {
+            SpeedKmh = BitConverter.ToInt16(data, 5) / 10.0,
+            Status = data[7],
+            SteerAngleDeg = BitConverter.ToInt16(data, 8) / 100.0,
+            CrossTrackErrorCm = (sbyte)data[10],
+            SectionBits1to8 = data[11],
+            SectionBits9to16 = data[12],
+            IsEngaged = (data[7] & 0x04) != 0,
+            IsGpsValid = (data[7] & 0x08) != 0
+        };
+    }
+
+    /// <summary>
+    /// Parse PGN 239 (Machine data from host).
+    /// </summary>
+    public static MachineCommand ParseMachineCommand(byte[] data)
+    {
+        return new MachineCommand
+        {
+            UTurnState = data[5],
+            SpeedByte = data[6],
+            HydLiftState = data[7],
+            TramState = data[8],
+            GeoStopState = data[9],
+            SectionBits1to8 = data[11],
+            SectionBits9to16 = data[12]
+        };
+    }
+}
+
+public struct AutoSteerCommand
+{
+    public double SpeedKmh;
+    public byte Status;
+    public double SteerAngleDeg;
+    public sbyte CrossTrackErrorCm;
+    public byte SectionBits1to8;
+    public byte SectionBits9to16;
+    public bool IsEngaged;
+    public bool IsGpsValid;
+}
+
+public struct MachineCommand
+{
+    public byte UTurnState;
+    public byte SpeedByte;
+    public byte HydLiftState;
+    public byte TramState;
+    public byte GeoStopState;
+    public byte SectionBits1to8;
+    public byte SectionBits9to16;
+    public ushort SectionBits => (ushort)(SectionBits1to8 | (SectionBits9to16 << 8));
+}

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
@@ -1,0 +1,179 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgValoniaGPS.IntegrationTests.VirtualModules;
+
+/// <summary>
+/// Virtual GPS receiver that sends $PANDA NMEA sentences via UDP.
+/// Supports single and dual antenna configurations.
+/// </summary>
+public class VirtualGpsReceiver : IDisposable
+{
+    private readonly UdpClient _udp;
+    private readonly IPEndPoint _target;
+    private CancellationTokenSource? _cts;
+    private Task? _sendTask;
+
+    // Position state
+    public double Latitude { get; set; } = 43.712800;
+    public double Longitude { get; set; } = -74.006000;
+    public double Altitude { get; set; } = 100.0;
+    public double HeadingDegrees { get; set; }
+    public double SpeedKnots { get; set; }
+    public int FixQuality { get; set; } = 4; // RTK Fixed
+    public int Satellites { get; set; } = 12;
+    public double Hdop { get; set; } = 0.7;
+    public double DifferentialAge { get; set; } = 1.0;
+
+    // IMU data (embedded in $PANDA)
+    public double RollDegrees { get; set; }
+    public double PitchDegrees { get; set; }
+    public double YawRateDegPerSec { get; set; }
+
+    // Dual antenna
+    public bool IsDualAntenna { get; set; }
+    public double DualHeadingDegrees { get; set; }
+
+    // Timing
+    public int UpdateRateHz { get; set; } = 10;
+
+    // Counters for test verification
+    public long SentCount { get; private set; }
+
+    public VirtualGpsReceiver(int targetPort = 9999, string targetIp = "127.0.0.1")
+    {
+        _udp = new UdpClient();
+        _target = new IPEndPoint(IPAddress.Parse(targetIp), targetPort);
+    }
+
+    public void Start()
+    {
+        _cts = new CancellationTokenSource();
+        _sendTask = Task.Run(() => SendLoop(_cts.Token));
+    }
+
+    public void Stop()
+    {
+        _cts?.Cancel();
+        _sendTask?.Wait(TimeSpan.FromSeconds(2));
+    }
+
+    /// <summary>
+    /// Send a single $PANDA sentence immediately (for test control).
+    /// </summary>
+    public void SendOnce()
+    {
+        var sentence = BuildPandaSentence();
+        var bytes = Encoding.ASCII.GetBytes(sentence);
+        _udp.Send(bytes, bytes.Length, _target);
+        SentCount++;
+    }
+
+    /// <summary>
+    /// Move the virtual GPS by applying speed and heading for one time step.
+    /// </summary>
+    public void Step(double deltaSeconds)
+    {
+        double speedMs = SpeedKnots * 0.514444; // knots to m/s
+        double headingRad = HeadingDegrees * Math.PI / 180.0;
+
+        // Approximate: 1 degree latitude ~ 111,320m, 1 degree longitude ~ 111,320 * cos(lat)
+        double dNorth = speedMs * Math.Cos(headingRad) * deltaSeconds;
+        double dEast = speedMs * Math.Sin(headingRad) * deltaSeconds;
+
+        Latitude += dNorth / 111320.0;
+        Longitude += dEast / (111320.0 * Math.Cos(Latitude * Math.PI / 180.0));
+    }
+
+    private async Task SendLoop(CancellationToken ct)
+    {
+        int intervalMs = 1000 / UpdateRateHz;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                SendOnce();
+                await Task.Delay(intervalMs, ct);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    private string BuildPandaSentence()
+    {
+        // Format: $PANDA,time,lat,N/S,lon,E/W,fix,sats,hdop,alt,age,speed,heading,roll,pitch,yaw*checksum
+        string time = DateTime.UtcNow.ToString("HHmmss.ff", CultureInfo.InvariantCulture);
+        string lat = FormatLatitude(Latitude);
+        string ns = Latitude >= 0 ? "N" : "S";
+        string lon = FormatLongitude(Longitude);
+        string ew = Longitude >= 0 ? "E" : "W";
+
+        var sb = new StringBuilder();
+        sb.Append("$PANDA,");
+        sb.Append(time); sb.Append(',');
+        sb.Append(lat); sb.Append(',');
+        sb.Append(ns); sb.Append(',');
+        sb.Append(lon); sb.Append(',');
+        sb.Append(ew); sb.Append(',');
+        sb.Append(FixQuality.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(Satellites.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(Hdop.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(Altitude.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(DifferentialAge.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(SpeedKnots.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(HeadingDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(RollDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(PitchDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(YawRateDegPerSec.ToString("F2", CultureInfo.InvariantCulture));
+
+        // Calculate NMEA checksum (XOR of all chars between $ and *)
+        string body = sb.ToString().Substring(1); // Skip the $
+        byte checksum = 0;
+        foreach (char c in body)
+            checksum ^= (byte)c;
+
+        sb.Append('*');
+        sb.Append(checksum.ToString("X2"));
+        sb.Append("\r\n");
+
+        return sb.ToString();
+    }
+
+    /// <summary>Format latitude as DDMM.MMMM</summary>
+    private static string FormatLatitude(double lat)
+    {
+        lat = Math.Abs(lat);
+        int degrees = (int)lat;
+        double minutes = (lat - degrees) * 60.0;
+        return $"{degrees:D2}{minutes:00.0000}";
+    }
+
+    /// <summary>Format longitude as DDDMM.MMMM</summary>
+    private static string FormatLongitude(double lon)
+    {
+        lon = Math.Abs(lon);
+        int degrees = (int)lon;
+        double minutes = (lon - degrees) * 60.0;
+        return $"{degrees:D3}{minutes:00.0000}";
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        _udp.Dispose();
+        _cts?.Dispose();
+    }
+}

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualMachineModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualMachineModule.cs
@@ -1,0 +1,145 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgValoniaGPS.IntegrationTests.VirtualModules;
+
+/// <summary>
+/// Virtual machine/implement module. Listens for PGN 239 (Machine Data) commands,
+/// responds with PGN 123 (hello). Simulates section relays, hydraulic lift,
+/// and tramline control.
+/// </summary>
+public class VirtualMachineModule : IDisposable
+{
+    private readonly UdpClient _udp;
+    private readonly IPEndPoint _hostEndpoint;
+    private CancellationTokenSource? _cts;
+    private Task? _receiveTask;
+    private Task? _helloTask;
+
+    // Current machine state (received from host)
+    public ushort ActiveSections { get; private set; }
+    public byte UTurnState { get; private set; }
+    public byte HydLiftState { get; private set; }
+    public byte TramState { get; private set; }
+    public byte GeoStopState { get; private set; }
+    public byte SpeedByte { get; private set; }
+
+    // Simulated hardware state
+    public bool IsHydraulicUp { get; set; }
+    public bool[] RelayStates { get; } = new bool[16];
+
+    // Counters
+    public long ReceivedCommandCount { get; private set; }
+    public long SentHelloCount { get; private set; }
+    public MachineCommand? LastCommand { get; private set; }
+
+    public VirtualMachineModule(int listenPort = 8888, int hostPort = 9999, string hostIp = "127.0.0.1")
+    {
+        _udp = new UdpClient(new IPEndPoint(IPAddress.Any, listenPort));
+        _hostEndpoint = new IPEndPoint(IPAddress.Parse(hostIp), hostPort);
+    }
+
+    public void Start()
+    {
+        _cts = new CancellationTokenSource();
+        _receiveTask = Task.Run(() => ReceiveLoop(_cts.Token));
+        _helloTask = Task.Run(() => HelloLoop(_cts.Token));
+    }
+
+    public void Stop()
+    {
+        _cts?.Cancel();
+        try { _receiveTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        try { _helloTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+    }
+
+    private async Task ReceiveLoop(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var result = await _udp.ReceiveAsync(ct);
+                ProcessPacket(result.Buffer);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (SocketException) { break; }
+        }
+    }
+
+    private void ProcessPacket(byte[] data)
+    {
+        if (!PgnProtocol.IsValidPacket(data, data.Length))
+            return;
+
+        byte pgn = PgnProtocol.GetPgn(data);
+
+        switch (pgn)
+        {
+            case PgnProtocol.PGN_MACHINE_TO_MODULE:
+                var cmd = PgnProtocol.ParseMachineCommand(data);
+                ActiveSections = cmd.SectionBits;
+                UTurnState = cmd.UTurnState;
+                HydLiftState = cmd.HydLiftState;
+                TramState = cmd.TramState;
+                GeoStopState = cmd.GeoStopState;
+                SpeedByte = cmd.SpeedByte;
+                LastCommand = cmd;
+                ReceivedCommandCount++;
+
+                // Update relay states from section bits
+                for (int i = 0; i < 16; i++)
+                    RelayStates[i] = (ActiveSections & (1 << i)) != 0;
+
+                // Simulate hydraulic lift
+                IsHydraulicUp = HydLiftState == 1;
+                break;
+
+            case PgnProtocol.PGN_HELLO_FROM_HOST:
+                SendHello();
+                break;
+
+            case PgnProtocol.PGN_MACHINE_CONFIG:
+                // Acknowledge config (no response needed)
+                break;
+        }
+    }
+
+    private void SendHello()
+    {
+        var packet = PgnProtocol.BuildHelloPacket(PgnProtocol.PGN_HELLO_MACHINE);
+        _udp.Send(packet, packet.Length, _hostEndpoint);
+        SentHelloCount++;
+    }
+
+    private async Task HelloLoop(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                SendHello();
+                await Task.Delay(1000, ct);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        _udp.Dispose();
+        _cts?.Dispose();
+    }
+}

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualModuleHub.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualModuleHub.cs
@@ -1,0 +1,125 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgValoniaGPS.IntegrationTests.VirtualModules;
+
+/// <summary>
+/// Orchestrates all virtual modules into a complete simulated hardware environment.
+/// Creates GPS, steer module, and machine module on configurable ports.
+///
+/// Usage:
+///   using var hub = new VirtualModuleHub();
+///   hub.Start();
+///   hub.Gps.HeadingDegrees = 90;
+///   hub.Gps.SpeedKnots = 5;
+///   // ... run tests ...
+///   hub.Stop();
+///
+/// For tests that share ports, use VirtualModuleHub.CreateIsolated() which
+/// allocates ephemeral ports to avoid conflicts.
+/// </summary>
+public class VirtualModuleHub : IDisposable
+{
+    public VirtualGpsReceiver Gps { get; }
+    public VirtualSteerModule Steer { get; }
+    public VirtualMachineModule Machine { get; }
+
+    /// <summary>Port the app should listen on (where GPS/modules send data).</summary>
+    public int HostReceivePort { get; }
+
+    /// <summary>Port where modules listen for commands from the app.</summary>
+    public int ModuleListenPort { get; }
+
+    public VirtualModuleHub(int hostReceivePort = 9999, int moduleListenPort = 8888)
+    {
+        HostReceivePort = hostReceivePort;
+        ModuleListenPort = moduleListenPort;
+
+        Gps = new VirtualGpsReceiver(targetPort: hostReceivePort);
+        // Steer and Machine share the same listen port (like real hardware on the same Teensy)
+        // For testing, we need separate instances so they each get their own socket.
+        // Use different ports or a shared listener. Here we use the hub as the dispatcher.
+        Steer = new VirtualSteerModule(listenPort: moduleListenPort, hostPort: hostReceivePort);
+        // Machine can't bind to the same port as Steer. In real hardware, one Teensy
+        // handles both. For testing, offset the machine to moduleListenPort + 1.
+        Machine = new VirtualMachineModule(listenPort: moduleListenPort + 1, hostPort: hostReceivePort);
+    }
+
+    /// <summary>
+    /// Create hub with ephemeral ports to avoid conflicts between parallel tests.
+    /// Returns the ports allocated so the app can be configured to use them.
+    /// </summary>
+    public static VirtualModuleHub CreateIsolated()
+    {
+        // Use high ephemeral ports to avoid conflicts
+        int basePort = 30000 + (Environment.CurrentManagedThreadId % 10000);
+        return new VirtualModuleHub(hostReceivePort: basePort, moduleListenPort: basePort + 1);
+    }
+
+    public void Start()
+    {
+        Steer.Start();
+        Machine.Start();
+        Gps.Start();
+    }
+
+    public void Stop()
+    {
+        Gps.Stop();
+        Steer.Stop();
+        Machine.Stop();
+    }
+
+    /// <summary>
+    /// Drive the virtual GPS in a straight line at given speed and heading.
+    /// Sends GPS updates for the specified duration.
+    /// </summary>
+    public async Task DriveAsync(double headingDeg, double speedKmh, double durationSeconds,
+        CancellationToken ct = default)
+    {
+        Gps.HeadingDegrees = headingDeg;
+        Gps.SpeedKnots = speedKmh / 1.852; // km/h to knots
+        double stepTime = 1.0 / Gps.UpdateRateHz;
+        int steps = (int)(durationSeconds * Gps.UpdateRateHz);
+
+        for (int i = 0; i < steps && !ct.IsCancellationRequested; i++)
+        {
+            Gps.Step(stepTime);
+            Gps.SendOnce();
+            await Task.Delay((int)(stepTime * 1000), ct);
+        }
+    }
+
+    /// <summary>
+    /// Send a burst of GPS positions without real-time delay (for fast tests).
+    /// </summary>
+    public void DriveFast(double headingDeg, double speedKmh, int frames)
+    {
+        Gps.HeadingDegrees = headingDeg;
+        Gps.SpeedKnots = speedKmh / 1.852;
+        double stepTime = 1.0 / Gps.UpdateRateHz;
+
+        for (int i = 0; i < frames; i++)
+        {
+            Gps.Step(stepTime);
+            Gps.SendOnce();
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        Gps.Dispose();
+        Steer.Dispose();
+        Machine.Dispose();
+    }
+}

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -1,0 +1,196 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgValoniaGPS.IntegrationTests.VirtualModules;
+
+/// <summary>
+/// Virtual steer module (Teensy). Listens for PGN 254 (AutoSteer) commands,
+/// responds with PGN 253 (steer feedback) and PGN 126 (hello).
+/// Simulates a wheel angle sensor (WAS) and steer motor.
+/// </summary>
+public class VirtualSteerModule : IDisposable
+{
+    private readonly UdpClient _udp;
+    private readonly IPEndPoint _hostEndpoint;
+    private CancellationTokenSource? _cts;
+    private Task? _receiveTask;
+    private Task? _helloTask;
+
+    // Simulated WAS (Wheel Angle Sensor) state
+    public double ActualSteerAngleDeg { get; set; }
+    public double CommandedSteerAngleDeg { get; private set; }
+    public bool SteerSwitchActive { get; set; } = true;
+    public bool WorkSwitchActive { get; set; }
+    public byte PwmDisplay { get; set; }
+
+    // IMU (if separate module, typically embedded in $PANDA now)
+    public double ImuHeadingDeg { get; set; }
+    public double ImuRollDeg { get; set; }
+
+    // Simulation behavior
+    public double SteerResponseRate { get; set; } = 0.5; // How fast WAS follows command (0-1)
+    public bool SimulateSteerResponse { get; set; } = true;
+
+    // Counters
+    public long ReceivedCommandCount { get; private set; }
+    public long SentFeedbackCount { get; private set; }
+    public long SentHelloCount { get; private set; }
+    public AutoSteerCommand? LastCommand { get; private set; }
+
+    public VirtualSteerModule(int listenPort = 8888, int hostPort = 9999, string hostIp = "127.0.0.1")
+    {
+        _udp = new UdpClient(new IPEndPoint(IPAddress.Any, listenPort));
+        _hostEndpoint = new IPEndPoint(IPAddress.Parse(hostIp), hostPort);
+    }
+
+    public void Start()
+    {
+        _cts = new CancellationTokenSource();
+        _receiveTask = Task.Run(() => ReceiveLoop(_cts.Token));
+        _helloTask = Task.Run(() => HelloLoop(_cts.Token));
+    }
+
+    public void Stop()
+    {
+        _cts?.Cancel();
+        try { _receiveTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        try { _helloTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+    }
+
+    /// <summary>
+    /// Send a single PGN 253 steer feedback packet.
+    /// </summary>
+    public void SendSteerFeedback()
+    {
+        var data = new byte[8];
+
+        // Bytes 0-1: Actual steer angle (degrees * 100, int16 LE)
+        short angleRaw = (short)(ActualSteerAngleDeg * 100);
+        data[0] = (byte)(angleRaw & 0xFF);
+        data[1] = (byte)((angleRaw >> 8) & 0xFF);
+
+        // Bytes 2-3: IMU heading (degrees * 10, int16 LE)
+        short headingRaw = (short)(ImuHeadingDeg * 10);
+        data[2] = (byte)(headingRaw & 0xFF);
+        data[3] = (byte)((headingRaw >> 8) & 0xFF);
+
+        // Bytes 4-5: IMU roll (degrees * 10, int16 LE)
+        short rollRaw = (short)(ImuRollDeg * 10);
+        data[4] = (byte)(rollRaw & 0xFF);
+        data[5] = (byte)((rollRaw >> 8) & 0xFF);
+
+        // Byte 6: Switch status
+        byte switches = 0;
+        if (!WorkSwitchActive) switches |= 0x01; // bit 0: work switch (inverted: 1=OFF)
+        if (SteerSwitchActive) switches |= 0x02;  // bit 1: steer switch
+        data[6] = switches;
+
+        // Byte 7: PWM display
+        data[7] = PwmDisplay;
+
+        var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_STEER_DATA, data);
+        _udp.Send(packet, packet.Length, _hostEndpoint);
+        SentFeedbackCount++;
+    }
+
+    /// <summary>
+    /// Send PGN 250 sensor data (pressure/current).
+    /// </summary>
+    public void SendSensorData(byte sensorValue)
+    {
+        var data = new byte[8];
+        data[0] = sensorValue;
+        var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_SENSOR_DATA, data);
+        _udp.Send(packet, packet.Length, _hostEndpoint);
+    }
+
+    private async Task ReceiveLoop(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var result = await _udp.ReceiveAsync(ct);
+                ProcessPacket(result.Buffer);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (SocketException) { break; }
+        }
+    }
+
+    private void ProcessPacket(byte[] data)
+    {
+        if (!PgnProtocol.IsValidPacket(data, data.Length))
+            return;
+
+        byte pgn = PgnProtocol.GetPgn(data);
+
+        switch (pgn)
+        {
+            case PgnProtocol.PGN_AUTOSTEER_TO_MODULE:
+                var cmd = PgnProtocol.ParseAutoSteerCommand(data);
+                CommandedSteerAngleDeg = cmd.SteerAngleDeg;
+                LastCommand = cmd;
+                ReceivedCommandCount++;
+
+                // Simulate WAS response
+                if (SimulateSteerResponse)
+                {
+                    ActualSteerAngleDeg += (CommandedSteerAngleDeg - ActualSteerAngleDeg) * SteerResponseRate;
+                }
+
+                // Send feedback after receiving command
+                SendSteerFeedback();
+                break;
+
+            case PgnProtocol.PGN_HELLO_FROM_HOST:
+                // Respond with steer module hello
+                SendHello();
+                break;
+
+            case PgnProtocol.PGN_STEER_SETTINGS:
+            case PgnProtocol.PGN_STEER_CONFIG:
+                // Acknowledge config packets (no response needed per protocol)
+                break;
+        }
+    }
+
+    private void SendHello()
+    {
+        var packet = PgnProtocol.BuildHelloPacket(PgnProtocol.PGN_HELLO_AUTOSTEER);
+        _udp.Send(packet, packet.Length, _hostEndpoint);
+        SentHelloCount++;
+    }
+
+    private async Task HelloLoop(CancellationToken ct)
+    {
+        // Send periodic hello even without host hello (for initial discovery)
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                SendHello();
+                await Task.Delay(1000, ct);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        _udp.Dispose();
+        _cts?.Dispose();
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/AgValoniaGPS.Services.Tests.csproj
+++ b/Tests/AgValoniaGPS.Services.Tests/AgValoniaGPS.Services.Tests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\AgValoniaGPS.Models\AgValoniaGPS.Models.csproj" />
     <ProjectReference Include="..\..\Shared\AgValoniaGPS.Services\AgValoniaGPS.Services.csproj" />
+    <ProjectReference Include="..\AgValoniaGPS.IntegrationTests\AgValoniaGPS.IntegrationTests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/AgValoniaGPS.Services.Tests/VirtualModuleTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/VirtualModuleTests.cs
@@ -308,6 +308,119 @@ public class VirtualModuleTests
         Assert.That(machine.SpeedByte, Is.EqualTo(200));
     }
 
+    [Test]
+    public async Task VirtualMachine_ReceivesPgnBuilderOutput()
+    {
+        // End-to-end: PgnBuilder.BuildMachinePgn → UDP → VirtualMachineModule parses it
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var machine = new VirtualMachineModule(listenPort: modulePort, hostPort: hostPort);
+        machine.Start();
+
+        // Build PGN 239 using the REAL PgnBuilder (same code AutoSteerService uses)
+        var state = new AgValoniaGPS.Models.VehicleState();
+        state.Speed = 18.5 / 3.6; // 18.5 km/h in m/s
+        state.SectionStates = 0x001F; // Sections 1-5 active
+
+        var pgnBytes = AgValoniaGPS.Services.AutoSteer.PgnBuilder.BuildMachinePgn(
+            ref state, uturn: 1, hydLift: 0, tram: 0, geoStop: 0);
+
+        // Send over UDP to virtual machine module
+        using var host = new UdpClient(hostPort);
+        var moduleEndpoint = new IPEndPoint(IPAddress.Loopback, modulePort);
+        host.Send(pgnBytes, pgnBytes.Length, moduleEndpoint);
+
+        await Task.Delay(500);
+
+        Assert.That(machine.ReceivedCommandCount, Is.EqualTo(1), "Should receive 1 command");
+        Assert.That(machine.ActiveSections, Is.EqualTo(0x001F), "Sections 1-5 active");
+        Assert.That(machine.RelayStates[0], Is.True, "Section 1 on");
+        Assert.That(machine.RelayStates[4], Is.True, "Section 5 on");
+        Assert.That(machine.RelayStates[5], Is.False, "Section 6 off");
+        Assert.That(machine.UTurnState, Is.EqualTo(1), "U-turn active");
+        Assert.That(machine.SpeedByte, Is.EqualTo(185), "Speed = 18.5 * 10");
+    }
+
+    [Test]
+    public async Task VirtualMachine_ReceivesAllSixteenSections()
+    {
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var machine = new VirtualMachineModule(listenPort: modulePort, hostPort: hostPort);
+        machine.Start();
+
+        // All 16 sections active
+        var state = new AgValoniaGPS.Models.VehicleState();
+        state.SectionStates = 0xFFFF;
+        state.Speed = 10.0 / 3.6; // 10 km/h in m/s
+
+        var pgnBytes = AgValoniaGPS.Services.AutoSteer.PgnBuilder.BuildMachinePgn(ref state);
+
+        using var host = new UdpClient(hostPort);
+        host.Send(pgnBytes, pgnBytes.Length, new IPEndPoint(IPAddress.Loopback, modulePort));
+
+        await Task.Delay(500);
+
+        Assert.That(machine.ActiveSections, Is.EqualTo(0xFFFF), "All 16 sections active");
+        for (int i = 0; i < 16; i++)
+            Assert.That(machine.RelayStates[i], Is.True, $"Section {i + 1} relay on");
+    }
+
+    [Test]
+    public async Task VirtualMachine_SpeedClampedAt255()
+    {
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var machine = new VirtualMachineModule(listenPort: modulePort, hostPort: hostPort);
+        machine.Start();
+
+        // Speed 30 km/h → 300 raw → clamped to 255
+        var state = new AgValoniaGPS.Models.VehicleState();
+        state.Speed = 30.0 / 3.6; // 30 km/h in m/s
+
+        var pgnBytes = AgValoniaGPS.Services.AutoSteer.PgnBuilder.BuildMachinePgn(ref state);
+
+        using var host = new UdpClient(hostPort);
+        host.Send(pgnBytes, pgnBytes.Length, new IPEndPoint(IPAddress.Loopback, modulePort));
+
+        await Task.Delay(500);
+
+        Assert.That(machine.SpeedByte, Is.EqualTo(255), "Speed byte clamped at 255");
+    }
+
+    [Test]
+    public async Task VirtualMachine_PgnBuilderCrcMatchesProtocol()
+    {
+        // Verify PgnBuilder's CRC is valid per PgnProtocol.IsValidPacket
+        var state = new AgValoniaGPS.Models.VehicleState();
+        state.SectionStates = 0x00AA;
+        state.Speed = 12.0 / 3.6; // 12 km/h in m/s
+
+        var pgnBytes = AgValoniaGPS.Services.AutoSteer.PgnBuilder.BuildMachinePgn(
+            ref state, uturn: 1, hydLift: 2, tram: 3, geoStop: 0);
+
+        Assert.That(PgnProtocol.IsValidPacket(pgnBytes, pgnBytes.Length), Is.True,
+            "PgnBuilder CRC must match PgnProtocol validation");
+
+        // Also verify the virtual module can parse it
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var machine = new VirtualMachineModule(listenPort: modulePort, hostPort: hostPort);
+        machine.Start();
+
+        using var host = new UdpClient(hostPort);
+        host.Send(pgnBytes, pgnBytes.Length, new IPEndPoint(IPAddress.Loopback, modulePort));
+
+        await Task.Delay(500);
+
+        Assert.That(machine.HydLiftState, Is.EqualTo(2));
+        Assert.That(machine.TramState, Is.EqualTo(3));
+    }
+
     #endregion
 
     #region Hub Integration Tests

--- a/Tests/AgValoniaGPS.Services.Tests/VirtualModuleTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/VirtualModuleTests.cs
@@ -1,0 +1,376 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AgValoniaGPS.IntegrationTests.VirtualModules;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class VirtualModuleTests
+{
+    #region PGN Protocol Tests
+
+    [Test]
+    public void PgnProtocol_BuildPacket_HasCorrectHeaderAndCrc()
+    {
+        var data = new byte[] { 0x01, 0x02, 0x03 };
+        var packet = PgnProtocol.BuildPacket(0xFD, data);
+
+        Assert.That(packet[0], Is.EqualTo(0x80), "Header1");
+        Assert.That(packet[1], Is.EqualTo(0x81), "Header2");
+        Assert.That(packet[2], Is.EqualTo(0x7F), "Source");
+        Assert.That(packet[3], Is.EqualTo(0xFD), "PGN");
+        Assert.That(packet[4], Is.EqualTo(3), "Data length");
+        Assert.That(packet[5], Is.EqualTo(0x01), "Data[0]");
+        Assert.That(packet[6], Is.EqualTo(0x02), "Data[1]");
+        Assert.That(packet[7], Is.EqualTo(0x03), "Data[2]");
+        Assert.That(PgnProtocol.IsValidPacket(packet, packet.Length), Is.True, "CRC valid");
+    }
+
+    [Test]
+    public void PgnProtocol_IsValidPacket_RejectsBadCrc()
+    {
+        var packet = PgnProtocol.BuildPacket(0xFD, new byte[] { 0x01 });
+        packet[^1] = 0xFF; // Corrupt CRC
+        Assert.That(PgnProtocol.IsValidPacket(packet, packet.Length), Is.False);
+    }
+
+    [Test]
+    public void PgnProtocol_HelloPacket_MatchesAgOpenFormat()
+    {
+        var hello = PgnProtocol.BuildHelloPacket(PgnProtocol.PGN_HELLO_AUTOSTEER);
+        Assert.That(hello[0], Is.EqualTo(0x80));
+        Assert.That(hello[1], Is.EqualTo(0x81));
+        Assert.That(hello[3], Is.EqualTo(0x7E), "PGN = 126 (autosteer hello)");
+        Assert.That(PgnProtocol.IsValidPacket(hello, hello.Length), Is.True);
+    }
+
+    [Test]
+    public void PgnProtocol_ParseMachineCommand_ExtractsSectionBits()
+    {
+        // Build a PGN 239 packet with sections 1, 3, 9 active
+        var data = new byte[8];
+        data[6] = 0x05; // bits 0 and 2 = sections 1 and 3
+        data[7] = 0x01; // bit 0 = section 9
+        var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_MACHINE_TO_MODULE, data);
+
+        var cmd = PgnProtocol.ParseMachineCommand(packet);
+        Assert.That(cmd.SectionBits, Is.EqualTo(0x0105));
+        Assert.That(cmd.SectionBits1to8, Is.EqualTo(0x05));
+        Assert.That(cmd.SectionBits9to16, Is.EqualTo(0x01));
+    }
+
+    [Test]
+    public void PgnProtocol_ParseAutoSteerCommand_ExtractsFields()
+    {
+        var data = new byte[8];
+        // Speed: 15.0 km/h = 150 raw
+        data[0] = 150 & 0xFF;
+        data[1] = (150 >> 8) & 0xFF;
+        // Status: engaged + GPS valid
+        data[2] = 0x0C;
+        // Steer angle: -12.5 degrees = -1250 raw
+        short angle = -1250;
+        data[3] = (byte)(angle & 0xFF);
+        data[4] = (byte)((angle >> 8) & 0xFF);
+        var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_AUTOSTEER_TO_MODULE, data);
+
+        var cmd = PgnProtocol.ParseAutoSteerCommand(packet);
+        Assert.That(cmd.SpeedKmh, Is.EqualTo(15.0).Within(0.1));
+        Assert.That(cmd.SteerAngleDeg, Is.EqualTo(-12.5).Within(0.1));
+        Assert.That(cmd.IsEngaged, Is.True);
+        Assert.That(cmd.IsGpsValid, Is.True);
+    }
+
+    #endregion
+
+    #region GPS Receiver Tests
+
+    [Test]
+    public void VirtualGps_SendOnce_ProducesValidPanda()
+    {
+        // Listen for a single NMEA sentence
+        using var listener = new UdpClient(0); // ephemeral port
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+
+        using var gps = new VirtualGpsReceiver(targetPort: port);
+        gps.Latitude = 43.712800;
+        gps.Longitude = -74.006000;
+        gps.HeadingDegrees = 90.0;
+        gps.SpeedKnots = 5.0;
+        gps.FixQuality = 4;
+        gps.Satellites = 12;
+        gps.RollDegrees = 1.5;
+
+        gps.SendOnce();
+
+        listener.Client.ReceiveTimeout = 2000;
+        IPEndPoint? remote = null;
+        var data = listener.Receive(ref remote);
+        var sentence = Encoding.ASCII.GetString(data).Trim();
+
+        Assert.That(sentence, Does.StartWith("$PANDA,"));
+        Assert.That(sentence, Does.Contain("*")); // Has checksum
+
+        // Parse the sentence
+        var parts = sentence.Split('*')[0].Split(',');
+        Assert.That(parts[0], Is.EqualTo("$PANDA"));
+        Assert.That(parts[3], Is.EqualTo("N")); // North hemisphere
+        Assert.That(parts[5], Is.EqualTo("W")); // West hemisphere
+        Assert.That(parts[6], Is.EqualTo("4")); // RTK Fixed
+        Assert.That(parts[7], Is.EqualTo("12")); // Satellites
+
+        // Verify NMEA checksum
+        string body = sentence.Substring(1, sentence.IndexOf('*') - 1);
+        byte expectedCrc = 0;
+        foreach (char c in body)
+            expectedCrc ^= (byte)c;
+        string crcStr = sentence.Substring(sentence.IndexOf('*') + 1);
+        byte actualCrc = byte.Parse(crcStr, NumberStyles.HexNumber);
+        Assert.That(actualCrc, Is.EqualTo(expectedCrc), "NMEA checksum mismatch");
+    }
+
+    [Test]
+    public void VirtualGps_PandaParsedByNmeaParser()
+    {
+        // Send $PANDA from virtual GPS → parse with real NmeaParserService
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+
+        using var gps = new VirtualGpsReceiver(targetPort: port);
+        gps.Latitude = 43.712800;
+        gps.Longitude = -74.006000;
+        gps.HeadingDegrees = 45.0;
+        gps.SpeedKnots = 10.0;
+        gps.FixQuality = 4;
+        gps.Satellites = 14;
+        gps.Hdop = 0.8;
+        gps.RollDegrees = -2.0;
+        gps.PitchDegrees = 1.0;
+        gps.YawRateDegPerSec = 0.5;
+
+        gps.SendOnce();
+
+        listener.Client.ReceiveTimeout = 2000;
+        IPEndPoint? remote = null;
+        var data = listener.Receive(ref remote);
+        var sentence = Encoding.ASCII.GetString(data).Trim();
+
+        // Parse with real NMEA parser, capturing via mock GpsService
+        var mockGps = Substitute.For<IGpsService>();
+        GpsData? received = null;
+        mockGps.When(x => x.UpdateGpsData(Arg.Any<GpsData>()))
+            .Do(ci => received = ci.Arg<GpsData>());
+
+        var parser = new NmeaParserService(mockGps);
+        parser.ParseSentence(sentence);
+
+        Assert.That(received, Is.Not.Null, "NmeaParser should parse the $PANDA sentence");
+        Assert.That(received!.CurrentPosition.Latitude, Is.EqualTo(43.712800).Within(0.001));
+        Assert.That(received.CurrentPosition.Longitude, Is.EqualTo(-74.006000).Within(0.001));
+        Assert.That(received.FixQuality, Is.EqualTo(4));
+        Assert.That(received.SatellitesInUse, Is.EqualTo(14));
+        Assert.That(received.Hdop, Is.EqualTo(0.8).Within(0.1));
+        Assert.That(received.CurrentPosition.Heading, Is.EqualTo(45.0).Within(0.1));
+        Assert.That(received.CurrentPosition.Speed, Is.GreaterThan(0)); // 10 knots in m/s
+    }
+
+    [Test]
+    public void VirtualGps_Step_MovesPosition()
+    {
+        using var gps = new VirtualGpsReceiver();
+        gps.Latitude = 0;
+        gps.Longitude = 0;
+        gps.HeadingDegrees = 0; // North
+        gps.SpeedKnots = 1.0;   // ~0.51 m/s
+
+        double startLat = gps.Latitude;
+        gps.Step(10.0); // 10 seconds
+
+        Assert.That(gps.Latitude, Is.GreaterThan(startLat),
+            "Moving north should increase latitude");
+    }
+
+    #endregion
+
+    #region Steer Module Tests
+
+    [Test]
+    public async Task VirtualSteer_RespondsToHello()
+    {
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var steer = new VirtualSteerModule(listenPort: modulePort, hostPort: hostPort);
+        using var host = new UdpClient(hostPort);
+        steer.Start();
+
+        // Send hello from host to module
+        var helloPacket = PgnProtocol.BuildPacket(PgnProtocol.PGN_HELLO_FROM_HOST,
+            new byte[] { 0xC8, 0xC8, 0x05 });
+        var moduleEndpoint = new IPEndPoint(IPAddress.Loopback, modulePort);
+        host.Send(helloPacket, helloPacket.Length, moduleEndpoint);
+
+        // Wait for hello response
+        host.Client.ReceiveTimeout = 2000;
+        await Task.Delay(200);
+
+        // Should have received at least one hello (periodic + response)
+        Assert.That(steer.SentHelloCount, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public async Task VirtualSteer_ProcessesAutoSteerCommand()
+    {
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var steer = new VirtualSteerModule(listenPort: modulePort, hostPort: hostPort);
+        steer.SimulateSteerResponse = true;
+        steer.SteerResponseRate = 1.0; // Instant response
+        steer.Start();
+
+        // Build PGN 254 with steer angle 15.0 degrees
+        var data = new byte[8];
+        short speed = 100; // 10 km/h
+        data[0] = (byte)(speed & 0xFF);
+        data[1] = (byte)((speed >> 8) & 0xFF);
+        data[2] = 0x0C; // engaged + GPS valid
+        short angle = 1500; // 15.0 degrees
+        data[3] = (byte)(angle & 0xFF);
+        data[4] = (byte)((angle >> 8) & 0xFF);
+
+        var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_AUTOSTEER_TO_MODULE, data);
+
+        using var host = new UdpClient(hostPort);
+        var moduleEndpoint = new IPEndPoint(IPAddress.Loopback, modulePort);
+        host.Send(packet, packet.Length, moduleEndpoint);
+
+        await Task.Delay(500);
+
+        Assert.That(steer.ReceivedCommandCount, Is.GreaterThan(0), "Should receive command");
+        Assert.That(steer.LastCommand!.Value.SteerAngleDeg, Is.EqualTo(15.0).Within(0.1));
+        Assert.That(steer.LastCommand!.Value.IsEngaged, Is.True);
+        Assert.That(steer.ActualSteerAngleDeg, Is.EqualTo(15.0).Within(0.5),
+            "WAS should follow commanded angle");
+    }
+
+    #endregion
+
+    #region Machine Module Tests
+
+    [Test]
+    public async Task VirtualMachine_TracksSectionStates()
+    {
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var machine = new VirtualMachineModule(listenPort: modulePort, hostPort: hostPort);
+        machine.Start();
+
+        // Build PGN 239 with sections 1,2,3 active and speed 20 km/h
+        var data = new byte[8];
+        data[0] = 0; // uturn
+        data[1] = 200; // speed * 10 = 20 km/h
+        data[6] = 0x07; // sections 1-3 active
+        data[7] = 0x00;
+
+        var packet = PgnProtocol.BuildPacket(PgnProtocol.PGN_MACHINE_TO_MODULE, data);
+
+        using var host = new UdpClient(hostPort);
+        var moduleEndpoint = new IPEndPoint(IPAddress.Loopback, modulePort);
+        host.Send(packet, packet.Length, moduleEndpoint);
+
+        await Task.Delay(500);
+
+        Assert.That(machine.ReceivedCommandCount, Is.GreaterThan(0));
+        Assert.That(machine.ActiveSections, Is.EqualTo(0x0007));
+        Assert.That(machine.RelayStates[0], Is.True, "Section 1 relay on");
+        Assert.That(machine.RelayStates[1], Is.True, "Section 2 relay on");
+        Assert.That(machine.RelayStates[2], Is.True, "Section 3 relay on");
+        Assert.That(machine.RelayStates[3], Is.False, "Section 4 relay off");
+        Assert.That(machine.SpeedByte, Is.EqualTo(200));
+    }
+
+    #endregion
+
+    #region Hub Integration Tests
+
+    [Test]
+    public void VirtualModuleHub_DriveFast_SendsMultipleGpsFrames()
+    {
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+
+        // Create hub sending to our listener port
+        using var hub = new VirtualModuleHub(hostReceivePort: port, moduleListenPort: GetEphemeralPort());
+
+        hub.Gps.Latitude = 43.0;
+        hub.Gps.Longitude = -74.0;
+        hub.DriveFast(headingDeg: 0, speedKmh: 36, frames: 50);
+
+        Assert.That(hub.Gps.SentCount, Is.EqualTo(50));
+        // At 36 km/h = 10 m/s, 50 frames at 10Hz = 5 seconds = 50m north
+        // 50m / 111320 m/deg = ~0.000449 degrees
+        Assert.That(hub.Gps.Latitude, Is.GreaterThan(43.0004),
+            "Should have moved north");
+    }
+
+    [Test]
+    public void VirtualModuleHub_DriveFast_AllFramesParseable()
+    {
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+        listener.Client.ReceiveTimeout = 1000;
+
+        using var hub = new VirtualModuleHub(hostReceivePort: port, moduleListenPort: GetEphemeralPort());
+        hub.DriveFast(headingDeg: 90, speedKmh: 20, frames: 10);
+
+        var mockGps = Substitute.For<IGpsService>();
+        int parsedCount = 0;
+        mockGps.When(x => x.UpdateGpsData(Arg.Any<GpsData>()))
+            .Do(ci => { if (ci.Arg<GpsData>().FixQuality > 0) parsedCount++; });
+        var parser = new NmeaParserService(mockGps);
+
+        // Read all sent frames
+        for (int i = 0; i < 10; i++)
+        {
+            try
+            {
+                IPEndPoint? remote = null;
+                var data = listener.Receive(ref remote);
+                var sentence = Encoding.ASCII.GetString(data).Trim();
+                parser.ParseSentence(sentence);
+            }
+            catch (SocketException) { break; }
+        }
+
+        Assert.That(parsedCount, Is.EqualTo(10),
+            "All frames should parse as valid GPS data");
+    }
+
+    #endregion
+
+    /// <summary>Get a random ephemeral port by binding to 0 and reading the assigned port.</summary>
+    private static int GetEphemeralPort()
+    {
+        using var tmp = new UdpClient(0);
+        return ((IPEndPoint)tmp.Client.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
Closes #53

## Summary
- **PGN 239 (Machine Data)** sent every GPS cycle alongside PGN 254
- Section bitmask wired from SectionControlService into PGN bytes 11-12
- U-turn state wired from YouTurn into PGN byte 5
- Speed, HydLift, Tram, GeoStop fields populated
- **Virtual UDP modules** for integration testing without hardware:
  - VirtualGpsReceiver: $PANDA NMEA with position, IMU, fix quality
  - VirtualSteerModule: PGN 254 listener, PGN 253 feedback, WAS simulation
  - VirtualMachineModule: PGN 239 listener, section relay tracking
  - VirtualModuleHub: orchestrator with DriveAsync/DriveFast helpers
- **17 tests** covering protocol, GPS parsing, module communication, and PGN 239 end-to-end

## Test plan
- [x] 17 virtual module tests pass
- [x] PgnBuilder output parsed correctly by virtual machine module over UDP
- [x] All 16 section bits verified through full pipeline
- [x] Speed byte clamping at 255 verified
- [x] CRC compatibility between PgnBuilder and PgnProtocol validated
- [x] $PANDA sentences parsed by real NmeaParserService

Generated with [Claude Code](https://claude.com/claude-code)