### PR TITLE
Speed up integration tests: reduce delays and increase time scale

### DIFF
--- a/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/App.axaml.cs
@@ -133,7 +133,7 @@ public partial class App : Application
                 {
                     try
                     {
-                        await Task.Delay(1000); // Let window fully render
+                        await Task.Delay(100); // Let window render initial frame
                         await callback(desktop);
                     }
                     catch (Exception ex)

--- a/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
+++ b/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
@@ -16,6 +16,8 @@
          - NewFieldDialogPanel.axaml (missing x:DataType)
          - NumericStepView.axaml (missing x:DataType)
     -->
+    <!-- TODO: Enable compiled bindings after fixing ~30 AVLN2000/AVLN2100 errors
+         across AgShare, AutoSteer, Configuration, Help, Language, NewField, NumericStep panels -->
     <!-- <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault> -->
   </PropertyGroup>
 

--- a/Tests/AgValoniaGPS.IntegrationTests/Program.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/Program.cs
@@ -61,7 +61,7 @@ sealed class Program
             if (fastArg.Contains('='))
                 _timeScale = double.Parse(fastArg.Split('=')[1]);
             else
-                _timeScale = 10.0;
+                _timeScale = 50.0;
 
             Clock.Set(new SystemClock { TimeScale = _timeScale });
             Console.WriteLine($"[IntTest] Fast mode: {_timeScale}x time scale");


### PR DESCRIPTION
## Summary
- Reduce app startup delay from 1000ms to 100ms (test hook in App.axaml.cs)
- Increase default --fast time scale from 10x to 50x (tested stable at 50x and 100x)
- Update compiled bindings TODO with actual error count (~30 errors, not 6)

## Measurements
| Mode | Time |
|------|------|
| No --fast (baseline) | 73s |
| --fast (10x, old default) | 69s |
| --fast (50x, new default) | 56s |
| --fast=100 | 56s |

The ~56s floor is compilation + app boot + simulation ticks. Compiled bindings (~30 AXAML errors to fix) could shave off more startup time but is a separate task.

## Test plan
- [x] All tests pass at 50x
- [x] All tests pass at 100x

Generated with [Claude Code](https://claude.com/claude-code)