### PR TITLE
Add Machine Config (PGN 238) and Pin Config (PGN 236)

### DIFF
--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -242,6 +242,20 @@ public class AutoSteerService : IAutoSteerService
         _driftNorthing = driftNorthing;
     }
 
+    public void SendMachineConfig()
+    {
+        var config = ConfigurationStore.Instance.Machine;
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+        _udpService.SendToModules(pgn);
+    }
+
+    public void SendMachinePinConfig()
+    {
+        var config = ConfigurationStore.Instance.Machine;
+        var pgn = PgnBuilder.BuildMachinePinsPgn(config);
+        _udpService.SendToModules(pgn);
+    }
+
     public void SetMachineState(ushort sectionBits, bool isInUTurn)
     {
         _state.SectionStates = sectionBits;

--- a/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
@@ -40,6 +40,8 @@ public static class PgnBuilder
     public const byte PGN_MACHINE = 0xEF;        // 239 - Machine Data
     public const byte PGN_STEER_SETTINGS = 0xFC; // 252 - Steer Settings
     public const byte PGN_STEER_CONFIG = 0xFB;   // 251 - Steer Config
+    public const byte PGN_MACHINE_CONFIG = 0xEE;  // 238 - Machine Config
+    public const byte PGN_MACHINE_PINS = 0xEC;   // 236 - Machine Pin Config
     public const byte PGN_STEER_DATA = 0xFD;     // 253 - Steer Data FROM Module
     public const byte PGN_SENSOR_DATA = 0xFA;    // 250 - Sensor Data FROM Module
 
@@ -48,6 +50,8 @@ public static class PgnBuilder
     public const int MACHINE_PGN_SIZE = 14;         // 5 header + 8 data + 1 crc
     public const int STEER_SETTINGS_PGN_SIZE = 14;  // 5 header + 8 data + 1 crc
     public const int STEER_CONFIG_PGN_SIZE = 11;    // 5 header + 5 data + 1 crc
+    public const int MACHINE_CONFIG_PGN_SIZE = 14;  // 5 header + 8 data + 1 crc
+    public const int MACHINE_PINS_PGN_SIZE = 30;    // 5 header + 24 data + 1 crc
 
     // Thread-local buffers to avoid allocation
     [ThreadStatic]
@@ -212,6 +216,74 @@ public static class PgnBuilder
         // CRC
         buf[13] = CalculateCrc(buf, 2, 11);
 
+        return buf;
+    }
+
+    /// <summary>
+    /// Build PGN 238 (0xEE) Machine Config - hydraulic settings and user values.
+    /// Sent to machine module when config changes (not periodic).
+    ///
+    /// Byte 5:  Raise time (seconds)
+    /// Byte 6:  Lower time (seconds)
+    /// Byte 7:  Enable hydraulic (0/1)
+    /// Byte 8:  set0 bitfield (bit0=InvertRelay, bit1=HydEnabled)
+    /// Byte 9:  User1 value (0-255)
+    /// Byte 10: User2 value (0-255)
+    /// Byte 11: User3 value (0-255)
+    /// Byte 12: User4 value (0-255)
+    /// </summary>
+    public static byte[] BuildMachineConfigPgn(MachineConfig config)
+    {
+        var buf = new byte[MACHINE_CONFIG_PGN_SIZE];
+
+        buf[0] = HEADER1;
+        buf[1] = HEADER2;
+        buf[2] = SOURCE;
+        buf[3] = PGN_MACHINE_CONFIG;
+        buf[4] = 8;
+
+        buf[5] = (byte)Math.Clamp(config.RaiseTime, 0, 255);
+        buf[6] = (byte)Math.Clamp(config.LowerTime, 0, 255);
+        buf[7] = config.HydraulicLiftEnabled ? (byte)1 : (byte)0;
+
+        // set0 bitfield
+        byte set0 = 0;
+        if (config.InvertRelay) set0 |= 0x01;
+        if (config.HydraulicLiftEnabled) set0 |= 0x02;
+        buf[8] = set0;
+
+        buf[9] = (byte)Math.Clamp(config.User1Value, 0, 255);
+        buf[10] = (byte)Math.Clamp(config.User2Value, 0, 255);
+        buf[11] = (byte)Math.Clamp(config.User3Value, 0, 255);
+        buf[12] = (byte)Math.Clamp(config.User4Value, 0, 255);
+
+        buf[13] = CalculateCrc(buf, 2, 11);
+        return buf;
+    }
+
+    /// <summary>
+    /// Build PGN 236 (0xEC) Machine Pin Config - 24 relay pin assignments.
+    /// Sent to machine module when pin config changes (not periodic).
+    ///
+    /// Bytes 5-28: Pin 0-23 function assignments (PinFunction enum value per byte)
+    /// </summary>
+    public static byte[] BuildMachinePinsPgn(MachineConfig config)
+    {
+        var buf = new byte[MACHINE_PINS_PGN_SIZE];
+
+        buf[0] = HEADER1;
+        buf[1] = HEADER2;
+        buf[2] = SOURCE;
+        buf[3] = PGN_MACHINE_PINS;
+        buf[4] = 24;
+
+        var pins = config.PinAssignments;
+        for (int i = 0; i < 24; i++)
+        {
+            buf[5 + i] = (byte)(i < pins.Length ? pins[i] : 0);
+        }
+
+        buf[29] = CalculateCrc(buf, 2, 27);
         return buf;
     }
 

