### PR TITLE
Add localization infrastructure with 21 languages (#40)

### DIFF
--- a/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
@@ -82,6 +82,18 @@ public partial class App : Application
         var configService = Services.GetRequiredService<IConfigurationService>();
         configService.LoadAppSettings();
 
+        // Apply saved language (#40)
+        var savedLang = settingsService.Settings.Language;
+        if (!string.IsNullOrEmpty(savedLang) && savedLang != "en")
+        {
+            try
+            {
+                AgValoniaGPS.Views.Localization.TranslationSource.Instance.CurrentCulture =
+                    new System.Globalization.CultureInfo(savedLang);
+            }
+            catch { /* fall back to English */ }
+        }
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             // Avoid duplicate validations from both Avalonia and the CommunityToolkit.
@@ -90,6 +102,18 @@ public partial class App : Application
 
             var mainWindow = new MainWindow();
             desktop.MainWindow = mainWindow;
+
+            // Wire language change to TranslationSource (#40)
+            var vm = Services.GetRequiredService<AgValoniaGPS.ViewModels.MainViewModel>();
+            vm.LanguageChanged += code =>
+            {
+                try
+                {
+                    AgValoniaGPS.Views.Localization.TranslationSource.Instance.CurrentCulture =
+                        new System.Globalization.CultureInfo(code);
+                }
+                catch { }
+            };
 
             desktop.Exit += (sender, args) =>
             {

--- a/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
@@ -104,16 +104,19 @@ public partial class App : Application
             desktop.MainWindow = mainWindow;
 
             // Wire language change to TranslationSource (#40)
-            var vm = Services.GetRequiredService<AgValoniaGPS.ViewModels.MainViewModel>();
-            vm.LanguageChanged += code =>
+            // Must use MainWindow's ViewModel (not DI - MainViewModel is Transient)
+            if (mainWindow.DataContext is AgValoniaGPS.ViewModels.MainViewModel windowVm)
             {
-                try
+                windowVm.LanguageChanged += code =>
                 {
-                    AgValoniaGPS.Views.Localization.TranslationSource.Instance.CurrentCulture =
-                        new System.Globalization.CultureInfo(code);
-                }
-                catch { }
-            };
+                    try
+                    {
+                        AgValoniaGPS.Views.Localization.TranslationSource.Instance.CurrentCulture =
+                            new System.Globalization.CultureInfo(code);
+                    }
+                    catch { }
+                };
+            }
 
             desktop.Exit += (sender, args) =>
             {

--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -57,6 +57,9 @@ namespace AgValoniaGPS.Models
         public double SectionPanelX { get; set; } = double.NaN;
         public double SectionPanelY { get; set; } = double.NaN;
 
+        // Localization
+        public string Language { get; set; } = "en";
+
         // UI state
         public bool GridVisible { get; set; } = true;
         public bool CompassVisible { get; set; } = true;

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -70,6 +70,7 @@ public class UIState : ReactiveObject
                 this.RaisePropertyChanged(nameof(IsViewSettingsDialogVisible));
                 this.RaisePropertyChanged(nameof(IsImportTracksDialogVisible));
                 this.RaisePropertyChanged(nameof(IsHelpDialogVisible));
+                this.RaisePropertyChanged(nameof(IsLanguageDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -110,6 +111,7 @@ public class UIState : ReactiveObject
     public bool IsViewSettingsDialogVisible => ActiveDialog == DialogType.ViewSettings;
     public bool IsImportTracksDialogVisible => ActiveDialog == DialogType.ImportTracks;
     public bool IsHelpDialogVisible => ActiveDialog == DialogType.Help;
+    public bool IsLanguageDialogVisible => ActiveDialog == DialogType.Language;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -236,7 +238,8 @@ public enum DialogType
     FlagList,
     ViewSettings,
     ImportTracks,
-    Help
+    Help,
+    Language
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -142,6 +142,37 @@ public partial class MainViewModel
             State.UI.CloseDialog();
         });
 
+        // Language Selection (#40)
+        ShowLanguageDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.ShowDialog(Models.State.DialogType.Language);
+        });
+
+        CloseLanguageDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.CloseDialog();
+        });
+
+        SetLanguageCommand = ReactiveCommand.Create<string>(code =>
+        {
+            if (string.IsNullOrEmpty(code)) return;
+            _settingsService.Settings.Language = code;
+            _settingsService.Save();
+
+            // Notify that language changed - Views layer applies via LanguageChanged event
+            LanguageChanged?.Invoke(code);
+
+            try
+            {
+                var culture = new System.Globalization.CultureInfo(code);
+                StatusMessage = $"Language: {culture.NativeName}";
+            }
+            catch
+            {
+                StatusMessage = $"Language: {code}";
+            }
+            State.UI.CloseDialog();
+        });
         // Debug Dump (#127)
         CreateDebugDumpCommand = ReactiveCommand.Create(() =>
         {
@@ -399,6 +430,9 @@ public partial class MainViewModel
     public ICommand? CloseViewSettingsDialogCommand { get; private set; }
     public ICommand? ShowHelpDialogCommand { get; private set; }
     public ICommand? CloseHelpDialogCommand { get; private set; }
+    public ICommand? ShowLanguageDialogCommand { get; private set; }
+    public ICommand? CloseLanguageDialogCommand { get; private set; }
+    public ICommand? SetLanguageCommand { get; private set; }
 }
 
 public class SettingsGroupItem

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2673,6 +2673,7 @@ public partial class MainViewModel : ReactiveObject
     // Events for views to wire up to map controls
     public event Action? ZoomInRequested;
     public event Action? ZoomOutRequested;
+    public event Action<string>? LanguageChanged;
 
     /// <summary>
     /// Platform-provided callback that captures the current window as a PNG byte array.

--- a/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
+++ b/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
@@ -35,6 +35,14 @@
     <ProjectReference Include="..\AgValoniaGPS.ViewModels\AgValoniaGPS.ViewModels.csproj" />
   </ItemGroup>
 
+  <!-- Localization: configure code generator for base .resx (#40) -->
+  <ItemGroup>
+    <EmbeddedResource Update="Localization\Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
   <!-- Shared Assets: Icons and Images accessible by both Desktop and iOS -->
   <ItemGroup>
     <AvaloniaResource Include="Assets\Icons\**\*.png" />

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -51,6 +51,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:QuickABSelectorPanel/>
         <dialogs:TracksDialogPanel/>
         <dialogs:ImportTracksDialogPanel/>
+        <dialogs:LanguageDialogPanel/>
         <dialogs:DrawABDialogPanel/>
         <dialogs:NtripProfilesDialogPanel/>
         <dialogs:NtripProfileEditorPanel/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
@@ -9,6 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -25,7 +26,7 @@ the Free Software Foundation, either version 3 of the License, or
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="420" MaxWidth="550">
             <StackPanel Spacing="12">
-                <TextBlock Text="AgValoniaGPS" FontSize="22" FontWeight="Bold"
+                <TextBlock Text="{loc:Localize Agvaloniagps}" FontSize="22" FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
 
                 <TextBlock x:Name="VersionText" FontSize="16" FontWeight="SemiBold"
@@ -34,28 +35,28 @@ the Free Software Foundation, either version 3 of the License, or
                 <TextBlock x:Name="GitHashText" FontSize="11"
                            Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
 
-                <TextBlock Text="Cross-platform agricultural GPS guidance"
+                <TextBlock Text="{loc:Localize CrossPlatformAgriculturalGpsGuidance}"
                            FontSize="12" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" HorizontalAlignment="Center"/>
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Based on AgOpenGPS by Brian Tee"
+                    <TextBlock Text="{loc:Localize BasedOnAgopengpsByBrianTee}"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
-                    <TextBlock Text="Built with Avalonia UI 11.3.9 and .NET 10.0"
+                    <TextBlock Text="{loc:Localize BuiltWithAvaloniaUi1139Andnet100}"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                 </StackPanel>
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <StackPanel Spacing="4">
-                    <TextBlock Text="License: GNU General Public License v3.0"
+                    <TextBlock Text="{loc:Localize LicenseGnuGeneralPublicLicenseV30}"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
-                    <TextBlock Text="github.com/chriskinal/AgValoniaGPS3"
+                    <TextBlock Text="{loc:Localize GithubcomChriskinalAgvaloniagps3}"
                                Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12"/>
                 </StackPanel>
 
-                <Button Content="Close" Margin="0,8,0,0"
+                <Button Content="{loc:Localize Close}" Margin="0,8,0,0"
                         Command="{Binding CloseAboutDialogCommand}"
                         Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="44" FontSize="16" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.AgShareDownloadDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -45,7 +46,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 MinWidth="400" MaxWidth="500" MaxHeight="600">
             <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
                 <!-- Header -->
-                <TextBlock Grid.Row="0" Text="Download from AgShare"
+                <TextBlock Grid.Row="0" Text="{loc:Localize DownloadFromAgshare}"
                            FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
@@ -79,12 +80,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Options -->
                 <StackPanel Grid.Row="2" Margin="0,10" Spacing="10">
                     <StackPanel Orientation="Horizontal" Spacing="10">
-                        <Button Content="Refresh" Click="Refresh_Click"
+                        <Button Content="{loc:Localize Refresh}" Click="Refresh_Click"
                                 Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
-                        <Button x:Name="BtnDownloadAll" Content="Download All" Click="DownloadAll_Click"
+                        <Button x:Name="BtnDownloadAll" Content="{loc:Localize DownloadAll}" Click="DownloadAll_Click"
                                 Background="#9B59B6" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
                     </StackPanel>
-                    <CheckBox x:Name="ForceOverwriteCheckBox" Content="Force overwrite existing fields"/>
+                    <CheckBox x:Name="ForceOverwriteCheckBox" Content="{loc:Localize ForceOverwriteExistingFields}"/>
                 </StackPanel>
 
                 <!-- Progress -->
@@ -92,18 +93,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <ProgressBar x:Name="ProgressBar" IsVisible="False"
                                  Height="8" Minimum="0" Maximum="100"
                                  Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-                    <TextBlock x:Name="StatusLabel" Text="Loading fields..."
+                    <TextBlock x:Name="StatusLabel" Text="{loc:Localize LoadingFields}"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                HorizontalAlignment="Center" Margin="0,5"/>
                 </StackPanel>
 
                 <!-- Action Buttons -->
                 <Grid Grid.Row="4" ColumnDefinitions="*,Auto,Auto" Margin="0,10,0,0">
-                    <Button Grid.Column="1" x:Name="BtnDownload" Content="Download Selected"
+                    <Button Grid.Column="1" x:Name="BtnDownload" Content="{loc:Localize DownloadSelected}"
                             Classes="DialogButton" IsEnabled="False"
                             Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Download_Click" Margin="0,0,10,0"/>
-                    <Button Grid.Column="2" Content="Cancel" Classes="DialogButton"
+                    <Button Grid.Column="2" Content="{loc:Localize Cancel}" Classes="DialogButton"
                             Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Cancel_Click"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -104,7 +105,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Title -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,12">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png" Width="24" Height="24" Margin="0,0,8,0"/>
-                    <TextBlock Text="AgShare Settings"
+                    <TextBlock Text="{loc:Localize AgshareSettings}"
                                FontSize="18"
                                FontWeight="Bold"
                                Foreground="#1ABC9C"
@@ -113,7 +114,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Server URL Field -->
                 <StackPanel Grid.Row="1" Margin="0,0,0,8">
-                    <TextBlock Classes="Label" Text="Server URL"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize ServerUrl}"/>
                     <Border x:Name="ServerUrlBorder" Classes="InputField"
                             PointerPressed="ServerUrl_PointerPressed">
                         <TextBlock x:Name="ServerUrlDisplay"
@@ -121,28 +122,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"
                                    TextTrimming="CharacterEllipsis"
-                                   Text="https://agshare.agopengps.com"/>
+                                   Text="{loc:Localize HttpsAgshareagopengpscom}"/>
                     </Border>
                 </StackPanel>
 
                 <!-- API Key Field -->
                 <StackPanel Grid.Row="2" Margin="0,0,0,8">
-                    <TextBlock Classes="Label" Text="API Key"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize ApiKey}"/>
                     <Border x:Name="ApiKeyBorder" Classes="InputField"
                             PointerPressed="ApiKey_PointerPressed">
                         <TextBlock x:Name="ApiKeyDisplay"
                                    FontSize="14"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"
-                                   Text="(not set)"/>
+                                   Text="{loc:Localize NotSet}"/>
                     </Border>
-                    <TextBlock Classes="Hint" Text="Get your API key from agshare.agopengps.com"/>
+                    <TextBlock Classes="Hint" Text="{loc:Localize GetYourApiKeyFromAgshareagopengpscom}"/>
                 </StackPanel>
 
                 <!-- Test Connection & Enable -->
                 <Grid Grid.Row="3" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,8">
                     <Button Grid.Column="0" Classes="TestButton" Click="TestConnection_Click">
-                        <TextBlock Text="Test Connection"/>
+                        <TextBlock Text="{loc:Localize TestConnection}"/>
                     </Button>
                     <TextBlock x:Name="ConnectionStatusLabel" Grid.Column="1"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
@@ -150,7 +151,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                TextWrapping="Wrap"
                                Text=""/>
                     <CheckBox x:Name="EnabledCheckBox" Grid.Column="2"
-                              Content="Enabled" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                              Content="{loc:Localize Enabled}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                               VerticalAlignment="Center"/>
                 </Grid>
 
@@ -165,13 +166,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid Grid.Row="5" ColumnDefinitions="*,*" Margin="0,4,0,0">
                     <Button Grid.Column="0"
                             Classes="DialogButton CancelButton"
-                            Content="Cancel"
+                            Content="{loc:Localize Cancel}"
                             HorizontalAlignment="Stretch"
                             Click="Cancel_Click"
                             Margin="0,0,6,0"/>
                     <Button Grid.Column="1"
                             Classes="DialogButton"
-                            Content="Save"
+                            Content="{loc:Localize Save}"
                             HorizontalAlignment="Stretch"
                             Click="Save_Click"
                             Margin="6,0,0,0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.AgShareUploadDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -45,7 +46,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 MinWidth="400" MaxWidth="500" MaxHeight="600">
             <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
                 <!-- Header -->
-                <TextBlock Grid.Row="0" Text="Upload to AgShare"
+                <TextBlock Grid.Row="0" Text="{loc:Localize UploadToAgshare}"
                            FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
@@ -82,12 +83,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Options -->
                 <StackPanel Grid.Row="2" Margin="0,10">
                     <StackPanel Orientation="Horizontal" Spacing="10">
-                        <Button Content="Select All" Click="SelectAll_Click"
+                        <Button Content="{loc:Localize SelectAll}" Click="SelectAll_Click"
                                 Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
-                        <Button Content="Deselect All" Click="DeselectAll_Click"
+                        <Button Content="{loc:Localize DeselectAll}" Click="DeselectAll_Click"
                                 Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
                     </StackPanel>
-                    <CheckBox x:Name="PublicCheckBox" Content="Make fields public" Margin="0,10,0,0"/>
+                    <CheckBox x:Name="PublicCheckBox" Content="{loc:Localize MakeFieldsPublic}" Margin="0,10,0,0"/>
                 </StackPanel>
 
                 <!-- Progress -->
@@ -95,18 +96,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <ProgressBar x:Name="ProgressBar" IsVisible="False"
                                  Height="8" Minimum="0" Maximum="100"
                                  Foreground="{DynamicResource SystemControlHighlightAccentBrush}" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-                    <TextBlock x:Name="StatusLabel" Text="Select fields to upload"
+                    <TextBlock x:Name="StatusLabel" Text="{loc:Localize SelectFieldsToUpload}"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
                                HorizontalAlignment="Center" Margin="0,5"/>
                 </StackPanel>
 
                 <!-- Action Buttons -->
                 <Grid Grid.Row="4" ColumnDefinitions="*,Auto,Auto" Margin="0,10,0,0">
-                    <Button Grid.Column="1" x:Name="BtnUpload" Content="Upload"
+                    <Button Grid.Column="1" x:Name="BtnUpload" Content="{loc:Localize Upload}"
                             Classes="DialogButton" IsEnabled="False"
                             Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Upload_Click" Margin="0,0,10,0"/>
-                    <Button Grid.Column="2" Content="Cancel" Classes="DialogButton"
+                    <Button Grid.Column="2" Content="{loc:Localize Cancel}" Classes="DialogButton"
                             Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Click="Cancel_Click"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppDirectoriesDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -37,7 +38,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 MinWidth="420" MaxWidth="600">
             <StackPanel Spacing="16">
                 <!-- Title -->
-                <TextBlock Text="App Directories" FontSize="20" FontWeight="Bold"
+                <TextBlock Text="{loc:Localize AppDirectories}" FontSize="20" FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
 
                 <!-- Directory list -->
@@ -58,7 +59,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </ItemsControl>
 
                 <!-- Close button -->
-                <Button Content="Close" Margin="0,8,0,0"
+                <Button Content="{loc:Localize Close}" Margin="0,8,0,0"
                         Command="{Binding CloseAppDirectoriesDialogCommand}"
                         Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="44" FontSize="16" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -122,7 +123,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Header -->
                 <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="12,8">
                     <Grid ColumnDefinitions="*,Auto">
-                        <TextBlock Text="Auto Steer Configuration" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                        <TextBlock Text="{loc:Localize AutoSteerConfiguration}" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <Button Grid.Column="1" Command="{Binding ClosePanelCommand}"
                                 Background="Transparent" BorderThickness="0" Padding="8,4" Cursor="Hand">
                             <TextBlock Text="X" FontSize="16" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
@@ -165,17 +166,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Pure Pursuit Controls -->
                                             <StackPanel Spacing="12" IsVisible="{Binding !AutoSteer.IsStanleyMode}">
                                                 <!-- Algorithm Label -->
-                                                <TextBlock Text="Pure Pursuit" FontSize="18" FontWeight="Bold" Foreground="#4A9A7E"
+                                                <TextBlock Text="{loc:Localize PurePursuit}" FontSize="18" FontWeight="Bold" Foreground="#4A9A7E"
                                                            HorizontalAlignment="Center"/>
 
                                                 <!-- Steer Response -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
                                                         <Grid ColumnDefinitions="Auto,*,Auto">
-                                                            <TextBlock Text="Fast" Foreground="#4A9A7E" FontSize="12"/>
-                                                            <TextBlock Grid.Column="1" Text="Steer Response" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                                            <TextBlock Text="{loc:Localize Fast}" Foreground="#4A9A7E" FontSize="12"/>
+                                                            <TextBlock Grid.Column="1" Text="{loc:Localize SteerResponse}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                        HorizontalAlignment="Center" FontWeight="SemiBold"/>
-                                                            <TextBlock Grid.Column="2" Text="Slow" Foreground="#E74C3C" FontSize="12"/>
+                                                            <TextBlock Grid.Column="2" Text="{loc:Localize Slow}" Foreground="#E74C3C" FontSize="12"/>
                                                         </Grid>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditSteerResponseCommand}"
@@ -193,7 +194,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <!-- Integral (Pure Pursuit) -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Integral" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                        <TextBlock Text="{loc:Localize Integral}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditIntegralGainCommand}"
@@ -205,7 +206,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                     Value="{Binding AutoSteer.IntegralGain}"
                                                                     VerticalAlignment="Center"/>
                                                         </Grid>
-                                                        <TextBlock Text="Slowly increases steer angle to reduce cross track error"
+                                                        <TextBlock Text="{loc:Localize SlowlyIncreasesSteerAngleToReduceCrossTrackError}"
                                                                    Foreground="#777" FontSize="10" TextWrapping="Wrap"
                                                                    HorizontalAlignment="Center" TextAlignment="Center"/>
                                                     </StackPanel>
@@ -215,13 +216,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Stanley Controls -->
                                             <StackPanel Spacing="12" IsVisible="{Binding AutoSteer.IsStanleyMode}">
                                                 <!-- Algorithm Label -->
-                                                <TextBlock Text="Stanley Gains" FontSize="18" FontWeight="Bold" Foreground="#E67E22"
+                                                <TextBlock Text="{loc:Localize StanleyGains}" FontSize="18" FontWeight="Bold" Foreground="#E67E22"
                                                            HorizontalAlignment="Center"/>
 
                                                 <!-- Aggressiveness -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Aggressiveness" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                        <TextBlock Text="{loc:Localize Aggressiveness}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditStanleyAggressivenessCommand}"
@@ -239,7 +240,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <!-- Overshoot Reduction -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Overshoot Reduction" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                        <TextBlock Text="{loc:Localize OvershootReduction}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditStanleyOvershootCommand}"
@@ -257,7 +258,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <!-- Integral (Stanley) -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
-                                                        <TextBlock Text="Integral" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                        <TextBlock Text="{loc:Localize Integral}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                    HorizontalAlignment="Center"/>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditStanleyIntegralCommand}"
@@ -289,13 +290,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8" HorizontalAlignment="Center">
                                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
-                                                        <TextBlock Text="-->" Foreground="#4A9A7E"/>
+                                                        <TextBlock Text="{loc:Localize }" Foreground="#4A9A7E"/>
                                                         <TextBlock Text="{Binding AutoSteer.WasOffset}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                    FontWeight="Bold" FontSize="18"/>
-                                                        <TextBlock Text="&lt;--" Foreground="#4A9A7E"/>
+                                                        <TextBlock Text="{loc:Localize lt}" Foreground="#4A9A7E"/>
                                                     </StackPanel>
-                                                    <TextBlock Text="Was Zero" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
-                                                    <Button Content="Zero WAS" Command="{Binding ZeroWasCommand}"
+                                                    <TextBlock Text="{loc:Localize WasZero}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
+                                                    <Button Content="{loc:Localize ZeroWas}" Command="{Binding ZeroWasCommand}"
                                                             HorizontalAlignment="Center" Padding="16,6"/>
                                                 </StackPanel>
                                             </Border>
@@ -312,7 +313,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                 Value="{Binding AutoSteer.CountsPerDegree}"
                                                                 VerticalAlignment="Center" Margin="8,0,0,0"/>
                                                     </Grid>
-                                                    <TextBlock Text="Counts Per Degree" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
+                                                    <TextBlock Text="{loc:Localize CountsPerDegree}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                                                 </StackPanel>
                                             </Border>
 
@@ -328,7 +329,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                 Value="{Binding AutoSteer.Ackermann}"
                                                                 VerticalAlignment="Center" Margin="8,0,0,0"/>
                                                     </Grid>
-                                                    <TextBlock Text="Ackermann" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
+                                                    <TextBlock Text="{loc:Localize Ackermann}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                                                 </StackPanel>
                                             </Border>
 
@@ -344,7 +345,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                 Value="{Binding AutoSteer.MaxSteerAngle}"
                                                                 VerticalAlignment="Center" Margin="8,0,0,0"/>
                                                     </Grid>
-                                                    <TextBlock Text="Max Steer Angle" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
+                                                    <TextBlock Text="{loc:Localize MaxSteerAngle}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
                                                 </StackPanel>
                                             </Border>
                                         </StackPanel>
@@ -361,7 +362,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
                                             <!-- Deadzone Header -->
