### PR TITLE
Add screenshot to debug dump (#127)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -204,6 +204,25 @@ public partial class MainView : UserControl
             viewModel.ZoomInRequested += () => _mapControl.Zoom(1.2);
             viewModel.ZoomOutRequested += () => _mapControl.Zoom(0.8);
 
+            // Wire screenshot provider for debug dump (#127)
+            viewModel.ScreenshotProvider = () =>
+            {
+                try
+                {
+                    var topLevel = TopLevel.GetTopLevel(this);
+                    if (topLevel == null) return null;
+                    var w = Math.Max((int)topLevel.Bounds.Width, 1);
+                    var h = Math.Max((int)topLevel.Bounds.Height, 1);
+                    var bmp = new Avalonia.Media.Imaging.RenderTargetBitmap(
+                        new Avalonia.PixelSize(w, h), new Avalonia.Vector(96, 96));
+                    bmp.Render(topLevel);
+                    using var ms = new System.IO.MemoryStream();
+                    bmp.Save(ms);
+                    return ms.ToArray();
+                }
+                catch { return null; }
+            };
+
             // Wire up MapClicked event for AB line creation
             _mapControl.MapClicked += OnMapClicked;
             _mapControl.UserPanned += () => _viewModel?.OnUserPan();

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -74,6 +74,9 @@ public partial class MainWindow : Window
             ViewModel.ZoomInRequested += () => MapControl?.Zoom(1.2);
             ViewModel.ZoomOutRequested += () => MapControl?.Zoom(1.0 / 1.2);
 
+            // Wire screenshot provider for debug dump (#127)
+            ViewModel.ScreenshotProvider = CaptureScreenshotPng;
+
             // Wire fullscreen toggle for immediate effect (ConfigurationViewModel
             // is created lazily, so subscribe when it appears)
             ViewModel.PropertyChanged += (s, e) =>
@@ -267,6 +270,26 @@ public partial class MainWindow : Window
             };
             System.Diagnostics.Debug.WriteLine($"[OnMapClicked] DrawCurve - Adding point: E={e.Easting:F2}, N={e.Northing:F2}");
             ViewModel.SetABPointCommand?.Execute(mapPosition);
+        }
+    }
+
+    private byte[]? CaptureScreenshotPng()
+    {
+        try
+        {
+            var w = Math.Max((int)Bounds.Width, 1);
+            var h = Math.Max((int)Bounds.Height, 1);
+            var bmp = new Avalonia.Media.Imaging.RenderTargetBitmap(
+                new PixelSize(w, h), new Vector(96, 96));
+            bmp.Render(this);
+
+            using var ms = new System.IO.MemoryStream();
+            bmp.Save(ms);
+            return ms.ToArray();
+        }
+        catch
+        {
+            return null;
         }
     }
 

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -206,6 +206,25 @@ public partial class MainView : UserControl
             viewModel.ZoomInRequested += () => _mapControl.Zoom(1.2);
             viewModel.ZoomOutRequested += () => _mapControl.Zoom(0.8);
 
+            // Wire screenshot provider for debug dump (#127)
+            viewModel.ScreenshotProvider = () =>
+            {
+                try
+                {
+                    var topLevel = TopLevel.GetTopLevel(this);
+                    if (topLevel == null) return null;
+                    var w = Math.Max((int)topLevel.Bounds.Width, 1);
+                    var h = Math.Max((int)topLevel.Bounds.Height, 1);
+                    var bmp = new Avalonia.Media.Imaging.RenderTargetBitmap(
+                        new Avalonia.PixelSize(w, h), new Avalonia.Vector(96, 96));
+                    bmp.Render(topLevel);
+                    using var ms = new System.IO.MemoryStream();
+                    bmp.Save(ms);
+                    return ms.ToArray();
+                }
+                catch { return null; }
+            };
+
             // Wire up MapClicked event for AB line creation
             _mapControl.MapClicked += OnMapClicked;
             _mapControl.UserPanned += () => _viewModel?.OnUserPan();

--- a/Shared/AgValoniaGPS.Services/DebugDumpService.cs
+++ b/Shared/AgValoniaGPS.Services/DebugDumpService.cs
@@ -36,7 +36,8 @@ public class DebugDumpService
     public static string CreateDump(
         ISettingsService settingsService,
         ApplicationState appState,
-        string? additionalNotes = null)
+        string? additionalNotes = null,
+        byte[]? screenshotPng = null)
     {
         var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
         var dumpDir = Path.Combine(Path.GetTempPath(), "AgValoniaGPS", "dumps");
@@ -130,7 +131,22 @@ public class DebugDumpService
         }
         catch { }
 
