### PR TITLE
Fix zoom button colors in light mode (#178)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -108,14 +108,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Zoom Controls - Bottom Right -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                             ZIndex="15" Margin="0,0,20,20" Spacing="10">
-                    <Button Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
-                            Width="50" Height="50" FontSize="28" FontWeight="Bold"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
-                    <Button Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
-                            Width="50" Height="50" FontSize="28" FontWeight="Bold"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
+                    <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"/>
+                    <Button Classes="ZoomButton" Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"/>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -116,14 +116,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Zoom Controls - Bottom Right (for touch/tablet users) -->
         <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                     ZIndex="15" Margin="0,0,20,20" Spacing="10">
-            <Button Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
-                    Width="50" Height="50" FontSize="28" FontWeight="Bold"
-                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
-            <Button Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
-                    Width="50" Height="50" FontSize="28" FontWeight="Bold"
-                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
+            <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"/>
+            <Button Classes="ZoomButton" Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"/>
             <!-- Compass / Camera Mode Button -->
             <Button Command="{Binding ToggleCameraModeCommand}"
                     Width="50" Height="50"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -108,14 +108,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Zoom Controls - Bottom Right -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                             ZIndex="15" Margin="0,0,20,20" Spacing="10">
-                    <Button Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
-                            Width="50" Height="50" FontSize="28" FontWeight="Bold"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
-                    <Button Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
-                            Width="50" Height="50" FontSize="28" FontWeight="Bold"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Background="#4A5568" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="8"/>
+                    <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"/>
+                    <Button Classes="ZoomButton" Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"/>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
@@ -135,13 +135,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Setter Property="FontWeight" Value="Bold"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="Background" Value="#4A5568"/>
-        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         <Setter Property="CornerRadius" Value="8"/>
         <Setter Property="BorderThickness" Value="0"/>
     </Style>
     <Style Selector="Button.ZoomButton:pointerover">
-        <Setter Property="Background" Value="#5A6578"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
     </Style>
 
 </Styles>


### PR DESCRIPTION
## Summary
- Zoom buttons had hardcoded dark `#4A5568` background, looked wrong in light mode
- Updated `ZoomButton` style in SharedStyles.axaml to use `DynamicResource` theme brushes
- Replaced inline button styling with shared `ZoomButton` class on all platforms

Follow-up to #179.