### PR TITLE
Fix ground texture tiles disappearing away from origin

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -2546,7 +2546,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             {
                 double worldX = tx * TILE_SIZE;
                 double worldY = ty * TILE_SIZE;
-                var destRect = new Rect(worldX, -(worldY + TILE_SIZE), TILE_SIZE, TILE_SIZE);
+                var destRect = new Rect(worldX, worldY, TILE_SIZE, TILE_SIZE);
                 context.DrawImage(_groundTexture!, destRect);
             }
         }


### PR DESCRIPTION
## Summary
- Remove manual Y-flip from tile rect calculation
- The camera transform already handles Y-axis flipping, so `-(worldY + TILE_SIZE)` caused double-inversion
- Tiles now use world coordinates directly: `Rect(worldX, worldY, TILE_SIZE, TILE_SIZE)`
- Fixes tiles disappearing at positions like lat 0.009, lon -0.002

One-line fix in DrawGroundTexture().

## Test plan
- [x] Integration tests pass
- [ ] Verify tiles visible at lat 0.009, lon -0.002
- [ ] Verify tiles visible at origin (0,0)

Generated with [Claude Code](https://claude.com/claude-code)