### PR TITLE
Wire lateral offset buttons: half-tool-width nudge + reset (#121)

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -615,6 +615,29 @@ public partial class MainViewModel
             NudgeTrack(ConfigStore.AutoSteer.NudgeDistance * 0.0025); // 1/4 of standard nudge, right
         });
 
+        // Half-tool-width nudge (legacy FormNudge half-tool buttons)
+        HalfToolNudgeLeftCommand = ReactiveCommand.Create(() =>
+        {
+            double halfWidth = (ConfigStore.ActualToolWidth - ConfigStore.Tool.Overlap) * 0.5;
+            NudgeTrack(-halfWidth);
+        });
+
+        HalfToolNudgeRightCommand = ReactiveCommand.Create(() =>
+        {
+            double halfWidth = (ConfigStore.ActualToolWidth - ConfigStore.Tool.Overlap) * 0.5;
+            NudgeTrack(halfWidth);
+        });
+
+        // Reset nudge to zero (legacy FormNudge zero button)
+        ResetNudgeCommand = ReactiveCommand.Create(() =>
+        {
+            if (SelectedTrack == null) return;
+            _nudgeOffset = 0;
+            SelectedTrack.NudgeDistance = 0;
+            _trackGuidanceState = null; // Force recalculation
+            StatusMessage = "Nudge reset to zero";
+        });
+
         // Bottom Strip Commands - cycle through preset coverage colors
         ChangeMappingColorCommand = ReactiveCommand.Create(() =>
         {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2668,6 +2668,9 @@ public partial class MainViewModel : ReactiveObject
     public ICommand? NudgeRightCommand { get; private set; }
     public ICommand? FineNudgeLeftCommand { get; private set; }
     public ICommand? FineNudgeRightCommand { get; private set; }
+    public ICommand? HalfToolNudgeLeftCommand { get; private set; }
+    public ICommand? HalfToolNudgeRightCommand { get; private set; }
+    public ICommand? ResetNudgeCommand { get; private set; }
     public ICommand? StartDrawABModeCommand { get; private set; }
     public ICommand? StartDrawCurveModeCommand { get; private set; }
     public ICommand? FinishDrawCurveCommand { get; private set; }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
@@ -294,6 +294,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/APlusMinusB.png" Stretch="Uniform"/>
                     </Button>
                 </StackPanel>
+
+                <!-- Half-Tool-Width Nudge + Reset -->
+                <StackPanel Orientation="Horizontal" Spacing="4" IsVisible="{Binding HasActiveTrack}">
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Nudge Left Half Tool Width"
+                            Command="{Binding HalfToolNudgeLeftCommand}">
+                        <TextBlock Text="&lt;&lt;" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Button>
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Reset Nudge"
+                            Command="{Binding ResetNudgeCommand}">
+                        <TextBlock Text="0" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Button>
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Nudge Right Half Tool Width"
+                            Command="{Binding HalfToolNudgeRightCommand}">
+                        <TextBlock Text="&gt;&gt;" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Button>
+                </StackPanel>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
Closes #121

## Summary
Added three commands matching legacy FormNudge convenience buttons:
- **HalfToolNudgeLeft/Right**: Nudge by `(toolWidth - overlap) / 2` - quickly shift one half-pass
- **ResetNudge**: Zero out the nudge offset

Buttons in BottomNavigationPanel after existing fine nudge buttons.

### Already existed (no changes needed):
- NudgeLeft/Right (snap distance)
- FineNudgeLeft/Right (1/4 snap)
- SnapToPivot (auto-nudge from XTE)
- Track.NudgeDistance persistence
- Tool.Offset in section positioning

## Test plan
- [x] Builds clean
- [ ] Test half-tool nudge shifts guidance line by correct amount
- [ ] Test reset returns to original line position

Generated with [Claude Code](https://claude.com/claude-code)