### PR TITLE
Add UI screenshot catalog for all dialogs, tabs, and panels

### DIFF
--- a/Tests/AgValoniaGPS.IntegrationTests/Program.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/Program.cs
@@ -36,11 +36,13 @@ sealed class Program
     static string _tempDir = string.Empty;
     static bool _scenarioFailed = false;
     static bool _headless = false;
+    static bool _catalogMode = false;
 
     [STAThread]
     public static int Main(string[] args)
     {
         _headless = args.Contains("--headless");
+        _catalogMode = args.Contains("--catalog");
 
         // Set up isolated test data
         var testDataDir = Path.Combine(AppContext.BaseDirectory, "TestData");
@@ -63,7 +65,7 @@ sealed class Program
         };
 
         // Hook scenario runner -- runs after MainWindow is shown
-        App.OnAppReady = RunScenario;
+        App.OnAppReady = _catalogMode ? RunCatalog : RunScenario;
 
         // Boot the real app
         try
@@ -101,6 +103,25 @@ sealed class Program
 
         Console.WriteLine("[IntTest] ALL SCENARIOS PASSED");
         return 0;
+    }
+
+    static async Task RunCatalog(IClassicDesktopStyleApplicationLifetime lifetime)
+    {
+        var window = lifetime.MainWindow as Window
+            ?? throw new Exception("MainWindow not found");
+        var vm = (MainViewModel)window.DataContext!;
+
+        try
+        {
+            await UIScreenshotCatalog.Run(window, vm);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[Catalog] ERROR: {ex.Message}");
+            _scenarioFailed = true;
+        }
+
+        lifetime.Shutdown();
     }
 
     static async Task RunScenario(IClassicDesktopStyleApplicationLifetime lifetime)

