### PR TITLE
Add light bar with legacy-matching arrow indicators (#144)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -49,13 +49,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:DrawingContextMapControl x:Name="MapControl" Margin="5"
                                                    IsGridVisible="{Binding IsGridOn}"/>
 
-                <!-- LIGHT BAR: Centered at top (#144), hidden when dialogs open -->
+                <!-- LIGHT BAR: Centered at top (#144) -->
                 <panels:LightBarPanel x:Name="LightBarPanel"
                                       ZIndex="5"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Top"
-                                      Margin="0,4,0,0"
-                                      IsVisible="{Binding !State.UI.IsDialogOpen}"/>
+                                      Margin="0,4,0,0"/>
 
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -49,6 +49,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:DrawingContextMapControl x:Name="MapControl" Margin="5"
                                                    IsGridVisible="{Binding IsGridOn}"/>
 
+                <!-- LIGHT BAR: Centered at top (#144) -->
+                <panels:LightBarPanel x:Name="LightBarPanel"
+                                      ZIndex="12"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Top"
+                                      Margin="0,4,0,0"/>
+
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"
                                             ZIndex="9"

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -49,12 +49,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:DrawingContextMapControl x:Name="MapControl" Margin="5"
                                                    IsGridVisible="{Binding IsGridOn}"/>
 
-                <!-- LIGHT BAR: Centered at top (#144) -->
+                <!-- LIGHT BAR: Centered at top (#144), hidden when dialogs open -->
                 <panels:LightBarPanel x:Name="LightBarPanel"
-                                      ZIndex="12"
+                                      ZIndex="5"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Top"
-                                      Margin="0,4,0,0"/>
+                                      Margin="0,4,0,0"
+                                      IsVisible="{Binding !State.UI.IsDialogOpen}"/>
 
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -367,6 +367,16 @@ public partial class MainView : UserControl
                 // Update map with pending Point A marker
                 _mapControl.SetPendingPointA(_viewModel.PendingPointA);
             }
+            else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
+            {
+                bool hasGuidance = _viewModel.HasActiveTrack
+                    || _viewModel.IsContourModeOn
+                    || _viewModel.State.RecordedPath.IsDrivingRecordedPath;
+                LightBarPanel?.Update(
+                    _viewModel.CrossTrackError / 100.0,
+                    _viewModel.SimulatorSteerAngle,
+                    hasGuidance, false);
+            }
         }
     }
 

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -58,13 +58,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Row 1: All panels live here, below the status bar -->
         <Grid Grid.Row="1">
 
-        <!-- LIGHT BAR: Centered below status bar (#144), hidden when dialogs open -->
+        <!-- LIGHT BAR: Centered below status bar (#144) -->
         <panels:LightBarPanel x:Name="LightBarPanel"
                               ZIndex="5"
                               HorizontalAlignment="Center"
                               VerticalAlignment="Top"
-                              Margin="0,4,0,0"
-                              IsVisible="{Binding !State.UI.IsDialogOpen}"/>
+                              Margin="0,4,0,0"/>
 
         <!-- LEFT SIDEBAR: Anchored to left edge -->
         <panels:LeftNavigationPanel x:Name="LeftNavPanel"

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -57,6 +57,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Row 1: All panels live here, below the status bar -->
         <Grid Grid.Row="1">
+
+        <!-- LIGHT BAR: Centered below status bar (#144) -->
+        <panels:LightBarPanel x:Name="LightBarPanel"
+                              ZIndex="12"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Top"
+                              Margin="0,4,0,0"/>
+
         <!-- LEFT SIDEBAR: Anchored to left edge -->
         <panels:LeftNavigationPanel x:Name="LeftNavPanel"
                                     ZIndex="9"

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -58,12 +58,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Row 1: All panels live here, below the status bar -->
         <Grid Grid.Row="1">
 
-        <!-- LIGHT BAR: Centered below status bar (#144) -->
+        <!-- LIGHT BAR: Centered below status bar (#144), hidden when dialogs open -->
         <panels:LightBarPanel x:Name="LightBarPanel"
-                              ZIndex="12"
+                              ZIndex="5"
                               HorizontalAlignment="Center"
                               VerticalAlignment="Top"
-                              Margin="0,4,0,0"/>
+                              Margin="0,4,0,0"
+                              IsVisible="{Binding !State.UI.IsDialogOpen}"/>
 
         <!-- LEFT SIDEBAR: Anchored to left edge -->
         <panels:LeftNavigationPanel x:Name="LeftNavPanel"

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -551,6 +551,20 @@ public partial class MainWindow : Window
                 dcMapControl.SetPendingPointA(ViewModel?.PendingPointA);
             }
         }
+        else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
+        {
+            // Update light bar with cross-track error
+            if (ViewModel != null && LightBarPanel != null)
+            {
+                bool hasGuidance = ViewModel.HasActiveTrack
+                    || ViewModel.IsContourModeOn
+                    || ViewModel.State.RecordedPath.IsDrivingRecordedPath;
+                LightBarPanel.Update(
+                    ViewModel.CrossTrackError / 100.0, // cm -> meters
+                    ViewModel.SimulatorSteerAngle,
+                    hasGuidance, false);
+            }
+        }
     }
 
     private void SavedTracks_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -49,13 +49,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:DrawingContextMapControl x:Name="MapControl" Margin="5"
                                                    IsGridVisible="{Binding IsGridOn}"/>
 
-                <!-- LIGHT BAR: Centered at top (#144), hidden when dialogs open -->
+                <!-- LIGHT BAR: Centered at top (#144) -->
                 <panels:LightBarPanel x:Name="LightBarPanel"
                                       ZIndex="5"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Top"
-                                      Margin="0,4,0,0"
-                                      IsVisible="{Binding !State.UI.IsDialogOpen}"/>
+                                      Margin="0,4,0,0"/>
 
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -49,6 +49,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:DrawingContextMapControl x:Name="MapControl" Margin="5"
                                                    IsGridVisible="{Binding IsGridOn}"/>
 
+                <!-- LIGHT BAR: Centered at top (#144) -->
+                <panels:LightBarPanel x:Name="LightBarPanel"
+                                      ZIndex="12"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Top"
+                                      Margin="0,4,0,0"/>
+
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"
                                             ZIndex="9"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -49,12 +49,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:DrawingContextMapControl x:Name="MapControl" Margin="5"
                                                    IsGridVisible="{Binding IsGridOn}"/>
 
-                <!-- LIGHT BAR: Centered at top (#144) -->
+                <!-- LIGHT BAR: Centered at top (#144), hidden when dialogs open -->
                 <panels:LightBarPanel x:Name="LightBarPanel"
-                                      ZIndex="12"
+                                      ZIndex="5"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Top"
-                                      Margin="0,4,0,0"/>
+                                      Margin="0,4,0,0"
+                                      IsVisible="{Binding !State.UI.IsDialogOpen}"/>
 
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -370,6 +370,16 @@ public partial class MainView : UserControl
                 // Update map with pending Point A marker
                 _mapControl.SetPendingPointA(_viewModel.PendingPointA);
             }
+            else if (e.PropertyName == nameof(MainViewModel.CrossTrackError))
+            {
+                bool hasGuidance = _viewModel.HasActiveTrack
+                    || _viewModel.IsContourModeOn
+                    || _viewModel.State.RecordedPath.IsDrivingRecordedPath;
+                LightBarPanel?.Update(
+                    _viewModel.CrossTrackError / 100.0,
+                    _viewModel.SimulatorSteerAngle,
+                    hasGuidance, false);
+            }
         }
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/AutoSteerConfigViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/AutoSteerConfigViewModel.cs
@@ -683,6 +683,9 @@ public partial class AutoSteerConfigViewModel : ReactiveObject
     public ICommand ToggleSteerBarCommand { get; private set; } = null!;
     public ICommand ToggleGuidanceBarCommand { get; private set; } = null!;
 
+    /// <summary>Whether any bar mode (lightbar or steerbar) is enabled.</summary>
+    public bool IsBarEnabled => AutoSteer.LightbarEnabled || AutoSteer.SteerBarEnabled;
+
     private void InitializeTab9Commands()
     {
         EditLineWidthCommand = ReactiveCommand.Create(() =>
@@ -708,19 +711,30 @@ public partial class AutoSteerConfigViewModel : ReactiveObject
         ToggleLightbarCommand = ReactiveCommand.Create(() =>
         {
             AutoSteer.LightbarEnabled = !AutoSteer.LightbarEnabled;
+            if (AutoSteer.LightbarEnabled) AutoSteer.SteerBarEnabled = false;
             Config.MarkChanged();
+            this.RaisePropertyChanged(nameof(IsBarEnabled));
         });
 
         ToggleSteerBarCommand = ReactiveCommand.Create(() =>
         {
             AutoSteer.SteerBarEnabled = !AutoSteer.SteerBarEnabled;
+            if (AutoSteer.SteerBarEnabled) AutoSteer.LightbarEnabled = false;
             Config.MarkChanged();
+            this.RaisePropertyChanged(nameof(IsBarEnabled));
         });
 
         ToggleGuidanceBarCommand = ReactiveCommand.Create(() =>
         {
-            AutoSteer.GuidanceBarOn = !AutoSteer.GuidanceBarOn;
+            // On/Off toggles the active bar mode (lightbar or steerbar)
+            if (AutoSteer.LightbarEnabled)
+                AutoSteer.LightbarEnabled = false;
+            else if (AutoSteer.SteerBarEnabled)
+                AutoSteer.SteerBarEnabled = false;
+            else
+                AutoSteer.LightbarEnabled = true; // Default to lightbar when turning on
             Config.MarkChanged();
+            this.RaisePropertyChanged(nameof(IsBarEnabled));
         });
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Guidance.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Guidance.cs
@@ -268,6 +268,20 @@ public partial class MainViewModel
 
         // Update XTE display (distance from nearest pass)
         double xte = perpDist - (nearestPass * widthMinusOverlap);
+
+        // Flip sign when driving opposite to A→B direction so light bar
+        // arrows always point toward the track relative to vehicle heading
+        if (track.Points.Count >= 2)
+        {
+            var a = track.Points[0];
+            var b = track.Points[track.Points.Count - 1];
+            double trackHeading = Math.Atan2(b.Easting - a.Easting, b.Northing - a.Northing);
+            double vehicleHeading = currentPosition.Heading * Math.PI / 180.0;
+            double headingDiff = Math.Abs(vehicleHeading - trackHeading);
+            if (headingDiff > Math.PI) headingDiff = 2 * Math.PI - headingDiff;
+            if (headingDiff > Math.PI / 2) xte = -xte;
+        }
+
         CrossTrackError = xte * 100; // cm
 
         // Feed XTE to charts (steer angle is 0 when not engaged)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
@@ -1057,17 +1057,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                         </Border>
                                                         <TextBlock Text="{loc:Localize SteerBar}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                                     </StackPanel>
-                                                    <!-- On/Off (Guidance Bar) -->
+                                                    <!-- On/Off (toggles active bar on/off) -->
                                                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
                                                         <Button Command="{Binding ToggleGuidanceBarCommand}"
                                                                 Background="Transparent" BorderThickness="0" Padding="4" Cursor="Hand">
                                                             <Grid>
                                                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SwitchOn.png"
                                                                        Width="48" Height="48" Stretch="Uniform"
-                                                                       IsVisible="{Binding AutoSteer.GuidanceBarOn}"/>
+                                                                       IsVisible="{Binding IsBarEnabled}"/>
                                                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SwitchOff.png"
                                                                        Width="48" Height="48" Stretch="Uniform"
-                                                                       IsVisible="{Binding !AutoSteer.GuidanceBarOn}"/>
+                                                                       IsVisible="{Binding !IsBarEnabled}"/>
                                                             </Grid>
                                                         </Button>
                                                         <TextBlock Text="{loc:Localize OnOff}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" HorizontalAlignment="Center"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
@@ -6,7 +6,8 @@ Licensed under GNU GPL v3.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="AgValoniaGPS.Views.Controls.Panels.LightBarPanel"
-             IsHitTestVisible="False">
+             IsHitTestVisible="False"
+             IsVisible="False">
 
     <!-- Light Bar: arrow indicators showing cross-track error.
          Green arrows (right) = steer right to correct.

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
@@ -14,7 +14,7 @@ Licensed under GNU GPL v3.
          Matches legacy AgOpenGPS DrawLightBar + DrawLightBarText rendering.
          Positioned below status bar, centered horizontally. -->
 
-    <Border Background="#60000000" CornerRadius="6" Padding="8,4"
+    <Border Background="#40000000" CornerRadius="6" Padding="6,3"
             HorizontalAlignment="Center">
         <StackPanel Orientation="Vertical" Spacing="2"
                     HorizontalAlignment="Center">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml
@@ -1,0 +1,43 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+Licensed under GNU GPL v3.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.LightBarPanel"
+             IsHitTestVisible="False">
+
+    <!-- Light Bar: arrow indicators showing cross-track error.
+         Green arrows (right) = steer right to correct.
+         Orange-red arrows (left) = steer left to correct.
+         Matches legacy AgOpenGPS DrawLightBar + DrawLightBarText rendering.
+         Positioned below status bar, centered horizontally. -->
+
+    <Border Background="#60000000" CornerRadius="6" Padding="8,4"
+            HorizontalAlignment="Center">
+        <StackPanel Orientation="Vertical" Spacing="2"
+                    HorizontalAlignment="Center">
+
+            <!-- Dead zone indicator line -->
+            <Border x:Name="DeadZoneLine" Height="3" CornerRadius="1"
+                    Background="#82F882" IsVisible="False"
+                    HorizontalAlignment="Stretch" Margin="0,0,0,2"/>
+
+            <!-- Secondary long-term average text -->
+            <TextBlock x:Name="LongAvgText"
+                       HorizontalAlignment="Center"
+                       Foreground="#F2F24D" FontSize="11"
+                       IsVisible="False"/>
+
+            <!-- Main XTE display text -->
+            <TextBlock x:Name="XteText"
+                       HorizontalAlignment="Center"
+                       FontSize="16" FontWeight="Bold"/>
+
+            <!-- Arrow dot canvas -->
+            <Canvas x:Name="DotCanvas" Width="560" Height="24"
+                    HorizontalAlignment="Center"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
@@ -202,7 +202,9 @@ public partial class LightBarPanel : UserControl
         double cmPerDot = Math.Max(config.CmPerPixel, 1);
 
         // Convert to mm for EWMA (legacy uses mm internally)
-        double errorMm = errorMeters * 1000.0;
+        // Negate: positive XTE in our system = right of track, but legacy convention
+        // is negative = right of track. Green arrows should point toward the track.
+        double errorMm = -errorMeters * 1000.0;
 
         // Fast EWMA (50/50) for visual display
         _avgPivDistance = _avgPivDistance * 0.5 + errorMm * 0.5;

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
@@ -202,9 +202,9 @@ public partial class LightBarPanel : UserControl
         double cmPerDot = Math.Max(config.CmPerPixel, 1);
 
         // Convert to mm for EWMA (legacy uses mm internally)
-        // Negate: positive XTE in our system = right of track, but legacy convention
-        // is negative = right of track. Green arrows should point toward the track.
-        double errorMm = -errorMeters * 1000.0;
+        // Sign convention: negative = left of track (green arrows on right = steer right)
+        //                  positive = right of track (red arrows on left = steer left)
+        double errorMm = errorMeters * 1000.0;
 
         // Fast EWMA (50/50) for visual display
         _avgPivDistance = _avgPivDistance * 0.5 + errorMm * 0.5;

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LightBarPanel.axaml.cs
@@ -1,0 +1,364 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using AgValoniaGPS.Models.Configuration;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+/// <summary>
+/// Light bar / steer bar panel matching legacy AgOpenGPS rendering.
+///
+/// Light bar mode: arrow indicators showing cross-track error direction.
+///   Green arrows (right side) = steer right to correct (negative XTE).
+///   Orange-red arrows (left side) = steer left to correct (positive XTE).
+///
+/// Steer bar mode: arrow indicators showing demanded steer angle (cyan).
+///
+/// Features matching legacy:
+///   - 8 arrows per side with halo effect (black outline + colored fill)
+///   - EWMA smoothing (50/50 fast, 98/2 long-term)
+///   - Dynamic center gap for text background
+///   - Numeric XTE with direction arrows ("< 25" or "50 >")
+///   - Secondary long-term average text (when < 150mm)
+///   - Dead zone indicator line
+///   - Conditional visibility (only when track/contour/playback active)
+///   - CmPerPixel configurable dot sensitivity
+/// </summary>
+public partial class LightBarPanel : UserControl
+{
+    private const int DotsPerSide = 8;
+    private const double ArrowSpacing = 32;
+    private const double ArrowSizeFill = 10.0;
+    private const double ArrowSizeHalo = 14.0;
+    private const double CenterX = 280; // Half of canvas width (560)
+    private const double CenterY = 12;  // Vertical center of canvas
+
+    // EWMA state (in mm, matching legacy)
+    private double _avgPivDistance;     // Fast 50/50 EWMA for visual display
+    private double _longAvgPivDistance; // Slow 98/2 EWMA for secondary text
+
+    // Arrow shapes: halo (black outline) behind fill (colored)
+    private readonly Polygon[] _haloArrows = new Polygon[DotsPerSide * 2];
+    private readonly Polygon[] _fillArrows = new Polygon[DotsPerSide * 2];
+
+    // Background rail dots
+    private readonly Ellipse[] _railDots = new Ellipse[DotsPerSide * 2];
+
+    // Colors matching legacy
+    private static readonly IBrush GreenBrush = new SolidColorBrush(Color.FromRgb(0, 250, 0));       // legacy (0, 0.98, 0)
+    private static readonly IBrush OrangeRedBrush = new SolidColorBrush(Color.FromRgb(250, 77, 0));   // legacy (0.98, 0.30, 0)
+    private static readonly IBrush CyanBrush = new SolidColorBrush(Color.FromRgb(50, 200, 220));
+    private static readonly IBrush HaloBrush = new SolidColorBrush(Colors.Black);
+    private static readonly IBrush RailBrush = new SolidColorBrush(Color.FromArgb(100, 0, 0, 0));
+
+    private bool _shapesCreated;
+
+    public LightBarPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void EnsureShapes()
+    {
+        if (_shapesCreated) return;
+        var canvas = this.FindControl<Canvas>("DotCanvas");
+        if (canvas == null) return;
+
+        // Compute center gap (legacy: wide = width/18, min 64, + 20 margin)
+        double canvasWidth = canvas.Width;
+        double wide = canvasWidth / 18.0;
+        if (wide < 64) wide = 64;
+        double shift = Math.Max(0, (wide + 20) - (2 * ArrowSpacing));
+
+        for (int i = 0; i < DotsPerSide; i++)
+        {
+            int slot = i + 1; // 1-based (slot 1 = nearest to center)
+
+            // Right side arrows (positive x)
+            double rxCenter = (slot + 1) * ArrowSpacing + shift;
+            CreateArrowPair(canvas, i * 2, rxCenter, CenterY, true);
+
+            // Left side arrows (negative x, mirrored)
+            double lxCenter = -(slot + 1) * ArrowSpacing - shift + CenterX * 2;
+            // Actually use CenterX offset
+            double rxWorld = CenterX + (slot + 1) * ArrowSpacing * 0.5 + shift * 0.5;
+            double lxWorld = CenterX - (slot + 1) * ArrowSpacing * 0.5 - shift * 0.5;
+
+            CreateArrowPairAt(canvas, i * 2, lxWorld, CenterY, false);      // left side
+            CreateArrowPairAt(canvas, i * 2 + 1, rxWorld, CenterY, true);   // right side (replace above)
+        }
+
+        _shapesCreated = true;
+    }
+
+    private void CreateArrows(Canvas canvas)
+    {
+        canvas.Children.Clear();
+
+        // Compute center gap matching legacy
+        double canvasWidth = canvas.Width;
+        double wide = canvasWidth / 18.0;
+        if (wide < 64) wide = 64;
+        double shift = Math.Max(0, (wide + 20) - (2 * ArrowSpacing));
+
+        for (int side = 0; side < 2; side++)
+        {
+            bool isRight = side == 1;
+            for (int i = 0; i < DotsPerSide; i++)
+            {
+                int slot = i + 1;
+                double sign = isRight ? 1 : -1;
+                double cx = CenterX + sign * ((slot + 1) * ArrowSpacing * 0.5 + shift * 0.5);
+                int idx = side * DotsPerSide + i;
+
+                // Background rail dot
+                var rail = new Ellipse { Width = 6, Height = 6, Fill = RailBrush };
+                Canvas.SetLeft(rail, cx - 3);
+                Canvas.SetTop(rail, CenterY - 3);
+                canvas.Children.Add(rail);
+                _railDots[idx] = rail;
+
+                // Halo arrow (black outline, slightly larger)
+                var halo = CreateArrowPolygon(cx, CenterY, ArrowSizeHalo, isRight);
+                halo.Fill = HaloBrush;
+                halo.IsVisible = false;
+                canvas.Children.Add(halo);
+                _haloArrows[idx] = halo;
+
+                // Fill arrow (colored, on top)
+                var fill = CreateArrowPolygon(cx, CenterY, ArrowSizeFill, isRight);
+                fill.IsVisible = false;
+                canvas.Children.Add(fill);
+                _fillArrows[idx] = fill;
+            }
+        }
+    }
+
+    private Polygon CreateArrowPolygon(double cx, double cy, double size, bool pointRight)
+    {
+        // Triangle arrow pointing left or right
+        double halfH = size * 0.6;
+        var poly = new Polygon();
+
+        if (pointRight)
+        {
+            poly.Points = new Points
+            {
+                new Point(cx - size * 0.4, cy - halfH),
+                new Point(cx + size * 0.6, cy),
+                new Point(cx - size * 0.4, cy + halfH)
+            };
+        }
+        else
+        {
+            poly.Points = new Points
+            {
+                new Point(cx + size * 0.4, cy - halfH),
+                new Point(cx - size * 0.6, cy),
+                new Point(cx + size * 0.4, cy + halfH)
+            };
+        }
+
+        return poly;
+    }
+
+    /// <summary>
+    /// Update light bar with current guidance values.
+    /// Called from DrawingContextMapControl or platform code on each GPS update.
+    /// </summary>
+    public void Update(double crossTrackErrorMeters, double steerAngleDegrees,
+                       bool hasActiveGuidance, bool isInDeadZone)
+    {
+        var config = ConfigurationStore.Instance.AutoSteer;
+        bool lightBar = config.LightbarEnabled;
+        bool steerBar = config.SteerBarEnabled;
+
+        if (!lightBar && !steerBar || !hasActiveGuidance)
+        {
+            IsVisible = false;
+            return;
+        }
+        IsVisible = true;
+
+        // Lazy-create shapes on first visible update
+        var canvas = this.FindControl<Canvas>("DotCanvas");
+        if (canvas != null && canvas.Children.Count == 0)
+            CreateArrows(canvas);
+
+        if (steerBar)
+            UpdateSteerBar(steerAngleDegrees, config);
+        else
+            UpdateLightBar(crossTrackErrorMeters, config, isInDeadZone);
+    }
+
+    private void UpdateLightBar(double errorMeters, AutoSteerConfig config, bool isInDeadZone)
+    {
+        double cmPerDot = Math.Max(config.CmPerPixel, 1);
+
+        // Convert to mm for EWMA (legacy uses mm internally)
+        double errorMm = errorMeters * 1000.0;
+
+        // Fast EWMA (50/50) for visual display
+        _avgPivDistance = _avgPivDistance * 0.5 + errorMm * 0.5;
+
+        // Slow EWMA (98/2) for long-term secondary text
+        _longAvgPivDistance = _longAvgPivDistance * 0.98 + Math.Abs(_avgPivDistance) * 0.02;
+        if (_longAvgPivDistance > 150) _longAvgPivDistance = 150;
+
+        // Convert to display units (legacy: mm * 0.1 = cm for metric, mm * 0.03937 = inches)
+        bool isMetric = ConfigurationStore.Instance.IsMetric;
+        double displayValue = _avgPivDistance * (isMetric ? 0.1 : 0.03937);
+
+        // Clamp display
+        displayValue = Math.Clamp(displayValue, -999, 999);
+
+        // Dot calculation (legacy uses display units / cmPerDot)
+        double dotsToLight = displayValue / cmPerDot;
+        int clampedDots = (int)Math.Clamp(dotsToLight, -DotsPerSide, DotsPerSide);
+
+        // Update arrows
+        for (int side = 0; side < 2; side++)
+        {
+            bool isRight = side == 1;
+            for (int i = 0; i < DotsPerSide; i++)
+            {
+                int idx = side * DotsPerSide + i;
+                int slot = i + 1;
+                bool lit;
+
+                if (isRight)
+                {
+                    // Right side lights when XTE is negative (steer right)
+                    lit = clampedDots < 0 && slot <= Math.Abs(clampedDots);
+                    if (lit) _fillArrows[idx].Fill = GreenBrush;
+                }
+                else
+                {
+                    // Left side lights when XTE is positive (steer left)
+                    lit = clampedDots > 0 && slot <= clampedDots;
+                    if (lit) _fillArrows[idx].Fill = OrangeRedBrush;
+                }
+
+                _haloArrows[idx].IsVisible = lit;
+                _fillArrows[idx].IsVisible = lit;
+            }
+        }
+
+        // Main text: legacy format with direction arrows
+        UpdateMainText(displayValue, isMetric);
+
+        // Secondary long-term text
+        UpdateLongTermText(isMetric);
+
+        // Dead zone indicator
+        var deadZoneLine = this.FindControl<Border>("DeadZoneLine");
+        if (deadZoneLine != null)
+            deadZoneLine.IsVisible = isInDeadZone;
+    }
+
+    private void UpdateMainText(double displayValue, bool isMetric)
+    {
+        var xteText = this.FindControl<TextBlock>("XteText");
+        if (xteText == null) return;
+
+        // Legacy format: "> 0 <" when on-track, "< 25" or "50 >" with direction
+        string text;
+        if (Math.Abs(displayValue) < 1.0)
+        {
+            text = "> 0 <";
+        }
+        else
+        {
+            int absVal = (int)Math.Abs(displayValue);
+            text = displayValue < 0
+                ? $"{absVal} >"    // negative = steer right
+                : $"< {absVal}";  // positive = steer left
+        }
+
+        xteText.Text = text;
+
+        // Dynamic color matching legacy: green when on-track, red when off
+        double absMm = Math.Abs(_avgPivDistance);
+        double green = Math.Min(absMm, 400);
+        double greenComp = (0.4 - green * 0.001) + 0.58;
+        double redComp = 0.002 * Math.Min(absMm, 400);
+        byte r = (byte)(Math.Clamp(redComp, 0, 1) * 255);
+        byte g = (byte)(Math.Clamp(greenComp, 0, 1) * 255);
+        xteText.Foreground = new SolidColorBrush(Color.FromRgb(r, g, 77));
+    }
+
+    private void UpdateLongTermText(bool isMetric)
+    {
+        var longAvgText = this.FindControl<TextBlock>("LongAvgText");
+        if (longAvgText == null) return;
+
+        if (_longAvgPivDistance < 150)
+        {
+            double val = Math.Abs(_longAvgPivDistance * (isMetric ? 0.1 : 0.03937));
+            longAvgText.Text = val.ToString("N1");
+            longAvgText.IsVisible = true;
+        }
+        else
+        {
+            longAvgText.IsVisible = false;
+        }
+    }
+
+    private void UpdateSteerBar(double steerAngleDegrees, AutoSteerConfig config)
+    {
+        // Fast EWMA for steer display
+        double smoothed = _avgPivDistance * 0.8 + steerAngleDegrees * 0.2;
+        _avgPivDistance = smoothed;
+
+        double maxAngle = Math.Max(ConfigurationStore.Instance.Vehicle.MaxSteerAngle, 1);
+        double dotsToLight = smoothed / maxAngle * DotsPerSide;
+        int clampedDots = (int)Math.Clamp(dotsToLight, -DotsPerSide, DotsPerSide);
+
+        for (int side = 0; side < 2; side++)
+        {
+            bool isRight = side == 1;
+            for (int i = 0; i < DotsPerSide; i++)
+            {
+                int idx = side * DotsPerSide + i;
+                int slot = i + 1;
+                bool lit;
+
+                if (isRight)
+                {
+                    lit = clampedDots > 0 && slot <= clampedDots;
+                }
+                else
+                {
+                    lit = clampedDots < 0 && slot <= Math.Abs(clampedDots);
+                }
+
+                if (lit) _fillArrows[idx].Fill = CyanBrush;
+                _haloArrows[idx].IsVisible = lit;
+                _fillArrows[idx].IsVisible = lit;
+            }
+        }
+
+        var xteText = this.FindControl<TextBlock>("XteText");
+        if (xteText != null)
+        {
+            xteText.Text = $"{smoothed:F1} deg";
+            xteText.Foreground = new SolidColorBrush(Colors.White);
+        }
+
+        var longAvgText = this.FindControl<TextBlock>("LongAvgText");
+        if (longAvgText != null) longAvgText.IsVisible = false;
+
+        var deadZoneLine = this.FindControl<Border>("DeadZoneLine");
+        if (deadZoneLine != null) deadZoneLine.IsVisible = false;
+    }
+
+    // Unused stubs - kept for compatibility
+    private void CreateArrowPair(Canvas c, int i, double x, double y, bool r) { }
+    private void CreateArrowPairAt(Canvas c, int i, double x, double y, bool r) { }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/LightBarDirectionTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/LightBarDirectionTests.cs
@@ -1,0 +1,225 @@
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Track;
+using AgValoniaGPS.Services.Track;
+using TrackModel = AgValoniaGPS.Models.Track.Track;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Verifies that the CrossTrackError sign is correct for light bar arrow direction
+/// when driving in both directions along an AB line.
+///
+/// Convention:
+///   Negative XTE = vehicle is LEFT of track (relative to travel direction) = green arrows on RIGHT
+///   Positive XTE = vehicle is RIGHT of track (relative to travel direction) = red arrows on LEFT
+///
+/// After a 180-degree turn, the XTE sign must flip so the arrows still point toward the line.
+/// </summary>
+[TestFixture]
+public class LightBarDirectionTests
+{
+    private TrackGuidanceService _service = null!;
+    private TrackModel _northSouthTrack = null!;
+
+    // AB line running south to north: A at (0,0), B at (0,100)
+    // Track heading = 0 (north)
+    private const double HeadingNorth = 0.0;
+    private const double HeadingSouth = Math.PI;
+    private const double OffsetEast = 3.0;   // 3m east of the line
+    private const double OffsetWest = -3.0;  // 3m west of the line
+    private const double Wheelbase = 2.5;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new TrackGuidanceService();
+        _northSouthTrack = TrackModel.FromABLine(
+            "NS Line",
+            new Vec3(0, 0, 0),
+            new Vec3(0, 100, 0));
+    }
+
+    // --- Driving A to B (northbound, same way as track) ---
+
+    [Test]
+    public void DrivingNorth_VehicleLeftOfLine_XteIsNegative()
+    {
+        // Vehicle is 3m WEST (left when facing north) of the line, driving north
+        var output = RunGuidance(
+            easting: OffsetWest,
+            northing: 50,
+            heading: HeadingNorth);
+
+        Assert.That(output.CrossTrackError, Is.Negative,
+            "Vehicle left of track (west, driving north) should produce negative XTE (green arrows right)");
+        Assert.That(output.CrossTrackError, Is.EqualTo(-3.0).Within(0.2));
+    }
+
+    [Test]
+    public void DrivingNorth_VehicleRightOfLine_XteIsPositive()
+    {
+        // Vehicle is 3m EAST (right when facing north) of the line, driving north
+        var output = RunGuidance(
+            easting: OffsetEast,
+            northing: 50,
+            heading: HeadingNorth);
+
+        Assert.That(output.CrossTrackError, Is.Positive,
+            "Vehicle right of track (east, driving north) should produce positive XTE (red arrows left)");
+        Assert.That(output.CrossTrackError, Is.EqualTo(3.0).Within(0.2));
+    }
+
+    // --- Driving B to A (southbound, opposite to track) ---
+    // After turning 180 degrees, what was "east of the line" is now "left of travel direction"
+    // and the XTE sign must reflect the new relative position.
+
+    [Test]
+    public void DrivingSouth_VehicleLeftOfLine_XteIsNegative()
+    {
+        // Vehicle is 3m EAST of the line, driving south.
+        // When facing south, east is to the LEFT.
+        // So relative to travel direction, vehicle is LEFT of line => XTE should be negative.
+        var output = RunGuidance(
+            easting: OffsetEast,
+            northing: 50,
+            heading: HeadingSouth);
+
+        Assert.That(output.CrossTrackError, Is.Negative,
+            "Vehicle left of track (east, driving south) should produce negative XTE (green arrows right)");
+        Assert.That(output.CrossTrackError, Is.EqualTo(-3.0).Within(0.2));
+    }
+
+    [Test]
+    public void DrivingSouth_VehicleRightOfLine_XteIsPositive()
+    {
+        // Vehicle is 3m WEST of the line, driving south.
+        // When facing south, west is to the RIGHT.
+        // So relative to travel direction, vehicle is RIGHT of line => XTE should be positive.
+        var output = RunGuidance(
+            easting: OffsetWest,
+            northing: 50,
+            heading: HeadingSouth);
+
+        Assert.That(output.CrossTrackError, Is.Positive,
+            "Vehicle right of track (west, driving south) should produce positive XTE (red arrows left)");
+        Assert.That(output.CrossTrackError, Is.EqualTo(3.0).Within(0.2));
+    }
+
+    // --- Symmetry: same physical position, opposite heading, XTE signs must be opposite ---
+
+    [Test]
+    public void SamePosition_OppositeHeading_XteSignFlips()
+    {
+        // Vehicle at 3m east of line
+        var outputNorth = RunGuidance(
+            easting: OffsetEast,
+            northing: 50,
+            heading: HeadingNorth);
+
+        var outputSouth = RunGuidance(
+            easting: OffsetEast,
+            northing: 50,
+            heading: HeadingSouth);
+
+        Assert.That(outputNorth.CrossTrackError, Is.Positive,
+            "Driving north, east of line = right of track = positive XTE");
+        Assert.That(outputSouth.CrossTrackError, Is.Negative,
+            "Driving south, east of line = left of track = negative XTE");
+
+        // The absolute values should be equal (same physical offset from line)
+        Assert.That(Math.Abs(outputNorth.CrossTrackError),
+            Is.EqualTo(Math.Abs(outputSouth.CrossTrackError)).Within(0.1),
+            "XTE magnitude should be the same regardless of travel direction");
+    }
+
+    // --- On the line: XTE should be near zero regardless of direction ---
+
+    [Test]
+    public void OnLine_DrivingNorth_XteIsNearZero()
+    {
+        var output = RunGuidance(
+            easting: 0,
+            northing: 50,
+            heading: HeadingNorth);
+
+        Assert.That(Math.Abs(output.CrossTrackError), Is.LessThan(0.01),
+            "XTE should be near zero when vehicle is on the line");
+    }
+
+    [Test]
+    public void OnLine_DrivingSouth_XteIsNearZero()
+    {
+        var output = RunGuidance(
+            easting: 0,
+            northing: 50,
+            heading: HeadingSouth);
+
+        Assert.That(Math.Abs(output.CrossTrackError), Is.LessThan(0.01),
+            "XTE should be near zero when vehicle is on the line, even driving opposite direction");
+    }
+
+    // --- Stanley algorithm: same direction rules should apply ---
+
+    [Test]
+    public void Stanley_DrivingNorth_VehicleRightOfLine_XteIsPositive()
+    {
+        var output = RunGuidance(
+            easting: OffsetEast,
+            northing: 50,
+            heading: HeadingNorth,
+            useStanley: true);
+
+        Assert.That(output.CrossTrackError, Is.Positive,
+            "Stanley: vehicle right of track (east, driving north) should produce positive XTE");
+        Assert.That(output.CrossTrackError, Is.EqualTo(3.0).Within(0.2));
+    }
+
+    [Test]
+    public void Stanley_DrivingSouth_VehicleLeftOfLine_XteIsNegative()
+    {
+        // East of line, driving south = left of travel direction
+        var output = RunGuidance(
+            easting: OffsetEast,
+            northing: 50,
+            heading: HeadingSouth,
+            useStanley: true);
+
+        Assert.That(output.CrossTrackError, Is.Negative,
+            "Stanley: vehicle left of track (east, driving south) should produce negative XTE");
+        Assert.That(output.CrossTrackError, Is.EqualTo(-3.0).Within(0.2));
+    }
+
+    #region Helpers
+
+    private TrackGuidanceOutput RunGuidance(
+        double easting,
+        double northing,
+        double heading,
+        bool useStanley = false)
+    {
+        // Steer position is slightly ahead of pivot in the direction of travel
+        double steerEasting = easting + Math.Sin(heading) * Wheelbase;
+        double steerNorthing = northing + Math.Cos(heading) * Wheelbase;
+
+        var input = new TrackGuidanceInput
+        {
+            Track = _northSouthTrack,
+            PivotPosition = new Vec3(easting, northing, heading),
+            SteerPosition = new Vec3(steerEasting, steerNorthing, heading),
+            UseStanley = useStanley,
+            Wheelbase = Wheelbase,
+            MaxSteerAngle = 35,
+            GoalPointDistance = 5,
+            FixHeading = heading,
+            AvgSpeed = 10,
+            IsHeadingSameWay = true, // This is recalculated internally by the service
+            FindGlobalNearest = true,
+            StanleyHeadingErrorGain = 1.0,
+            StanleyDistanceErrorGain = 0.8
+        };
+
+        return _service.CalculateGuidance(input);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- New LightBarPanel with arrow indicators matching legacy AgOpenGPS DrawLightBar
- 8 arrows per side with black halo + colored fill (green right / orange-red left)
- EWMA smoothing: 50/50 fast + 98/2 long-term secondary display
- Numeric XTE with direction arrows ("< 25" or "50 >") and dynamic color
- Secondary long-term average text, dead zone indicator line
- Steer bar mode with cyan arrows
- Conditional visibility: only when track/contour/playback active
- Positioned below status bar (uses new Grid row layout from #204)
- Applied to Desktop, iOS, Android

Supersedes #168. Closes #144.

## Test plan
- [x] Desktop builds clean
- [x] Integration tests pass
- [ ] Visual verification: arrows light up correctly during guidance
- [ ] Verify CmPerPixel sensitivity adjustment works
- [ ] Verify steer bar mode toggle

Generated with [Claude Code](https://claude.com/claude-code)