--- a/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
@@ -124,6 +124,18 @@ public interface IAutoSteerService
     void SetDriftCompensation(double driftEasting, double driftNorthing);
 
     /// <summary>
+    /// Send PGN 238 (Machine Config) to machine module.
+    /// Contains hydraulic lift timing, relay invert, and user values.
+    /// </summary>
+    void SendMachineConfig();
+
+    /// <summary>
+    /// Send PGN 236 (Machine Pin Config) to machine module.
+    /// Contains 24 relay pin function assignments.
+    /// </summary>
+    void SendMachinePinConfig();
+
+    /// <summary>
     /// Update machine control state sent via PGN 239.
     /// Called by ViewModel after section control updates.
     /// </summary>

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/PgnProtocol.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/PgnProtocol.cs
@@ -26,7 +26,8 @@ public static class PgnProtocol
     public const byte PGN_MACHINE_TO_MODULE = 0xEF;     // 239
     public const byte PGN_STEER_SETTINGS = 0xFC;        // 252
     public const byte PGN_STEER_CONFIG = 0xFB;          // 251
-    public const byte PGN_MACHINE_CONFIG = 0xEE;        // 238
+    public const byte PGN_MACHINE_CONFIG = 0xEE;         // 238
+    public const byte PGN_MACHINE_PINS = 0xEC;           // 236
     public const byte PGN_HELLO_FROM_HOST = 0xC8;       // 200
     public const byte PGN_SCAN = 0xCA;                  // 202
     public const byte PGN_IP_CONFIG = 0xC9;             // 201
@@ -117,6 +118,34 @@ public static class PgnProtocol
     }
 
     /// <summary>
+    /// Parse PGN 238 (Machine config from host).
+    /// </summary>
+    public static MachineConfigPacket ParseMachineConfig(byte[] data)
+    {
+        return new MachineConfigPacket
+        {
+            RaiseTime = data[5],
+            LowerTime = data[6],
+            EnableHyd = data[7],
+            Set0 = data[8],
+            User1 = data[9],
+            User2 = data[10],
+            User3 = data[11],
+            User4 = data[12]
+        };
+    }
+
+    /// <summary>
+    /// Parse PGN 236 (Machine pin config from host).
+    /// </summary>
+    public static MachinePinConfigPacket ParseMachinePinConfig(byte[] data)
+    {
+        var pins = new byte[24];
+        Array.Copy(data, 5, pins, 0, Math.Min(24, data.Length - 6));
+        return new MachinePinConfigPacket { PinAssignments = pins };
+    }
+
+    /// <summary>
     /// Parse PGN 239 (Machine data from host).
     /// </summary>
     public static MachineCommand ParseMachineCommand(byte[] data)
@@ -156,4 +185,23 @@ public struct MachineCommand
     public byte SectionBits1to8;
     public byte SectionBits9to16;
     public ushort SectionBits => (ushort)(SectionBits1to8 | (SectionBits9to16 << 8));
+}
+
+public struct MachineConfigPacket
+{
+    public byte RaiseTime;
+    public byte LowerTime;
+    public byte EnableHyd;
+    public byte Set0;
+    public byte User1;
+    public byte User2;
+    public byte User3;
+    public byte User4;
+    public bool InvertRelay => (Set0 & 0x01) != 0;
+    public bool HydEnabled => (Set0 & 0x02) != 0;
+}
+
+public struct MachinePinConfigPacket
+{
+    public byte[] PinAssignments; // 24 bytes
 }

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualMachineModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualMachineModule.cs
@@ -39,6 +39,12 @@ public class VirtualMachineModule : IDisposable
     public bool IsHydraulicUp { get; set; }
     public bool[] RelayStates { get; } = new bool[16];
 