-                                            <TextBlock Text="---Deadzone---" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                            <TextBlock Text="{loc:Localize Deadzone}" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Deadzone values in a row -->
@@ -373,7 +374,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                             <TextBlock Text="{Binding AutoSteer.DeadzoneHeading, StringFormat='{}{0:F1}'}"
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
-                                                        <TextBlock Text="Heading" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize Heading}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Border>
@@ -384,7 +385,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                             <TextBlock Text="{Binding AutoSteer.DeadzoneDelay}"
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
                                                         </Button>
-                                                        <TextBlock Text="On-Delay" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize OnDelay}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Border>
@@ -393,7 +394,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Speed Factor -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Speed Factor" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                    <TextBlock Text="{loc:Localize SpeedFactor}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditSpeedFactorCommand}">
@@ -410,7 +411,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Acquire Factor -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Acquire Factor" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                    <TextBlock Text="{loc:Localize AcquireFactor}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditAcquireFactorCommand}">
@@ -421,7 +422,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                 Value="{Binding AutoSteer.AcquireFactor}"
                                                                 VerticalAlignment="Center" Margin="8,0,0,0"/>
                                                     </Grid>
-                                                    <TextBlock Text="Acquire = Factor * Hold" Foreground="#777" FontSize="10"
+                                                    <TextBlock Text="{loc:Localize AcquireFactorHold}" Foreground="#777" FontSize="10"
                                                                HorizontalAlignment="Center"/>
                                                 </StackPanel>
                                             </Border>
@@ -438,13 +439,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <!-- Tab 4 Content: Gain -->
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="Gain" FontSize="18" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize Gain}" FontSize="18" FontWeight="Bold" Foreground="#4A9A7E"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Proportional Gain -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Proportional Gain" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                    <TextBlock Text="{loc:Localize ProportionalGain}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditProportionalGainCommand}">
@@ -461,7 +462,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Max PWM -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Max Limit" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                    <TextBlock Text="{loc:Localize MaxLimit}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditMaxPwmCommand}">
@@ -478,7 +479,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Min PWM -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Minimum to Move" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                    <TextBlock Text="{loc:Localize MinimumToMove}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditMinPwmCommand}">
@@ -500,7 +501,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="8" Margin="0,8,0,0"
                                     IsVisible="{Binding IsFullMode}">
                                 <StackPanel Spacing="8">
-                                    <TextBlock Text="Test Mode" FontSize="14" FontWeight="Bold" Foreground="#F39C12"
+                                    <TextBlock Text="{loc:Localize TestMode}" FontSize="14" FontWeight="Bold" Foreground="#F39C12"
                                                HorizontalAlignment="Center"/>
 
                                     <!-- Free Drive Toggle -->
@@ -515,20 +516,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                        Width="32" Height="32" Stretch="Uniform"
                                                        IsVisible="{Binding !IsFreeDriveMode}"/>
                                             </Grid>
-                                            <TextBlock Grid.Column="1" Text="Free Drive" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" Text="{loc:Localize FreeDrive}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                         </Grid>
                                     </Button>
 
                                     <!-- Steer Left/Right/Zero Buttons -->
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="4"
                                                 IsEnabled="{Binding IsFreeDriveMode}">
-                                        <Button Content="◀ LEFT" Padding="16,8"
+                                        <Button Content="{loc:Localize Left}" Padding="16,8"
                                                 Background="#DD3498DB"
                                                 Command="{Binding SteerLeftCommand}"/>
                                         <Button Content="0" Padding="20,8"
                                                 Background="#DD27AE60" FontWeight="Bold" FontSize="16"
                                                 Command="{Binding SteerCenterCommand}"/>
-                                        <Button Content="RIGHT ▶" Padding="16,8"
+                                        <Button Content="{loc:Localize Right}" Padding="16,8"
                                                 Background="#DD3498DB"
                                                 Command="{Binding SteerRightCommand}"/>
                                     </StackPanel>
@@ -538,13 +539,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             HorizontalAlignment="Center" IsVisible="{Binding IsFreeDriveMode}">
                                         <StackPanel Orientation="Horizontal" Spacing="16">
                                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                                <TextBlock Text="Set:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{loc:Localize Set}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                                                 <TextBlock Text="{Binding FreeDriveSteerAngle, StringFormat='{}{0:F0}°'}"
                                                            Foreground="#F39C12" FontWeight="Bold"
                                                            FontSize="16" VerticalAlignment="Center" Width="40" TextAlignment="Right"/>
                                             </StackPanel>
                                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                                <TextBlock Text="PWM:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
+                                                <TextBlock Text="{loc:Localize Pwm}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                                                 <TextBlock Text="{Binding PwmDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"
                                                            FontSize="16" VerticalAlignment="Center" Width="30" TextAlignment="Right"/>
                                             </StackPanel>
@@ -557,7 +558,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <TextBlock Text="{Binding ActualSteerAngle, StringFormat='{}{0:F1}°'}"
                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="18"
                                                        HorizontalAlignment="Center"/>
-                                            <TextBlock Text="Actual Steer Angle" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"
+                                            <TextBlock Text="{loc:Localize ActualSteerAngle}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10"
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
                                     </Border>
@@ -586,7 +587,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Turn Sensor -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
-                                                    <TextBlock Text="Turn Sensor" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
+                                                    <TextBlock Text="{loc:Localize TurnSensor}" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
@@ -600,7 +601,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <!-- Counts field - visible when Turn Sensor enabled -->
                                                         <StackPanel Grid.Column="1" IsVisible="{Binding AutoSteer.TurnSensorEnabled}"
                                                                     Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                                                            <TextBlock Text="Counts" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
+                                                            <TextBlock Text="{loc:Localize Counts}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                                                             <Button Classes="TappableValue" Command="{Binding EditTurnSensorCountsCommand}"
                                                                     Padding="16,8">
                                                                 <TextBlock Text="{Binding AutoSteer.TurnSensorCounts}"
@@ -614,7 +615,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Pressure Turn -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
-                                                    <TextBlock Text="Pressure Turn" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
+                                                    <TextBlock Text="{loc:Localize PressureTurn}" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
@@ -628,7 +629,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <!-- Pressure fields - visible when Pressure Sensor enabled -->
                                                         <StackPanel Grid.Column="1" IsVisible="{Binding AutoSteer.PressureSensorEnabled}"
                                                                     Spacing="4">
-                                                            <TextBlock Text="Off at %" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center" FontSize="12"/>
+                                                            <TextBlock Text="{loc:Localize OffAt}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center" FontSize="12"/>
                                                             <!-- Actual pressure reading from PGN -->
                                                             <ProgressBar Minimum="0" Maximum="100" Value="{Binding ActualPressurePercent}"
                                                                          Height="16" Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
@@ -649,7 +650,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Current Turn -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
-                                                    <TextBlock Text="Current Turn" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
+                                                    <TextBlock Text="{loc:Localize CurrentTurn}" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
@@ -663,7 +664,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         <!-- Current fields - visible when Current Sensor enabled -->
                                                         <StackPanel Grid.Column="1" IsVisible="{Binding AutoSteer.CurrentSensorEnabled}"
                                                                     Spacing="4">
-                                                            <TextBlock Text="Off at %" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center" FontSize="12"/>
+                                                            <TextBlock Text="{loc:Localize OffAt}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center" FontSize="12"/>
                                                             <!-- Actual current reading from PGN -->
                                                             <ProgressBar Minimum="0" Maximum="100" Value="{Binding ActualCurrentPercent}"
                                                                          Height="16" Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
@@ -692,7 +693,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="8">
-                                            <TextBlock Text="Hardware Config" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize HardwareConfig}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Toggle buttons for hardware settings -->
@@ -708,7 +709,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Danfoss" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize Danfoss}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
 
                                                     <!-- Invert WAS -->
@@ -721,7 +722,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Invert WAS" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize InvertWas}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
 
                                                     <!-- Invert Motor -->
@@ -734,7 +735,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Invert Motor" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize InvertMotor}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
 
                                                     <!-- Invert Relays -->
@@ -747,7 +748,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Invert Relays" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize InvertRelays}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </WrapPanel>
                                             </Border>
@@ -756,35 +757,35 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="Motor Driver" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize MotorDriver}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.MotorDriver}"
                                                                   Width="120">
-                                                            <ComboBoxItem Content="IBT2"/>
-                                                            <ComboBoxItem Content="Cytron"/>
+                                                            <ComboBoxItem Content="{loc:Localize Ibt2}"/>
+                                                            <ComboBoxItem Content="{loc:Localize Cytron}"/>
                                                         </ComboBox>
                                                     </Grid>
 
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="AD Converter" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize AdConverter}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.AdConverter}"
                                                                   Width="120">
-                                                            <ComboBoxItem Content="Differential"/>
-                                                            <ComboBoxItem Content="Single"/>
+                                                            <ComboBoxItem Content="{loc:Localize Differential}"/>
+                                                            <ComboBoxItem Content="{loc:Localize Single}"/>
                                                         </ComboBox>
                                                     </Grid>
 
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="External Enable" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize ExternalEnable}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.ExternalEnable}"
                                                                   Width="120">
-                                                            <ComboBoxItem Content="None"/>
-                                                            <ComboBoxItem Content="Switch"/>
-                                                            <ComboBoxItem Content="Button"/>
+                                                            <ComboBoxItem Content="{loc:Localize None}"/>
+                                                            <ComboBoxItem Content="{loc:Localize Switch}"/>
+                                                            <ComboBoxItem Content="{loc:Localize Button}"/>
                                                         </ComboBox>
                                                     </Grid>
 
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="IMU Axis Swap" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize ImuAxisSwap}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                                         <ComboBox Grid.Column="1" SelectedIndex="{Binding AutoSteer.ImuAxisSwap}"
                                                                   Width="120">
                                                             <ComboBoxItem Content="X"/>
@@ -805,7 +806,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="Steering Algorithm" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize SteeringAlgorithm}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Stanley/Pure toggle -->
@@ -813,11 +814,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <Button Classes="ToggleButton" Command="{Binding ToggleStanleyModeCommand}"
                                                         HorizontalAlignment="Stretch">
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="Algorithm" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                                        <TextBlock Text="{loc:Localize Algorithm}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                                         <Grid Grid.Column="1">
-                                                            <TextBlock Text="Stanley" Foreground="#4A9A7E" FontWeight="Bold"
+                                                            <TextBlock Text="{loc:Localize Stanley}" Foreground="#4A9A7E" FontWeight="Bold"
                                                                        IsVisible="{Binding AutoSteer.IsStanleyMode}"/>
-                                                            <TextBlock Text="Pure Pursuit" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontWeight="Bold"
+                                                            <TextBlock Text="{loc:Localize PurePursuit}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontWeight="Bold"
                                                                        IsVisible="{Binding !AutoSteer.IsStanleyMode}"/>
                                                         </Grid>
                                                     </Grid>
@@ -828,10 +829,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
                                                     <Grid ColumnDefinitions="Auto,*,Auto">
-                                                        <TextBlock Text="Out" Foreground="#E74C3C" FontSize="11"/>
-                                                        <TextBlock Grid.Column="1" Text="U-Turn Compensation" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                                        <TextBlock Text="{loc:Localize Out}" Foreground="#E74C3C" FontSize="11"/>
+                                                        <TextBlock Grid.Column="1" Text="{loc:Localize UTurnCompensation}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                    HorizontalAlignment="Center" FontWeight="SemiBold"/>
-                                                        <TextBlock Grid.Column="2" Text="In" Foreground="#4A9A7E" FontSize="11"/>
+                                                        <TextBlock Grid.Column="2" Text="{loc:Localize In}" Foreground="#4A9A7E" FontSize="11"/>
                                                     </Grid>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditUTurnCompensationCommand}">
@@ -848,7 +849,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Sidehill Compensation -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
-                                                    <TextBlock Text="Sidehill / Degree" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
+                                                    <TextBlock Text="{loc:Localize SidehillDegree}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"
                                                                HorizontalAlignment="Center"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditSidehillCompensationCommand}">
@@ -867,11 +868,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                 <Button Classes="ToggleButton" Command="{Binding ToggleSteerInReverseCommand}"
                                                         HorizontalAlignment="Stretch">
                                                     <Grid ColumnDefinitions="*,Auto">
-                                                        <TextBlock Text="Steer in Reverse" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                                        <TextBlock Text="{loc:Localize SteerInReverse}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                                         <Grid Grid.Column="1">
-                                                            <TextBlock Text="ON" Foreground="#4A9A7E" FontWeight="Bold"
+                                                            <TextBlock Text="{loc:Localize On2}" Foreground="#4A9A7E" FontWeight="Bold"
                                                                        IsVisible="{Binding AutoSteer.SteerInReverse}"/>
-                                                            <TextBlock Text="OFF" Foreground="#E74C3C" FontWeight="Bold"
+                                                            <TextBlock Text="{loc:Localize Off2}" Foreground="#E74C3C" FontWeight="Bold"
                                                                        IsVisible="{Binding !AutoSteer.SteerInReverse}"/>
                                                         </Grid>
                                                     </Grid>
@@ -889,7 +890,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="Speed Limits" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize SpeedLimits}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Speed Settings -->
@@ -899,7 +900,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/con_VehicleFunctionSpeedLimit.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Manual Turns" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize ManualTurns}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditManualTurnsSpeedCommand}"
                                                                 HorizontalAlignment="Stretch">
@@ -907,14 +908,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
-                                                        <TextBlock Text="km/h" Foreground="#777" FontSize="10"
+                                                        <TextBlock Text="{loc:Localize KilometersPerHour}" Foreground="#777" FontSize="10"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- Min Speed -->
                                                     <StackPanel Grid.Column="1" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_MinAutoSteer.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Min Speed" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize MinSpeed}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditMinSteerSpeedCommand}"
                                                                 HorizontalAlignment="Stretch">
@@ -922,14 +923,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
-                                                        <TextBlock Text="km/h" Foreground="#777" FontSize="10"
+                                                        <TextBlock Text="{loc:Localize KilometersPerHour}" Foreground="#777" FontSize="10"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- Max Speed -->
                                                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_MaxAutoSteer.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Max Speed" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize MaxSpeed}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditMaxSteerSpeedCommand}"
                                                                 HorizontalAlignment="Stretch">
@@ -937,7 +938,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
-                                                        <TextBlock Text="km/h" Foreground="#777" FontSize="10"
+                                                        <TextBlock Text="{loc:Localize KilometersPerHour}" Foreground="#777" FontSize="10"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Grid>
@@ -954,7 +955,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="Display Settings" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize DisplaySettings}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Numeric inputs row 1: Line Width & Nudge Distance -->
@@ -964,7 +965,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="0" Margin="0,0,4,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_LineWith.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Line Width" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize LineWidth}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditLineWidthCommand}"
                                                                 HorizontalAlignment="Stretch">
@@ -972,14 +973,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
-                                                        <TextBlock Text="pixels" Foreground="#777" FontSize="10"
+                                                        <TextBlock Text="{loc:Localize Pixels}" Foreground="#777" FontSize="10"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- Nudge Distance -->
                                                     <StackPanel Grid.Column="1" Margin="4,0,0,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_SnapDistance.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Nudge Distance" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize NudgeDistance}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditNudgeDistanceCommand}"
                                                                 HorizontalAlignment="Stretch">
@@ -987,7 +988,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
-                                                        <TextBlock Text="cm" Foreground="#777" FontSize="10"
+                                                        <TextBlock Text="{loc:Localize Cm}" Foreground="#777" FontSize="10"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Grid>
@@ -1000,7 +1001,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <StackPanel Grid.Column="0" Margin="0,0,4,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_GuidanceLookAhead.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Next Guidance" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize NextGuidance}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditNextGuidanceTimeCommand}"
                                                                 HorizontalAlignment="Stretch">
@@ -1008,14 +1009,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
-                                                        <TextBlock Text="sec" Foreground="#777" FontSize="10"
+                                                        <TextBlock Text="{loc:Localize Sec}" Foreground="#777" FontSize="10"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- Cm -> Pixel -->
                                                     <StackPanel Grid.Column="1" Margin="4,0,0,0" HorizontalAlignment="Center">
                                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConV_CmPixel.png"
                                                                Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Cm -> Pixel" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
+                                                        <TextBlock Text="{loc:Localize CmPixel}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"
                                                                    HorizontalAlignment="Center"/>
                                                         <Button Classes="TappableValue" Command="{Binding EditCmPerPixelCommand}"
                                                                 HorizontalAlignment="Stretch">
@@ -1023,7 +1024,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"
                                                                        HorizontalAlignment="Center"/>
                                                         </Button>
-                                                        <TextBlock Text="cm/px" Foreground="#777" FontSize="10"
+                                                        <TextBlock Text="{loc:Localize CmPx}" Foreground="#777" FontSize="10"
                                                                    HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Grid>
@@ -1042,7 +1043,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Lightbar" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize Lightbar}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- Steering Bar -->
                                                     <StackPanel Grid.Column="1" HorizontalAlignment="Center">
@@ -1054,7 +1055,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        Width="48" Height="48" Stretch="Uniform"/>
                                                             </Button>
                                                         </Border>
-                                                        <TextBlock Text="Steer Bar" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize SteerBar}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                     <!-- On/Off (Guidance Bar) -->
                                                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
@@ -1069,7 +1070,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                                        IsVisible="{Binding !AutoSteer.GuidanceBarOn}"/>
                                                             </Grid>
                                                         </Button>
-                                                        <TextBlock Text="On/Off" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="{loc:Localize OnOff}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Grid>
                                             </Border>
@@ -1086,7 +1087,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png"
                                                Width="32" Height="32" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                        <TextBlock Text="Wizard" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Localize Wizard}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <!-- Reset -->
@@ -1095,7 +1096,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Reset_Default.png"
                                                Width="32" Height="32" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                        <TextBlock Text="Defaults" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Localize Defaults}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <!-- Send+Save with unsaved changes warning -->
@@ -1110,7 +1111,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                    Width="24" Height="24" Stretch="Uniform" VerticalAlignment="Center"
                                                    IsVisible="{Binding HasUnsavedRightSideChanges}"/>
                                         </StackPanel>
-                                        <TextBlock Text="Send+Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Localize Sendsave}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <!-- Close -->
@@ -1130,17 +1131,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Status Values - Fixed width columns to prevent layout shift -->
                         <StackPanel Orientation="Horizontal" Spacing="16">
                             <StackPanel Orientation="Horizontal" Width="80">
-                                <TextBlock Text="Set:" Classes="StatusLabel" VerticalAlignment="Center" Width="30"/>
+                                <TextBlock Text="{loc:Localize Set}" Classes="StatusLabel" VerticalAlignment="Center" Width="30"/>
                                 <TextBlock Text="{Binding SetSteerAngle, StringFormat='{}{0:F1}°'}"
                                            Classes="StatusValue" VerticalAlignment="Center" Width="50" TextAlignment="Right"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Width="80">
-                                <TextBlock Text="Act:" Classes="StatusLabel" VerticalAlignment="Center" Width="30"/>
+                                <TextBlock Text="{loc:Localize Act}" Classes="StatusLabel" VerticalAlignment="Center" Width="30"/>
                                 <TextBlock Text="{Binding ActualSteerAngle, StringFormat='{}{0:F1}°'}"
                                            Classes="StatusValue" VerticalAlignment="Center" Width="50" TextAlignment="Right"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Width="80">
-                                <TextBlock Text="Err:" Classes="StatusLabel" VerticalAlignment="Center" Width="30"/>
+                                <TextBlock Text="{loc:Localize Err}" Classes="StatusLabel" VerticalAlignment="Center" Width="30"/>
                                 <TextBlock Text="{Binding SteerError, StringFormat='{}{0:F1}°'}"
                                            Foreground="#E74C3C" FontWeight="Bold" FontSize="14"
                                            VerticalAlignment="Center" Width="50" TextAlignment="Right"/>
@@ -1151,7 +1152,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Button Grid.Column="1" Command="{Binding ToggleFullModeCommand}"
                                 Background="{DynamicResource SystemControlHighlightAccentBrush}" Padding="12,6" CornerRadius="4">
                             <StackPanel Orientation="Horizontal" Spacing="4">
-                                <TextBlock Text="|||" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
+                                <TextBlock Text="{loc:Localize 2}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                                 <Grid>
                                     <TextBlock Text="◀" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"
                                                IsVisible="{Binding IsFullMode}"/>
@@ -1208,9 +1209,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                     <!-- Confirm/Cancel -->
                     <Grid Grid.Row="3" ColumnDefinitions="*,*" Margin="0,12,0,0">
-                        <Button Grid.Column="0" Content="Cancel" Command="{Binding CancelNumericInputCommand}"
+                        <Button Grid.Column="0" Content="{loc:Localize Cancel}" Command="{Binding CancelNumericInputCommand}"
                                 Margin="0,0,4,0" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-                        <Button Grid.Column="1" Content="OK" Command="{Binding ConfirmNumericInputCommand}"
+                        <Button Grid.Column="1" Content="{loc:Localize OK}" Command="{Binding ConfirmNumericInputCommand}"
                                 Margin="4,0,0,0" Background="{DynamicResource SystemControlHighlightAccentBrush}"/>
                     </Grid>
                 </Grid>
@@ -1230,19 +1231,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Reset_Default.png"
                                Width="40" Height="40" Stretch="Uniform"/>
-                        <TextBlock Text="Reset to Defaults?" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                        <TextBlock Text="{loc:Localize ResetToDefaults}" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
 
                     <!-- Warning Message -->
-                    <TextBlock Text="This will reset ALL AutoSteer settings to factory defaults and send them to the module."
+                    <TextBlock Text="{loc:Localize ThisWillResetAllAutosteerSettingsToFactoryDefaultsAndSendThemToTheModule}"
                                TextWrapping="Wrap" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" TextAlignment="Center"/>
 
                     <!-- Buttons -->
                     <Grid ColumnDefinitions="*,*" Margin="0,8,0,0">
-                        <Button Grid.Column="0" Content="Cancel" Command="{Binding CancelResetCommand}"
+                        <Button Grid.Column="0" Content="{loc:Localize Cancel}" Command="{Binding CancelResetCommand}"
                                 Margin="0,0,4,0" Padding="16,10" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-                        <Button Grid.Column="1" Content="Reset" Command="{Binding ConfirmResetCommand}"
+                        <Button Grid.Column="1" Content="{loc:Localize Reset}" Command="{Binding ConfirmResetCommand}"
                                 Margin="4,0,0,0" Padding="16,10" Background="#DDE74C3C"/>
                     </Grid>
                 </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -98,9 +99,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Grid.Column="0">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="24" Height="24"/>
-                                <TextBlock Text="Draw Field Boundary" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18"/>
+                                <TextBlock Text="{loc:Localize DrawFieldBoundary}" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18"/>
                             </StackPanel>
