### PR TITLE
Add Help dialog with external links (#16)

### DIFF
--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -69,6 +69,7 @@ public class UIState : ReactiveObject
                 this.RaisePropertyChanged(nameof(IsFlagListDialogVisible));
                 this.RaisePropertyChanged(nameof(IsViewSettingsDialogVisible));
                 this.RaisePropertyChanged(nameof(IsImportTracksDialogVisible));
+                this.RaisePropertyChanged(nameof(IsHelpDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -108,6 +109,7 @@ public class UIState : ReactiveObject
     public bool IsFlagListDialogVisible => ActiveDialog == DialogType.FlagList;
     public bool IsViewSettingsDialogVisible => ActiveDialog == DialogType.ViewSettings;
     public bool IsImportTracksDialogVisible => ActiveDialog == DialogType.ImportTracks;
+    public bool IsHelpDialogVisible => ActiveDialog == DialogType.Help;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -233,7 +235,8 @@ public enum DialogType
     FlagByLatLon,
     FlagList,
     ViewSettings,
-    ImportTracks
+    ImportTracks,
+    Help
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -131,6 +131,17 @@ public partial class MainViewModel
             State.UI.CloseDialog();
         });
 
+        // Help (#16)
+        ShowHelpDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.ShowDialog(Models.State.DialogType.Help);
+        });
+
+        CloseHelpDialogCommand = ReactiveCommand.Create(() =>
+        {
+            State.UI.CloseDialog();
+        });
+
         // Debug Dump (#127)
         CreateDebugDumpCommand = ReactiveCommand.Create(() =>
         {
@@ -380,6 +391,8 @@ public partial class MainViewModel
 
     public ICommand? ShowViewSettingsDialogCommand { get; private set; }
     public ICommand? CloseViewSettingsDialogCommand { get; private set; }
+    public ICommand? ShowHelpDialogCommand { get; private set; }
+    public ICommand? CloseHelpDialogCommand { get; private set; }
 }
 
 public class SettingsGroupItem

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -61,6 +61,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:FlagByLatLonDialogPanel/>
         <dialogs:FlagListDialogPanel/>
         <dialogs:ViewSettingsDialogPanel/>
+        <dialogs:HelpDialogPanel/>
         <dialogs:OffsetFixDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml
@@ -1,0 +1,60 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.HelpDialogPanel"
+             IsVisible="{Binding State.UI.IsHelpDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsHelpDialogVisible}">
+
+    <!-- Semi-transparent backdrop -->
+    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="12" Padding="24"
+                MaxWidth="420"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                BoxShadow="0 4 16 #40000000">
+
+            <StackPanel Spacing="16">
+                <TextBlock Text="Help" FontSize="22" FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+
+                <TextBlock Text="AgValoniaGPS - Agricultural GPS Guidance"
+                           FontSize="14" HorizontalAlignment="Center"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+
+                <!-- Link buttons -->
+                <StackPanel Spacing="8">
+                    <Button Classes="ModernButton" HorizontalAlignment="Stretch" MinHeight="44"
+                            x:Name="BtnGitHub" Click="OnGitHubClick">
+                        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                            <TextBlock Text="GitHub Repository" FontSize="15" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+
+                    <Button Classes="ModernButton" HorizontalAlignment="Stretch" MinHeight="44"
+                            x:Name="BtnDiscussions" Click="OnDiscussionsClick">
+                        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                            <TextBlock Text="Discussions / Forum" FontSize="15" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+
+                    <Button Classes="ModernButton" HorizontalAlignment="Stretch" MinHeight="44"
+                            x:Name="BtnReleases" Click="OnReleasesClick">
+                        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                            <TextBlock Text="Check for Updates" FontSize="15" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+
+                    <Button Classes="ModernButton" HorizontalAlignment="Stretch" MinHeight="44"
+                            x:Name="BtnYouTube" Click="OnYouTubeClick">
+                        <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                            <TextBlock Text="YouTube Tutorials" FontSize="15" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+
+                <Button Content="Close" Classes="ModernButton"
+                        HorizontalAlignment="Center" MinWidth="120"
+                        Command="{Binding CloseHelpDialogCommand}"/>
+            </StackPanel>
+        </Border>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml.cs
@@ -1,0 +1,52 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class HelpDialogPanel : UserControl
+{
+    public HelpDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void OnGitHubClick(object? sender, RoutedEventArgs e)
+        => OpenUrl("https://github.com/AgOpenGPS-Official/AgValoniaGPS");
+
+    private void OnDiscussionsClick(object? sender, RoutedEventArgs e)
+        => OpenUrl("https://discourse.agopengps.com/");
+
+    private void OnReleasesClick(object? sender, RoutedEventArgs e)
+        => OpenUrl("https://github.com/AgOpenGPS-Official/AgValoniaGPS/releases");
+
+    private void OnYouTubeClick(object? sender, RoutedEventArgs e)
+        => OpenUrl("https://www.youtube.com/@AgOpenGPS/videos");
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+            vm.CloseHelpDialogCommand?.Execute(null);
+    }
+
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                Process.Start("open", url);
+            else
+                Process.Start("xdg-open", url);
+        }
+        catch { }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -97,7 +97,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Help & Info -->
             <Button Classes="ModernButton" Content="AgShare API" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAgShareSettingsDialogCommand}"/>
-            <Button Classes="ModernButton" Content="Help" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"/>
+            <Button Classes="ModernButton" Content="Help" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
+                    Command="{Binding ShowHelpDialogCommand}"/>
             <Button Classes="ModernButton" Content="About" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAboutDialogCommand}"/>
             <Button Classes="ModernButton" Content="Bug Report Dump" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"


### PR DESCRIPTION
## What changed

- Wire Help button in FileMenuPanel to new Help dialog
- Dialog shows 4 link buttons: GitHub repo, Discourse forum, Releases, YouTube
- Opens URLs in default browser (cross-platform via Process.Start)
- Matches legacy AgOpenGPS Help dialog functionality

## Related issue

Closes #16

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] Tested on: Desktop (build verified)

Generated with [Claude Code](https://claude.com/claude-code)