+    // Config state (received from host)
+    public MachineConfigPacket? LastConfig { get; private set; }
+    public MachinePinConfigPacket? LastPinConfig { get; private set; }
+    public long ReceivedConfigCount { get; private set; }
+    public long ReceivedPinConfigCount { get; private set; }
+
     // Counters
     public long ReceivedCommandCount { get; private set; }
     public long SentHelloCount { get; private set; }
@@ -111,7 +117,13 @@ public class VirtualMachineModule : IDisposable
                 break;
 
             case PgnProtocol.PGN_MACHINE_CONFIG:
-                // Acknowledge config (no response needed)
+                LastConfig = PgnProtocol.ParseMachineConfig(data);
+                ReceivedConfigCount++;
+                break;
+
+            case PgnProtocol.PGN_MACHINE_PINS:
+                LastPinConfig = PgnProtocol.ParseMachinePinConfig(data);
+                ReceivedPinConfigCount++;
                 break;
         }
     }

--- a/Tests/AgValoniaGPS.Services.Tests/MachineConfigPgnTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/MachineConfigPgnTests.cs
@@ -1,0 +1,272 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using AgValoniaGPS.IntegrationTests.VirtualModules;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.AutoSteer;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class MachineConfigPgnTests
+{
+    #region PGN 238 (Machine Config) Builder Tests
+
+    [Test]
+    public void BuildMachineConfig_HasCorrectHeader()
+    {
+        var config = new MachineConfig();
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+
+        Assert.That(pgn[0], Is.EqualTo(0x80), "Header1");
+        Assert.That(pgn[1], Is.EqualTo(0x81), "Header2");
+        Assert.That(pgn[2], Is.EqualTo(0x7F), "Source");
+        Assert.That(pgn[3], Is.EqualTo(0xEE), "PGN 238");
+        Assert.That(pgn[4], Is.EqualTo(8), "Data length");
+        Assert.That(pgn.Length, Is.EqualTo(14), "Total packet size");
+    }
+
+    [Test]
+    public void BuildMachineConfig_EncodesHydraulicSettings()
+    {
+        var config = new MachineConfig
+        {
+            RaiseTime = 5,
+            LowerTime = 3,
+            HydraulicLiftEnabled = true
+        };
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+
+        Assert.That(pgn[5], Is.EqualTo(5), "RaiseTime");
+        Assert.That(pgn[6], Is.EqualTo(3), "LowerTime");
+        Assert.That(pgn[7], Is.EqualTo(1), "EnableHyd");
+    }
+
+    [Test]
+    public void BuildMachineConfig_EncodesSet0Bitfield()
+    {
+        var config = new MachineConfig
+        {
+            InvertRelay = true,
+            HydraulicLiftEnabled = true
+        };
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+
+        Assert.That(pgn[8] & 0x01, Is.EqualTo(1), "InvertRelay bit");
+        Assert.That(pgn[8] & 0x02, Is.EqualTo(2), "HydEnabled bit");
+    }
+
+    [Test]
+    public void BuildMachineConfig_EncodesUserValues()
+    {
+        var config = new MachineConfig
+        {
+            User1Value = 10,
+            User2Value = 20,
+            User3Value = 30,
+            User4Value = 40
+        };
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+
+        Assert.That(pgn[9], Is.EqualTo(10), "User1");
+        Assert.That(pgn[10], Is.EqualTo(20), "User2");
+        Assert.That(pgn[11], Is.EqualTo(30), "User3");
+        Assert.That(pgn[12], Is.EqualTo(40), "User4");
+    }
+
+    [Test]
+    public void BuildMachineConfig_CrcIsValid()
+    {
+        var config = new MachineConfig
+        {
+            RaiseTime = 7,
+            LowerTime = 2,
+            HydraulicLiftEnabled = true,
+            InvertRelay = true,
+            User1Value = 100
+        };
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+
+        Assert.That(PgnProtocol.IsValidPacket(pgn, pgn.Length), Is.True,
+            "PgnBuilder CRC must pass PgnProtocol validation");
+    }
+
+    [Test]
+    public void BuildMachineConfig_ClampsValues()
+    {
+        var config = new MachineConfig
+        {
+            RaiseTime = 999,   // Should clamp to 255
+            User1Value = -5    // Should clamp to 0
+        };
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+
+        Assert.That(pgn[5], Is.EqualTo(255), "RaiseTime clamped");
+        Assert.That(pgn[9], Is.EqualTo(0), "User1 clamped to 0");
+    }
+
+    #endregion
+
+    #region PGN 236 (Machine Pin Config) Builder Tests
+
+    [Test]
+    public void BuildMachinePins_HasCorrectHeader()
+    {
+        var config = new MachineConfig();
+        var pgn = PgnBuilder.BuildMachinePinsPgn(config);
+
+        Assert.That(pgn[0], Is.EqualTo(0x80), "Header1");
+        Assert.That(pgn[1], Is.EqualTo(0x81), "Header2");
+        Assert.That(pgn[3], Is.EqualTo(0xEC), "PGN 236");
+        Assert.That(pgn[4], Is.EqualTo(24), "Data length = 24 pins");
+        Assert.That(pgn.Length, Is.EqualTo(30), "Total packet size");
+    }
+
+    [Test]
+    public void BuildMachinePins_DefaultPinsFirstSixSections()
+    {
+        var config = new MachineConfig();
+        var pgn = PgnBuilder.BuildMachinePinsPgn(config);
+
+        // Default: pins 0-5 = sections 1-6
+        Assert.That(pgn[5], Is.EqualTo((byte)PinFunction.Section1));
+        Assert.That(pgn[6], Is.EqualTo((byte)PinFunction.Section2));
+        Assert.That(pgn[7], Is.EqualTo((byte)PinFunction.Section3));
+        Assert.That(pgn[8], Is.EqualTo((byte)PinFunction.Section4));
+        Assert.That(pgn[9], Is.EqualTo((byte)PinFunction.Section5));
+        Assert.That(pgn[10], Is.EqualTo((byte)PinFunction.Section6));
+        // Remaining pins = None
+        for (int i = 6; i < 24; i++)
+            Assert.That(pgn[5 + i], Is.EqualTo((byte)PinFunction.None), $"Pin {i} should be None");
+    }
+
+    [Test]
+    public void BuildMachinePins_CustomPinAssignments()
+    {
+        var config = new MachineConfig();
+        config.SetPinAssignment(0, PinFunction.HydUp);
+        config.SetPinAssignment(1, PinFunction.HydDown);
+        config.SetPinAssignment(10, PinFunction.TramLeft);
+        config.SetPinAssignment(11, PinFunction.TramRight);
+        config.SetPinAssignment(23, PinFunction.GeoStop);
+
+        var pgn = PgnBuilder.BuildMachinePinsPgn(config);
+
+        Assert.That(pgn[5], Is.EqualTo((byte)PinFunction.HydUp), "Pin 0 = HydUp");
+        Assert.That(pgn[6], Is.EqualTo((byte)PinFunction.HydDown), "Pin 1 = HydDown");
+        Assert.That(pgn[15], Is.EqualTo((byte)PinFunction.TramLeft), "Pin 10 = TramLeft");
+        Assert.That(pgn[16], Is.EqualTo((byte)PinFunction.TramRight), "Pin 11 = TramRight");
+        Assert.That(pgn[28], Is.EqualTo((byte)PinFunction.GeoStop), "Pin 23 = GeoStop");
+    }
+
+    [Test]
+    public void BuildMachinePins_CrcIsValid()
+    {
+        var config = new MachineConfig();
+        config.SetPinAssignment(0, PinFunction.Section1);
+        config.SetPinAssignment(23, PinFunction.GeoStop);
+
+        var pgn = PgnBuilder.BuildMachinePinsPgn(config);
+
+        Assert.That(PgnProtocol.IsValidPacket(pgn, pgn.Length), Is.True,
+            "PgnBuilder CRC must pass PgnProtocol validation");
+    }
+
+    #endregion
+
+    #region End-to-End UDP Tests
+
+    [Test]
+    public async Task MachineConfig_SentAndReceivedOverUdp()
+    {
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var machine = new VirtualMachineModule(listenPort: modulePort, hostPort: hostPort);
+        machine.Start();
+
+        var config = new MachineConfig
+        {
+            RaiseTime = 6,
+            LowerTime = 4,
+            HydraulicLiftEnabled = true,
+            InvertRelay = true,
+            User1Value = 42,
+            User2Value = 99,
+            User3Value = 0,
+            User4Value = 255
+        };
+
+        var pgn = PgnBuilder.BuildMachineConfigPgn(config);
+
+        using var host = new UdpClient(hostPort);
+        host.Send(pgn, pgn.Length, new IPEndPoint(IPAddress.Loopback, modulePort));
+
+        await Task.Delay(500);
+
+        Assert.That(machine.ReceivedConfigCount, Is.EqualTo(1));
+        var received = machine.LastConfig!.Value;
+        Assert.That(received.RaiseTime, Is.EqualTo(6));
+        Assert.That(received.LowerTime, Is.EqualTo(4));
+        Assert.That(received.EnableHyd, Is.EqualTo(1));
+        Assert.That(received.InvertRelay, Is.True);
+        Assert.That(received.HydEnabled, Is.True);
+        Assert.That(received.User1, Is.EqualTo(42));
+        Assert.That(received.User2, Is.EqualTo(99));
+        Assert.That(received.User3, Is.EqualTo(0));
+        Assert.That(received.User4, Is.EqualTo(255));
+    }
+
+    [Test]
+    public async Task MachinePinConfig_SentAndReceivedOverUdp()
+    {
+        int modulePort = GetEphemeralPort();
+        int hostPort = GetEphemeralPort();
+
+        using var machine = new VirtualMachineModule(listenPort: modulePort, hostPort: hostPort);
+        machine.Start();
+
+        var config = new MachineConfig();
+        config.SetPinAssignment(0, PinFunction.HydUp);
+        config.SetPinAssignment(1, PinFunction.HydDown);
+        config.SetPinAssignment(2, PinFunction.Section1);
+        config.SetPinAssignment(3, PinFunction.Section2);
+        config.SetPinAssignment(22, PinFunction.TramLeft);
+        config.SetPinAssignment(23, PinFunction.GeoStop);
+
+        var pgn = PgnBuilder.BuildMachinePinsPgn(config);
+
+        using var host = new UdpClient(hostPort);
+        host.Send(pgn, pgn.Length, new IPEndPoint(IPAddress.Loopback, modulePort));
+
+        await Task.Delay(500);
+
+        Assert.That(machine.ReceivedPinConfigCount, Is.EqualTo(1));
+        var pins = machine.LastPinConfig!.Value.PinAssignments;
+        Assert.That(pins[0], Is.EqualTo((byte)PinFunction.HydUp));
+        Assert.That(pins[1], Is.EqualTo((byte)PinFunction.HydDown));
+        Assert.That(pins[2], Is.EqualTo((byte)PinFunction.Section1));
+        Assert.That(pins[3], Is.EqualTo((byte)PinFunction.Section2));
+        Assert.That(pins[22], Is.EqualTo((byte)PinFunction.TramLeft));
+        Assert.That(pins[23], Is.EqualTo((byte)PinFunction.GeoStop));
+        // Unassigned pins should be None
+        Assert.That(pins[10], Is.EqualTo((byte)PinFunction.None));
+    }
+
+    #endregion
+
+    private static int GetEphemeralPort()
+    {
+        using var tmp = new UdpClient(0);
+        return ((IPEndPoint)tmp.Client.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
Closes #38, closes #39

## Summary
- **PGN 238 (Machine Config)**: Hydraulic lift raise/lower timing, relay invert flag, 4 user-configurable values
- **PGN 236 (Pin Config)**: 24 relay pin function assignments (sections 1-16, HydUp/Down, TramLeft/Right, GeoStop)
- Both sent on demand via `AutoSteerService.SendMachineConfig()` / `SendMachinePinConfig()`
- MachineConfig model with PinFunction enum already existed; this adds the PGN wire format

## Test plan
- [x] 12 tests pass covering:
  - Header format, PGN numbers, packet sizes
  - Hydraulic settings encoding (raise/lower time, enable)
  - set0 bitfield (InvertRelay + HydEnabled bits)
  - User values 1-4
  - Value clamping (overflow and underflow)
  - Default pin assignments (pins 0-5 = sections 1-6)
  - Custom pin assignments (HydUp, HydDown, TramLeft, GeoStop)
  - CRC compatibility with PgnProtocol validation
  - End-to-end UDP: PgnBuilder output received by VirtualMachineModule

Generated with [Claude Code](https://claude.com/claude-code)