-                            <TextBlock Text="Tap on the map to add boundary points. Pan with drag, pinch to zoom."
+                            <TextBlock Text="{loc:Localize TapOnTheMapToAddBoundaryPointsPanWithDragPinchToZoom}"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,5,0,0"/>
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
@@ -126,7 +127,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 Click="BtnDraw_Click" ToolTip.Tip="Toggle drawing mode">
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="20" Height="20"/>
-                                <TextBlock x:Name="BtnDrawText" Text="Draw" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
+                                <TextBlock x:Name="BtnDrawText" Text="{loc:Localize Draw}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
 
@@ -134,13 +135,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 Click="BtnUndo_Click" ToolTip.Tip="Remove last point" IsEnabled="False">
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BackSpace.png" Width="20" Height="20"/>
-                                <TextBlock Text="Undo" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
+                                <TextBlock Text="{loc:Localize Undo}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
 
                         <Button x:Name="BtnClear" Classes="ToolButton"
                                 Click="BtnClear_Click" ToolTip.Tip="Clear all points" IsEnabled="False">
-                            <TextBlock Text="Clear" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                            <TextBlock Text="{loc:Localize Clear}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         </Button>
                     </StackPanel>
                 </Border>
@@ -148,7 +149,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Bottom action bar -->
                 <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Padding="15" CornerRadius="0,0,12,12">
                     <Grid ColumnDefinitions="Auto,*,Auto,Auto">
-                        <CheckBox x:Name="ChkSaveBackground" Grid.Column="0" Content="Include Background Image"
+                        <CheckBox x:Name="ChkSaveBackground" Grid.Column="0" Content="{loc:Localize IncludeBackgroundImage}"
                                   IsChecked="{Binding BoundaryMapIncludeBackground}"
                                   VerticalAlignment="Center"/>
 
@@ -156,13 +157,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <Button Grid.Column="2" Classes="CancelButton" Margin="0,0,10,0"
                                 Command="{Binding CancelBoundaryMapDialogCommand}" ToolTip.Tip="Cancel">
-                            <TextBlock Text="Cancel" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                            <TextBlock Text="{loc:Localize Cancel}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         </Button>
 
                         <Button x:Name="BtnSave" Grid.Column="3" Classes="OkButton"
                                 Click="BtnSave_Click" ToolTip.Tip="Save boundary"
                                 IsEnabled="{Binding BoundaryMapCanSave}">
-                            <TextBlock Text="Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
+                            <TextBlock Text="{loc:Localize Save}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"/>
                         </Button>
                     </Grid>
                 </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -67,7 +68,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Header with title -->
                 <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,8">
-                    <TextBlock Text="Configuration" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                    <TextBlock Text="{loc:Localize Configuration}" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                 </Border>
 
                 <!-- Main content area with TabControl -->
@@ -240,13 +241,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding CancelNumericInputCommand}"
                                         HorizontalContentAlignment="Center">
-                                    <TextBlock Text="Cancel"/>
+                                    <TextBlock Text="{loc:Localize Cancel}"/>
                                 </Button>
                                 <Button Grid.Column="1" Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding ConfirmNumericInputCommand}"
                                         HorizontalContentAlignment="Center">
-                                    <TextBlock Text="OK"/>
+                                    <TextBlock Text="{loc:Localize OK}"/>
                                 </Button>
                             </Grid>
                         </Grid>
@@ -350,7 +351,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Button Classes="KeyButton" Content="v" Command="{Binding TextInputKeyCommand}" CommandParameter="v"/>
                                     <Button Classes="KeyButton" Content="b" Command="{Binding TextInputKeyCommand}" CommandParameter="b"/>
                                     <Button Classes="KeyButton" Content="n" Command="{Binding TextInputKeyCommand}" CommandParameter="n"/>
-                                    <Button Classes="KeyButton" Content="m" Command="{Binding TextInputKeyCommand}" CommandParameter="m"/>
+                                    <Button Classes="KeyButton" Content="{loc:Localize Meters}" Command="{Binding TextInputKeyCommand}" CommandParameter="m"/>
                                     <Button Classes="KeyButton" Content="." Command="{Binding TextInputKeyCommand}" CommandParameter="."/>
                                     <Button Classes="KeyButton" Content="-" Command="{Binding TextInputKeyCommand}" CommandParameter="-"/>
                                     <Button Classes="KeyButton" Content="_" Command="{Binding TextInputKeyCommand}" CommandParameter="_"/>
@@ -360,9 +361,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4,0,0">
                                     <Button Classes="KeyButton SpecialKey" Content="⌫" MinWidth="60"
                                             Command="{Binding TextInputBackspaceCommand}"/>
-                                    <Button Classes="KeyButton" Content="Space" MinWidth="140"
+                                    <Button Classes="KeyButton" Content="{loc:Localize Space}" MinWidth="140"
                                             Command="{Binding TextInputSpaceCommand}"/>
-                                    <Button Classes="KeyButton SpecialKey" Content="Clear" MinWidth="60"
+                                    <Button Classes="KeyButton SpecialKey" Content="{loc:Localize Clear}" MinWidth="60"
                                             Command="{Binding TextInputClearCommand}"/>
                                     <Button Classes="KeyButton" Content="@" Command="{Binding TextInputKeyCommand}" CommandParameter="@"/>
                                     <Button Classes="KeyButton" Content=":" Command="{Binding TextInputKeyCommand}" CommandParameter=":"/>
@@ -376,13 +377,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding CancelTextInputCommand}"
                                         HorizontalContentAlignment="Center">
-                                    <TextBlock Text="Cancel"/>
+                                    <TextBlock Text="{loc:Localize Cancel}"/>
                                 </Button>
                                 <Button Grid.Column="1" Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding ConfirmTextInputCommand}"
                                         HorizontalContentAlignment="Center">
-                                    <TextBlock Text="OK"/>
+                                    <TextBlock Text="{loc:Localize OK}"/>
                                 </Button>
                             </Grid>
                         </Grid>
@@ -460,7 +461,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                     Command="{Binding CancelColorPickerCommand}"
                                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center">
-                                <TextBlock Text="Cancel"/>
+                                <TextBlock Text="{loc:Localize Cancel}"/>
                             </Button>
                         </Grid>
                     </Border>
@@ -475,14 +476,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Units display -->
                         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" Margin="0,0,24,0">
-                            <TextBlock Text="Units:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Units}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                             <TextBlock Text="{Binding Display.IsMetric, Converter={x:Static conv:BoolToStringConverter.Instance}, ConverterParameter='Metric|Imperial'}"
                                        Foreground="#4A9" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Width display -->
                         <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8" Margin="0,0,24,0">
-                            <TextBlock Text="Width:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Width}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
                             <TextBlock Text="{Binding Tool.Width, StringFormat='{}{0:F2} m'}"
                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -48,13 +49,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Action Buttons -->
                 <Grid ColumnDefinitions="*,*" Margin="0,12,0,0">
-                    <Button Grid.Column="0" Content="No" Margin="0,0,8,0"
+                    <Button Grid.Column="0" Content="{loc:Localize No}" Margin="0,0,8,0"
                             Command="{Binding CancelConfirmationDialogCommand}"
                             Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="50" FontSize="18" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Padding="0" CornerRadius="6"/>
-                    <Button Grid.Column="1" Content="Yes" Margin="8,0,0,0"
+                    <Button Grid.Column="1" Content="{loc:Localize Yes}" Margin="8,0,0,0"
                             Command="{Binding ConfirmConfirmationDialogCommand}"
                             Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="50" FontSize="18" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/DataIODialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/DataIODialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -105,8 +106,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="12,12,0,0" Padding="20,15">
                     <Grid ColumnDefinitions="*,Auto">
                         <StackPanel>
-                            <TextBlock Text="Data I/O Configuration" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="20" FontWeight="Bold"/>
-                            <TextBlock Text="Network and GPS settings" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,5,0,0"/>
+                            <TextBlock Text="{loc:Localize DataIOConfiguration}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="20" FontWeight="Bold"/>
+                            <TextBlock Text="{loc:Localize NetworkAndGpsSettings}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,5,0,0"/>
                         </StackPanel>
                         <Button Grid.Column="1" Background="Transparent" BorderThickness="0"
                                 Command="{Binding CloseDataIODialogCommand}" Cursor="Hand" VerticalAlignment="Top">
@@ -122,10 +123,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- UDP Communication Section -->
                         <Border Classes="Panel">
                             <StackPanel Spacing="10">
-                                <TextBlock Classes="Header" Text="UDP Communication"/>
+                                <TextBlock Classes="Header" Text="{loc:Localize UdpCommunication}"/>
 
                                 <Grid ColumnDefinitions="140,*">
-                                    <TextBlock Classes="Label" Text="Network Status:" VerticalAlignment="Center"/>
+                                    <TextBlock Classes="Label" Text="{loc:Localize NetworkStatus}" VerticalAlignment="Center"/>
                                     <TextBlock Grid.Column="1" Text="{Binding NetworkStatus}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
                                 </Grid>
                             </StackPanel>
@@ -134,11 +135,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Module Connections Section -->
                         <Border Classes="Panel">
                             <StackPanel Spacing="10">
-                                <TextBlock Classes="Header" Text="Module Connections"/>
+                                <TextBlock Classes="Header" Text="{loc:Localize ModuleConnections}"/>
 
                                 <Grid ColumnDefinitions="140,Auto,*" RowDefinitions="Auto,Auto,Auto">
                                     <!-- AutoSteer -->
-                                    <TextBlock Classes="Label" Text="AutoSteer:" VerticalAlignment="Center"/>
+                                    <TextBlock Classes="Label" Text="{loc:Localize Autosteer}" VerticalAlignment="Center"/>
                                     <Ellipse Grid.Column="1" Width="12" Height="12" Margin="0,0,10,0"
                                              Fill="{Binding State.Connections.IsAutoSteerDataOk, Converter={StaticResource BoolToColorConverter}}"/>
                                     <TextBlock Grid.Column="2"
@@ -146,7 +147,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
 
                                     <!-- Machine -->
-                                    <TextBlock Grid.Row="1" Classes="Label" Text="Machine:" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                                    <TextBlock Grid.Row="1" Classes="Label" Text="{loc:Localize Machine}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                                     <Ellipse Grid.Row="1" Grid.Column="1" Width="12" Height="12" Margin="0,8,10,0"
                                              Fill="{Binding State.Connections.IsMachineDataOk, Converter={StaticResource BoolToColorConverter}}"/>
                                     <TextBlock Grid.Row="1" Grid.Column="2" Margin="0,8,0,0"
@@ -154,7 +155,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center"/>
 
                                     <!-- IMU -->
-                                    <TextBlock Grid.Row="2" Classes="Label" Text="IMU:" VerticalAlignment="Center" Margin="0,8,0,0"/>
+                                    <TextBlock Grid.Row="2" Classes="Label" Text="{loc:Localize Imu}" VerticalAlignment="Center" Margin="0,8,0,0"/>
                                     <Ellipse Grid.Row="2" Grid.Column="1" Width="12" Height="12" Margin="0,8,10,0"
                                              Fill="{Binding State.Connections.IsImuDataOk, Converter={StaticResource BoolToColorConverter}}"/>
                                     <TextBlock Grid.Row="2" Grid.Column="2" Margin="0,8,0,0"
@@ -167,25 +168,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- GPS Data Section -->
                         <Border Classes="Panel">
                             <StackPanel Spacing="8">
-                                <TextBlock Classes="Header" Text="GPS Data"/>
+                                <TextBlock Classes="Header" Text="{loc:Localize GpsData}"/>
 
                                 <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
-                                    <TextBlock Classes="Label" Text="Status:"/>
+                                    <TextBlock Classes="Label" Text="{loc:Localize Status}"/>
                                     <TextBlock Grid.Column="1" Text="{Binding StatusMessage}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
 
-                                    <TextBlock Grid.Row="1" Classes="Label" Text="Fix Quality:" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="1" Classes="Label" Text="{loc:Localize FixQuality}" Margin="0,6,0,0"/>
                                     <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding State.Vehicle.FixQualityText}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
-                                    <TextBlock Grid.Row="2" Classes="Label" Text="Satellites:" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="2" Classes="Label" Text="{loc:Localize Satellites}" Margin="0,6,0,0"/>
                                     <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding State.Vehicle.SatelliteCount}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
-                                    <TextBlock Grid.Row="3" Classes="Label" Text="Latitude:" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="3" Classes="Label" Text="{loc:Localize Latitude2}" Margin="0,6,0,0"/>
                                     <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding State.Vehicle.Latitude, StringFormat='{}{0:F6}°'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
-                                    <TextBlock Grid.Row="4" Classes="Label" Text="Longitude:" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="4" Classes="Label" Text="{loc:Localize Longitude2}" Margin="0,6,0,0"/>
                                     <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding State.Vehicle.Longitude, StringFormat='{}{0:F6}°'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
 
-                                    <TextBlock Grid.Row="5" Classes="Label" Text="Speed:" Margin="0,6,0,0"/>
+                                    <TextBlock Grid.Row="5" Classes="Label" Text="{loc:Localize Speed2}" Margin="0,6,0,0"/>
                                     <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding State.Vehicle.Speed, StringFormat='{}{0:F2} m/s'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="0,6,0,0"/>
                                 </Grid>
                             </StackPanel>
@@ -195,7 +196,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Footer -->
                 <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="0,0,12,12" Padding="15">
-                    <Button Classes="ModernButton" Content="Close"
+                    <Button Classes="ModernButton" Content="{loc:Localize Close}"
                             Command="{Binding CloseDataIODialogCommand}"
                             HorizontalAlignment="Stretch" Background="#27AE60"/>
                 </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -69,11 +70,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Padding="20" BoxShadow="0 8 32 #40000000">
             <StackPanel Spacing="16">
                 <!-- Title -->
-                <TextBlock Text="Draw Track on Map"
+                <TextBlock Text="{loc:Localize DrawTrackOnMap}"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" FontWeight="Bold"
                            HorizontalAlignment="Center"/>
 
-                <TextBlock Text="Tap on the map to place points"
+                <TextBlock Text="{loc:Localize TapOnTheMapToPlacePoints}"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14"
                            HorizontalAlignment="Center"/>
 
@@ -85,8 +86,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
-                            <TextBlock Text="Straight" FontSize="12" HorizontalAlignment="Center"/>
-                            <TextBlock Text="(2 pts)" FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Straight}" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize 2Pts}" FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -96,8 +97,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackCurve.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
-                            <TextBlock Text="Curve" FontSize="12" HorizontalAlignment="Center"/>
-                            <TextBlock Text="(3+ pts)" FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Curve}" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize 3Pts}" FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -107,7 +108,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Cancel64.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
-                            <TextBlock Text="Cancel" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Cancel}" FontSize="12" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
                 </StackPanel>
@@ -115,11 +116,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Instructions for straight line -->
                 <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="8" Padding="12">
                     <StackPanel Spacing="4">
-                        <TextBlock Text="Straight Line:" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="13"/>
-                        <TextBlock Text="Tap 2 points to create a straight AB line"
+                        <TextBlock Text="{loc:Localize StraightLine}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="13"/>
+                        <TextBlock Text="{loc:Localize Tap2PointsToCreateAStraightAbLine}"
                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
-                        <TextBlock Text="Curve:" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="13" Margin="0,8,0,0"/>
-                        <TextBlock Text="Tap 3+ points, then tap Finish in the status bar"
+                        <TextBlock Text="{loc:Localize Curve2}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="13" Margin="0,8,0,0"/>
+                        <TextBlock Text="{loc:Localize Tap3PointsThenTapFinishInTheStatusBar}"
                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                     </StackPanel>
                 </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ErrorDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ErrorDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -47,7 +48,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            Margin="0,8"/>
 
                 <!-- OK Button -->
-                <Button Content="OK" Margin="0,12,0,0"
+                <Button Content="{loc:Localize OK}" Margin="0,12,0,0"
                         Command="{Binding DismissErrorDialogCommand}"
                         Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Center" Width="120" Height="50"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -96,15 +97,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Padding="16">
             <Grid RowDefinitions="Auto,Auto,*,Auto">
                 <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="Select Field to Open"/>
+                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize SelectFieldToOpen}"/>
 
                 <!-- Column Headers -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
                     <Grid ColumnDefinitions="*,120,80,80">
-                        <TextBlock Grid.Column="0" Text="Field Name" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="1" Text="NTRIP Profile" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="2" Text="Distance" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Right"/>
-                        <TextBlock Grid.Column="3" Text="Area (ha)" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="0" Text="{loc:Localize FieldName}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="1" Text="{loc:Localize NtripProfile}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="2" Text="{loc:Localize Distance}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="3" Text="{loc:Localize AreaHa}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Right"/>
                     </Grid>
                 </Border>
 
@@ -132,22 +133,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Action Buttons -->
                 <Grid Grid.Row="3" ColumnDefinitions="Auto,Auto,*,Auto,Auto" Margin="0,12,0,0">
                     <!-- Delete Field Button -->
-                    <Button Grid.Column="0" Classes="DialogButton DangerButton" Content="Delete"
+                    <Button Grid.Column="0" Classes="DialogButton DangerButton" Content="{loc:Localize Delete}"
                             Command="{Binding DeleteSelectedFieldCommand}"/>
 
                     <!-- Sort Button -->
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Sort A-Z"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize SortAZ}"
                             Command="{Binding SortFieldsCommand}" Margin="8,0,0,0"/>
 
                     <!-- Spacer -->
                     <Border Grid.Column="2"/>
 
                     <!-- Cancel Button -->
-                    <Button Grid.Column="3" Classes="DialogButton CancelButton" Content="Cancel"
+                    <Button Grid.Column="3" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
                             Command="{Binding CancelFieldSelectionDialogCommand}"/>
 
                     <!-- Open Button -->
-                    <Button Grid.Column="4" Classes="DialogButton" Content="Open"
+                    <Button Grid.Column="4" Classes="DialogButton" Content="{loc:Localize Open}"
                             Command="{Binding ConfirmFieldSelectionDialogCommand}" Margin="8,0,0,0"/>
                 </Grid>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
@@ -9,6 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -26,10 +27,10 @@ the Free Software Foundation, either version 3 of the License, or
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="400" MaxWidth="500">
             <StackPanel Spacing="16">
-                <TextBlock Text="Place Flag by Lat/Lon" FontSize="20" FontWeight="Bold"
+                <TextBlock Text="{loc:Localize PlaceFlagByLatLon}" FontSize="20" FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
 
-                <TextBlock Text="Enter WGS84 coordinates in decimal degrees"
+                <TextBlock Text="{loc:Localize EnterWgs84CoordinatesInDecimalDegrees}"
                            FontSize="12"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                            HorizontalAlignment="Center"/>
@@ -38,7 +39,7 @@ the Free Software Foundation, either version 3 of the License, or
 
                 <!-- Latitude -->
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Latitude (-90 to 90)"
+                    <TextBlock Text="{loc:Localize Latitude90To902}"
                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                FontSize="13"/>
                     <TextBox Text="{Binding FlagLatitudeInput, Mode=TwoWay}"
@@ -48,7 +49,7 @@ the Free Software Foundation, either version 3 of the License, or
 
                 <!-- Longitude -->
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Longitude (-180 to 180)"
+                    <TextBlock Text="{loc:Localize Longitude180To1802}"
                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                FontSize="13"/>
                     <TextBox Text="{Binding FlagLongitudeInput, Mode=TwoWay}"
@@ -66,12 +67,12 @@ the Free Software Foundation, either version 3 of the License, or
 
                 <!-- Buttons -->
                 <Grid ColumnDefinitions="*,12,*">
-                    <Button Grid.Column="0" Content="Cancel"
+                    <Button Grid.Column="0" Content="{loc:Localize Cancel}"
                             Command="{Binding CloseFlagByLatLonDialogCommand}"
                             Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
-                    <Button Grid.Column="2" Content="Place Flag"
+                    <Button Grid.Column="2" Content="{loc:Localize PlaceFlag}"
                             Command="{Binding PlaceFlagByLatLonCommand}"
                             Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagListDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagListDialogPanel.axaml
@@ -9,6 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -34,7 +35,7 @@ the Free Software Foundation, either version 3 of the License, or
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,12">
-                    <TextBlock Text="Flags" FontSize="18" FontWeight="Bold"
+                    <TextBlock Text="{loc:Localize Flags}" FontSize="18" FontWeight="Bold"
                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                     <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
                 </StackPanel>
@@ -108,12 +109,12 @@ the Free Software Foundation, either version 3 of the License, or
                             BorderThickness="1" CornerRadius="8" Padding="16"
                             MaxWidth="300" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <StackPanel Spacing="8">
-                            <TextBlock Text="Rename Flag" FontSize="14" FontWeight="Bold"
+                            <TextBlock Text="{loc:Localize RenameFlag}" FontSize="14" FontWeight="Bold"
                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                             <TextBox x:Name="NameEditBox" FontSize="14" Watermark="Enter flag name"/>
                             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
-                                <Button Content="OK" Padding="16,6" Click="NameEditOK_Click"/>
-                                <Button Content="Cancel" Padding="16,6" Click="NameEditCancel_Click"/>
+                                <Button Content="{loc:Localize OK}" Padding="16,6" Click="NameEditOK_Click"/>
+                                <Button Content="{loc:Localize Cancel}" Padding="16,6" Click="NameEditCancel_Click"/>
                             </StackPanel>
                         </StackPanel>
                     </Border>
@@ -122,13 +123,13 @@ the Free Software Foundation, either version 3 of the License, or
                 <!-- Footer buttons -->
                 <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8"
                             HorizontalAlignment="Right" Margin="0,12,0,0">
-                    <Button Content="Place Flag Here" Padding="12,6"
+                    <Button Content="{loc:Localize PlaceFlagHere}" Padding="12,6"
                             Command="{Binding PlaceFlagHereCommand}"/>
-                    <Button Content="Place on Map" Padding="12,6"
+                    <Button Content="{loc:Localize PlaceOnMap}" Padding="12,6"
                             Command="{Binding PlaceFlagOnClickCommand}"/>
-                    <Button Content="Delete All" Padding="12,6"
+                    <Button Content="{loc:Localize DeleteAll}" Padding="12,6"
                             Command="{Binding DeleteAllFlagsCommand}"/>
-                    <Button Content="Close" Padding="12,6"
+                    <Button Content="{loc:Localize Close}" Padding="12,6"
                             Command="{Binding CloseFlagListCommand}"/>
                 </StackPanel>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -138,14 +139,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 BoxShadow="0 8 32 #40000000">
             <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto" Margin="20">
                 <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="Create Field From Existing"/>
+                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize CreateFieldFromExisting}"/>
 
                 <!-- Column Headers -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8">
                     <Grid ColumnDefinitions="*,80,80">
-                        <TextBlock Grid.Column="0" Text="Field Name" Foreground="#E74C3C" FontWeight="Bold" FontSize="14"/>
-                        <TextBlock Grid.Column="1" Text="Distance" Foreground="#E74C3C" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
-                        <TextBlock Grid.Column="2" Text="Area (ha)" Foreground="#E74C3C" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="0" Text="{loc:Localize FieldName}" Foreground="#E74C3C" FontWeight="Bold" FontSize="14"/>
+                        <TextBlock Grid.Column="1" Text="{loc:Localize Distance}" Foreground="#E74C3C" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="2" Text="{loc:Localize AreaHa}" Foreground="#E74C3C" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
                     </Grid>
                 </Border>
 
