### PR TITLE
Remove Line Smooth toggle (#85)

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -225,17 +225,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="Guide Count" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
-                        <!-- Row 3: Line Smooth, Direction Markers, Section Lines -->
-                        <StackPanel Grid.Row="3" Grid.Column="0" Spacing="4" HorizontalAlignment="Center">
-                            <Button Classes="DisplayToggle"
-                                    Background="{Binding Display.LineSmoothEnabled, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
-                                    BorderBrush="{Binding Display.LineSmoothEnabled, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
-                                    Command="{Binding ToggleLineSmoothCommand}">
-                                <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_LineSmooth.png"
-                                       Width="60" Height="60" Stretch="Uniform"/>
-                            </Button>
-                            <TextBlock Text="Line Smooth" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center"/>
-                        </StackPanel>
+                        <!-- Row 3: Direction Markers, Section Lines -->
+                        <!-- Line Smooth removed: Avalonia Skia renderer handles AA by default (#85) -->
 
                         <!-- Hidden: bitmap coverage system does not populate geometry cache (#117) -->
                         <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center"


### PR DESCRIPTION
## What changed

Removed the Line Smooth toggle button from Display config tab. Avalonia's Skia renderer handles anti-aliasing by default - no user toggle needed (unlike legacy WinForms GDI+ SmoothingMode).

## Related issue

Closes #85

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] Tested on: Desktop (build verified)

Generated with [Claude Code](https://claude.com/claude-code)