### PR TITLE
Fix zoom buttons and dark mode default (#178)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/App.axaml
+++ b/Platforms/AgValoniaGPS.Android/App.axaml
@@ -19,7 +19,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AgValoniaGPS.Android.App"
              xmlns:local="using:AgValoniaGPS.Android"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
 
     <Application.Resources>
         <!-- Include shared resources (converters) -->

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -107,12 +107,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Zoom Controls - Bottom Right -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                            Margin="0,0,20,20" Spacing="10">
-                    <Button Content="+" Command="{Binding ZoomInCommand}"
+                            ZIndex="15" Margin="0,0,20,20" Spacing="10">
+                    <Button Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
-                    <Button Content="-" Command="{Binding ZoomOutCommand}"
+                    <Button Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -201,9 +201,6 @@ public partial class MainView : UserControl
             mapService.RegisterMapControl(_mapControl);
             System.Diagnostics.Debug.WriteLine("[MainView] MapControl registered with MapService.");
 
-            viewModel.ZoomInRequested += () => _mapControl.Zoom(1.2);
-            viewModel.ZoomOutRequested += () => _mapControl.Zoom(0.8);
-
             // Wire screenshot provider for debug dump (#127)
             viewModel.ScreenshotProvider = () =>
             {

--- a/Platforms/AgValoniaGPS.Desktop/App.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/App.axaml
@@ -19,7 +19,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AgValoniaGPS.Desktop.App"
              xmlns:local="using:AgValoniaGPS.Desktop"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
 
     <Application.Resources>
         <!-- Include shared resources (converters) -->

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -115,12 +115,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Zoom Controls - Bottom Right (for touch/tablet users) -->
         <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                    ZIndex="10" Margin="0,0,20,20" Spacing="10">
-            <Button Content="+" Command="{Binding ZoomInCommand}"
+                    ZIndex="15" Margin="0,0,20,20" Spacing="10">
+            <Button Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
                     Width="50" Height="50" FontSize="28" FontWeight="Bold"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
-            <Button Content="-" Command="{Binding ZoomOutCommand}"
+            <Button Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
                     Width="50" Height="50" FontSize="28" FontWeight="Bold"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -70,10 +70,6 @@ public partial class MainWindow : Window
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
             ViewModel.SavedTracks.CollectionChanged += SavedTracks_CollectionChanged;
 
-            // Wire zoom commands to map control
-            ViewModel.ZoomInRequested += () => MapControl?.Zoom(1.2);
-            ViewModel.ZoomOutRequested += () => MapControl?.Zoom(1.0 / 1.2);
-
             // Wire screenshot provider for debug dump (#127)
             ViewModel.ScreenshotProvider = CaptureScreenshotPng;
 

--- a/Platforms/AgValoniaGPS.iOS/App.axaml
+++ b/Platforms/AgValoniaGPS.iOS/App.axaml
@@ -19,7 +19,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AgValoniaGPS.iOS.App"
              xmlns:local="using:AgValoniaGPS.iOS"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
 
     <Application.Resources>
         <!-- Include shared resources (converters) -->

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -107,12 +107,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Zoom Controls - Bottom Right -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                            Margin="0,0,20,20" Spacing="10">
-                    <Button Content="+" Command="{Binding ZoomInCommand}"
+                            ZIndex="15" Margin="0,0,20,20" Spacing="10">
+                    <Button Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
-                    <Button Content="-" Command="{Binding ZoomOutCommand}"
+                    <Button Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
                             Width="50" Height="50" FontSize="28" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -203,9 +203,6 @@ public partial class MainView : UserControl
             mapService.RegisterMapControl(_mapControl);
             System.Diagnostics.Debug.WriteLine("[MainView] MapControl registered with MapService.");
 
-            viewModel.ZoomInRequested += () => _mapControl.Zoom(1.2);
-            viewModel.ZoomOutRequested += () => _mapControl.Zoom(0.8);
-
             // Wire screenshot provider for debug dump (#127)
             viewModel.ScreenshotProvider = () =>
             {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System.Reactive;
+using AgValoniaGPS.Models.Configuration;
 using Avalonia;
 using Avalonia.Styling;
 using ReactiveUI;
@@ -76,6 +77,8 @@ public partial class MainViewModel
             IsDayMode = !IsDayMode;
             _mapService.SetDayMode(IsDayMode);
             ApplyThemeVariant(IsDayMode);
+            // Disable auto day/night when user manually toggles theme
+            ConfigurationStore.Instance.Display.AutoDayNight = false;
         });
 
         Toggle2D3DCommand = ReactiveCommand.Create(() =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -961,13 +961,11 @@ public partial class MainViewModel
         ZoomInCommand = ReactiveCommand.Create(() =>
         {
             _mapService.Zoom(1.2);
-            ZoomInRequested?.Invoke();
         });
 
         ZoomOutCommand = ReactiveCommand.Create(() =>
         {
             _mapService.Zoom(0.8);
-            ZoomOutRequested?.Invoke();
         });
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2672,9 +2672,6 @@ public partial class MainViewModel : ReactiveObject
     public ICommand? ZoomInCommand { get; private set; }
     public ICommand? ZoomOutCommand { get; private set; }
 
-    // Events for views to wire up to map controls
-    public event Action? ZoomInRequested;
-    public event Action? ZoomOutRequested;
     public event Action<string>? LanguageChanged;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fix zoom buttons not responding by removing double-call bug and raising ZIndex above panel overlay
- Fix app defaulting to dark mode by changing `RequestedThemeVariant` from `Default` to `Light`
- Disable `AutoDayNight` when user manually toggles day/night to prevent override

## Changes
- Remove `ZoomInRequested`/`ZoomOutRequested` events (zoom now goes through `_mapService.Zoom()` only)
- Raise zoom button ZIndex to 15 (above Canvas at 10) on all platforms
- Add `ClickMode="Press"` to zoom buttons for touch responsiveness
- Set `RequestedThemeVariant="Light"` in Desktop/iOS/Android App.axaml
- Disable `AutoDayNight` on manual theme toggle

## Test plan
- [ ] Verify zoom in/out buttons work on Desktop
- [ ] Verify app starts in light mode
- [ ] Verify day/night toggle works and stays after toggling
- [ ] Verify mouse wheel zoom still works