@@ -169,7 +170,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Name input row -->
                 <StackPanel Grid.Row="3" Margin="0,12,0,0" Spacing="6">
-                    <TextBlock Text="New Field Name:" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
+                    <TextBlock Text="{loc:Localize NewFieldName}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBox Grid.Column="0"
                                  Classes="DialogInput"
@@ -218,7 +219,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyFlagsCommand}" ToolTip.Tip="Include Flags">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FlagRed.png" Width="24" Height="24"/>
-                            <TextBlock Text="Flags" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Flags}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -227,7 +228,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyMappingCommand}" ToolTip.Tip="Include Mapping">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/MappingOn.png" Width="24" Height="24"/>
-                            <TextBlock Text="Map" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Map}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -236,7 +237,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyHeadlandCommand}" ToolTip.Tip="Include Headland">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandOn.png" Width="24" Height="24"/>
-                            <TextBlock Text="Head" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Head}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -245,7 +246,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ToggleCopyLinesCommand}" ToolTip.Tip="Include AB Lines">
                         <StackPanel HorizontalAlignment="Center" Spacing="2">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png" Width="24" Height="24"/>
-                            <TextBlock Text="Lines" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Lines}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
                 </Grid>
@@ -253,10 +254,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Action Buttons -->
                 <Grid Grid.Row="5" ColumnDefinitions="*,Auto,Auto" Margin="0,16,0,0">
                     <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Cancel"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
                             MinWidth="80" MinHeight="44"
                             Command="{Binding CancelFromExistingFieldDialogCommand}"/>
-                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="Create"
+                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="{loc:Localize Create}"
                             MinWidth="80" MinHeight="44" Margin="12,0,0,0"
                             Command="{Binding ConfirmFromExistingFieldDialogCommand}"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandBuilderDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandBuilderDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -37,11 +38,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 MinWidth="320" MaxWidth="400">
             <StackPanel Spacing="12">
                 <!-- Title -->
-                <TextBlock Text="Headland Builder" FontSize="20" FontWeight="Bold"
+                <TextBlock Text="{loc:Localize HeadlandBuilder}" FontSize="20" FontWeight="Bold"
                            Foreground="#1ABC9C" HorizontalAlignment="Center"/>
 
                 <!-- Status message if no boundary -->
-                <TextBlock Text="No boundary loaded - please create or load a field first"
+                <TextBlock Text="{loc:Localize NoBoundaryLoadedPleaseCreateOrLoadAFieldFirst}"
                            FontSize="14" Foreground="#E74C3C" HorizontalAlignment="Center"
                            TextWrapping="Wrap" TextAlignment="Center"
                            IsVisible="{Binding !HasBoundary}"/>
@@ -52,7 +53,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Distance Setting -->
                     <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Padding="12">
                         <StackPanel Spacing="8">
-                            <TextBlock Text="Headland Distance (meters)" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize HeadlandDistanceMeters}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto,Auto">
                                 <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundListLowBrush}" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandDistance, StringFormat={}{0:F1}}"
@@ -67,7 +68,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="4"
                                             Command="{Binding DecrementHeadlandDistanceCommand}"/>
                                 </StackPanel>
-                                <Button Grid.Column="2" Content="Tool Width" Width="80" Height="58"
+                                <Button Grid.Column="2" Content="{loc:Localize ToolWidth}" Width="80" Height="58"
                                         FontSize="11" Background="#2980B9" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         CornerRadius="6" Margin="8,0,0,0"
                                         Command="{Binding SetHeadlandToToolWidthCommand}"
@@ -79,7 +80,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- Passes Setting -->
                     <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="8" Padding="12">
                         <StackPanel Spacing="8">
-                            <TextBlock Text="Number of Passes" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize NumberOfPasses}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto">
                                 <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundListLowBrush}" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandPasses}"
@@ -103,7 +104,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             IsVisible="{Binding HeadlandPreviewLine, Converter={x:Static ObjectConverters.IsNotNull}}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
                             <Ellipse Width="12" Height="12" Fill="#F39C12"/>
-                            <TextBlock Text="Preview shown on map" Foreground="#F39C12" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize PreviewShownOnMap}" Foreground="#F39C12" FontSize="12"/>
                         </StackPanel>
                     </Border>
 
@@ -112,25 +113,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             IsVisible="{Binding HasHeadland}">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
                             <Ellipse Width="12" Height="12" Fill="#1ABC9C"/>
-                            <TextBlock Text="Headland line active" Foreground="#1ABC9C" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize HeadlandLineActive}" Foreground="#1ABC9C" FontSize="12"/>
                         </StackPanel>
                     </Border>
                 </StackPanel>
 
                 <!-- Action Buttons -->
                 <Grid ColumnDefinitions="*,*,*" Margin="0,8,0,0" IsVisible="{Binding HasBoundary}">
-                    <Button Grid.Column="0" Content="Clear" Margin="0,0,4,0"
+                    <Button Grid.Column="0" Content="{loc:Localize Clear}" Margin="0,0,4,0"
                             Command="{Binding ClearHeadlandCommand}"
                             Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="14"
                             HorizontalContentAlignment="Center" CornerRadius="6"
                             IsEnabled="{Binding HasHeadland}"/>
-                    <Button Grid.Column="1" Content="Build" Margin="4,0,4,0"
+                    <Button Grid.Column="1" Content="{loc:Localize Build}" Margin="4,0,4,0"
                             Command="{Binding BuildHeadlandCommand}"
                             Background="#1ABC9C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="14"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
-                    <Button Grid.Column="2" Content="Close" Margin="4,0,0,0"
+                    <Button Grid.Column="2" Content="{loc:Localize Close}" Margin="4,0,0,0"
                             Command="{Binding CloseHeadlandBuilderCommand}"
                             Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="14"
@@ -138,7 +139,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Grid>
 
                 <!-- Close button for when no boundary -->
-                <Button Content="Close" Margin="0,8,0,0"
+                <Button Content="{loc:Localize Close}" Margin="0,8,0,0"
                         Command="{Binding CloseHeadlandBuilderCommand}"
                         Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="44" FontSize="14"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HeadlandDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -106,9 +107,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <Grid ColumnDefinitions="Auto,*,Auto">
                             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="10">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandOn.png" Width="24" Height="24"/>
-                                <TextBlock Text="Headland Editor" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18" VerticalAlignment="Center"/>
+                                <TextBlock Text="{loc:Localize HeadlandEditor}" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18" VerticalAlignment="Center"/>
                             </StackPanel>
-                            <TextBlock Grid.Column="2" Text="Click 2 points on the boundary to define headland line"
+                            <TextBlock Grid.Column="2" Text="{loc:Localize Click2PointsOnTheBoundaryToDefineHeadlandLine}"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" VerticalAlignment="Center"/>
                         </Grid>
                     </Border>
@@ -128,7 +129,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Track Type Selection -->
                         <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,12">
-                            <TextBlock Text="Track Type" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize TrackType}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,*" Height="60">
                                 <RadioButton Grid.Column="0" GroupName="HeadlandTrackType" HorizontalAlignment="Stretch"
                                              IsChecked="{Binding IsHeadlandCurveMode}" Margin="0,0,4,0">
@@ -152,7 +153,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </RadioButton.Styles>
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackCurve.png" Width="32" Height="32"/>
-                                        <TextBlock Text="Curve" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                        <TextBlock Text="{loc:Localize Curve}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                     </StackPanel>
                                 </RadioButton>
                                 <RadioButton Grid.Column="1" GroupName="HeadlandTrackType" HorizontalAlignment="Stretch"
@@ -177,7 +178,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </RadioButton.Styles>
                                     <StackPanel HorizontalAlignment="Center">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAB.png" Width="32" Height="32"/>
-                                        <TextBlock Text="Line" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                        <TextBlock Text="{loc:Localize Line}" FontSize="10" HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                     </StackPanel>
                                 </RadioButton>
                             </Grid>
@@ -185,7 +186,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Distance Setting -->
                         <StackPanel Grid.Row="1" Spacing="8" Margin="0,0,0,12">
-                            <TextBlock Text="Headland Distance" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize HeadlandDistance}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto">
                                 <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="6" Padding="12,8">
                                     <TextBlock Text="{Binding HeadlandDistance, StringFormat={}{0:F1} m}"
@@ -207,7 +208,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Tool Width Multiplier -->
                         <StackPanel Grid.Row="2" Spacing="8" Margin="0,0,0,12">
-                            <TextBlock Text="Tool Widths" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize ToolWidths}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                             <Grid ColumnDefinitions="*,Auto">
                                 <Border Grid.Column="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="6" Padding="8">
                                     <TextBlock Text="{Binding HeadlandCalculatedWidth, StringFormat={}{0:F2} m}"
@@ -238,14 +239,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Command="{Binding BuildHeadlandCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandBuild.png" Width="24" Height="24"/>
-                                    <TextBlock Text="Build" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{loc:Localize Build}" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Grid.Column="1" Classes="ToolButton" HorizontalAlignment="Stretch" Margin="4,0,0,0"
                                     Command="{Binding ResetHeadlandCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandReset.png" Width="24" Height="24"/>
-                                    <TextBlock Text="Reset" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{loc:Localize Reset}" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </Grid>
@@ -256,14 +257,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Command="{Binding ClipHeadlandLineCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandSlice.png" Width="24" Height="24"/>
-                                    <TextBlock Text="Clip" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{loc:Localize Clip}" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Grid.Column="1" Classes="ToolButton" HorizontalAlignment="Stretch" Margin="4,0,0,0"
                                     Command="{Binding UndoHeadlandCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/UndoButton.png" Width="24" Height="24"/>
-                                    <TextBlock Text="Undo" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{loc:Localize Undo}" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </Grid>
@@ -278,7 +279,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandSectionOff.png"
                                            Width="28" Height="28" IsVisible="{Binding !IsHeadlandSectionControlled}"/>
                                 </Panel>
-                                <TextBlock Text="Section Control" VerticalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                <TextBlock Text="{loc:Localize SectionControl}" VerticalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                             </StackPanel>
                         </ToggleButton>
 
@@ -291,14 +292,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Command="{Binding TurnOffHeadlandCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SwitchOff.png" Width="24" Height="24"/>
-                                    <TextBlock Text="Off" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{loc:Localize Off}" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Grid.Column="1" Classes="ActionButton" HorizontalAlignment="Stretch" Margin="4,0,0,0"
                                     Command="{Binding CloseHeadlandDialogCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png" Width="24" Height="24"/>
-                                    <TextBlock Text="Done" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{loc:Localize Done}" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -56,10 +57,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 MinWidth="420" MaxWidth="520" MaxHeight="650">
             <StackPanel Spacing="12">
                 <!-- Title -->
-                <TextBlock Text="Hotkey Configuration" FontSize="20" FontWeight="Bold"
+                <TextBlock Text="{loc:Localize HotkeyConfiguration}" FontSize="20" FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"/>
 
-                <TextBlock Text="Click a key button, then press a new key to reassign."
+                <TextBlock Text="{loc:Localize ClickAKeyButtonThenPressANewKeyToReassign}"
                            FontSize="12" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"
                            TextWrapping="Wrap" TextAlignment="Center"/>
 
@@ -76,12 +77,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Bottom buttons -->
                 <Grid ColumnDefinitions="*,Auto,Auto">
-                    <Button Grid.Column="1" Content="Reset Defaults" Margin="0,0,8,0"
+                    <Button Grid.Column="1" Content="{loc:Localize ResetDefaults}" Margin="0,0,8,0"
                             Command="{Binding ResetHotkeysToDefaultCommand}"
                             Background="#E67E22" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Width="130" Height="40" FontSize="14"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
-                    <Button Grid.Column="2" Content="OK"
+                    <Button Grid.Column="2" Content="{loc:Localize OK}"
                             Command="{Binding CloseHotkeyConfigDialogCommand}"
                             Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Width="80" Height="40" FontSize="16" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -88,12 +89,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Padding="16">
             <Grid RowDefinitions="Auto,Auto,*,Auto">
                 <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="Import Tracks From Field"/>
+                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize ImportTracksFromField}"/>
 
                 <!-- Description -->
                 <TextBlock Grid.Row="1" Foreground="#BDC3C7" FontSize="13" Margin="0,0,0,8"
                            TextWrapping="Wrap"
-                           Text="Select a field to import its tracks into the current field:"/>
+                           Text="{loc:Localize SelectAFieldToImportItsTracksIntoTheCurrentField}"/>
 
                 <!-- Field list -->
                 <ScrollViewer Grid.Row="2" MinHeight="150" MaxHeight="250">
@@ -114,7 +115,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Buttons -->
                 <Grid Grid.Row="3" ColumnDefinitions="*,Auto" Margin="0,12,0,0">
                     <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Cancel"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
                             Command="{Binding CloseImportTracksDialogCommand}"/>
                 </Grid>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -131,11 +132,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="10">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="24" Height="24"/>
-                    <TextBlock Classes="Header" Text="Import Field from ISO-XML"/>
+                    <TextBlock Classes="Header" Text="{loc:Localize ImportFieldFromIsoXml}"/>
                 </StackPanel>
 
                 <!-- Info text -->
-                <TextBlock Grid.Row="1" Text="Place ISO-XML folders (containing TASKDATA.xml) in Documents/AgValoniaGPS/Import"
+                <TextBlock Grid.Row="1" Text="{loc:Localize PlaceIsoXmlFoldersContainingTaskdataxmlInDocumentsAgvaloniagpsImport}"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="12" TextWrapping="Wrap" Margin="0,0,0,8"/>
 
                 <!-- ISO-XML Folders ListBox -->
@@ -149,7 +150,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <DataTemplate>
                             <Grid ColumnDefinitions="*,Auto">
                                 <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"/>
-                                <TextBlock Grid.Column="1" Text="TASKDATA" Foreground="#E67E22" FontSize="11"
+                                <TextBlock Grid.Column="1" Text="{loc:Localize Taskdata}" Foreground="#E67E22" FontSize="11"
                                            IsVisible="{Binding IsTaskData}"/>
                             </Grid>
                         </DataTemplate>
@@ -158,7 +159,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Field name input -->
                 <StackPanel Grid.Row="3" Margin="0,12,0,0" Spacing="6">
-                    <TextBlock Text="New Field Name:" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
+                    <TextBlock Text="{loc:Localize NewFieldName}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBox Grid.Column="0"
                                  Classes="DialogInput"
@@ -193,10 +194,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Action Buttons -->
                 <Grid Grid.Row="5" ColumnDefinitions="*,Auto,Auto" Margin="0,16,0,0">
                     <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Cancel"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
                             MinWidth="80" MinHeight="44"
                             Command="{Binding CancelIsoXmlImportDialogCommand}"/>
-                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="Import"
+                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="{loc:Localize Import}"
                             MinWidth="80" MinHeight="44" Margin="12,0,0,0"
                             Command="{Binding ConfirmIsoXmlImportDialogCommand}"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -131,11 +132,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="10">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/GoogleEarth.png" Width="24" Height="24"/>
-                    <TextBlock Classes="Header" Text="Import Field from KML"/>
+                    <TextBlock Classes="Header" Text="{loc:Localize ImportFieldFromKml}"/>
                 </StackPanel>
 
                 <!-- Info text -->
-                <TextBlock Grid.Row="1" Text="Place KML files in Documents/AgValoniaGPS/Import"
+                <TextBlock Grid.Row="1" Text="{loc:Localize PlaceKmlFilesInDocumentsAgvaloniagpsImport}"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="12" Margin="0,0,0,8"/>
 
                 <!-- KML Files ListBox -->
@@ -177,7 +178,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Field name input -->
                 <StackPanel Grid.Row="4" Margin="0,12,0,0" Spacing="6">
-                    <TextBlock Text="New Field Name:" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
+                    <TextBlock Text="{loc:Localize NewFieldName}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13"/>
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBox Grid.Column="0"
                                  Classes="DialogInput"
@@ -212,10 +213,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Action Buttons -->
                 <Grid Grid.Row="6" ColumnDefinitions="*,Auto,Auto" Margin="0,16,0,0">
                     <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Cancel"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
                             MinWidth="80" MinHeight="44"
                             Command="{Binding CancelKmlImportDialogCommand}"/>
-                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="Import"
+                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="{loc:Localize Import}"
                             MinWidth="80" MinHeight="44" Margin="12,0,0,0"
                             Command="{Binding ConfirmKmlImportDialogCommand}"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.LanguageDialogPanel"
              IsVisible="{Binding State.UI.IsLanguageDialogVisible}"
              IsHitTestVisible="{Binding State.UI.IsLanguageDialogVisible}">
@@ -13,14 +14,14 @@
                 BoxShadow="0 4 16 #40000000">
 
             <StackPanel Spacing="12">
-                <TextBlock Text="Select Language" FontSize="20" FontWeight="Bold"
+                <TextBlock Text="{loc:Localize SelectLanguage}" FontSize="20" FontWeight="Bold"
                            HorizontalAlignment="Center"/>
 
                 <ScrollViewer MaxHeight="450">
                     <ItemsControl x:Name="LanguageList"/>
                 </ScrollViewer>
 
-                <Button Content="Cancel" Classes="ModernButton"
+                <Button Content="{loc:Localize Cancel}" Classes="ModernButton"
                         HorizontalAlignment="Center" MinWidth="120"
                         Command="{Binding CloseLanguageDialogCommand}"/>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml
@@ -1,0 +1,29 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.LanguageDialogPanel"
+             IsVisible="{Binding State.UI.IsLanguageDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsLanguageDialogVisible}">
+
+    <!-- Semi-transparent backdrop -->
+    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="12" Padding="20"
+                MaxWidth="400" MaxHeight="600"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                BoxShadow="0 4 16 #40000000">
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="Select Language" FontSize="20" FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+
+                <ScrollViewer MaxHeight="450">
+                    <ItemsControl x:Name="LanguageList"/>
+                </ScrollViewer>
+
+                <Button Content="Cancel" Classes="ModernButton"
+                        HorizontalAlignment="Center" MinWidth="120"
+                        Command="{Binding CloseLanguageDialogCommand}"/>
+            </StackPanel>
+        </Border>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml.cs
@@ -3,28 +3,38 @@
 //
 // Licensed under GNU GPL v3. See LICENSE.md.
 
+using System.Collections.Generic;
 using System.Globalization;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Media;
 using AgValoniaGPS.Views.Localization;
 
 namespace AgValoniaGPS.Views.Controls.Dialogs;
 
 public partial class LanguageDialogPanel : UserControl
 {
+    private readonly List<Button> _buttons = new();
+
     public LanguageDialogPanel()
     {
         InitializeComponent();
         BuildLanguageButtons();
+
+        // Update highlight when dialog becomes visible
+        PropertyChanged += (s, e) =>
+        {
+            if (e.Property.Name == nameof(IsVisible) && IsVisible)
+                HighlightCurrentLanguage();
+        };
     }
 
     private void BuildLanguageButtons()
     {
         var list = this.FindControl<ItemsControl>("LanguageList");
         if (list == null) return;
-
-        var items = new System.Collections.Generic.List<Button>();
 
         foreach (var code in TranslationSource.AvailableLanguages)
         {
@@ -47,7 +57,7 @@ public partial class LanguageDialogPanel : UserControl
                 HorizontalContentAlignment = HorizontalAlignment.Left,
                 MinHeight = 40,
                 FontSize = 15,
-                Margin = new Avalonia.Thickness(0, 1),
+                Margin = new Thickness(0, 1),
             };
             btn.Classes.Add("ModernButton");
             btn.Click += (s, e) =>
@@ -56,12 +66,33 @@ public partial class LanguageDialogPanel : UserControl
                     DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
                 {
                     vm.SetLanguageCommand?.Execute(langCode);
+                    HighlightCurrentLanguage();
                 }
             };
-            items.Add(btn);
+            _buttons.Add(btn);
         }
 