-        // 8. User notes
+        // 8. Screenshot
+        if (screenshotPng != null && screenshotPng.Length > 0)
+        {
+            try
+            {
+                var entry = archive.CreateEntry("screenshot.png");
+                using var entryStream = entry.Open();
+                entryStream.Write(screenshotPng, 0, screenshotPng.Length);
+            }
+            catch (Exception ex)
+            {
+                AddTextEntry(archive, "screenshot_error.txt", ex.ToString());
+            }
+        }
+
+        // 9. User notes
         if (!string.IsNullOrEmpty(additionalNotes))
         {
             AddTextEntry(archive, "user_notes.txt", additionalNotes);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -136,7 +136,13 @@ public partial class MainViewModel
         {
             try
             {
-                var zipPath = Services.DebugDumpService.CreateDump(_settingsService, _appState);
+                // Capture screenshot before creating dump (runs on UI thread)
+                byte[]? screenshot = null;
+                try { screenshot = ScreenshotProvider?.Invoke(); }
+                catch { /* screenshot is optional */ }
+
+                var zipPath = Services.DebugDumpService.CreateDump(
+                    _settingsService, _appState, screenshotPng: screenshot);
                 StatusMessage = $"Debug dump saved: {zipPath}";
                 _logger.LogInformation($"Debug dump created: {zipPath}");
             }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2664,6 +2664,13 @@ public partial class MainViewModel : ReactiveObject
     public event Action? ZoomInRequested;
     public event Action? ZoomOutRequested;
 
+    /// <summary>
+    /// Platform-provided callback that captures the current window as a PNG byte array.
+    /// Set by platform code (MainWindow/MainView) after ViewModel is created.
+    /// Used by debug dump to include a screenshot.
+    /// </summary>
+    public Func<byte[]?>? ScreenshotProvider { get; set; }
+
     // Boundary Recording Commands
     public ICommand? ToggleBoundaryPanelCommand { get; private set; }
     public ICommand? StartBoundaryRecordingCommand { get; private set; }

--- a/Tests/AgValoniaGPS.IntegrationTests/Program.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/Program.cs
@@ -411,6 +411,53 @@ sealed class Program
 
         // --- Charts Scenarios (PR #79) ---
         await RunChartsScenario(window, vm, simService);
+
+        // --- Debug Dump Screenshot (#127) ---
+        await RunDebugDumpTest(window, vm);
+    }
+
+    static async Task RunDebugDumpTest(Window window, MainViewModel vm)
+    {
+        Console.Write("[DebugDump] Test screenshot in dump... ");
+
+        // Trigger debug dump command
+        vm.CreateDebugDumpCommand?.Execute(null);
+        await Delay(500);
+
+        // Find the dump zip
+        var dumpDir = Path.Combine(Path.GetTempPath(), "AgValoniaGPS", "dumps");
+        if (!Directory.Exists(dumpDir))
+            throw new Exception("Dump directory not created");
+
+        var zips = Directory.GetFiles(dumpDir, "debug_dump_*.zip")
+            .OrderByDescending(File.GetLastWriteTime)
+            .ToArray();
+        if (zips.Length == 0)
+            throw new Exception("No dump zip found");
+
+        var zipPath = zips[0];
+        Console.Write($"[zip={Path.GetFileName(zipPath)}] ");
+
+        // Verify screenshot.png exists in the zip
+        using var zipStream = File.OpenRead(zipPath);
+        using var archive = new System.IO.Compression.ZipArchive(zipStream, System.IO.Compression.ZipArchiveMode.Read);
+        var screenshotEntry = archive.GetEntry("screenshot.png");
+        if (screenshotEntry == null)
+            throw new Exception("screenshot.png not found in dump zip");
+
+        Console.Write($"[screenshot={screenshotEntry.Length / 1024}KB] ");
+
+        if (screenshotEntry.Length < 1000)
+            throw new Exception($"Screenshot too small ({screenshotEntry.Length} bytes) - likely empty");
+
+        // Extract screenshot for visual verification
+        var extractPath = Path.Combine(_screenshotDir, "debug_dump_screenshot.png");
+        using (var entryStream = screenshotEntry.Open())
+        using (var fileStream = File.Create(extractPath))
+            entryStream.CopyTo(fileStream);
+
+        Console.Write($"[extracted={new FileInfo(extractPath).Length / 1024}KB] ");
+        Console.WriteLine("OK");
     }
 
     static async Task RunCompassScenario(


### PR DESCRIPTION
## What changed

- Debug dump now captures a screenshot of the current window as `screenshot.png` in the ZIP
- Platform code (Desktop, iOS, Android) provides a `ScreenshotProvider` callback using `RenderTargetBitmap`
- Screenshot capture is optional - if it fails, the dump is still created without it

## Related issue

Closes #127

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes
- [x] Tested on: Desktop (build verified)

Generated with [Claude Code](https://claude.com/claude-code)