--- a/Tests/AgValoniaGPS.IntegrationTests/UIScreenshotCatalog.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/UIScreenshotCatalog.cs
@@ -1,0 +1,224 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.ViewModels;
+
+namespace AgValoniaGPS.IntegrationTests;
+
+/// <summary>
+/// Captures screenshots of every UI element in both light and dark mode.
+/// Run via: dotnet run --project Tests/AgValoniaGPS.IntegrationTests/ -- --headless --catalog
+/// Screenshots saved to screenshots/catalog/{dark,light}/
+/// </summary>
+public static class UIScreenshotCatalog
+{
+    private static string _baseDir = "";
+
+    public static async Task Run(Window window, MainViewModel vm)
+    {
+        _baseDir = Path.Combine(AppContext.BaseDirectory, "screenshots", "catalog");
+
+        Console.WriteLine($"[Catalog] Capturing UI catalog to: {_baseDir}");
+
+        foreach (var theme in new[] { "dark", "light" })
+        {
+            bool isDayMode = theme == "light";
+            var themeDir = Path.Combine(_baseDir, theme);
+            Directory.CreateDirectory(themeDir);
+
+            // Switch theme
+            if (Avalonia.Application.Current != null)
+            {
+                Avalonia.Application.Current.RequestedThemeVariant =
+                    isDayMode ? ThemeVariant.Light : ThemeVariant.Dark;
+            }
+            vm.IsDayMode = isDayMode;
+            await Pump(200);
+
+            Console.WriteLine($"[Catalog] === {theme.ToUpper()} MODE ===");
+
+            // 1. Main view (clean, no dialogs)
+            vm.State.UI.CloseDialog();
+            if (vm.ConfigurationViewModel != null)
+                vm.ConfigurationViewModel.IsDialogVisible = false;
+            vm.State.UI.IsSimulatorPanelVisible = false;
+            await Pump(200);
+            Capture(window, themeDir, "00_main_view");
+
+            // 2. Main view with simulator panel
+            vm.State.UI.IsSimulatorPanelVisible = true;
+            await Pump(200);
+            Capture(window, themeDir, "01_simulator_panel");
+            vm.State.UI.IsSimulatorPanelVisible = false;
+
+            // 3. Dialogs
+            var dialogs = new (DialogType type, string name)[]
+            {
+                (DialogType.FieldSelection, "field_selection"),
+                (DialogType.Tracks, "tracks"),
+                (DialogType.NewField, "new_field"),
+                (DialogType.DataIO, "data_io"),
+                (DialogType.HeadlandBuilder, "headland_builder"),
+                (DialogType.QuickABSelector, "quick_ab_selector"),
+                (DialogType.DrawAB, "draw_ab"),
+                (DialogType.NtripProfiles, "ntrip_profiles"),
+                (DialogType.AgShareSettings, "agshare_settings"),
+                (DialogType.AppDirectories, "app_directories"),
+                (DialogType.HotkeyConfig, "hotkey_config"),
+                (DialogType.About, "about"),
+                (DialogType.LogViewer, "log_viewer"),
+                (DialogType.FlagByLatLon, "flag_by_latlon"),
+                (DialogType.FlagList, "flag_list"),
+                (DialogType.ViewSettings, "view_settings"),
+                (DialogType.ImportTracks, "import_tracks"),
+                (DialogType.KmlImport, "kml_import"),
+                (DialogType.IsoXmlImport, "isoxml_import"),
+                (DialogType.SimCoords, "sim_coords"),
+            };
+
+            foreach (var (type, name) in dialogs)
+            {
+                try
+                {
+                    vm.State.UI.ShowDialog(type);
+                    await Pump(200);
+                    Capture(window, themeDir, $"dialog_{name}");
+                    vm.State.UI.CloseDialog();
+                    await Pump(100);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"  [SKIP] dialog_{name}: {ex.Message}");
+                    vm.State.UI.CloseDialog();
+                    await Pump(100);
+                }
+            }
+
+            // 4. Configuration dialog with each tab
+            try
+            {
+                vm.ShowConfigurationDialogCommand?.Execute(null);
+                await Pump(300);
+
+                if (vm.ConfigurationViewModel != null)
+                {
+                    var tabNames = new[]
+                    {
+                        "vehicle", "tool", "uturn", "machine_control",
+                        "tram_lines", "data_sources", "display", "additional_options"
+                    };
+
+                    // Find the TabControl in the visual tree
+                    var tabControl = FindTabControl(window);
+
+                    for (int i = 0; i < tabNames.Length; i++)
+                    {
+                        if (tabControl != null && i < tabControl.ItemCount)
+                        {
+                            tabControl.SelectedIndex = i;
+                            await Pump(200);
+                        }
+                        Capture(window, themeDir, $"config_tab_{i}_{tabNames[i]}");
+                    }
+
+                    vm.ConfigurationViewModel.IsDialogVisible = false;
+                    await Pump(100);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  [SKIP] config tabs: {ex.Message}");
+                if (vm.ConfigurationViewModel != null)
+                    vm.ConfigurationViewModel.IsDialogVisible = false;
+                await Pump(100);
+            }
+
+            // 5. Panels (non-modal, show over main view)
+            vm.State.UI.CloseDialog();
+
+            // Section control panel
+            vm.State.UI.IsSectionControlPanelVisible = true;
+            await Pump(200);
+            Capture(window, themeDir, "panel_section_control");
+            vm.State.UI.IsSectionControlPanelVisible = false;
+
+            // Boundary panel
+            vm.State.UI.IsBoundaryPanelVisible = true;
+            await Pump(200);
+            Capture(window, themeDir, "panel_boundary");
+            vm.State.UI.IsBoundaryPanelVisible = false;
+
+            // Offset fix panel
+            vm.State.UI.IsOffsetFixPanelVisible = true;
+            await Pump(200);
+            Capture(window, themeDir, "panel_offset_fix");
+            vm.State.UI.IsOffsetFixPanelVisible = false;
+
+            // View settings panel
+            vm.State.UI.IsViewSettingsPanelVisible = true;
+            await Pump(200);
+            Capture(window, themeDir, "panel_view_settings");
+            vm.State.UI.IsViewSettingsPanelVisible = false;
+
+            await Pump(100);
+        }
+
+        // Count screenshots
+        int total = Directory.GetFiles(_baseDir, "*.png", SearchOption.AllDirectories).Length;
+        Console.WriteLine($"[Catalog] Done: {total} screenshots captured");
+    }
+
+    private static void Capture(Window window, string dir, string name)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var pixelSize = new PixelSize(
+            Math.Max((int)window.Bounds.Width, 1),
+            Math.Max((int)window.Bounds.Height, 1));
+        var bitmap = new RenderTargetBitmap(pixelSize, new Vector(96, 96));
+        bitmap.Render(window);
+
+        var path = Path.Combine(dir, $"{name}.png");
+        bitmap.Save(path);
+        var kb = new FileInfo(path).Length / 1024;
+        Console.WriteLine($"  [{kb}KB] {name}");
+    }
+
+    private static async Task Pump(int ms)
+    {
+        await Task.Delay(ms);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static TabControl? FindTabControl(Visual root)
+    {
+        if (root is TabControl tc && tc.Classes.Contains("MainConfigTabs"))
+            return tc;
+
+        foreach (var child in root.GetVisualDescendants())
+        {
+            if (child is TabControl tabCtrl && tabCtrl.Classes.Contains("MainConfigTabs"))
+                return tabCtrl;
+        }
+
+        return null;
+    }
+}