-        list.ItemsSource = items;
+        list.ItemsSource = _buttons;
+    }
+
+    private void HighlightCurrentLanguage()
+    {
+        var currentCode = TranslationSource.Instance.CurrentCulture.Name;
+        // Fallback: "en" has empty culture name
+        if (string.IsNullOrEmpty(currentCode))
+            currentCode = "en";
+
+        foreach (var btn in _buttons)
+        {
+            bool isSelected = btn.Tag is string code &&
+                (code == currentCode || currentCode.StartsWith(code));
+
+            btn.FontWeight = isSelected ? FontWeight.Bold : FontWeight.Normal;
+            btn.BorderThickness = isSelected ? new Thickness(2) : new Thickness(1);
+            btn.BorderBrush = isSelected
+                ? new SolidColorBrush(Color.FromRgb(50, 180, 50))
+                : null;
+        }
     }
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml.cs
@@ -1,0 +1,72 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using AgValoniaGPS.Views.Localization;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class LanguageDialogPanel : UserControl
+{
+    public LanguageDialogPanel()
+    {
+        InitializeComponent();
+        BuildLanguageButtons();
+    }
+
+    private void BuildLanguageButtons()
+    {
+        var list = this.FindControl<ItemsControl>("LanguageList");
+        if (list == null) return;
+
+        var items = new System.Collections.Generic.List<Button>();
+
+        foreach (var code in TranslationSource.AvailableLanguages)
+        {
+            string displayName;
+            try
+            {
+                var ci = new CultureInfo(code);
+                displayName = $"{ci.NativeName}  ({code})";
+            }
+            catch
+            {
+                displayName = code;
+            }
+
+            var btn = new Button
+            {
+                Content = displayName,
+                Tag = code,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                HorizontalContentAlignment = HorizontalAlignment.Left,
+                MinHeight = 40,
+                FontSize = 15,
+                Margin = new Avalonia.Thickness(0, 1),
+            };
+            btn.Classes.Add("ModernButton");
+            btn.Click += (s, e) =>
+            {
+                if (s is Button b && b.Tag is string langCode &&
+                    DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+                {
+                    vm.SetLanguageCommand?.Execute(langCode);
+                }
+            };
+            items.Add(btn);
+        }
+
+        list.ItemsSource = items;
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+            vm.CloseLanguageDialogCommand?.Execute(null);
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
@@ -9,6 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -28,27 +29,27 @@ the Free Software Foundation, either version 3 of the License, or
             <Grid RowDefinitions="Auto,Auto,*,Auto">
                 <!-- Header -->
                 <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12,12,0,0" Padding="16,12">
-                    <TextBlock Text="Application Log" FontSize="18" FontWeight="Bold"
+                    <TextBlock Text="{loc:Localize ApplicationLog}" FontSize="18" FontWeight="Bold"
                                Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
                 </Border>
 
                 <!-- Filter bar -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundListLowBrush}" Padding="12,8">
                     <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
-                        <Button Content="Debug" Padding="10,4" CornerRadius="4"
+                        <Button Content="{loc:Localize Debug}" Padding="10,4" CornerRadius="4"
                                 Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Debug"/>
-                        <Button Content="Info" Padding="10,4" CornerRadius="4"
+                        <Button Content="{loc:Localize Info}" Padding="10,4" CornerRadius="4"
                                 Background="#2980B9" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Information"/>
-                        <Button Content="Warning" Padding="10,4" CornerRadius="4"
+                        <Button Content="{loc:Localize Warning}" Padding="10,4" CornerRadius="4"
                                 Background="#F39C12" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Warning"/>
-                        <Button Content="Error" Padding="10,4" CornerRadius="4"
+                        <Button Content="{loc:Localize Error}" Padding="10,4" CornerRadius="4"
                                 Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Error"/>
                         <Border Width="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="4,0"/>
-                        <Button Content="Clear" Padding="10,4" CornerRadius="4"
+                        <Button Content="{loc:Localize Clear}" Padding="10,4" CornerRadius="4"
                                 Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding ClearLogEntriesCommand}"/>
                     </StackPanel>
@@ -82,7 +83,7 @@ the Free Software Foundation, either version 3 of the License, or
                 </Border>
 
                 <!-- Close button -->
-                <Button Grid.Row="3" Content="Close" Margin="16,4,16,12"
+                <Button Grid.Row="3" Content="{loc:Localize Close}" Margin="16,4,16,12"
                         Command="{Binding CloseLogViewerDialogCommand}"
                         Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
@@ -100,11 +101,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Grid RowDefinitions="Auto,*,Auto" Margin="24">
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Spacing="6" Margin="0,0,0,20">
-                    <TextBlock Text="Create New Field"
+                    <TextBlock Text="{loc:Localize CreateNewField}"
                                FontSize="24"
                                FontWeight="Bold"
                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                    <TextBlock Text="Enter field name - origin will be set to current GPS position"
+                    <TextBlock Text="{loc:Localize EnterFieldNameOriginWillBeSetToCurrentGpsPosition}"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                                FontSize="14"
                                TextWrapping="Wrap"/>
@@ -114,7 +115,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="1" Spacing="16">
                     <!-- Field Name -->
                     <StackPanel Spacing="8">
-                        <TextBlock Text="Field Name:"
+                        <TextBlock Text="{loc:Localize FieldName2}"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                    FontSize="16"/>
                         <TextBox Classes="DialogInput"
@@ -132,7 +133,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <!-- GPS Position Display -->
                     <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="8" Padding="16">
                         <StackPanel Spacing="8">
-                            <TextBlock Text="Current GPS Position:"
+                            <TextBlock Text="{loc:Localize CurrentGpsPosition}"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                        FontSize="14"
                                        FontWeight="SemiBold"/>
@@ -150,7 +151,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Border>
 
                     <!-- Helper text -->
-                    <TextBlock Text="The field origin will be set to your current GPS position when you create the field."
+                    <TextBlock Text="{loc:Localize TheFieldOriginWillBeSetToYourCurrentGpsPositionWhenYouCreateTheField}"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                FontSize="13"
                                TextWrapping="Wrap"/>
@@ -163,10 +164,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Spacing="12"
                             Margin="0,24,0,0">
                     <Button Classes="CancelButton"
-                            Content="Cancel"
+                            Content="{loc:Localize Cancel}"
                             Command="{Binding CancelNewFieldDialogCommand}"/>
                     <Button Classes="DialogButton"
-                            Content="Create"
+                            Content="{loc:Localize Create}"
                             Command="{Binding ConfirmNewFieldDialogCommand}"/>
                 </StackPanel>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -97,11 +98,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Padding="20">
             <StackPanel Spacing="12">
                 <!-- Header -->
-                <TextBlock Classes="Header" Text="Edit NTRIP Profile"/>
+                <TextBlock Classes="Header" Text="{loc:Localize EditNtripProfile}"/>
 
                 <!-- Profile Name -->
                 <StackPanel>
-                    <TextBlock Classes="Label" Text="Profile Name"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize ProfileName}"/>
                     <TextBox Text="{Binding EditingNtripProfile.Name, FallbackValue='', TargetNullValue=''}" Watermark="e.g., Local Base Station"/>
                 </StackPanel>
 
@@ -109,22 +110,22 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Caster Settings Section -->
-                <TextBlock Text="Caster Settings" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
+                <TextBlock Text="{loc:Localize CasterSettings}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
 
                 <!-- Host -->
                 <StackPanel>
-                    <TextBlock Classes="Label" Text="Caster Host"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize CasterHost}"/>
                     <TextBox Text="{Binding EditingNtripProfile.CasterHost, FallbackValue='', TargetNullValue=''}" Watermark="e.g., rtk2go.com"/>
                 </StackPanel>
 
                 <!-- Port -->
                 <Grid ColumnDefinitions="*,*" Margin="0,0,0,0">
                     <StackPanel Grid.Column="0" Margin="0,0,6,0">
-                        <TextBlock Classes="Label" Text="Port"/>
+                        <TextBlock Classes="Label" Text="{loc:Localize Port}"/>
                         <TextBox Text="{Binding EditingNtripProfile.CasterPort, FallbackValue=2101}" Watermark="2101"/>
                     </StackPanel>
                     <StackPanel Grid.Column="1" Margin="6,0,0,0">
-                        <TextBlock Classes="Label" Text="Mount Point"/>
+                        <TextBlock Classes="Label" Text="{loc:Localize MountPoint}"/>
                         <TextBox Text="{Binding EditingNtripProfile.MountPoint, FallbackValue='', TargetNullValue=''}" Watermark="NEAR-RTCM3"/>
                     </StackPanel>
                 </Grid>
@@ -132,18 +133,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Credentials -->
                 <Grid ColumnDefinitions="*,*" Margin="0,0,0,0">
                     <StackPanel Grid.Column="0" Margin="0,0,6,0">
-                        <TextBlock Classes="Label" Text="Username"/>
+                        <TextBlock Classes="Label" Text="{loc:Localize Username}"/>
                         <TextBox Text="{Binding EditingNtripProfile.Username, FallbackValue='', TargetNullValue=''}" Watermark="(optional)"/>
                     </StackPanel>
                     <StackPanel Grid.Column="1" Margin="6,0,0,0">
-                        <TextBlock Classes="Label" Text="Password"/>
+                        <TextBlock Classes="Label" Text="{loc:Localize Password}"/>
                         <TextBox Text="{Binding EditingNtripProfile.Password, FallbackValue='', TargetNullValue=''}" Watermark="(optional)" PasswordChar="*"/>
                     </StackPanel>
                 </Grid>
 
                 <!-- Test Connection -->
                 <Grid ColumnDefinitions="Auto,*" Margin="0,8,0,0">
-                    <Button Grid.Column="0" Classes="DialogButton TestButton" Content="Test Connection"
+                    <Button Grid.Column="0" Classes="DialogButton TestButton" Content="{loc:Localize TestConnection}"
                             Command="{Binding TestNtripConnectionCommand}"
                             IsEnabled="{Binding !IsTestingNtripConnection}"/>
                     <TextBlock Grid.Column="1" Text="{Binding NtripTestStatus}"
@@ -156,8 +157,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Field Associations Section -->
-                <TextBlock Text="Associated Fields" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
-                <TextBlock Text="Select fields that will use this NTRIP profile:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Margin="0,0,0,4"/>
+                <TextBlock Text="{loc:Localize AssociatedFields}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
+                <TextBlock Text="{loc:Localize SelectFieldsThatWillUseThisNtripProfile}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Margin="0,0,0,4"/>
 
                 <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" CornerRadius="4"
                         MaxHeight="120" Padding="4">
@@ -172,17 +173,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         </ItemsControl>
                     </ScrollViewer>
                 </Border>
-                <TextBlock Text="Fields not selected will use the default profile (if set)." Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,4,0,0"/>
+                <TextBlock Text="{loc:Localize FieldsNotSelectedWillUseTheDefaultProfileIfSet}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,4,0,0"/>
 
                 <!-- Separator -->
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Options -->
                 <CheckBox IsChecked="{Binding EditingNtripProfile.AutoConnectOnFieldLoad, FallbackValue=True}"
-                          Content="Auto-connect when associated field is loaded"/>
+                          Content="{loc:Localize AutoConnectWhenAssociatedFieldIsLoaded}"/>
 
                 <CheckBox IsChecked="{Binding EditingNtripProfile.IsDefault, FallbackValue=False}"
-                          Content="Set as default profile (for fields without specific association)"/>
+                          Content="{loc:Localize SetAsDefaultProfileForFieldsWithoutSpecificAssociation}"/>
 
                 <!-- Action Buttons -->
                 <Grid ColumnDefinitions="*,Auto,Auto" Margin="0,8,0,0">
@@ -190,11 +191,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Border Grid.Column="0"/>
 
                     <!-- Cancel Button -->
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Cancel"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
                             Command="{Binding CancelNtripProfileEditCommand}" Margin="0,0,8,0"/>
 
                     <!-- Save Button -->
-                    <Button Grid.Column="2" Classes="DialogButton" Content="Save Profile"
+                    <Button Grid.Column="2" Classes="DialogButton" Content="{loc:Localize SaveProfile}"
                             Command="{Binding SaveNtripProfileCommand}"/>
                 </Grid>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -108,7 +109,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Padding="16">
             <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
                 <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="NTRIP Profiles"/>
+                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize NtripProfiles}"/>
 
                 <!-- Toolbar -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="4" Margin="0,0,0,12">
@@ -148,9 +149,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Column Headers -->
                 <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
                     <Grid ColumnDefinitions="*,150,60">
-                        <TextBlock Grid.Column="0" Text="Profile Name" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="1" Text="Caster" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="2" Text="Default" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{loc:Localize ProfileName}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="1" Text="{loc:Localize Caster}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="2" Text="{loc:Localize Default}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
                     </Grid>
                 </Border>
 
@@ -186,7 +187,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Border Grid.Column="0"/>
 
                     <!-- Close Button -->
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Close"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Close}"
                             Command="{Binding CloseNtripProfilesDialogCommand}"/>
                 </Grid>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -73,12 +74,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Action Buttons -->
                 <Grid ColumnDefinitions="*,*" Margin="0,8,0,0">
-                    <Button Grid.Column="0" Content="Cancel" Margin="0,0,4,0"
+                    <Button Grid.Column="0" Content="{loc:Localize Cancel}" Margin="0,0,4,0"
                             Command="{Binding CancelNumericInputDialogCommand}"
                             Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="16"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
-                    <Button Grid.Column="1" Content="OK" Margin="4,0,0,0"
+                    <Button Grid.Column="1" Content="{loc:Localize OK}" Margin="4,0,0,0"
                             Command="{Binding ConfirmNumericInputDialogCommand}"
                             Background="#1ABC9C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="16"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.OffsetFixDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -16,7 +17,7 @@
         <StackPanel Spacing="8">
             <!-- Header with close button -->
             <Grid ColumnDefinitions="*,Auto">
-                <TextBlock Text="GPS Offset Fix" FontSize="16" FontWeight="Bold"
+                <TextBlock Text="{loc:Localize GpsOffsetFix}" FontSize="16" FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                 <Button Grid.Column="1" Content="X" Width="28" Height="28"
                         Command="{Binding CloseOffsetFixDialogCommand}"
@@ -62,9 +63,9 @@
 
             <!-- Manual offset input -->
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="4">
-                <TextBlock Grid.Row="0" Grid.Column="0" Text="N/S (m)" FontSize="11"
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="{loc:Localize NSM}" FontSize="11"
                            Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
-                <TextBlock Grid.Row="0" Grid.Column="1" Text="E/W (m)" FontSize="11"
+                <TextBlock Grid.Row="0" Grid.Column="1" Text="{loc:Localize EWM}" FontSize="11"
                            Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
                 <TextBox Grid.Row="1" Grid.Column="0" x:Name="NorthingInput"
                          Text="{Binding State.Field.DriftNorthing, StringFormat='{}{0:F3}', Mode=TwoWay}"
@@ -74,7 +75,7 @@
                          FontSize="16" FontWeight="Bold" HorizontalContentAlignment="Center"/>
             </Grid>
 
-            <TextBlock Text="1 cm per click" FontSize="10"
+            <TextBlock Text="{loc:Localize 1CmPerClick}" FontSize="10"
                        Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                        HorizontalAlignment="Center"/>
         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -69,11 +70,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Padding="20" BoxShadow="0 8 32 #40000000">
             <StackPanel Spacing="16">
                 <!-- Title -->
-                <TextBlock Text="Quick AB Line Creator"
+                <TextBlock Text="{loc:Localize QuickAbLineCreator}"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="18" FontWeight="Bold"
                            HorizontalAlignment="Center"/>
 
-                <TextBlock Text="Select creation mode:"
+                <TextBlock Text="{loc:Localize SelectCreationMode}"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14"
                            HorizontalAlignment="Center"/>
 
@@ -85,7 +86,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAPlus.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
-                            <TextBlock Text="A+ Line" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize ALine}" FontSize="12" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -95,7 +96,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAB.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
-                            <TextBlock Text="Drive A-B" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize DriveAB2}" FontSize="12" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -105,7 +106,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Cancel64.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
-                            <TextBlock Text="Cancel" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Cancel}" FontSize="12" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
 
@@ -115,7 +116,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Spacing="8" HorizontalAlignment="Center">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackCurve.png"
                                    Width="40" Height="40" Stretch="Uniform"/>
-                            <TextBlock Text="Curve" FontSize="12" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Curve}" FontSize="12" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Button>
                 </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -96,7 +97,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto">
                 <!-- Title -->
                 <TextBlock Grid.Row="0"
-                           Text="Enter GPS Coordinates"
+                           Text="{loc:Localize EnterGpsCoordinates}"
                            FontSize="18"
                            FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
@@ -106,7 +107,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Latitude Field (on-screen keyboard mode) -->
                 <StackPanel Grid.Row="1" Margin="0,0,0,8"
                             IsVisible="{Binding Display.KeyboardEnabled}">
-                    <TextBlock Classes="Label" Text="Latitude (-90 to +90)"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize Latitude90To90}"/>
                     <Border x:Name="LatitudeBorder" Classes="InputField"
                             PointerPressed="Latitude_PointerPressed">
                         <TextBlock x:Name="LatitudeDisplay"
@@ -121,7 +122,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Longitude Field (on-screen keyboard mode) -->
                 <StackPanel Grid.Row="2" Margin="0,0,0,12"
                             IsVisible="{Binding Display.KeyboardEnabled}">
-                    <TextBlock Classes="Label" Text="Longitude (-180 to +180)"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize Longitude180To180}"/>
                     <Border x:Name="LongitudeBorder" Classes="InputField"
                             PointerPressed="Longitude_PointerPressed">
                         <TextBlock x:Name="LongitudeDisplay"
@@ -145,13 +146,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Direct text input fallback (when on-screen keyboard disabled) -->
                 <StackPanel Grid.Row="1" Margin="0,0,0,8"
                             IsVisible="{Binding Display.KeyboardEnabled, Converter={StaticResource InverseBool}}">
-                    <TextBlock Classes="Label" Text="Latitude (-90 to +90)"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize Latitude90To90}"/>
                     <TextBox x:Name="LatitudeInput" FontSize="18" FontWeight="Bold"
                              Watermark="0.00000000" Margin="0,4"/>
                 </StackPanel>
                 <StackPanel Grid.Row="2" Margin="0,0,0,12"
                             IsVisible="{Binding Display.KeyboardEnabled, Converter={StaticResource InverseBool}}">
-                    <TextBlock Classes="Label" Text="Longitude (-180 to +180)"/>
+                    <TextBlock Classes="Label" Text="{loc:Localize Longitude180To180}"/>
                     <TextBox x:Name="LongitudeInput" FontSize="18" FontWeight="Bold"
                              Watermark="0.00000000" Margin="0,4"/>
                 </StackPanel>
@@ -160,13 +161,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid Grid.Row="4" ColumnDefinitions="*,*" Margin="0,4,0,0">
                     <Button Grid.Column="0"
                             Classes="DialogButton CancelButton"
-                            Content="Cancel"
+                            Content="{loc:Localize Cancel}"
                             HorizontalAlignment="Stretch"
                             Click="Cancel_Click"
                             Margin="0,0,6,0"/>
                     <Button Grid.Column="1"
                             Classes="DialogButton"
-                            Content="OK"
+                            Content="{loc:Localize OK}"
                             HorizontalAlignment="Stretch"
                             Click="OK_Click"
                             Margin="6,0,0,0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -109,7 +110,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Padding="16">
             <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
                 <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="AB Line Tracks"/>
+                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize AbLineTracks}"/>
 
                 <!-- Toolbar -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="4" Margin="0,0,0,12">
@@ -158,9 +159,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Column Headers -->
                 <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
                     <Grid ColumnDefinitions="*,80,60">
-                        <TextBlock Grid.Column="0" Text="Track Name" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
-                        <TextBlock Grid.Column="1" Text="Type" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
-                        <TextBlock Grid.Column="2" Text="Active" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{loc:Localize TrackName}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Grid.Column="1" Text="{loc:Localize Type}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{loc:Localize Active}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold" TextAlignment="Center"/>
                     </Grid>
                 </Border>
 
@@ -176,10 +177,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         <TextBlock Grid.Column="0" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"
                                                    VerticalAlignment="Center"/>
                                         <Panel Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                            <TextBlock Text="Contour" Foreground="#27AE60" FontSize="14" IsVisible="{Binding IsContour}"/>
-                                            <TextBlock Text="Path" Foreground="#8E44AD" FontSize="14" IsVisible="{Binding IsRecordedPath}"/>
-                                            <TextBlock Text="Curve" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding IsCurve}"/>
-                                            <TextBlock Text="Line" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding IsABLine}"/>
+                                            <TextBlock Text="{loc:Localize Contour}" Foreground="#27AE60" FontSize="14" IsVisible="{Binding IsContour}"/>
+                                            <TextBlock Text="{loc:Localize Path}" Foreground="#8E44AD" FontSize="14" IsVisible="{Binding IsRecordedPath}"/>
+                                            <TextBlock Text="{loc:Localize Curve}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding IsCurve}"/>
+                                            <TextBlock Text="{loc:Localize Line}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding IsABLine}"/>
                                         </Panel>
                                         <Panel Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
                                             <Ellipse Width="16" Height="16" Fill="#27AE60" IsVisible="{Binding IsActive}"/>
@@ -198,7 +199,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <Border Grid.Column="0"/>
 
                     <!-- Close Button -->
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Close"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Close}"
                             Command="{Binding CloseTracksDialogCommand}"/>
                 </Grid>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
@@ -9,6 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
@@ -28,9 +29,9 @@ the Free Software Foundation, either version 3 of the License, or
                 <!-- Header -->
                 <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12,12,0,0" Padding="16,12">
                     <StackPanel Spacing="4" HorizontalAlignment="Center">
-                        <TextBlock Text="All Settings" FontSize="18" FontWeight="Bold"
+                        <TextBlock Text="{loc:Localize AllSettings}" FontSize="18" FontWeight="Bold"
                                    Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
-                        <TextBlock Text="Read-only view of current configuration values"
+                        <TextBlock Text="{loc:Localize ReadOnlyViewOfCurrentConfigurationValues}"
                                    FontSize="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </Border>
@@ -72,7 +73,7 @@ the Free Software Foundation, either version 3 of the License, or
                 </Border>
 
                 <!-- Close button -->
-                <Button Grid.Row="2" Content="Close" Margin="16,4,16,12"
+                <Button Grid.Row="2" Content="{loc:Localize Close}" Margin="16,4,16,12"
                         Command="{Binding CloseViewSettingsDialogCommand}"
                         Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                         HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -328,7 +329,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding PlaceFlagHereCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="8" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FlagRed.png" Width="20" Height="20" Stretch="Uniform"/>
-                        <TextBlock Text="Place Here" VerticalAlignment="Center" FontSize="13"
+                        <TextBlock Text="{loc:Localize PlaceHere}" VerticalAlignment="Center" FontSize="13"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                     </StackPanel>
                 </Button>
@@ -340,7 +341,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding PlaceFlagOnClickCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="8" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FlagGrn.png" Width="20" Height="20" Stretch="Uniform"/>
-                        <TextBlock Text="Place on Map" VerticalAlignment="Center" FontSize="13"
+                        <TextBlock Text="{loc:Localize PlaceOnMap}" VerticalAlignment="Center" FontSize="13"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                     </StackPanel>
                 </Button>
@@ -352,7 +353,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ShowFlagListCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="8" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FlagYel.png" Width="20" Height="20" Stretch="Uniform"/>
-                        <TextBlock Text="Flag List" VerticalAlignment="Center" FontSize="13"
+                        <TextBlock Text="{loc:Localize FlagList}" VerticalAlignment="Center" FontSize="13"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                     </StackPanel>
                 </Button>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -60,7 +61,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" FontSize="18" FontWeight="Bold"
                            Foreground="#FFFFFF" VerticalAlignment="Center" Margin="8,0,0,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Start or Delete A Boundary" FontSize="14" FontWeight="SemiBold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize StartOrDeleteBoundary}" FontSize="14" FontWeight="SemiBold"
                            Foreground="#1ABC9C" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="28" Height="28" Margin="0,0,4,0"
                         Background="Transparent" BorderThickness="0" Foreground="#FFFFFF"
@@ -104,11 +105,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- Column Headers -->
             <Grid ColumnDefinitions="*,*,*" Background="{DynamicResource SystemControlHighlightAccentBrush}" Margin="4,0,4,0">
-                <TextBlock Grid.Column="0" Text="Boundary" HorizontalAlignment="Center"
+                <TextBlock Grid.Column="0" Text="{loc:Localize Boundary}" HorizontalAlignment="Center"
                            FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-                <TextBlock Grid.Column="1" Text="Area" HorizontalAlignment="Center"
+                <TextBlock Grid.Column="1" Text="{loc:Localize Area}" HorizontalAlignment="Center"
                            FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-                <TextBlock Grid.Column="2" Text="Drive Thru" HorizontalAlignment="Center"
+                <TextBlock Grid.Column="2" Text="{loc:Localize DriveThru}" HorizontalAlignment="Center"
                            FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
             </Grid>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -55,7 +56,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Vehicle Configuration" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize VehicleConfiguration}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
@@ -70,14 +71,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ShowNewProfileDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png" Width="28" Height="28"/>
-                        <TextBlock Text="New Profile" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize NewProfile}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
                         Command="{Binding ShowLoadProfileDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileOpen.png" Width="28" Height="28"/>
-                        <TextBlock Text="Load Profile" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize LoadProfile}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -86,7 +87,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ShowConfigurationDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Settings48.png" Width="28" Height="28"/>
-                        <TextBlock Text="Vehicle Settings" VerticalAlignment="Center" FontSize="12" FontWeight="SemiBold"/>
+                        <TextBlock Text="{loc:Localize VehicleSettings}" VerticalAlignment="Center" FontSize="12" FontWeight="SemiBold"/>
                     </StackPanel>
                 </Button>
             </Grid>
