### PR TITLE
Add light bar cross-track error visualization (#144)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -105,6 +105,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                           DataContext="{Binding}"/>
                 </Canvas>
 
+                <!-- Light Bar Panel (#144) -->
+                <panels:LightBarPanel x:Name="LightBarPanel"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Bottom"
+                                      Margin="0,0,0,8"/>
+
                 <!-- Zoom Controls - Bottom Right -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                             ZIndex="15" Margin="0,0,20,20" Spacing="10">

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -436,6 +436,10 @@ public partial class MainView : UserControl
                     _viewModel.NumSections,
                     _viewModel.GetSectionButtonStates());
             }
+            else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
+            {
+                LightBarPanel?.UpdateCrossTrackError(_viewModel.CrossTrackError);
+            }
             else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
             {
                 // Update map control click selection mode

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -438,7 +438,7 @@ public partial class MainView : UserControl
             }
             else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
             {
-                LightBarPanel?.UpdateCrossTrackError(_viewModel.CrossTrackError);
+                LightBarPanel?.Update(_viewModel.CrossTrackError, _viewModel.SimulatorSteerAngle);
             }
             else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
             {

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -166,6 +166,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                   Canvas.Left="400" Canvas.Top="480"
                                   DataContext="{Binding}"/>
         </Canvas>
+
+        <!-- Light Bar Panel (#144) - bottom center overlay -->
+        <panels:LightBarPanel x:Name="LightBarPanel"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Bottom"
+                              Margin="0,0,0,8"/>
     </Grid>
 
     <!-- Flag Placement Banner -->

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -663,7 +663,7 @@ public partial class MainWindow : Window
         else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
         {
             if (ViewModel != null)
-                LightBarPanel?.UpdateCrossTrackError(ViewModel.CrossTrackError);
+                LightBarPanel?.Update(ViewModel.CrossTrackError, ViewModel.SimulatorSteerAngle);
         }
         else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
         {

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -660,6 +660,11 @@ public partial class MainWindow : Window
             // Brightness control depends on platform-specific implementation
             // Currently marked as not supported in DisplaySettingsService
         }
+        else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
+        {
+            if (ViewModel != null)
+                LightBarPanel?.UpdateCrossTrackError(ViewModel.CrossTrackError);
+        }
         else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
         {
             if (MapControl is DrawingContextMapControl dcMapControl)

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -105,6 +105,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                           DataContext="{Binding}"/>
                 </Canvas>
 
+                <!-- Light Bar Panel (#144) -->
+                <panels:LightBarPanel x:Name="LightBarPanel"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Bottom"
+                                      Margin="0,0,0,8"/>
+
                 <!-- Zoom Controls - Bottom Right -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                             ZIndex="15" Margin="0,0,20,20" Spacing="10">

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -443,7 +443,7 @@ public partial class MainView : UserControl
             }
             else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
             {
-                LightBarPanel?.UpdateCrossTrackError(_viewModel.CrossTrackError);
+                LightBarPanel?.Update(_viewModel.CrossTrackError, _viewModel.SimulatorSteerAngle);
             }
             else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
             {

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -441,6 +441,10 @@ public partial class MainView : UserControl
                     _viewModel.NumSections,
                     _viewModel.GetSectionButtonStates());
             }
+            else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
+            {
+                LightBarPanel?.UpdateCrossTrackError(_viewModel.CrossTrackError);
+            }
             else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
             {
                 // Update map control click selection mode

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
@@ -1,0 +1,26 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.LightBarPanel"
+             IsHitTestVisible="False">
+
+    <!-- Light Bar: row of LED dots showing cross-track error.
+         Green dots (right) = steer right to correct.
+         Red dots (left) = steer left to correct.
+         Positioned at bottom-center of screen via platform layout. -->
+
+    <Border Background="#60000000" CornerRadius="6" Padding="8,4"
+            HorizontalAlignment="Center" VerticalAlignment="Bottom">
+        <StackPanel Orientation="Vertical" Spacing="2"
+                    HorizontalAlignment="Center">
+
+            <!-- Numeric XTE display -->
+            <TextBlock x:Name="XteText"
+                       HorizontalAlignment="Center"
+                       Foreground="White" FontSize="13" FontWeight="SemiBold"/>
+
+            <!-- LED dot canvas -->
+            <Canvas x:Name="DotCanvas" Width="520" Height="20"
+                    HorizontalAlignment="Center"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
@@ -1,0 +1,136 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using AgValoniaGPS.Models.Configuration;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+/// <summary>
+/// Light bar panel showing cross-track error as a row of LED-like dots.
+/// Green dots = steer right, red dots = steer left.
+/// 8 dots per side, configurable cm per dot via AutoSteerConfig.CmPerPixel.
+/// </summary>
+public partial class LightBarPanel : UserControl
+{
+    private const int DotsPerSide = 8;
+    private const double DotSpacing = 32;
+    private const double DotRadius = 6;
+    private const double CenterX = 260; // Half of canvas width (520)
+
+    private readonly Ellipse[] _dots = new Ellipse[DotsPerSide * 2 + 1]; // left 8 + center + right 8
+    private double _smoothedError; // EWMA-filtered cross-track error in cm
+
+    // Dot colors
+    private static readonly IBrush DimBrush = new SolidColorBrush(Color.FromArgb(80, 128, 128, 128));
+    private static readonly IBrush GreenBrush = new SolidColorBrush(Color.FromRgb(50, 220, 50));
+    private static readonly IBrush RedBrush = new SolidColorBrush(Color.FromRgb(220, 50, 50));
+    private static readonly IBrush CenterOnBrush = new SolidColorBrush(Color.FromRgb(255, 255, 80));
+    private static readonly IBrush CenterOffBrush = new SolidColorBrush(Color.FromArgb(120, 200, 200, 80));
+
+    public LightBarPanel()
+    {
+        InitializeComponent();
+        CreateDots();
+    }
+
+    private void CreateDots()
+    {
+        var canvas = this.FindControl<Canvas>("DotCanvas");
+        if (canvas == null) return;
+
+        for (int i = 0; i < _dots.Length; i++)
+        {
+            int idx = i - DotsPerSide; // -8 to +8, 0 = center
+            var dot = new Ellipse
+            {
+                Width = DotRadius * 2,
+                Height = DotRadius * 2,
+                Fill = DimBrush
+            };
+
+            double x = CenterX + idx * DotSpacing - DotRadius;
+            double y = (20 - DotRadius * 2) / 2; // Center vertically
+
+            Canvas.SetLeft(dot, x);
+            Canvas.SetTop(dot, y);
+            canvas.Children.Add(dot);
+            _dots[i] = dot;
+        }
+    }
+
+    /// <summary>
+    /// Update the light bar with a new cross-track error value.
+    /// Positive = right of line (steer left to correct = red dots on left).
+    /// Negative = left of line (steer right to correct = green dots on right).
+    /// </summary>
+    public void UpdateCrossTrackError(double errorMeters)
+    {
+        var config = ConfigurationStore.Instance.AutoSteer;
+        if (!config.LightbarEnabled)
+        {
+            IsVisible = false;
+            return;
+        }
+        IsVisible = true;
+
+        double cmPerDot = Math.Max(config.CmPerPixel, 1);
+        double errorCm = errorMeters * 100.0;
+
+        // EWMA smoothing (50/50 weight like legacy)
+        _smoothedError = _smoothedError * 0.5 + errorCm * 0.5;
+
+        // How many dots to light up
+        double dotsToLight = _smoothedError / cmPerDot;
+        int clampedDots = (int)Math.Clamp(dotsToLight, -DotsPerSide, DotsPerSide);
+
+        // Update dots
+        for (int i = 0; i < _dots.Length; i++)
+        {
+            int idx = i - DotsPerSide; // -8 to +8
+
+            if (idx == 0)
+            {
+                // Center dot: bright when on-track (within 1 dot)
+                _dots[i].Fill = Math.Abs(dotsToLight) < 1.0 ? CenterOnBrush : CenterOffBrush;
+            }
+            else if (idx > 0 && clampedDots < 0)
+            {
+                // Right side: green when error is negative (left of line, steer right)
+                _dots[i].Fill = idx <= Math.Abs(clampedDots) ? GreenBrush : DimBrush;
+            }
+            else if (idx < 0 && clampedDots > 0)
+            {
+                // Left side: red when error is positive (right of line, steer left)
+                _dots[i].Fill = Math.Abs(idx) <= clampedDots ? RedBrush : DimBrush;
+            }
+            else
+            {
+                _dots[i].Fill = DimBrush;
+            }
+        }
+
+        // Update numeric display
+        var xteText = this.FindControl<TextBlock>("XteText");
+        if (xteText != null)
+        {
+            bool isMetric = ConfigurationStore.Instance.IsMetric;
+            if (isMetric)
+            {
+                int displayCm = (int)Math.Round(_smoothedError);
+                xteText.Text = $"{displayCm} cm";
+            }
+            else
+            {
+                double inches = _smoothedError / 2.54;
+                xteText.Text = $"{inches:F1} in";
+            }
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
@@ -13,9 +13,11 @@ using AgValoniaGPS.Models.Configuration;
 namespace AgValoniaGPS.Views.Controls.Panels;
 
 /// <summary>
-/// Light bar panel showing cross-track error as a row of LED-like dots.
-/// Green dots = steer right, red dots = steer left.
+/// Light bar / steer bar panel.
+/// Light bar mode: shows cross-track error as LED dots (green right / red left).
+/// Steer bar mode: shows demanded steer angle as LED dots (cyan).
 /// 8 dots per side, configurable cm per dot via AutoSteerConfig.CmPerPixel.
+/// Works with or without autosteer hardware - just needs an active track.
 /// </summary>
 public partial class LightBarPanel : UserControl
 {
@@ -24,13 +26,15 @@ public partial class LightBarPanel : UserControl
     private const double DotRadius = 6;
     private const double CenterX = 260; // Half of canvas width (520)
 
-    private readonly Ellipse[] _dots = new Ellipse[DotsPerSide * 2 + 1]; // left 8 + center + right 8
-    private double _smoothedError; // EWMA-filtered cross-track error in cm
+    private readonly Ellipse[] _dots = new Ellipse[DotsPerSide * 2 + 1];
+    private double _smoothedXte;
+    private double _smoothedSteer;
 
     // Dot colors
     private static readonly IBrush DimBrush = new SolidColorBrush(Color.FromArgb(80, 128, 128, 128));
     private static readonly IBrush GreenBrush = new SolidColorBrush(Color.FromRgb(50, 220, 50));
     private static readonly IBrush RedBrush = new SolidColorBrush(Color.FromRgb(220, 50, 50));
+    private static readonly IBrush CyanBrush = new SolidColorBrush(Color.FromRgb(50, 200, 220));
     private static readonly IBrush CenterOnBrush = new SolidColorBrush(Color.FromRgb(255, 255, 80));
     private static readonly IBrush CenterOffBrush = new SolidColorBrush(Color.FromArgb(120, 200, 200, 80));
 
@@ -56,7 +60,7 @@ public partial class LightBarPanel : UserControl
             };
 
             double x = CenterX + idx * DotSpacing - DotRadius;
-            double y = (20 - DotRadius * 2) / 2; // Center vertically
+            double y = (20 - DotRadius * 2) / 2;
 
             Canvas.SetLeft(dot, x);
             Canvas.SetTop(dot, y);
@@ -66,71 +70,97 @@ public partial class LightBarPanel : UserControl
     }
 
     /// <summary>
-    /// Update the light bar with a new cross-track error value.
-    /// Positive = right of line (steer left to correct = red dots on left).
-    /// Negative = left of line (steer right to correct = green dots on right).
+    /// Update light bar / steer bar with current guidance values.
+    /// Called on every CrossTrackError property change.
     /// </summary>
-    public void UpdateCrossTrackError(double errorMeters)
+    public void Update(double crossTrackErrorMeters, double steerAngleDegrees)
     {
         var config = ConfigurationStore.Instance.AutoSteer;
-        if (!config.LightbarEnabled)
+        bool lightBar = config.LightbarEnabled;
+        bool steerBar = config.SteerBarEnabled;
+
+        if (!lightBar && !steerBar)
         {
             IsVisible = false;
             return;
         }
         IsVisible = true;
 
+        if (steerBar)
+            UpdateSteerBar(steerAngleDegrees, config);
+        else
+            UpdateLightBar(crossTrackErrorMeters, config);
+    }
+
+    // Legacy compat: single-param method for existing call sites
+    public void UpdateCrossTrackError(double errorMeters)
+    {
+        Update(errorMeters, 0);
+    }
+
+    private void UpdateLightBar(double errorMeters, AutoSteerConfig config)
+    {
         double cmPerDot = Math.Max(config.CmPerPixel, 1);
         double errorCm = errorMeters * 100.0;
 
-        // EWMA smoothing (50/50 weight like legacy)
-        _smoothedError = _smoothedError * 0.5 + errorCm * 0.5;
+        _smoothedXte = _smoothedXte * 0.5 + errorCm * 0.5;
 
-        // How many dots to light up
-        double dotsToLight = _smoothedError / cmPerDot;
+        double dotsToLight = _smoothedXte / cmPerDot;
         int clampedDots = (int)Math.Clamp(dotsToLight, -DotsPerSide, DotsPerSide);
 
-        // Update dots
         for (int i = 0; i < _dots.Length; i++)
         {
-            int idx = i - DotsPerSide; // -8 to +8
+            int idx = i - DotsPerSide;
 
             if (idx == 0)
-            {
-                // Center dot: bright when on-track (within 1 dot)
                 _dots[i].Fill = Math.Abs(dotsToLight) < 1.0 ? CenterOnBrush : CenterOffBrush;
-            }
             else if (idx > 0 && clampedDots < 0)
-            {
-                // Right side: green when error is negative (left of line, steer right)
                 _dots[i].Fill = idx <= Math.Abs(clampedDots) ? GreenBrush : DimBrush;
-            }
             else if (idx < 0 && clampedDots > 0)
-            {
-                // Left side: red when error is positive (right of line, steer left)
                 _dots[i].Fill = Math.Abs(idx) <= clampedDots ? RedBrush : DimBrush;
-            }
             else
-            {
                 _dots[i].Fill = DimBrush;
-            }
         }
 
-        // Update numeric display
+        UpdateText(_smoothedXte, "cm", "in", 2.54);
+    }
+
+    private void UpdateSteerBar(double steerAngleDegrees, AutoSteerConfig config)
+    {
+        _smoothedSteer = _smoothedSteer * 0.5 + steerAngleDegrees * 0.5;
+
+        // Scale: max steer angle maps to all dots
+        double maxAngle = Math.Max(ConfigurationStore.Instance.Vehicle.MaxSteerAngle, 1);
+        double dotsToLight = _smoothedSteer / maxAngle * DotsPerSide;
+        int clampedDots = (int)Math.Clamp(dotsToLight, -DotsPerSide, DotsPerSide);
+
+        for (int i = 0; i < _dots.Length; i++)
+        {
+            int idx = i - DotsPerSide;
+
+            if (idx == 0)
+                _dots[i].Fill = Math.Abs(dotsToLight) < 0.5 ? CenterOnBrush : CenterOffBrush;
+            else if (idx > 0 && clampedDots > 0)
+                _dots[i].Fill = idx <= clampedDots ? CyanBrush : DimBrush;
+            else if (idx < 0 && clampedDots < 0)
+                _dots[i].Fill = Math.Abs(idx) <= Math.Abs(clampedDots) ? CyanBrush : DimBrush;
+            else
+                _dots[i].Fill = DimBrush;
+        }
+
         var xteText = this.FindControl<TextBlock>("XteText");
         if (xteText != null)
-        {
-            bool isMetric = ConfigurationStore.Instance.IsMetric;
-            if (isMetric)
-            {
-                int displayCm = (int)Math.Round(_smoothedError);
-                xteText.Text = $"{displayCm} cm";
-            }
-            else
-            {
-                double inches = _smoothedError / 2.54;
-                xteText.Text = $"{inches:F1} in";
-            }
-        }
+            xteText.Text = $"{_smoothedSteer:F1} deg";
+    }
+
+    private void UpdateText(double valueCm, string metricUnit, string imperialUnit, double convFactor)
+    {
+        var xteText = this.FindControl<TextBlock>("XteText");
+        if (xteText == null) return;
+
+        if (ConfigurationStore.Instance.IsMetric)
+            xteText.Text = $"{(int)Math.Round(valueCm)} {metricUnit}";
+        else
+            xteText.Text = $"{valueCm / convFactor:F1} {imperialUnit}";
     }
 }


### PR DESCRIPTION
## What changed

- New shared `LightBarPanel` AXAML control with 17 LED-like dots (8 per side + center)
- Green dots = steer right to correct, red dots = steer left to correct
- Center dot turns bright yellow when on-track (within 1 dot threshold)
- EWMA-smoothed cross-track error (50/50 weight, matching legacy)
- Numeric XTE display in cm (metric) or inches (imperial)
- Respects `AutoSteerConfig.LightbarEnabled` and `CmPerPixel` settings
- Positioned at bottom-center of screen on all platforms

## Related issue

Closes #144

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes
- [x] Tested on: Desktop (headless integration test)

## Screenshots

Light bar visible at bottom center during autosteer driving test.

Generated with [Claude Code](https://claude.com/claude-code)