--- a/Tools/generate-ui-catalog.sh
+++ b/Tools/generate-ui-catalog.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Generate UI screenshot catalog PDF
+# Usage: ./generate-ui-catalog.sh [output.pdf]
+#
+# Runs the integration test in headless --catalog mode, then
+# assembles all screenshots into a single PDF.
+#
+# Requirements: dotnet, python3, Pillow (pip3 install Pillow)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT="${1:-$REPO_ROOT/AgValoniaGPS_UI_Catalog.pdf}"
+
+echo "=== Capturing screenshots ==="
+dotnet run --project "$REPO_ROOT/Tests/AgValoniaGPS.IntegrationTests/" -- --headless --catalog
+
+CATDIR="$REPO_ROOT/Tests/AgValoniaGPS.IntegrationTests/bin/Debug/net10.0/screenshots/catalog"
+
+if [ ! -d "$CATDIR/dark" ] || [ ! -d "$CATDIR/light" ]; then
+    echo "ERROR: Screenshots not found in $CATDIR"
+    exit 1
+fi
+
+echo ""
+echo "=== Generating PDF ==="
+python3 "$SCRIPT_DIR/screenshots-to-pdf.py" "$CATDIR" "$OUTPUT"
+
+echo ""
+echo "Output: $OUTPUT"

--- a/Tools/screenshots-to-pdf.py
+++ b/Tools/screenshots-to-pdf.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Assemble screenshot catalog into a labeled PDF.
+
+Usage: python3 screenshots-to-pdf.py <catalog_dir> [output.pdf] [--small]
+
+The catalog_dir should contain dark/ and light/ subdirectories with PNG files.
+Each page gets a header label showing the theme and screenshot name.
+Use --small to resize images for smaller file size (~2 MB vs ~8 MB).
+"""
+
+import os
+import sys
+from PIL import Image, ImageDraw, ImageFont
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <catalog_dir> [output.pdf] [--small]")
+        sys.exit(1)
+
+    catalog_dir = sys.argv[1]
+    small = "--small" in sys.argv
+    remaining = [a for a in sys.argv[2:] if a != "--small"]
+    output = remaining[0] if remaining else "AgValoniaGPS_UI_Catalog.pdf"
+
+    pages = []
+
+    for theme in ["dark", "light"]:
+        theme_dir = os.path.join(catalog_dir, theme)
+        if not os.path.isdir(theme_dir):
+            print(f"WARNING: {theme_dir} not found, skipping")
+            continue
+
+        files = sorted(f for f in os.listdir(theme_dir) if f.endswith(".png"))
+
+        for f in files:
+            path = os.path.join(theme_dir, f)
+            img = Image.open(path).convert("RGB")
+
+            if small:
+                img = img.resize((640, 480), Image.LANCZOS)
+
+            # Add label header
+            name = f.replace(".png", "").replace("_", " ").title()
+            label = f"{theme.upper()}: {name}"
+            labeled = add_label(img, label, theme)
+
+            pages.append(labeled)
+            print(f"  {theme}/{f}")
+
+    if not pages:
+        print("No images found!")
+        sys.exit(1)
+
+    pages[0].save(output, save_all=True, append_images=pages[1:], resolution=96)
+    size_mb = os.path.getsize(output) / (1024 * 1024)
+    print(f"\nPDF: {output} ({len(pages)} pages, {size_mb:.1f} MB)")
+
+
+def add_label(img, label, theme):
+    """Add a text label bar at the top of the image."""
+    bar_height = 30
+    width, height = img.size
+
+    # Create new image with label bar
+    new_img = Image.new("RGB", (width, height + bar_height))
+
+    # Draw label bar
+    draw = ImageDraw.Draw(new_img)
+    bg_color = (40, 40, 40) if theme == "dark" else (220, 220, 220)
+    text_color = (200, 200, 200) if theme == "dark" else (30, 30, 30)
+    draw.rectangle([0, 0, width, bar_height], fill=bg_color)
+
+    try:
+        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 16)
+    except (IOError, OSError):
+        font = ImageFont.load_default()
+
+    draw.text((10, 6), label, fill=text_color, font=font)
+
+    # Paste original image below label
+    new_img.paste(img, (0, bar_height))
+    return new_img
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
New `--catalog` flag for the integration test harness that captures 68 screenshots covering every UI element in both dark and light mode:
- 20 dialogs
- 8 configuration tabs
- 4 panels
- 2 main views

Run: `dotnet run --project Tests/AgValoniaGPS.IntegrationTests/ -- --headless --catalog`

## Test plan
- [x] 68 screenshots captured successfully
- [x] All dialogs open and close without errors
- [x] Config tabs switch correctly
- [x] Theme switching works between captures

Generated with [Claude Code](https://claude.com/claude-code)