@@ -107,7 +108,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <Border Classes="FloatingPanel" MinWidth="300" IsVisible="{Binding IsProfileSelectionVisible}"
             HorizontalAlignment="Center" VerticalAlignment="Center">
         <StackPanel Spacing="8">
-            <TextBlock Text="Select Profile" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+            <TextBlock Text="{loc:Localize SelectProfile}" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                        HorizontalAlignment="Center" Margin="0,4,0,8"/>
 
             <ListBox ItemsSource="{Binding AvailableProfiles}"
@@ -121,10 +122,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </ListBox>
 
             <Grid ColumnDefinitions="*,*" ColumnSpacing="8" Margin="0,8,0,0">
-                <Button Grid.Column="0" Content="Cancel" HorizontalContentAlignment="Center"
+                <Button Grid.Column="0" Content="{loc:Localize Cancel}" HorizontalContentAlignment="Center"
                         Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="6" Height="36"
                         Command="{Binding CancelProfileSelectionCommand}"/>
-                <Button Grid.Column="1" Content="Load" HorizontalContentAlignment="Center"
+                <Button Grid.Column="1" Content="{loc:Localize Load}" HorizontalContentAlignment="Center"
                         Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="6" Height="36"
                         Command="{Binding LoadSelectedProfileCommand}"/>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -54,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Field Tools" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize FieldTools}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
@@ -70,7 +71,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowBoundaryDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="28" Height="28"/>
-                        <TextBlock Text="Boundary" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize Boundary}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <!-- Grid.Column="1" Grid.Row="0" is intentionally blank -->
@@ -80,7 +81,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowHeadlandDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/HeadlandOn.png" Width="28" Height="28"/>
-                        <TextBlock Text="Headland" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize Headland}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
@@ -96,14 +97,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TramAll.png" Width="28" Height="28"/>
-                        <TextBlock Text="Tram Lines" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize TramLines}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TramMulti.png" Width="28" Height="28"/>
-                        <TextBlock Text="Tram Lines Builder" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize TramLinesBuilder}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -112,14 +113,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding DeleteAppliedAreaCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TrashApplied.png" Width="28" Height="28"/>
-                        <TextBlock Text="Delete Applied Area" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize DeleteAppliedArea}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="3" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FlagRed.png" Width="28" Height="28"/>
-                        <TextBlock Text="Flag By Lat Lon" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize FlagByLatLon}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -128,14 +129,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/RecPath.png" Width="28" Height="28"/>
-                        <TextBlock Text="Recorded Path" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize RecordedPath}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="4" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryFromTracks.png" Width="28" Height="28"/>
-                        <TextBlock Text="Import Tracks" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize ImportTracks}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -54,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Application Settings" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize ApplicationSettings}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
@@ -64,45 +65,45 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <!-- General Settings -->
-            <Button Classes="ModernButton" Content="Language" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize Language}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowLanguageDialogCommand}"/>
-            <Button Classes="ModernButton" Content="Reset All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize ResetAllSettings}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ResetAllSettingsCommand}"/>
 
             <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- App Configuration -->
-            <Button Classes="ModernButton" Content="View All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize ViewAllSettings}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowViewSettingsDialogCommand}"/>
-            <Button Classes="ModernButton" Content="App Directories" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize AppDirectories}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAppDirectoriesDialogCommand}"/>
-            <Button Classes="ModernButton" Content="Log Viewer" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize LogViewer}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowLogViewerDialogCommand}"/>
-            <Button Classes="ModernButton" Content="Hotkeys" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize Hotkeys}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowHotkeyConfigDialogCommand}"/>
 
             <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- NTRIP Profiles -->
-            <Button Classes="ModernButton" Content="NTRIP Profiles" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize NtripProfiles}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowNtripProfilesDialogCommand}"/>
 
             <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- Simulator -->
-            <Button Classes="ModernButton" Content="Simulator" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize Simulator}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ToggleSimulatorPanelCommand}"/>
 
             <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
             <!-- Help & Info -->
-            <Button Classes="ModernButton" Content="AgShare API" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize AgShareApi}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAgShareSettingsDialogCommand}"/>
-            <Button Classes="ModernButton" Content="Help" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize Help}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowHelpDialogCommand}"/>
-            <Button Classes="ModernButton" Content="About" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize About}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAboutDialogCommand}"/>
-            <Button Classes="ModernButton" Content="Bug Report Dump" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+            <Button Classes="ModernButton" Content="{loc:Localize BugReportDump}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding CreateDebugDumpCommand}"/>
         </StackPanel>
     </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -64,7 +64,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
             <!-- General Settings -->
-            <Button Classes="ModernButton" Content="Language" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
+            <Button Classes="ModernButton" Content="Language" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding ShowLanguageDialogCommand}"/>
             <Button Classes="ModernButton" Content="Reset All Settings" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ResetAllSettingsCommand}"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -43,7 +44,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Heading Chart" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize HeadingChart}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -54,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Start New Field" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize StartNewField}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
@@ -70,7 +71,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowIsoXmlImportDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ISOXML.png" Width="28" Height="28"/>
-                        <TextBlock Text="ISO-XML" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize IsoXml}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
@@ -78,7 +79,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         IsEnabled="{Binding IsFieldOpen}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileClose.png" Width="28" Height="28"/>
-                        <TextBlock Text="Close" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize Close}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -87,14 +88,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowKmlImportDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/GoogleEarth.png" Width="28" Height="28"/>
-                        <TextBlock Text="From KML" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize FromKml}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press" Command="{Binding DriveInCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SteerDriveOn.png" Width="28" Height="28"/>
-                        <TextBlock Text="Drive In" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize DriveIn}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -103,14 +104,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowFromExistingFieldDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileExisting.png" Width="28" Height="28"/>
-                        <TextBlock Text="From Existing" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize FromExisting}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press" Command="{Binding ShowFieldSelectionDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileOpen.png" Width="28" Height="28"/>
-                        <TextBlock Text="Open" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize Open}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -119,14 +120,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowNewFieldDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png" Width="28" Height="28"/>
-                        <TextBlock Text="New From Default" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize NewFromDefault}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="3" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press" Command="{Binding ResumeFieldCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FilePrevious.png" Width="28" Height="28"/>
-                        <TextBlock Text="Resume" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize Resume}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -135,14 +136,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowAgShareDownloadDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png" Width="28" Height="28"/>
-                        <TextBlock Text="AgShare Download" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize AgShareDownload}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="4" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press" Command="{Binding ShowAgShareUploadDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png" Width="28" Height="28"/>
-                        <TextBlock Text="AgShare Upload" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize AgShareUpload}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -151,7 +152,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         ClickMode="Press" Command="{Binding ShowOffsetFixDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/YouTurnReverse.png" Width="28" Height="28"/>
-                        <TextBlock Text="Offset Fix" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize OffsetFix}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -54,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="GPS Simulator" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize GpsSimulator}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
@@ -66,7 +67,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Simulator Controls -->
             <StackPanel Spacing="8" Margin="12">
                 <!-- Simulator Enable/Disable -->
-                <CheckBox Content="Simulator Enabled"
+                <CheckBox Content="{loc:Localize SimulatorEnabled}"
                           IsChecked="{Binding IsSimulatorEnabled}"
                           FontWeight="Bold"
                           FontSize="13"
@@ -77,7 +78,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ShowSimCoordsDialogCommand}"
                         IsEnabled="{Binding !IsSimulatorEnabled}"
                         ToolTip.Tip="Enter starting GPS coordinates (disable simulator first)">
-                    <TextBlock Text="Enter Sim Coords" FontSize="12" IsHitTestVisible="False"/>
+                    <TextBlock Text="{loc:Localize EnterSimCoords}" FontSize="12" IsHitTestVisible="False"/>
                 </Button>
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
@@ -88,7 +89,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Command="{Binding ResetSimulatorCommand}"
                             ToolTip.Tip="Reset to starting position">
                         <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                            <TextBlock Text="Reset" FontSize="12"/>
+                            <TextBlock Text="{loc:Localize Reset}" FontSize="12"/>
                         </StackPanel>
                     </Button>
                     <Button Grid.Column="1" Classes="ModernButton" Margin="4,0,0,0" ClickMode="Press"
@@ -128,7 +129,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Row 4: Speed Slider (-10 to +25 kph) -->
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Grid.Column="0" Text="Speed" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    <TextBlock Grid.Column="0" Text="{loc:Localize Speed}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center" Margin="0,4,0,0"/>
                     <CheckBox Grid.Column="1" Content="10x" IsChecked="{Binding IsSimulatorSpeed10x}"
                               FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,0"
                               ToolTip.Tip="10x speed multiplier for large fields"/>
@@ -162,7 +163,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding SimulatorReverseDirectionCommand}"
                         ToolTip.Tip="Reverse direction (180 turn)">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <TextBlock Text="Reverse Direction" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize ReverseDirection}" FontSize="12"/>
                     </StackPanel>
                 </Button>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -43,7 +44,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Steer Chart" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize SteerChart}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -54,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Tools" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize Tools}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
@@ -69,13 +70,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ShowSteerWizardCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png" Width="28" Height="28"/>
-                        <TextBlock Text="Steer Wizard" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize SteerWizard}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png" Width="28" Height="28"/>
-                        <TextBlock Text="Log Viewer" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize LogViewer}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -83,13 +84,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoSteerOn.png" Width="28" Height="28"/>
-                        <TextBlock Text="Steer Chart" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize SteerChart}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesHeading.png" Width="28" Height="28"/>
-                        <TextBlock Text="Heading Chart" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize HeadingChart}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
 
@@ -97,13 +98,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Button Grid.Column="0" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoManualIsAuto.png" Width="28" Height="28"/>
-                        <TextBlock Text="XTE Chart" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize XteChart}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
                 <Button Grid.Column="1" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesRoll.png" Width="28" Height="28"/>
-                        <TextBlock Text="Roll Correction" VerticalAlignment="Center" FontSize="12"/>
+                        <TextBlock Text="{loc:Localize RollCorrection}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -74,7 +75,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            IsHitTestVisible="False"/>
                 <!-- Title -->
                 <TextBlock Grid.Column="1"
-                           Text="View Settings"
+                           Text="{loc:Localize ViewSettings}"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            FontSize="16"
                            FontWeight="Bold"
@@ -100,11 +101,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Camera Controls -->
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Background="Transparent">
                 <Button Grid.Row="0" Grid.Column="0" Classes="ModernButton"
-                        Content="Tilt Down" Margin="2" ClickMode="Press"
+                        Content="{loc:Localize TiltDown}" Margin="2" ClickMode="Press"
                         Command="{Binding DecreaseCameraPitchCommand}"
                         ToolTip.Tip="Tilt camera down"/>
                 <Button Grid.Row="0" Grid.Column="1" Classes="ModernButton"
-                        Content="Tilt Up" Margin="2" ClickMode="Press"
+                        Content="{loc:Localize TiltUp}" Margin="2" ClickMode="Press"
                         Command="{Binding IncreaseCameraPitchCommand}"
                         ToolTip.Tip="Tilt camera up"/>
                 <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Classes="ModernButton"
@@ -118,15 +119,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Display Options -->
             <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Background="Transparent">
                 <Button Grid.Row="0" Grid.Column="0" Classes="ModernButton"
-                        Content="North" Margin="2" ClickMode="Press"
+                        Content="{loc:Localize North}" Margin="2" ClickMode="Press"
                         Command="{Binding ToggleNorthUpCommand}"
                         ToolTip.Tip="North-up/Track-up"/>
                 <Button Grid.Row="0" Grid.Column="1" Classes="ModernButton"
-                        Content="Grid" Margin="2" ClickMode="Press"
+                        Content="{loc:Localize Grid}" Margin="2" ClickMode="Press"
                         Command="{Binding ToggleGridCommand}"
                         ToolTip.Tip="Toggle grid"/>
                 <Button Grid.Row="1" Grid.Column="0" Classes="ModernButton"
-                        Content="Day/Night" Margin="2" ClickMode="Press"
+                        Content="{loc:Localize DayNight}" Margin="2" ClickMode="Press"
                         Command="{Binding ToggleDayNightCommand}"
                         ToolTip.Tip="Day/Night mode"/>
                 <TextBlock Grid.Row="1" Grid.Column="1"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
@@ -17,6 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
@@ -43,7 +44,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
                            VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Cross Track Error" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
+                <TextBlock Grid.Column="1" Text="{loc:Localize CrossTrackError}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
                            VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"

--- a/Shared/AgValoniaGPS.Views/Localization/LocalizeExtension.cs
+++ b/Shared/AgValoniaGPS.Views/Localization/LocalizeExtension.cs
@@ -4,15 +4,17 @@
 // Licensed under GNU GPL v3. See LICENSE.md.
 
 using System;
+using System.Globalization;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Markup.Xaml;
 
 namespace AgValoniaGPS.Views.Localization;
 
 /// <summary>
-/// AXAML markup extension for localized strings.
-/// Usage: Content="{loc:Localize Key=ABLine}"
-/// Falls back to the key name if no translation is found.
+/// AXAML markup extension for localized strings with live updating.
+/// Usage: Content="{loc:Localize ABLine}"
+/// When the language changes at runtime, all bound strings update automatically.
 /// </summary>
 public class LocalizeExtension : MarkupExtension
 {
@@ -30,6 +32,36 @@ public class LocalizeExtension : MarkupExtension
         if (string.IsNullOrEmpty(Key))
             return string.Empty;
 
-        return TranslationSource.Instance[Key];
+        // Return a binding to TranslationSource.CurrentCulture with a converter
+        // that resolves the string key. When culture changes, PropertyChanged fires
+        // and the binding re-evaluates, giving us live language switching.
+        var binding = new Binding
+        {
+            Source = TranslationSource.Instance,
+            Path = nameof(TranslationSource.CurrentCulture),
+            Converter = TranslationConverter.Instance,
+            ConverterParameter = Key,
+            Mode = BindingMode.OneWay
+        };
+
+        return binding;
     }
+}
+
+/// <summary>
+/// Converter that resolves a localization key when the culture binding updates.
+/// </summary>
+internal class TranslationConverter : IValueConverter
+{
+    public static readonly TranslationConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (parameter is string key)
+            return TranslationSource.Instance[key];
+        return parameter?.ToString() ?? string.Empty;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
 }

