### PR TITLE
Wire elevation log data capture toggle (#120)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -124,6 +124,9 @@ public static class ServiceCollectionExtensions
         // Configuration service (single source of truth)
         services.AddSingleton<IConfigurationService, ConfigurationService>();
 
+        // Elevation log service (#120)
+        services.AddSingleton<IElevationLogService, ElevationLogService>();
+
         // Android-specific services
         services.AddSingleton<IMapService, MapService>();
 

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -126,6 +126,9 @@ public static class ServiceCollectionExtensions
         // Configuration service (single source of truth)
         services.AddSingleton<IConfigurationService, ConfigurationService>();
 
+        // Elevation log service (#120)
+        services.AddSingleton<IElevationLogService, ElevationLogService>();
+
         // Platform-specific services (Desktop implementations)
         services.AddSingleton<MapService>();
         services.AddSingleton<IMapService>(sp => sp.GetRequiredService<MapService>());

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -124,6 +124,9 @@ public static class ServiceCollectionExtensions
         // Configuration service (single source of truth)
         services.AddSingleton<IConfigurationService, ConfigurationService>();
 
+        // Elevation log service (#120)
+        services.AddSingleton<IElevationLogService, ElevationLogService>();
+
         // iOS-specific services
         services.AddSingleton<IMapService, MapService>();
 

--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -61,6 +61,7 @@ namespace AgValoniaGPS.Models
         public bool GridVisible { get; set; } = true;
         public bool CompassVisible { get; set; } = true;
         public bool SpeedVisible { get; set; } = true;
+        public bool ElevationLogEnabled { get; set; } = false;
 
         // Camera settings
         public double CameraZoom { get; set; } = 100.0;

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -322,6 +322,7 @@ public class ConfigurationService(
         store.Display.GridVisible = settings.GridVisible;
         store.Display.CompassVisible = settings.CompassVisible;
         store.Display.SpeedVisible = settings.SpeedVisible;
+        store.Display.ElevationLogEnabled = settings.ElevationLogEnabled;
         store.Display.CameraZoom = settings.CameraZoom;
         store.Display.CameraPitch = settings.CameraPitch;
 
@@ -390,6 +391,7 @@ public class ConfigurationService(
         settings.GridVisible = store.Display.GridVisible;
         settings.CompassVisible = store.Display.CompassVisible;
         settings.SpeedVisible = store.Display.SpeedVisible;
+        settings.ElevationLogEnabled = store.Display.ElevationLogEnabled;
         settings.CameraZoom = store.Display.CameraZoom;
         settings.CameraPitch = store.Display.CameraPitch;
 

--- a/Shared/AgValoniaGPS.Services/ElevationLogService.cs
+++ b/Shared/AgValoniaGPS.Services/ElevationLogService.cs
@@ -1,0 +1,83 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Logs GPS elevation data to Elevation.txt in the field directory.
+/// Matches legacy AgOpenGPS format and behavior.
+/// </summary>
+public class ElevationLogService : IElevationLogService
+{
+    private const double MinDistanceMeters = 2.9;
+    private const double MinDistanceSq = MinDistanceMeters * MinDistanceMeters;
+
+    private readonly StringBuilder _buffer = new();
+    private double _lastEasting = double.NaN;
+    private double _lastNorthing = double.NaN;
+
+    public bool IsEnabled { get; set; }
+
+    public void CreateHeader(string fieldDirectory, double startLat, double startLon)
+    {
+        var path = Path.Combine(fieldDirectory, "Elevation.txt");
+        using var writer = new StreamWriter(path, false, Encoding.UTF8);
+        writer.WriteLine($"$Elevation");
+        writer.WriteLine($"Timestamp,{DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        writer.WriteLine($"StartLat,{startLat.ToString("F7", CultureInfo.InvariantCulture)}");
+        writer.WriteLine($"StartLon,{startLon.ToString("F7", CultureInfo.InvariantCulture)}");
+        writer.WriteLine("Latitude,Longitude,Elevation,FixQuality,Easting,Northing,Heading,Roll");
+    }
+
+    public void LogPoint(double latitude, double longitude, double altitude,
+        double antennaHeight, int fixQuality,
+        double easting, double northing, double heading, double roll)
+    {
+        if (!IsEnabled) return;
+
+        // Distance gate: only log when moved >2.9m
+        if (!double.IsNaN(_lastEasting))
+        {
+            double dx = easting - _lastEasting;
+            double dy = northing - _lastNorthing;
+            if (dx * dx + dy * dy < MinDistanceSq)
+                return;
+        }
+
+        _lastEasting = easting;
+        _lastNorthing = northing;
+
+        double elevation = altitude - antennaHeight;
+
+        _buffer.AppendLine(string.Format(CultureInfo.InvariantCulture,
+            "{0:F7},{1:F7},{2:F3},{3},{4:F3},{5:F3},{6:F3},{7:F3}",
+            latitude, longitude, elevation, fixQuality,
+            easting, northing, heading, roll));
+    }
+
+    public void Flush(string fieldDirectory)
+    {
+        if (_buffer.Length == 0) return;
+
+        var path = Path.Combine(fieldDirectory, "Elevation.txt");
+
+        // Append to existing file (create if needed)
+        File.AppendAllText(path, _buffer.ToString(), Encoding.UTF8);
+        _buffer.Clear();
+    }
+
+    public void Clear()
+    {
+        _buffer.Clear();
+        _lastEasting = double.NaN;
+        _lastNorthing = double.NaN;
+    }
+}

--- a/Shared/AgValoniaGPS.Services/Interfaces/IElevationLogService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IElevationLogService.cs
@@ -1,0 +1,30 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// Logs GPS elevation data to CSV when enabled and a field is open.
+/// Legacy format: Elevation.txt with lat, lon, elevation, quality, easting, northing, heading, roll.
+/// Only logs when vehicle moves >2.9m since last sample.
+/// </summary>
+public interface IElevationLogService
+{
+    bool IsEnabled { get; set; }
+
+    /// <summary>Create CSV header for a new field.</summary>
+    void CreateHeader(string fieldDirectory, double startLat, double startLon);
+
+    /// <summary>Log a point if distance gate is satisfied (>2.9m since last).</summary>
+    void LogPoint(double latitude, double longitude, double altitude,
+        double antennaHeight, int fixQuality,
+        double easting, double northing, double heading, double roll);
+
+    /// <summary>Flush buffered rows to Elevation.txt.</summary>
+    void Flush(string fieldDirectory);
+
+    /// <summary>Clear buffer (on field close).</summary>
+    void Clear();
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -177,6 +177,10 @@ public partial class MainViewModel
                 };
                 _fieldService.SetActiveField(field);
 
+                // Create elevation log header if enabled (#120)
+                if (Models.Configuration.ConfigurationStore.Instance.Display.ElevationLogEnabled)
+                    _elevationLogService.CreateHeader(fieldPath, NewFieldLatitude, NewFieldLongitude);
+
                 _settingsService.Settings.LastOpenedField = NewFieldName;
                 _settingsService.Save();
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -232,6 +232,19 @@ public partial class MainViewModel
             AddContourPoint(posEasting, posNorthing, data.CurrentPosition.Heading);
         }
 
+        // Log elevation data if enabled (#120)
+        if (Models.Configuration.ConfigurationStore.Instance.Display.ElevationLogEnabled && IsFieldOpen)
+        {
+            _elevationLogService.IsEnabled = true;
+            var config = Models.Configuration.ConfigurationStore.Instance;
+            _elevationLogService.LogPoint(
+                data.CurrentPosition.Latitude, data.CurrentPosition.Longitude,
+                data.CurrentPosition.Altitude, config.Vehicle.AntennaHeight,
+                data.FixQuality,
+                posEasting, posNorthing, data.CurrentPosition.Heading,
+                RollDegrees);
+        }
+
         // Update headland proximity distance for HUD readout
         UpdateHeadlandProximity(data.CurrentPosition);
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -72,6 +72,7 @@ public partial class MainViewModel : ReactiveObject
     private readonly INtripProfileService _ntripProfileService;
     private readonly IChartDataService _chartDataService;
     private readonly IAudioService _audioService;
+    private readonly IElevationLogService _elevationLogService;
     private readonly ILogger<MainViewModel> _logger;
     private readonly ApplicationState _appState;
     private readonly DispatcherTimer _simulatorTimer;
@@ -163,6 +164,7 @@ public partial class MainViewModel : ReactiveObject
         INtripProfileService ntripProfileService,
         IChartDataService chartDataService,
         IAudioService audioService,
+        IElevationLogService elevationLogService,
         ILogger<MainViewModel> logger,
         ApplicationState appState)
     {
@@ -194,6 +196,7 @@ public partial class MainViewModel : ReactiveObject
         _ntripProfileService = ntripProfileService;
         _chartDataService = chartDataService;
         _audioService = audioService;
+        _elevationLogService = elevationLogService;
         _appState = appState;
         _nmeaParser = new NmeaParserService(gpsService);
         _fieldPlaneFileService = new FieldPlaneFileService();
@@ -1166,6 +1169,9 @@ public partial class MainViewModel : ReactiveObject
             // Handle NTRIP profile
             _ = HandleNtripProfileForFieldAsync(fieldName);
 
+            // Sync elevation log enabled state from config
+            _elevationLogService.IsEnabled = Models.Configuration.ConfigurationStore.Instance.Display.ElevationLogEnabled;
+
             // Save as last opened field
             _settingsService.Settings.LastOpenedField = fieldName;
             _settingsService.Save();
@@ -1213,6 +1219,10 @@ public partial class MainViewModel : ReactiveObject
             // Save coverage
             _coverageMapService.SaveToFile(ActiveField.DirectoryPath);
             _logger.LogDebug($"[Coverage] Saved coverage to {ActiveField.DirectoryPath}");
+
+            // Flush elevation log
+            _elevationLogService.Flush(ActiveField.DirectoryPath);
+            _elevationLogService.Clear();
 
             // Save tracks
             SaveTracksToFile();

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -624,6 +624,7 @@ public class ConfigurationServiceMappingTests
         _settings.GridVisible = false;
         _settings.CompassVisible = false;
         _settings.SpeedVisible = false;
+        _settings.ElevationLogEnabled = true;
         _settings.CameraZoom = 9999;
         _settings.CameraPitch = -50;
         _settings.NtripCasterIp = "MAPPED";

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -62,6 +62,7 @@ public class MainViewModelBuilder
             ntripProfileService: NtripProfileService,
             chartDataService: Substitute.For<IChartDataService>(),
             audioService: Substitute.For<IAudioService>(),
+            elevationLogService: Substitute.For<IElevationLogService>(),
             logger: NullLogger<MainViewModel>.Instance,
             appState: new ApplicationState());
     }


### PR DESCRIPTION
## What changed

- Add `ElevationLogEnabled` to `AppSettings` with `ConfigurationService` bidirectional mapping
- Create `IElevationLogService` + `ElevationLogService` - CSV logger with 2.9m distance gate
- Log: latitude, longitude, elevation (altitude - antenna height), fix quality, easting, northing, heading, roll
- CSV header created on new field, data flushed on field close
- Hook into GPS pipeline in `MainViewModel.GpsHandling`
- Register in DI on all platforms (Desktop, iOS, Android)
- Update `ConfigurationServiceMappingTests` completeness test

Toggle UI already exists in DisplayConfigTab - no UI changes needed.

## Related issue

Closes #120

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes (72 + 299 = 371 tests)
- [x] Tested on: Desktop (build verified)

Generated with [Claude Code](https://claude.com/claude-code)