### PR TITLE
Document cross-platform parity rule and add doc cross-references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 This file provides guidance to Claude Code when working with this repository.
 
+**Key documentation:**
+- **[Plans/ARCHITECTURE.md](Plans/ARCHITECTURE.md)** - Full architecture: services, state management, data flow
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contributor guide with cross-platform parity rules
+- **[PGN.md](PGN.md)** - UDP packet protocol for hardware communication
+
 ## Project Overview
 
 AgValoniaGPS3 is a cross-platform agricultural GPS guidance application built with Avalonia UI. It's a clean rewrite achieving **91.7% shared code** across platforms.
@@ -333,8 +338,8 @@ User-Agent: NTRIP AgValoniaGPS
 
 ## Code Style
 
+- **Cross-platform parity is mandatory.** All code MUST go in `Shared/` unless it requires platform-specific APIs. Platforms only contain: app entry point, DI setup, MainWindow/MainView shell with drag handlers, MapService registration. See `CONTRIBUTING.md` for examples of violations fixed in #187-192.
 - Use `Classes.Active` binding for state-based styling instead of converters where possible
-- Keep platform code minimal - prefer shared code
 - Dialogs are overlay panels via `DialogOverlayHost`, not separate windows
 - Use dependency injection for services
 - Use shared `GeometryMath` utilities instead of duplicating distance/angle calculations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ Thank you for your interest in contributing to AgValoniaGPS! This document lists
 - **`develop`** - Active development branch, PR target for all new work
 - **Feature branches** - Create `feature/your-feature` off `develop` for each issue
 
+## Key Documents
+
+- **[Plans/ARCHITECTURE.md](Plans/ARCHITECTURE.md)** - Full architecture documentation: service communication, state management, domain models, data flow diagrams
+- **[CLAUDE.md](CLAUDE.md)** - Build commands, key files reference, common development tasks
+- **[PGN.md](PGN.md)** - UDP packet protocol for hardware communication
+
 ## Architecture Overview
 
 - **Shared code** (~92%): Located in `Shared/` folder
@@ -47,6 +53,20 @@ Thank you for your interest in contributing to AgValoniaGPS! This document lists
   - `AgValoniaGPS.Desktop/` - Windows/macOS/Linux
   - `AgValoniaGPS.iOS/` - iOS/iPadOS
   - `AgValoniaGPS.Android/` - Android
+
+### Cross-Platform Parity Rule
+
+**All code MUST go in `Shared/` unless it requires platform-specific APIs.** This is a hard architectural requirement, not a preference. Putting code in a single platform folder means the other platforms lose that feature.
+
+**What goes in `Shared/`:** UI controls, panels, dialogs, view models, services, models, converters, styles, icons, localization strings.
+
+**What goes in `Platforms/`:** Application entry point (`App.axaml.cs`), DI container setup, `MainWindow`/`MainView` (layout shell + drag handlers), `MapService` (map control registration), platform-specific APIs (file pickers, notifications).
+
+**Example violations fixed in #187-192:**
+- Status bar indicators were in Desktop `MainWindow.axaml` instead of a shared `StatusBarPanel`
+- Localization init was Desktop-only in `App.axaml.cs` instead of all three platforms
+- Flag placement banner existed only in Desktop
+- Screenshot capture code was duplicated across all three platforms instead of a shared helper
 
 ## Features Needing Implementation
 

--- a/Plans/ARCHITECTURE.md
+++ b/Plans/ARCHITECTURE.md
@@ -38,7 +38,19 @@ The architecture achieves **91.7% shared code** across platforms (Windows, macOS
 1. **Unified Track Model** - "An AB line is just a curve with 2 points" (Brian, AgOpenGPS creator)
 2. **Zero-Copy Hot Path** - GPS→Guidance→PGN pipeline has ~0.1ms latency
 3. **Reactive State** - All state objects use ReactiveUI for automatic UI binding
-4. **Platform Abstraction** - Shared views with platform-specific services only where necessary
+4. **Cross-Platform Parity** - All code MUST go in `Shared/` unless it requires platform-specific APIs
+
+### Cross-Platform Code Rule
+
+This is a hard architectural requirement. Putting code in a single platform folder breaks feature parity for all other platforms.
+
+**`Shared/` (mandatory for):** All UI controls, panels, dialogs, view models, services, models, converters, styles, icons, localization, utilities.
+
+**`Platforms/` (only for):** Application entry point (`App.axaml.cs`, `Program.cs`), DI container setup, `MainWindow`/`MainView` layout shell with platform-specific drag handlers, `MapService` (map control registration), platform APIs (file pickers, immersive mode, etc.).
+
+When adding a new feature, verify it works on all platforms. If a UI element appears in one platform's AXAML, it must be a shared control referenced by all three.
+
+See issues #187-192 for examples of violations that were fixed: status bars, localization, flag banners, compass buttons, and screenshot utilities were moved from Desktop-only to Shared.
 
 ---
 


### PR DESCRIPTION
## Summary
- CLAUDE.md: add key document links (ARCHITECTURE.md, CONTRIBUTING.md, PGN.md), strengthen shared code rule to mandatory
- CONTRIBUTING.md: add Key Documents section, add Cross-Platform Parity Rule section with examples from #187-192
- ARCHITECTURE.md: replace "Platform Abstraction" principle with explicit Cross-Platform Code Rule listing what goes in Shared/ vs Platforms/