--- a/Shared/AgValoniaGPS.Views/Localization/LocalizeExtension.cs
+++ b/Shared/AgValoniaGPS.Views/Localization/LocalizeExtension.cs
@@ -1,0 +1,35 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml;
+
+namespace AgValoniaGPS.Views.Localization;
+
+/// <summary>
+/// AXAML markup extension for localized strings.
+/// Usage: Content="{loc:Localize Key=ABLine}"
+/// Falls back to the key name if no translation is found.
+/// </summary>
+public class LocalizeExtension : MarkupExtension
+{
+    public string Key { get; set; } = string.Empty;
+
+    public LocalizeExtension() { }
+
+    public LocalizeExtension(string key)
+    {
+        Key = key;
+    }
+
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        if (string.IsNullOrEmpty(Key))
+            return string.Empty;
+
+        return TranslationSource.Instance[Key];
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.da.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.da.resx
@@ -1,0 +1,78 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB Linje</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Om…</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Areal</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autostyring</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Markgrænse</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Afbryd</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Lukke</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Indstillinger</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Slet</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Vis</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Afstand</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Aktiver</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Retning</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Forager</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Sprog</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Nudge:</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Offset</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pause</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Genoptag</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sektioner:</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Lav spor</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.de.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.de.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>A-B Linie</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Über...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Fläche</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Lenkungseinstellungen</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Schlaggrenze erstellen</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Abbrechen</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Schließen</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Konfiguration</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Löschen</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Display</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Entfernung</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Aktivieren</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Richtung</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Vorgewende</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Hilfe</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Sprache</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Latitude</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Nudge:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Aus</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Offset</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>An</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Überlappung:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pause</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Reset</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Fortsetzen</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Reihen:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Start</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Spuren</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.es.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.es.resx
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>Línea AB</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Acerca de...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Área</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autoguiado</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Lindero</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Cancelar</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Cerrar</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Configuración</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Distancia</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Cabecero</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Ayuda</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Idioma</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Offset (desfase)</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pausa</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Continuar</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.et.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.et.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB-joon</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Tarkvara kohta...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Pindala</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Automaatne roolimine</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Põllupiir</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Tühista</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Sulge</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Konfiguratsioon</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Kustuta</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Näita</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Distants</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Lülita sisse</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Suund</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Põllu ots</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Abi</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Keel</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Laiuskraad</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Nihe:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Väljas</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Nihe</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Sees</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Ülekatte:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Paus</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Lähtesta</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Jätka</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sektsioone:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Alusta</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Rajad</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.fi.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.fi.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>Ab -linja</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Tietoja...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Alue</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Automaattiohjauksen</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Raja</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Peru</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Sulje</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Asetukset</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Poista</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Näytä</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Etäisyys</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Aktivoi</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Suunta</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Päiste</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Ohje</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Kieli</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Leveysaste</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Linjan Korjaus:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Pois</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Siirto</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Päällä</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Limitys:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Tauko</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Nollaa</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Jatkaa</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Lohkoja:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Aloita</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Luo opastuslinjoja</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.fr.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.fr.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>Ligne AB</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>À propos de...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Zone</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autoguidage</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Bordures</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Annuler</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Fermer</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Configuration</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Supprimer</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Afficher</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Distance</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Activer</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Cap</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Tournières</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Aide</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Langue</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Latitude</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Décalage:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Off</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Décalage</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>On</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Doublure:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pause</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Reset</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Reprendre</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sections:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Start</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Voies</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.hu.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.hu.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB egyenes</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>A programról...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Terület</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Automata kormányzás</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Művelési határ</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Mégsem</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Bezár</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Beállítások</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Törlés</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Megjelenít</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Távolság</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Engedélyezés</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Irány</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Forgó</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Segítség</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Nyelv</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Szélesség</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Nyomvonalelhúzás:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Ki</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Eltolás</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Be</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Átfedés:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pause</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Reset</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Folytatás</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Szakaszok:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Indítás</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Nyomok</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.it.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.it.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>Linea AB</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>A Proposito Di…</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Area</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autoguida</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Confine</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Cancella</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Chiudere</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Configurazione</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Cancella</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Schermo</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Distanza</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Attiva</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Direzione</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Capezzagna</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Aiuto</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Lingua</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Latitudine</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Spinta:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Off</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Offset</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>On</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Sormonto:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pausa</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Reset</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Continua</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sezioni:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Start</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Tracce</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.ko.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.ko.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB라인</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>조향보조설명...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>구역</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>자동핸들</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>구역지정</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>취소</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>닫기</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>설정</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>삭제</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>디스플레이</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>거리</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>활성</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>진행방향</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>회전구역</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>도움말</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>언어</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>위도</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>소폭조정:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>끄기</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>수정</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>켜기</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>겹침:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>일시중지</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>재설정</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>일시정지작업</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>구획:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>시작</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>트랙들</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.lt.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.lt.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB linija</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Apie...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Plotas</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Vairo nuostatos</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Ribos</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Atšaukti</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Uždaryti</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Profiliai</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Ištrinti</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Ekranas</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Atstumas</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Įgalinti</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Kryptis</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Galulaukės</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Pagalba</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Kalba</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Platuma</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Stumtelti:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>išjungta</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Poslinkis</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Įjungta</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Persidengimas:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pauzė</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Atkurti</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Pratęsti paskutinį</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sekcijos:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Startas</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Vėžės</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.lv.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.lv.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB Līnija</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Par...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Platība</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Automātiskā stūrēšana</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Robeža</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Atcelt</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Aizvērt</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Konfigurācija</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Dzēst</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Parādīt</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Attālums</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Iespējot</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Virziens</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Laukmala</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Palīdzība</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Valoda</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Platums</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Pabīdīt:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Izslēgts</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Nobīde</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Ieslēgts</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Pārklājums:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pauze</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Atiestatīt</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Turpināt</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sekcijas:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Sākt</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Izveidojiet vadības līnijas</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.nl.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.nl.resx
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB-lijn</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Over...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Areaal</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autostuur</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Perceelgrens</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Afbreken</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Sluiten</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Configuratie</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Verwijder</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Activeer Knoppen</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Afstand</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Activeer</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Richting</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Kopakker</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Taal</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Lengtegraad</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Lijn-Nudge:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Uit</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Verschuiving</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Aan</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Overlapping:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pauze</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Herstel</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Hervat</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Secties:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Start</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Maak Geleidingslijnen</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.no.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.no.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB Linje</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Om...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Areal</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autostyring</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Grense</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Avbryt</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Lukk</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Konfigurasjon</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Slett</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Vis</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Avstand</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Aktiver</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Retning</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Vendeteig</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Hjelp</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Språk</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Breddegrad</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Flytt:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Av</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Forskyvning</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>På</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Overlapp:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pause</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Tilbakestill</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Fortsett</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Skesjoner:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Start</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Spor</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.pl.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.pl.resx
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>Prosta AB</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>O programie…</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Powierzchnia</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autoprowadzenie</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Granica</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Zamknij</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Zamknij</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Konfiguracja</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Usuń</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Display</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Odległość</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Włącz</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Nagłówek</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Uwrocie</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Pomoc</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Język</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Szerokość geograficzna</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Off</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Przesunięcie</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>On</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Nakładka:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pauza</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Reset</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Wznawianie</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sekcje:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Start</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.pt.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.pt.resx
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>Linha AB</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Sobre...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Área</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Direção Automática</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Limite</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Fechar</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Configuração</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Distância</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Promontório</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Ajuda</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Linguagem</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Desvio</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pausa</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Retomar</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.resx
@@ -486,4 +486,679 @@
   <data xml:space="preserve" name="XteChart">
     <value>XTE Chart</value>
   </data>
+  <data xml:space="preserve" name="">
+    <value>--&gt;</value>
+  </data>
+  <data xml:space="preserve" name="1CmPerClick">
+    <value>1 cm per click</value>
+  </data>
+  <data xml:space="preserve" name="2">
+    <value>|||</value>
+  </data>
+  <data xml:space="preserve" name="2Pts">
+    <value>(2 pts)</value>
+  </data>
+  <data xml:space="preserve" name="3Pts">
+    <value>(3+ pts)</value>
+  </data>
+  <data xml:space="preserve" name="ALine">
+    <value>A+ Line</value>
+  </data>
+  <data xml:space="preserve" name="AbLineTracks">
+    <value>AB Line Tracks</value>
+  </data>
+  <data xml:space="preserve" name="Ackermann">
+    <value>Ackermann</value>
+  </data>
+  <data xml:space="preserve" name="AcquireFactor">
+    <value>Acquire Factor</value>
+  </data>
+  <data xml:space="preserve" name="AcquireFactorHold">
+    <value>Acquire = Factor * Hold</value>
+  </data>
+  <data xml:space="preserve" name="Act">
+    <value>Act:</value>
+  </data>
+  <data xml:space="preserve" name="ActualSteerAngle">
+    <value>Actual Steer Angle</value>
+  </data>
+  <data xml:space="preserve" name="AdConverter">
+    <value>AD Converter</value>
+  </data>
+  <data xml:space="preserve" name="Aggressiveness">
+    <value>Aggressiveness</value>
+  </data>
+  <data xml:space="preserve" name="AgshareSettings">
+    <value>AgShare Settings</value>
+  </data>
+  <data xml:space="preserve" name="Agvaloniagps">
+    <value>AgValoniaGPS</value>
+  </data>
+  <data xml:space="preserve" name="Algorithm">
+    <value>Algorithm</value>
+  </data>
+  <data xml:space="preserve" name="AllSettings">
+    <value>All Settings</value>
+  </data>
+  <data xml:space="preserve" name="ApiKey">
+    <value>API Key</value>
+  </data>
+  <data xml:space="preserve" name="ApplicationLog">
+    <value>Application Log</value>
+  </data>
+  <data xml:space="preserve" name="AreaHa">
+    <value>Area (ha)</value>
+  </data>
+  <data xml:space="preserve" name="AssociatedFields">
+    <value>Associated Fields</value>
+  </data>
+  <data xml:space="preserve" name="AutoConnectWhenAssociatedFieldIsLoaded">
+    <value>Auto-connect when associated field is loaded</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteerConfiguration">
+    <value>Auto Steer Configuration</value>
+  </data>
+  <data xml:space="preserve" name="Autosteer">
+    <value>AutoSteer:</value>
+  </data>
+  <data xml:space="preserve" name="BasedOnAgopengpsByBrianTee">
+    <value>Based on AgOpenGPS by Brian Tee</value>
+  </data>
+  <data xml:space="preserve" name="BuiltWithAvaloniaUi1139Andnet100">
+    <value>Built with Avalonia UI 11.3.9 and .NET 10.0</value>
+  </data>
+  <data xml:space="preserve" name="Button">
+    <value>Button</value>
+  </data>
+  <data xml:space="preserve" name="Caster">
+    <value>Caster</value>
+  </data>
+  <data xml:space="preserve" name="CasterHost">
+    <value>Caster Host</value>
+  </data>
+  <data xml:space="preserve" name="CasterSettings">
+    <value>Caster Settings</value>
+  </data>
+  <data xml:space="preserve" name="Click2PointsOnTheBoundaryToDefineHeadlandLine">
+    <value>Click 2 points on the boundary to define headland line</value>
+  </data>
+  <data xml:space="preserve" name="ClickAKeyButtonThenPressANewKeyToReassign">
+    <value>Click a key button, then press a new key to reassign.</value>
+  </data>
+  <data xml:space="preserve" name="Clip">
+    <value>Clip</value>
+  </data>
+  <data xml:space="preserve" name="Cm">
+    <value>cm</value>
+  </data>
+  <data xml:space="preserve" name="CmPixel">
+    <value>Cm -&gt; Pixel</value>
+  </data>
+  <data xml:space="preserve" name="CmPx">
+    <value>cm/px</value>
+  </data>
+  <data xml:space="preserve" name="Counts">
+    <value>Counts</value>
+  </data>
+  <data xml:space="preserve" name="CountsPerDegree">
+    <value>Counts Per Degree</value>
+  </data>
+  <data xml:space="preserve" name="CreateFieldFromExisting">
+    <value>Create Field From Existing</value>
+  </data>
+  <data xml:space="preserve" name="CrossPlatformAgriculturalGpsGuidance">
+    <value>Cross-platform agricultural GPS guidance</value>
+  </data>
+  <data xml:space="preserve" name="CurrentGpsPosition">
+    <value>Current GPS Position:</value>
+  </data>
+  <data xml:space="preserve" name="CurrentTurn">
+    <value>Current Turn</value>
+  </data>
+  <data xml:space="preserve" name="Curve2">
+    <value>Curve:</value>
+  </data>
+  <data xml:space="preserve" name="Cytron">
+    <value>Cytron</value>
+  </data>
+  <data xml:space="preserve" name="Danfoss">
+    <value>Danfoss</value>
+  </data>
+  <data xml:space="preserve" name="DataIOConfiguration">
+    <value>Data I/O Configuration</value>
+  </data>
+  <data xml:space="preserve" name="Deadzone">
+    <value>---Deadzone---</value>
+  </data>
+  <data xml:space="preserve" name="Debug">
+    <value>Debug</value>
+  </data>
+  <data xml:space="preserve" name="Default">
+    <value>Default</value>
+  </data>
+  <data xml:space="preserve" name="Defaults">
+    <value>Defaults</value>
+  </data>
+  <data xml:space="preserve" name="DeleteAll">
+    <value>Delete All</value>
+  </data>
+  <data xml:space="preserve" name="DeselectAll">
+    <value>Deselect All</value>
+  </data>
+  <data xml:space="preserve" name="Differential">
+    <value>Differential</value>
+  </data>
+  <data xml:space="preserve" name="DisplaySettings">
+    <value>Display Settings</value>
+  </data>
+  <data xml:space="preserve" name="DownloadAll">
+    <value>Download All</value>
+  </data>
+  <data xml:space="preserve" name="DownloadFromAgshare">
+    <value>Download from AgShare</value>
+  </data>
+  <data xml:space="preserve" name="DownloadSelected">
+    <value>Download Selected</value>
+  </data>
+  <data xml:space="preserve" name="DrawFieldBoundary">
+    <value>Draw Field Boundary</value>
+  </data>
+  <data xml:space="preserve" name="DrawTrackOnMap">
+    <value>Draw Track on Map</value>
+  </data>
+  <data xml:space="preserve" name="DriveAB2">
+    <value>Drive A-B</value>
+  </data>
+  <data xml:space="preserve" name="EWM">
+    <value>E/W (m)</value>
+  </data>
+  <data xml:space="preserve" name="EditNtripProfile">
+    <value>Edit NTRIP Profile</value>
+  </data>
+  <data xml:space="preserve" name="Enabled">
+    <value>Enabled</value>
+  </data>
+  <data xml:space="preserve" name="EnterFieldNameOriginWillBeSetToCurrentGpsPosition">
+    <value>Enter field name - origin will be set to current GPS position</value>
+  </data>
+  <data xml:space="preserve" name="EnterGpsCoordinates">
+    <value>Enter GPS Coordinates</value>
+  </data>
+  <data xml:space="preserve" name="EnterWgs84CoordinatesInDecimalDegrees">
+    <value>Enter WGS84 coordinates in decimal degrees</value>
+  </data>
+  <data xml:space="preserve" name="Err">
+    <value>Err:</value>
+  </data>
+  <data xml:space="preserve" name="Error">
+    <value>Error</value>
+  </data>
+  <data xml:space="preserve" name="ExternalEnable">
+    <value>External Enable</value>
+  </data>
+  <data xml:space="preserve" name="Fast">
+    <value>Fast</value>
+  </data>
+  <data xml:space="preserve" name="FieldName2">
+    <value>Field Name:</value>
+  </data>
+  <data xml:space="preserve" name="FieldsNotSelectedWillUseTheDefaultProfileIfSet">
+    <value>Fields not selected will use the default profile (if set).</value>
+  </data>
+  <data xml:space="preserve" name="FixQuality">
+    <value>Fix Quality:</value>
+  </data>
+  <data xml:space="preserve" name="Flags">
+    <value>Flags</value>
+  </data>
+  <data xml:space="preserve" name="ForceOverwriteExistingFields">
+    <value>Force overwrite existing fields</value>
+  </data>
+  <data xml:space="preserve" name="FreeDrive">
+    <value>Free Drive</value>
+  </data>
+  <data xml:space="preserve" name="Gain">
+    <value>Gain</value>
+  </data>
+  <data xml:space="preserve" name="GetYourApiKeyFromAgshareagopengpscom">
+    <value>Get your API key from agshare.agopengps.com</value>
+  </data>
+  <data xml:space="preserve" name="GithubcomChriskinalAgvaloniagps3">
+    <value>github.com/chriskinal/AgValoniaGPS3</value>
+  </data>
+  <data xml:space="preserve" name="GpsData">
+    <value>GPS Data</value>
+  </data>
+  <data xml:space="preserve" name="GpsOffsetFix">
+    <value>GPS Offset Fix</value>
+  </data>
+  <data xml:space="preserve" name="HardwareConfig">
+    <value>Hardware Config</value>
+  </data>
+  <data xml:space="preserve" name="Head">
+    <value>Head</value>
+  </data>
+  <data xml:space="preserve" name="HeadlandBuilder">
+    <value>Headland Builder</value>
+  </data>
+  <data xml:space="preserve" name="HeadlandDistance">
+    <value>Headland Distance</value>
+  </data>
+  <data xml:space="preserve" name="HeadlandDistanceMeters">
+    <value>Headland Distance (meters)</value>
+  </data>
+  <data xml:space="preserve" name="HeadlandEditor">
+    <value>Headland Editor</value>
+  </data>
+  <data xml:space="preserve" name="HeadlandLineActive">
+    <value>Headland line active</value>
+  </data>
+  <data xml:space="preserve" name="HotkeyConfiguration">
+    <value>Hotkey Configuration</value>
+  </data>
+  <data xml:space="preserve" name="HttpsAgshareagopengpscom">
+    <value>https://agshare.agopengps.com</value>
+  </data>
+  <data xml:space="preserve" name="Ibt2">
+    <value>IBT2</value>
+  </data>
+  <data xml:space="preserve" name="ImportFieldFromIsoXml">
+    <value>Import Field from ISO-XML</value>
+  </data>
+  <data xml:space="preserve" name="ImportFieldFromKml">
+    <value>Import Field from KML</value>
+  </data>
+  <data xml:space="preserve" name="ImportTracksFromField">
+    <value>Import Tracks From Field</value>
+  </data>
+  <data xml:space="preserve" name="Imu">
+    <value>IMU:</value>
+  </data>
+  <data xml:space="preserve" name="ImuAxisSwap">
+    <value>IMU Axis Swap</value>
+  </data>
+  <data xml:space="preserve" name="In">
+    <value>In</value>
+  </data>
+  <data xml:space="preserve" name="IncludeBackgroundImage">
+    <value>Include Background Image</value>
+  </data>
+  <data xml:space="preserve" name="Info">
+    <value>Info</value>
+  </data>
+  <data xml:space="preserve" name="Integral">
+    <value>Integral</value>
+  </data>
+  <data xml:space="preserve" name="InvertMotor">
+    <value>Invert Motor</value>
+  </data>
+  <data xml:space="preserve" name="InvertRelays">
+    <value>Invert Relays</value>
+  </data>
+  <data xml:space="preserve" name="InvertWas">
+    <value>Invert WAS</value>
+  </data>
+  <data xml:space="preserve" name="Lat">
+    <value>Lat:</value>
+  </data>
+  <data xml:space="preserve" name="Latitude2">
+    <value>Latitude:</value>
+  </data>
+  <data xml:space="preserve" name="Latitude90To90">
+    <value>Latitude (-90 to +90)</value>
+  </data>
+  <data xml:space="preserve" name="Latitude90To902">
+    <value>Latitude (-90 to 90)</value>
+  </data>
+  <data xml:space="preserve" name="Left">
+    <value>◀ LEFT</value>
+  </data>
+  <data xml:space="preserve" name="LicenseGnuGeneralPublicLicenseV30">
+    <value>License: GNU General Public License v3.0</value>
+  </data>
+  <data xml:space="preserve" name="Lightbar">
+    <value>Lightbar</value>
+  </data>
+  <data xml:space="preserve" name="LineWidth">
+    <value>Line Width</value>
+  </data>
+  <data xml:space="preserve" name="Lines">
+    <value>Lines</value>
+  </data>
+  <data xml:space="preserve" name="LoadingFields">
+    <value>Loading fields...</value>
+  </data>
+  <data xml:space="preserve" name="Lon">
+    <value>Lon:</value>
+  </data>
+  <data xml:space="preserve" name="Longitude180To180">
+    <value>Longitude (-180 to +180)</value>
+  </data>
+  <data xml:space="preserve" name="Longitude180To1802">
+    <value>Longitude (-180 to 180)</value>
+  </data>
+  <data xml:space="preserve" name="Longitude2">
+    <value>Longitude:</value>
+  </data>
+  <data xml:space="preserve" name="Machine">
+    <value>Machine:</value>
+  </data>
+  <data xml:space="preserve" name="MakeFieldsPublic">
+    <value>Make fields public</value>
+  </data>
+  <data xml:space="preserve" name="ManualTurns">
+    <value>Manual Turns</value>
+  </data>
+  <data xml:space="preserve" name="Map">
+    <value>Map</value>
+  </data>
+  <data xml:space="preserve" name="MaxLimit">
+    <value>Max Limit</value>
+  </data>
+  <data xml:space="preserve" name="MaxSpeed">
+    <value>Max Speed</value>
+  </data>
+  <data xml:space="preserve" name="MaxSteerAngle">
+    <value>Max Steer Angle</value>
+  </data>
+  <data xml:space="preserve" name="MinSpeed">
+    <value>Min Speed</value>
+  </data>
+  <data xml:space="preserve" name="MinimumToMove">
+    <value>Minimum to Move</value>
+  </data>
+  <data xml:space="preserve" name="ModuleConnections">
+    <value>Module Connections</value>
+  </data>
+  <data xml:space="preserve" name="MotorDriver">
+    <value>Motor Driver</value>
+  </data>
+  <data xml:space="preserve" name="MountPoint">
+    <value>Mount Point</value>
+  </data>
+  <data xml:space="preserve" name="NSM">
+    <value>N/S (m)</value>
+  </data>
+  <data xml:space="preserve" name="NetworkAndGpsSettings">
+    <value>Network and GPS settings</value>
+  </data>
+  <data xml:space="preserve" name="NetworkStatus">
+    <value>Network Status:</value>
+  </data>
+  <data xml:space="preserve" name="NewFieldName">
+    <value>New Field Name:</value>
+  </data>
+  <data xml:space="preserve" name="NextGuidance">
+    <value>Next Guidance</value>
+  </data>
+  <data xml:space="preserve" name="NoBoundaryLoadedPleaseCreateOrLoadAFieldFirst">
+    <value>No boundary loaded - please create or load a field first</value>
+  </data>
+  <data xml:space="preserve" name="None">
+    <value>None</value>
+  </data>
+  <data xml:space="preserve" name="NotSet">
+    <value>(not set)</value>
+  </data>
+  <data xml:space="preserve" name="NtripProfile">
+    <value>NTRIP Profile</value>
+  </data>
+  <data xml:space="preserve" name="NudgeDistance">
+    <value>Nudge Distance</value>
+  </data>
+  <data xml:space="preserve" name="NumberOfPasses">
+    <value>Number of Passes</value>
+  </data>
+  <data xml:space="preserve" name="Off2">
+    <value>OFF</value>
+  </data>
+  <data xml:space="preserve" name="OffAt">
+    <value>Off at %</value>
+  </data>
+  <data xml:space="preserve" name="On2">
+    <value>ON</value>
+  </data>
+  <data xml:space="preserve" name="OnDelay">
+    <value>On-Delay</value>
+  </data>
+  <data xml:space="preserve" name="OnOff">
+    <value>On/Off</value>
+  </data>
+  <data xml:space="preserve" name="Out">
+    <value>Out</value>
+  </data>
+  <data xml:space="preserve" name="OvershootReduction">
+    <value>Overshoot Reduction</value>
+  </data>
+  <data xml:space="preserve" name="Password">
+    <value>Password</value>
+  </data>
+  <data xml:space="preserve" name="Pixels">
+    <value>pixels</value>
+  </data>
+  <data xml:space="preserve" name="PlaceFlagByLatLon">
+    <value>Place Flag by Lat/Lon</value>
+  </data>
+  <data xml:space="preserve" name="PlaceFlagHere">
+    <value>Place Flag Here</value>
+  </data>
+  <data xml:space="preserve" name="PlaceIsoXmlFoldersContainingTaskdataxmlInDocumentsAgvaloniagpsImport">
+    <value>Place ISO-XML folders (containing TASKDATA.xml) in Documents/AgValoniaGPS/Import</value>
+  </data>
+  <data xml:space="preserve" name="PlaceKmlFilesInDocumentsAgvaloniagpsImport">
+    <value>Place KML files in Documents/AgValoniaGPS/Import</value>
+  </data>
+  <data xml:space="preserve" name="Points">
+    <value>Points:</value>
+  </data>
+  <data xml:space="preserve" name="Port">
+    <value>Port</value>
+  </data>
+  <data xml:space="preserve" name="PressureTurn">
+    <value>Pressure Turn</value>
+  </data>
+  <data xml:space="preserve" name="PreviewShownOnMap">
+    <value>Preview shown on map</value>
+  </data>
+  <data xml:space="preserve" name="ProfileName">
+    <value>Profile Name</value>
+  </data>
+  <data xml:space="preserve" name="ProportionalGain">
+    <value>Proportional Gain</value>
+  </data>
+  <data xml:space="preserve" name="PurePursuit">
+    <value>Pure Pursuit</value>
+  </data>
+  <data xml:space="preserve" name="Pwm">
+    <value>PWM:</value>
+  </data>
+  <data xml:space="preserve" name="QuickAbLineCreator">
+    <value>Quick AB Line Creator</value>
+  </data>
+  <data xml:space="preserve" name="ReadOnlyViewOfCurrentConfigurationValues">
+    <value>Read-only view of current configuration values</value>
+  </data>
+  <data xml:space="preserve" name="RenameFlag">
+    <value>Rename Flag</value>
+  </data>
+  <data xml:space="preserve" name="ResetDefaults">
+    <value>Reset Defaults</value>
+  </data>
+  <data xml:space="preserve" name="ResetToDefaults">
+    <value>Reset to Defaults?</value>
+  </data>
+  <data xml:space="preserve" name="Right">
+    <value>RIGHT ▶</value>
+  </data>
+  <data xml:space="preserve" name="Satellites">
+    <value>Satellites:</value>
+  </data>
+  <data xml:space="preserve" name="SaveProfile">
+    <value>Save Profile</value>
+  </data>
+  <data xml:space="preserve" name="Sec">
+    <value>sec</value>
+  </data>
+  <data xml:space="preserve" name="SelectAFieldToImportItsTracksIntoTheCurrentField">
+    <value>Select a field to import its tracks into the current field:</value>
+  </data>
+  <data xml:space="preserve" name="SelectAll">
+    <value>Select All</value>
+  </data>
+  <data xml:space="preserve" name="SelectCreationMode">
+    <value>Select creation mode:</value>
+  </data>
+  <data xml:space="preserve" name="SelectFieldToOpen">
+    <value>Select Field to Open</value>
+  </data>
+  <data xml:space="preserve" name="SelectFieldsThatWillUseThisNtripProfile">
+    <value>Select fields that will use this NTRIP profile:</value>
+  </data>
+  <data xml:space="preserve" name="SelectFieldsToUpload">
+    <value>Select fields to upload</value>
+  </data>
+  <data xml:space="preserve" name="Sendsave">
+    <value>Send+Save</value>
+  </data>
+  <data xml:space="preserve" name="ServerUrl">
+    <value>Server URL</value>
+  </data>
+  <data xml:space="preserve" name="Set">
+    <value>Set:</value>
+  </data>
+  <data xml:space="preserve" name="SetAsDefaultProfileForFieldsWithoutSpecificAssociation">
+    <value>Set as default profile (for fields without specific association)</value>
+  </data>
+  <data xml:space="preserve" name="SidehillDegree">
+    <value>Sidehill / Degree</value>
+  </data>
+  <data xml:space="preserve" name="Single">
+    <value>Single</value>
+  </data>
+  <data xml:space="preserve" name="Slow">
+    <value>Slow</value>
+  </data>
+  <data xml:space="preserve" name="SlowlyIncreasesSteerAngleToReduceCrossTrackError">
+    <value>Slowly increases steer angle to reduce cross track error</value>
+  </data>
+  <data xml:space="preserve" name="SortAZ">
+    <value>Sort A-Z</value>
+  </data>
+  <data xml:space="preserve" name="Space">
+    <value>Space</value>
+  </data>
+  <data xml:space="preserve" name="Speed2">
+    <value>Speed:</value>
+  </data>
+  <data xml:space="preserve" name="SpeedFactor">
+    <value>Speed Factor</value>
+  </data>
+  <data xml:space="preserve" name="SpeedLimits">
+    <value>Speed Limits</value>
+  </data>
+  <data xml:space="preserve" name="Stanley">
+    <value>Stanley</value>
+  </data>
+  <data xml:space="preserve" name="StanleyGains">
+    <value>Stanley Gains</value>
+  </data>
+  <data xml:space="preserve" name="Status">
+    <value>Status:</value>
+  </data>
+  <data xml:space="preserve" name="SteerBar">
+    <value>Steer Bar</value>
+  </data>
+  <data xml:space="preserve" name="SteerInReverse">
+    <value>Steer in Reverse</value>
+  </data>
+  <data xml:space="preserve" name="SteerResponse">
+    <value>Steer Response</value>
+  </data>
+  <data xml:space="preserve" name="SteeringAlgorithm">
+    <value>Steering Algorithm</value>
+  </data>
+  <data xml:space="preserve" name="Straight">
+    <value>Straight</value>
+  </data>
+  <data xml:space="preserve" name="StraightLine">
+    <value>Straight Line:</value>
+  </data>
+  <data xml:space="preserve" name="Switch">
+    <value>Switch</value>
+  </data>
+  <data xml:space="preserve" name="Tap2PointsToCreateAStraightAbLine">
+    <value>Tap 2 points to create a straight AB line</value>
+  </data>
+  <data xml:space="preserve" name="Tap3PointsThenTapFinishInTheStatusBar">
+    <value>Tap 3+ points, then tap Finish in the status bar</value>
+  </data>
+  <data xml:space="preserve" name="TapOnTheMapToAddBoundaryPointsPanWithDragPinchToZoom">
+    <value>Tap on the map to add boundary points. Pan with drag, pinch to zoom.</value>
+  </data>
+  <data xml:space="preserve" name="TapOnTheMapToPlacePoints">
+    <value>Tap on the map to place points</value>
+  </data>
+  <data xml:space="preserve" name="Taskdata">
+    <value>TASKDATA</value>
+  </data>
+  <data xml:space="preserve" name="TestConnection">
+    <value>Test Connection</value>
+  </data>
+  <data xml:space="preserve" name="TestMode">
+    <value>Test Mode</value>
+  </data>
+  <data xml:space="preserve" name="TheFieldOriginWillBeSetToYourCurrentGpsPositionWhenYouCreateTheField">
+    <value>The field origin will be set to your current GPS position when you create the field.</value>
+  </data>
+  <data xml:space="preserve" name="ThisWillResetAllAutosteerSettingsToFactoryDefaultsAndSendThemToTheModule">
+    <value>This will reset ALL AutoSteer settings to factory defaults and send them to the module.</value>
+  </data>
+  <data xml:space="preserve" name="ToolWidths">
+    <value>Tool Widths</value>
+  </data>
+  <data xml:space="preserve" name="TrackName">
+    <value>Track Name</value>
+  </data>
+  <data xml:space="preserve" name="TrackType">
+    <value>Track Type</value>
+  </data>
+  <data xml:space="preserve" name="TurnSensor">
+    <value>Turn Sensor</value>
+  </data>
+  <data xml:space="preserve" name="Type">
+    <value>Type</value>
+  </data>
+  <data xml:space="preserve" name="UTurnCompensation">
+    <value>U-Turn Compensation</value>
+  </data>
+  <data xml:space="preserve" name="UdpCommunication">
+    <value>UDP Communication</value>
+  </data>
+  <data xml:space="preserve" name="Units">
+    <value>Units:</value>
+  </data>
+  <data xml:space="preserve" name="UploadToAgshare">
+    <value>Upload to AgShare</value>
+  </data>
+  <data xml:space="preserve" name="Username">
+    <value>Username</value>
+  </data>
+  <data xml:space="preserve" name="Warning">
+    <value>Warning</value>
+  </data>
+  <data xml:space="preserve" name="WasZero">
+    <value>Was Zero</value>
+  </data>
+  <data xml:space="preserve" name="Width">
+    <value>Width:</value>
+  </data>
+  <data xml:space="preserve" name="Wizard">
+    <value>Wizard</value>
+  </data>
+  <data xml:space="preserve" name="ZeroWas">
+    <value>Zero WAS</value>
+  </data>
+  <data xml:space="preserve" name="lt">
+    <value>&amp;lt;--</value>
+  </data>
 </root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.resx
@@ -327,4 +327,163 @@
   <data xml:space="preserve" name="YouTurn">
     <value>U-Turn</value>
   </data>
+  <data xml:space="preserve" name="Active">
+    <value>Active</value>
+  </data>
+  <data xml:space="preserve" name="AgShareDownload">
+    <value>AgShare Download</value>
+  </data>
+  <data xml:space="preserve" name="AgShareUpload">
+    <value>AgShare Upload</value>
+  </data>
+  <data xml:space="preserve" name="ApplicationSettings">
+    <value>Application Settings</value>
+  </data>
+  <data xml:space="preserve" name="Build">
+    <value>Build</value>
+  </data>
+  <data xml:space="preserve" name="Clear">
+    <value>Clear</value>
+  </data>
+  <data xml:space="preserve" name="Create">
+    <value>Create</value>
+  </data>
+  <data xml:space="preserve" name="CrossTrackError">
+    <value>Cross Track Error</value>
+  </data>
+  <data xml:space="preserve" name="Curve">
+    <value>Curve</value>
+  </data>
+  <data xml:space="preserve" name="DayNight">
+    <value>Day/Night</value>
+  </data>
+  <data xml:space="preserve" name="DeleteAppliedArea">
+    <value>Delete Applied Area</value>
+  </data>
+  <data xml:space="preserve" name="Done">
+    <value>Done</value>
+  </data>
+  <data xml:space="preserve" name="Draw">
+    <value>Draw</value>
+  </data>
+  <data xml:space="preserve" name="DriveIn">
+    <value>Drive In</value>
+  </data>
+  <data xml:space="preserve" name="DriveThru">
+    <value>Drive Thru</value>
+  </data>
+  <data xml:space="preserve" name="EnterSimCoords">
+    <value>Enter Sim Coords</value>
+  </data>
+  <data xml:space="preserve" name="FlagList">
+    <value>Flag List</value>
+  </data>
+  <data xml:space="preserve" name="FromKml">
+    <value>From KML</value>
+  </data>
+  <data xml:space="preserve" name="GpsSimulator">
+    <value>GPS Simulator</value>
+  </data>
+  <data xml:space="preserve" name="Grid">
+    <value>Grid</value>
+  </data>
+  <data xml:space="preserve" name="HeadingChart">
+    <value>Heading Chart</value>
+  </data>
+  <data xml:space="preserve" name="Import">
+    <value>Import</value>
+  </data>
+  <data xml:space="preserve" name="IsoXml">
+    <value>ISO-XML</value>
+  </data>
+  <data xml:space="preserve" name="Line">
+    <value>Line</value>
+  </data>
+  <data xml:space="preserve" name="Load">
+    <value>Load</value>
+  </data>
+  <data xml:space="preserve" name="LoadProfile">
+    <value>Load Profile</value>
+  </data>
+  <data xml:space="preserve" name="NewFromDefault">
+    <value>New From Default</value>
+  </data>
+  <data xml:space="preserve" name="NewProfile">
+    <value>New Profile</value>
+  </data>
+  <data xml:space="preserve" name="North">
+    <value>North</value>
+  </data>
+  <data xml:space="preserve" name="Open">
+    <value>Open</value>
+  </data>
+  <data xml:space="preserve" name="Path">
+    <value>Path</value>
+  </data>
+  <data xml:space="preserve" name="PlaceHere">
+    <value>Place Here</value>
+  </data>
+  <data xml:space="preserve" name="PlaceOnMap">
+    <value>Place on Map</value>
+  </data>
+  <data xml:space="preserve" name="Refresh">
+    <value>Refresh</value>
+  </data>
+  <data xml:space="preserve" name="ReverseDirection">
+    <value>Reverse Direction</value>
+  </data>
+  <data xml:space="preserve" name="RollCorrection">
+    <value>Roll Correction</value>
+  </data>
+  <data xml:space="preserve" name="SelectLanguage">
+    <value>Select Language</value>
+  </data>
+  <data xml:space="preserve" name="SelectProfile">
+    <value>Select Profile</value>
+  </data>
+  <data xml:space="preserve" name="SimulatorEnabled">
+    <value>Simulator Enabled</value>
+  </data>
+  <data xml:space="preserve" name="StartNewField">
+    <value>Start New Field</value>
+  </data>
+  <data xml:space="preserve" name="StartOrDeleteBoundary">
+    <value>Start or Delete A Boundary</value>
+  </data>
+  <data xml:space="preserve" name="SteerChart">
+    <value>Steer Chart</value>
+  </data>
+  <data xml:space="preserve" name="SteerWizard">
+    <value>Steer Wizard</value>
+  </data>
+  <data xml:space="preserve" name="TiltDown">
+    <value>Tilt Down</value>
+  </data>
+  <data xml:space="preserve" name="TiltUp">
+    <value>Tilt Up</value>
+  </data>
+  <data xml:space="preserve" name="TramLines">
+    <value>Tram Lines</value>
+  </data>
+  <data xml:space="preserve" name="TramLinesBuilder">
+    <value>Tram Lines Builder</value>
+  </data>
+  <data xml:space="preserve" name="Undo">
+    <value>Undo</value>
+  </data>
+  <data xml:space="preserve" name="Upload">
+    <value>Upload</value>
+  </data>
+  <data xml:space="preserve" name="VehicleConfiguration">
+    <value>Vehicle Configuration</value>
+  </data>
+  <data xml:space="preserve" name="VehicleSettings">
+    <value>Vehicle Settings</value>
+  </data>
+  <data xml:space="preserve" name="ViewSettings">
+    <value>View Settings</value>
+  </data>
+  <data xml:space="preserve" name="XteChart">
+    <value>XTE Chart</value>
+  </data>
 </root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.resx
@@ -1,0 +1,330 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABCurve">
+    <value>AB Curve</value>
+  </data>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB Line</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>About</value>
+  </data>
+  <data xml:space="preserve" name="Acres">
+    <value>ac</value>
+  </data>
+  <data xml:space="preserve" name="AgShareApi">
+    <value>AgShare API</value>
+  </data>
+  <data xml:space="preserve" name="Altitude">
+    <value>Altitude</value>
+  </data>
+  <data xml:space="preserve" name="Antenna">
+    <value>Antenna</value>
+  </data>
+  <data xml:space="preserve" name="AppDirectories">
+    <value>App Directories</value>
+  </data>
+  <data xml:space="preserve" name="Apply">
+    <value>Apply</value>
+  </data>
+  <data xml:space="preserve" name="AreYouSure">
+    <value>Are you sure?</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Area</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Auto Steer</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Boundary</value>
+  </data>
+  <data xml:space="preserve" name="BugReportDump">
+    <value>Bug Report Dump</value>
+  </data>
+  <data xml:space="preserve" name="BuildHeadland">
+    <value>Build Headland</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Cancel</value>
+  </data>
+  <data xml:space="preserve" name="CentimetersPerSecond">
+    <value>cm/s</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Close</value>
+  </data>
+  <data xml:space="preserve" name="CloseField">
+    <value>Close Field</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Configuration</value>
+  </data>
+  <data xml:space="preserve" name="ConfirmDelete">
+    <value>Confirm Delete</value>
+  </data>
+  <data xml:space="preserve" name="Contour">
+    <value>Contour</value>
+  </data>
+  <data xml:space="preserve" name="CreateNewField">
+    <value>Create New Field</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Delete</value>
+  </data>
+  <data xml:space="preserve" name="DeleteAllFlags">
+    <value>Delete All Flags</value>
+  </data>
+  <data xml:space="preserve" name="DeleteContours">
+    <value>Delete Contours</value>
+  </data>
+  <data xml:space="preserve" name="DeleteHeadland">
+    <value>Delete Headland</value>
+  </data>
+  <data xml:space="preserve" name="DgpsFix">
+    <value>DGPS Fix</value>
+  </data>
+  <data xml:space="preserve" name="Disable">
+    <value>Disable</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Display</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Distance</value>
+  </data>
+  <data xml:space="preserve" name="DrawAB">
+    <value>Draw AB</value>
+  </data>
+  <data xml:space="preserve" name="DriveAB">
+    <value>Drive AB</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Enable</value>
+  </data>
+  <data xml:space="preserve" name="FieldName">
+    <value>Field Name</value>
+  </data>
+  <data xml:space="preserve" name="FieldTools">
+    <value>Field Tools</value>
+  </data>
+  <data xml:space="preserve" name="Fields">
+    <value>Fields</value>
+  </data>
+  <data xml:space="preserve" name="FileMenu">
+    <value>File Menu</value>
+  </data>
+  <data xml:space="preserve" name="FlagByLatLon">
+    <value>Flag By Lat Lon</value>
+  </data>
+  <data xml:space="preserve" name="FromExisting">
+    <value>From Existing</value>
+  </data>
+  <data xml:space="preserve" name="GpsActive">
+    <value>GPS Active</value>
+  </data>
+  <data xml:space="preserve" name="GpsFix">
+    <value>GPS Fix</value>
+  </data>
+  <data xml:space="preserve" name="Guidance">
+    <value>Guidance</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Heading</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Headland</value>
+  </data>
+  <data xml:space="preserve" name="Hectares">
+    <value>ha</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Help</value>
+  </data>
+  <data xml:space="preserve" name="HitchLength">
+    <value>Hitch Length</value>
+  </data>
+  <data xml:space="preserve" name="Hotkeys">
+    <value>Hotkeys</value>
+  </data>
+  <data xml:space="preserve" name="Implement">
+    <value>Implement</value>
+  </data>
+  <data xml:space="preserve" name="ImportTracks">
+    <value>Import Tracks</value>
+  </data>
+  <data xml:space="preserve" name="JobMenu">
+    <value>Job Menu</value>
+  </data>
+  <data xml:space="preserve" name="Kilometers">
+    <value>km</value>
+  </data>
+  <data xml:space="preserve" name="KilometersPerHour">
+    <value>km/h</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Language</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Latitude</value>
+  </data>
+  <data xml:space="preserve" name="LogViewer">
+    <value>Log Viewer</value>
+  </data>
+  <data xml:space="preserve" name="Longitude">
+    <value>Longitude</value>
+  </data>
+  <data xml:space="preserve" name="ManualLeft">
+    <value>Manual Left</value>
+  </data>
+  <data xml:space="preserve" name="ManualRight">
+    <value>Manual Right</value>
+  </data>
+  <data xml:space="preserve" name="Meters">
+    <value>m</value>
+  </data>
+  <data xml:space="preserve" name="MilesPerHour">
+    <value>mph</value>
+  </data>
+  <data xml:space="preserve" name="NewField">
+    <value>New Field</value>
+  </data>
+  <data xml:space="preserve" name="No">
+    <value>No</value>
+  </data>
+  <data xml:space="preserve" name="NoFix">
+    <value>No Fix</value>
+  </data>
+  <data xml:space="preserve" name="NtripProfiles">
+    <value>NTRIP Profiles</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Nudge</value>
+  </data>
+  <data xml:space="preserve" name="OK">
+    <value>OK</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Off</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Offset</value>
+  </data>
+  <data xml:space="preserve" name="OffsetFix">
+    <value>Offset Fix</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>On</value>
+  </data>
+  <data xml:space="preserve" name="OpenField">
+    <value>Open Field</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Overlap</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pause</value>
+  </data>
+  <data xml:space="preserve" name="PlaceFlag">
+    <value>Place Flag</value>
+  </data>
+  <data xml:space="preserve" name="RecordedPath">
+    <value>Recorded Path</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Reset</value>
+  </data>
+  <data xml:space="preserve" name="ResetAllSettings">
+    <value>Reset All Settings</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Resume</value>
+  </data>
+  <data xml:space="preserve" name="RtkFix">
+    <value>RTK Fix</value>
+  </data>
+  <data xml:space="preserve" name="RtkFloat">
+    <value>RTK Float</value>
+  </data>
+  <data xml:space="preserve" name="Save">
+    <value>Save</value>
+  </data>
+  <data xml:space="preserve" name="SectionControl">
+    <value>Section Control</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sections</value>
+  </data>
+  <data xml:space="preserve" name="SelectField">
+    <value>Select Field</value>
+  </data>
+  <data xml:space="preserve" name="SetA">
+    <value>Set A</value>
+  </data>
+  <data xml:space="preserve" name="SetB">
+    <value>Set B</value>
+  </data>
+  <data xml:space="preserve" name="Simulator">
+    <value>Simulator</value>
+  </data>
+  <data xml:space="preserve" name="SkipRows">
+    <value>Skip Rows</value>
+  </data>
+  <data xml:space="preserve" name="SnapToPivot">
+    <value>Snap to Pivot</value>
+  </data>
+  <data xml:space="preserve" name="Sources">
+    <value>Sources</value>
+  </data>
+  <data xml:space="preserve" name="Speed">
+    <value>Speed</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Start</value>
+  </data>
+  <data xml:space="preserve" name="Stop">
+    <value>Stop</value>
+  </data>
+  <data xml:space="preserve" name="ToolWidth">
+    <value>Tool Width</value>
+  </data>
+  <data xml:space="preserve" name="Tools">
+    <value>Tools</value>
+  </data>
+  <data xml:space="preserve" name="TrackWidth">
+    <value>Track Width</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Tracks</value>
+  </data>
+  <data xml:space="preserve" name="Vehicle">
+    <value>Vehicle</value>
+  </data>
+  <data xml:space="preserve" name="ViewAllSettings">
+    <value>View All Settings</value>
+  </data>
+  <data xml:space="preserve" name="WaitingForGps">
+    <value>Waiting for GPS</value>
+  </data>
+  <data xml:space="preserve" name="Wheelbase">
+    <value>Wheelbase</value>
+  </data>
+  <data xml:space="preserve" name="Yes">
+    <value>Yes</value>
+  </data>
+  <data xml:space="preserve" name="YouTurn">
+    <value>U-Turn</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.ru.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.ru.resx
@@ -1,0 +1,87 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>Линия АВ</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>О программе...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Площадь</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Автопилот</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Граница</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Отмена</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Закрыть</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Конфигурация</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Удалить</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Отображать</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Включить</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Отступ</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Помощь</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Язык</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Широта</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Сдвиг линии:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Выкл.</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Смещение</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Вкл.</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Пауза</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Сброс</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Продолжить</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Секции:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Начать</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.sk.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.sk.resx
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB línia</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>O programe...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Plocha</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autopilota</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Hranica</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Zavrieť</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Nastavenie</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Vzdialenosť</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Úvrať</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Pomoc</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Jazyk</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Vzdialenosť</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pauza</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Obnoviť posledné</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.sr.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.sr.resx
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB linija</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>O programu...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Površina</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Autopilot</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Granica</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Prekini</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Zatvori</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Podešavanja</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Obriši</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Displej</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Rastojanje</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Omogući</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Pravac</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Uvrtine</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Pomoć</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Jezik</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Pomeraj:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>OFF</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Odstojanje</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>ON</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Preklop:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Pauza</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Nastavi</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Sekcije:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Pokreni</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.tr.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.tr.resx
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB Çizgisi</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>Hakkında...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Alan</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Otomatik Yönlendirme</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Sınır</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>İptal et</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>Kapamak</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Yapılandırması</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Sil</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Görüntüle</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Uzaklık</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Yön</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Sürülmemiş Alan</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Yardım</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Lisan</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Enlem</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Ofset</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Duraklat</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Devam et</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.uk.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.uk.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>АВ лінії</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>О програмі...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>Площа</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>Налаштування Автопілота</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>Межа</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>Скасувати</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>завершувати</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>Налаштування</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>Видалити</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>Дисплей</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>Відстань</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>Увімкнути</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>Заголовок</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>Відступ</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>Допомога</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>Мова</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>Широта</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>Підштовхування:</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>Вимк</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>Зміщення</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>Увімк</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>Перекриття:</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>Пауза</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>Скинути</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>Відновити</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>Розділи:</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>Початок</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>Треки</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.zh-Hans.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.zh-Hans.resx
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data xml:space="preserve" name="ABLine">
+    <value>AB 直线</value>
+  </data>
+  <data xml:space="preserve" name="About">
+    <value>关于...</value>
+  </data>
+  <data xml:space="preserve" name="Area">
+    <value>面积</value>
+  </data>
+  <data xml:space="preserve" name="AutoSteer">
+    <value>方向盘配置</value>
+  </data>
+  <data xml:space="preserve" name="Boundary">
+    <value>边界</value>
+  </data>
+  <data xml:space="preserve" name="Cancel">
+    <value>取消</value>
+  </data>
+  <data xml:space="preserve" name="Close">
+    <value>关闭</value>
+  </data>
+  <data xml:space="preserve" name="Configuration">
+    <value>方向盘配置</value>
+  </data>
+  <data xml:space="preserve" name="Delete">
+    <value>删除</value>
+  </data>
+  <data xml:space="preserve" name="Display">
+    <value>显示</value>
+  </data>
+  <data xml:space="preserve" name="Distance">
+    <value>距离</value>
+  </data>
+  <data xml:space="preserve" name="Enable">
+    <value>确保</value>
+  </data>
+  <data xml:space="preserve" name="Heading">
+    <value>标题</value>
+  </data>
+  <data xml:space="preserve" name="Headland">
+    <value>地头</value>
+  </data>
+  <data xml:space="preserve" name="Help">
+    <value>帮助</value>
+  </data>
+  <data xml:space="preserve" name="Language">
+    <value>语言</value>
+  </data>
+  <data xml:space="preserve" name="Latitude">
+    <value>纬度</value>
+  </data>
+  <data xml:space="preserve" name="Nudge">
+    <value>推测：</value>
+  </data>
+  <data xml:space="preserve" name="Off">
+    <value>关</value>
+  </data>
+  <data xml:space="preserve" name="Offset">
+    <value>偏移</value>
+  </data>
+  <data xml:space="preserve" name="On">
+    <value>开</value>
+  </data>
+  <data xml:space="preserve" name="Overlap">
+    <value>重叠：</value>
+  </data>
+  <data xml:space="preserve" name="Pause">
+    <value>暂停</value>
+  </data>
+  <data xml:space="preserve" name="Reset">
+    <value>重置</value>
+  </data>
+  <data xml:space="preserve" name="Resume">
+    <value>简介</value>
+  </data>
+  <data xml:space="preserve" name="Sections">
+    <value>部分：</value>
+  </data>
+  <data xml:space="preserve" name="Start">
+    <value>开始</value>
+  </data>
+  <data xml:space="preserve" name="Tracks">
+    <value>轨道</value>
+  </data>
+</root>

--- a/Shared/AgValoniaGPS.Views/Localization/TranslationSource.cs
+++ b/Shared/AgValoniaGPS.Views/Localization/TranslationSource.cs
@@ -1,0 +1,74 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Resources;
+
+namespace AgValoniaGPS.Views.Localization;
+
+/// <summary>
+/// Singleton that provides access to localized strings from Strings.resx.
+/// Supports runtime culture switching.
+/// </summary>
+public class TranslationSource : INotifyPropertyChanged
+{
+    public static TranslationSource Instance { get; } = new();
+
+    private readonly ResourceManager _resourceManager =
+        new("AgValoniaGPS.Views.Localization.Strings",
+            typeof(TranslationSource).Assembly);
+
+    private CultureInfo _currentCulture = CultureInfo.CurrentUICulture;
+
+    public string this[string key]
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(key)) return string.Empty;
+            var value = _resourceManager.GetString(key, _currentCulture);
+            return value ?? key; // Fall back to key name
+        }
+    }
+
+    public CultureInfo CurrentCulture
+    {
+        get => _currentCulture;
+        set
+        {
+            if (Equals(_currentCulture, value)) return;
+            _currentCulture = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(string.Empty));
+        }
+    }
+
+    /// <summary>
+    /// Get the display name for a language code (e.g. "de" -> "Deutsch").
+    /// </summary>
+    public static string GetLanguageDisplayName(string code)
+    {
+        try
+        {
+            return new CultureInfo(code).NativeName;
+        }
+        catch
+        {
+            return code;
+        }
+    }
+
+    /// <summary>
+    /// Available language codes (those with .resx translation files).
+    /// </summary>
+    public static readonly string[] AvailableLanguages = new[]
+    {
+        "en", "da", "de", "es", "et", "fi", "fr", "hu", "it", "ko",
+        "lt", "lv", "nl", "no", "pl", "pt", "ru", "sk", "sr", "tr",
+        "uk", "zh-Hans"
+    };
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -594,6 +594,7 @@ public class ConfigurationServiceMappingTests
             "LastRunDate",          // Checked directly at startup
             "LastUsedVehicleProfile", // Mapped via ActiveProfileName (different name)
             "HotkeyBindings",       // Mapped via Hotkeys.LoadFromDictionary (special handling)
+            "Language",              // Used directly from AppSettings for localization
             // Panel positions with NaN defaults - mapped but tested separately
             "LeftNavPanelX", "LeftNavPanelY",
             "RightNavPanelX", "RightNavPanelY",


### PR DESCRIPTION
## What changed

- .resx-based localization infrastructure with 105 base English strings
- 21 language translations ported from legacy AgOpenGPS:
  da, de, es, et, fi, fr, hu, it, ko, lt, lv, nl, no, pl, pt, ru, sk, sr, tr, uk, zh-Hans
- `TranslationSource` singleton with runtime culture switching
- `LocalizeExtension` AXAML markup extension for string bindings
- Language selection dialog (shows native language names)
- Language button wired in FileMenuPanel
- Language preference persisted in AppSettings
- Applied on startup

AXAML panels can be incrementally converted using:
```xml
xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
Content="{loc:Localize ABLine}"
```

## Related issue

Closes #40

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes (72 + 299 = 371 tests)
- [x] Tested on: Desktop (headless integration test)

Generated with [Claude Code](https://claude.com/claude-code)