### PR TITLE
Show non-intersecting headland segments as red dashed

### DIFF
--- a/Shared/AgValoniaGPS.Models/Headland/HeadlandSegment.cs
+++ b/Shared/AgValoniaGPS.Models/Headland/HeadlandSegment.cs
@@ -92,4 +92,10 @@ public class HeadlandSegment : INotifyPropertyChanged
         get => _endExtension;
         set { if (_endExtension != value) { _endExtension = value; OnPropertyChanged(); } }
     }
+
+    /// <summary>
+    /// Whether this segment intersects the headland at both ends, forming a loop.
+    /// Set by BuildHeadlandFromSegments. False = doesn't affect headland, shown as red.
+    /// </summary>
+    public bool IsEffective { get; set; }
 }

--- a/Shared/AgValoniaGPS.Services/Headland/HeadlandSegmentFileService.cs
+++ b/Shared/AgValoniaGPS.Services/Headland/HeadlandSegmentFileService.cs
@@ -33,6 +33,8 @@ public static class HeadlandSegmentFileService
                 Name = seg.Name,
                 Type = seg.Type.ToString(),
                 Offset = seg.Offset,
+                StartExtension = seg.StartExtension,
+                EndExtension = seg.EndExtension,
                 BoundaryIndex = seg.BoundaryIndex,
                 BoundaryStartIndex = seg.BoundaryStartIndex,
                 BoundaryEndIndex = seg.BoundaryEndIndex,
@@ -65,6 +67,8 @@ public static class HeadlandSegmentFileService
                     Name = dto.Name ?? "",
                     Type = Enum.TryParse<HeadlandSegmentType>(dto.Type, out var t) ? t : HeadlandSegmentType.Line,
                     Offset = dto.Offset,
+                    StartExtension = dto.StartExtension,
+                    EndExtension = dto.EndExtension,
                     BoundaryIndex = dto.BoundaryIndex,
                     BoundaryStartIndex = dto.BoundaryStartIndex,
                     BoundaryEndIndex = dto.BoundaryEndIndex,
@@ -106,6 +110,8 @@ public static class HeadlandSegmentFileService
         public string? Name { get; set; }
         public string? Type { get; set; }
         public double Offset { get; set; }
+        public double StartExtension { get; set; } = 50;
+        public double EndExtension { get; set; } = 50;
         public int BoundaryIndex { get; set; }
         public int BoundaryStartIndex { get; set; }
         public int BoundaryEndIndex { get; set; }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3245,12 +3245,13 @@ public partial class MainViewModel : ObservableObject
         int cutsApplied = 0;
 
         // Build all offset lines with extensions
-        var offsetLines = new List<(Models.Headland.HeadlandSegment seg, List<Vec3> line)>();
+        // Track list of segments per chain (merging combines multiple segments)
+        var offsetLines = new List<(List<Models.Headland.HeadlandSegment> segs, List<Vec3> line)>();
         foreach (var seg in HeadlandSegments)
         {
             if (seg.OffsetPoints.Count < 2) continue;
             var ol = BuildOffsetLineWithExtensions(seg);
-            offsetLines.Add((seg, ol));
+            offsetLines.Add((new List<Models.Headland.HeadlandSegment> { seg }, ol));
         }
 
         // Try to merge chained offset lines that intersect each other
@@ -3296,30 +3297,62 @@ public partial class MainViewModel : ObservableObject
                     if (found)
                     {
                         // Trim A at intersection: keep A[0..aSegIdx] + intersectPt
-                        // Then append B from the closest end
                         var trimmedA = new List<Vec3>();
                         for (int k = 0; k <= aSegIdx; k++)
                             trimmedA.Add(lineA[k]);
                         trimmedA.Add(intersectPt);
 
-                        // Determine which end of B to connect from
+                        // Find which segment of B contains the intersection and trim B too
+                        int bSegIdx = -1;
+                        for (int bi = 0; bi < lineB.Count - 1; bi++)
+                        {
+                            if (LineSegmentIntersection(
+                                lineA[aSegIdx].Easting, lineA[aSegIdx].Northing, lineA[aSegIdx + 1].Easting, lineA[aSegIdx + 1].Northing,
+                                lineB[bi].Easting, lineB[bi].Northing, lineB[bi + 1].Easting, lineB[bi + 1].Northing,
+                                out double t2, out double u2))
+                            {
+                                if (t2 >= 0 && t2 <= 1 && u2 >= 0 && u2 <= 1)
+                                {
+                                    bSegIdx = bi;
+                                    break;
+                                }
+                            }
+                        }
+
+                        // Determine which end of B to connect from and trim at intersection
                         double dBStart = System.Math.Pow(lineB[0].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[0].Northing - intersectPt.Northing, 2);
                         double dBEnd = System.Math.Pow(lineB[^1].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[^1].Northing - intersectPt.Northing, 2);
 
                         var combined = new List<Vec3>(trimmedA);
                         if (dBStart < dBEnd)
-                            combined.AddRange(lineB);
+                        {
+                            // B goes forward from intersection: trim B start, keep bSegIdx+1..end
+                            if (bSegIdx >= 0)
+                                for (int k = bSegIdx + 1; k < lineB.Count; k++)
+                                    combined.Add(lineB[k]);
+                            else
+                                combined.AddRange(lineB);
+                        }
                         else
                         {
-                            var rev = new List<Vec3>(lineB);
-                            rev.Reverse();
-                            combined.AddRange(rev);
+                            // B goes backward from intersection: trim B end, keep 0..bSegIdx reversed
+                            if (bSegIdx >= 0)
+                                for (int k = bSegIdx; k >= 0; k--)
+                                    combined.Add(lineB[k]);
+                            else
+                            {
+                                var rev = new List<Vec3>(lineB);
+                                rev.Reverse();
+                                combined.AddRange(rev);
+                            }
                         }
 
-                        offsetLines[a] = (offsetLines[a].seg, combined);
+                        var mergedSegs = new List<Models.Headland.HeadlandSegment>(offsetLines[a].segs);
+                        mergedSegs.AddRange(offsetLines[b].segs);
+                        offsetLines[a] = (mergedSegs, combined);
                         offsetLines.RemoveAt(b);
                         merged = true;
-                        _logger.LogDebug($"[Headland] Merged offset lines: {offsetLines[a].seg.Name} + removed segment");
+                        _logger.LogDebug($"[Headland] Merged offset lines: {mergedSegs.Count} segments combined");
                     }
                 }
             }
@@ -3329,7 +3362,7 @@ public partial class MainViewModel : ObservableObject
         // These can divide the polygon without touching the boundary
         for (int ci = 0; ci < offsetLines.Count; ci++)
         {
-            var (closedSeg, closedLine) = offsetLines[ci];
+            var (closedSegs, closedLine) = offsetLines[ci];
             if (closedLine.Count < 4) continue;
             double loopDist = System.Math.Sqrt(
                 System.Math.Pow(closedLine[0].Easting - closedLine[^1].Easting, 2) +
@@ -3353,14 +3386,14 @@ public partial class MainViewModel : ObservableObject
                 {
                     // Loop is outside the centroid - headland is unchanged
                     // (the loop is in the headland area, not the working area)
-                    closedSeg.IsEffective = true;
+                    foreach (var cs in closedSegs) cs.IsEffective = true;
                     _logger.LogDebug($"[Headland] Closed loop found (outside centroid) - headland unchanged");
                 }
                 else
                 {
                     // Loop contains centroid - the loop IS the headland
                     headland = loopPoly;
-                    closedSeg.IsEffective = true;
+                    foreach (var cs in closedSegs) cs.IsEffective = true;
                     cutsApplied++;
                     _logger.LogDebug($"[Headland] Closed loop contains centroid - used as headland");
                 }
@@ -3371,8 +3404,9 @@ public partial class MainViewModel : ObservableObject
         }
 
         // Process each offset line (possibly merged chains)
-        foreach (var (seg, offsetLine) in offsetLines)
+        foreach (var (segs, offsetLine) in offsetLines)
         {
+            var seg = segs[0]; // Primary segment for logging
 
             // Find intersection of offset line with headland polygon
             // Search from each end, limited to half the line to avoid finding the wrong end
@@ -3386,14 +3420,32 @@ public partial class MainViewModel : ObservableObject
             int endIntersectIdx = -1;
             Vec3 endIntersectPt = default;
             int endStart = System.Math.Max(1, offsetLine.Count - halfCount);
-            for (int oi = endStart; oi < offsetLine.Count && endIntersectIdx < 0; oi++)
+            // Search from end backward to find the far-end intersection first
+            for (int oi = offsetLine.Count - 1; oi >= endStart && endIntersectIdx < 0; oi--)
                 endIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi - 1], offsetLine[oi], headland, out endIntersectPt);
 
             _logger.LogDebug($"[Headland] Segment '{seg.Name}': start intersect={startIntersectIdx}, end intersect={endIntersectIdx}, offsetLine pts={offsetLine.Count}, headland pts={headland.Count}");
 
-            seg.IsEffective = startIntersectIdx >= 0 && endIntersectIdx >= 0 && startIntersectIdx != endIntersectIdx;
+            // Check that both ends intersect at different locations
+            // Allow same headland segment if intersection points are far apart
+            bool intersectionsFarEnough = false;
+            if (startIntersectIdx >= 0 && endIntersectIdx >= 0)
+            {
+                if (startIntersectIdx != endIntersectIdx)
+                {
+                    intersectionsFarEnough = true;
+                }
+                else
+                {
+                    double ptDist = System.Math.Sqrt(
+                        System.Math.Pow(startIntersectPt.Easting - endIntersectPt.Easting, 2) +
+                        System.Math.Pow(startIntersectPt.Northing - endIntersectPt.Northing, 2));
+                    intersectionsFarEnough = ptDist > 1.0; // At least 1m apart
+                }
+            }
+            foreach (var s in segs) s.IsEffective = intersectionsFarEnough;
 
-            if (seg.IsEffective)
+            if (intersectionsFarEnough)
             {
                 // Both ends intersect - split the polygon into two halves
                 int count = headland.Count - 1; // exclude closing duplicate
@@ -3411,29 +3463,51 @@ public partial class MainViewModel : ObservableObject
                 var divLineReverse = new List<Vec3>(divLine);
                 divLineReverse.Reverse();
 
-                // Path A: start at startIntersectPt, walk headland forward to endIntersectPt, then divLine back
                 var pathA = new List<Vec3>();
-                int idx = (startIntersectIdx + 1) % count;
-                pathA.Add(startIntersectPt);
-                while (idx != (endIntersectIdx + 1) % count)
-                {
-                    pathA.Add(headland[idx]);
-                    idx = (idx + 1) % count;
-                    if (pathA.Count > count + 2) break;
-                }
-                pathA.Add(endIntersectPt);
-
-                // Path B: start at endIntersectPt, walk headland forward to startIntersectPt, then divLine back
                 var pathB = new List<Vec3>();
-                idx = (endIntersectIdx + 1) % count;
-                pathB.Add(endIntersectPt);
-                while (idx != (startIntersectIdx + 1) % count)
+                int idx;
+
+                if (startIntersectIdx == endIntersectIdx)
                 {
-                    pathB.Add(headland[idx]);
-                    idx = (idx + 1) % count;
-                    if (pathB.Count > count + 2) break;
+                    // Both intersections on the same headland segment
+                    // pathA: just the direct connection between the two points
+                    pathA.Add(startIntersectPt);
+                    pathA.Add(endIntersectPt);
+
+                    // pathB: walk the entire headland polygon
+                    pathB.Add(endIntersectPt);
+                    idx = (endIntersectIdx + 1) % count;
+                    for (int step = 0; step < count; step++)
+                    {
+                        pathB.Add(headland[idx]);
+                        idx = (idx + 1) % count;
+                    }
+                    pathB.Add(startIntersectPt);
                 }
-                pathB.Add(startIntersectPt);
+                else
+                {
+                    // Path A: start at startIntersectPt, walk headland forward to endIntersectPt
+                    idx = (startIntersectIdx + 1) % count;
+                    pathA.Add(startIntersectPt);
+                    while (idx != (endIntersectIdx + 1) % count)
+                    {
+                        pathA.Add(headland[idx]);
+                        idx = (idx + 1) % count;
+                        if (pathA.Count > count + 2) break;
+                    }
+                    pathA.Add(endIntersectPt);
+
+                    // Path B: start at endIntersectPt, walk headland forward to startIntersectPt
+                    idx = (endIntersectIdx + 1) % count;
+                    pathB.Add(endIntersectPt);
+                    while (idx != (startIntersectIdx + 1) % count)
+                    {
+                        pathB.Add(headland[idx]);
+                        idx = (idx + 1) % count;
+                        if (pathB.Count > count + 2) break;
+                    }
+                    pathB.Add(startIntersectPt);
+                }
 
                 // Complete each polygon by adding the dividing line
                 // pathA + divLineReverse forms polygon A
@@ -3459,6 +3533,7 @@ public partial class MainViewModel : ObservableObject
                 else if (bContains && !aContains) chosen = polyB;
                 else chosen = System.Math.Abs(CalculateSignedArea(polyA)) >= System.Math.Abs(CalculateSignedArea(polyB)) ? polyA : polyB;
                 if (chosen.Count > 0)
+                {
                     // Remove consecutive duplicate points
                     for (int d = chosen.Count - 1; d > 0; d--)
                     {
@@ -3467,6 +3542,7 @@ public partial class MainViewModel : ObservableObject
                         if (ddx * ddx + ddy * ddy < 0.01) chosen.RemoveAt(d);
                     }
                     chosen.Add(chosen[0]); // close loop
+                }
 
                 headland = chosen;
                 cutsApplied++;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3055,24 +3055,66 @@ public partial class MainViewModel : ObservableObject
 
         var result = new List<Vec3>();
 
-        for (int i = 0; i < segment.BoundaryPoints.Count; i++)
+        // Edge-based offset: shift each edge by offset distance, then intersect consecutive edges
+        // This handles curves correctly (constant distance from boundary)
+        var pts = segment.BoundaryPoints;
+        int ptCount = pts.Count;
+
+        if (ptCount == 2)
         {
-            var pt = segment.BoundaryPoints[i];
-
-            // Calculate normal from boundary direction
-            Vec3 prev = i > 0 ? segment.BoundaryPoints[i - 1] : segment.BoundaryPoints[i];
-            Vec3 next = i < segment.BoundaryPoints.Count - 1 ? segment.BoundaryPoints[i + 1] : segment.BoundaryPoints[i];
-
-            double dx = next.Easting - prev.Easting;
-            double dy = next.Northing - prev.Northing;
+            // Simple line: just shift both points by the perpendicular
+            double dx = pts[1].Easting - pts[0].Easting;
+            double dy = pts[1].Northing - pts[0].Northing;
             double len = System.Math.Sqrt(dx * dx + dy * dy);
             if (len < 0.001) len = 1;
+            double nx = sign * dy / len * offset;
+            double ny = sign * -dx / len * offset;
+            result.Add(new Vec3(pts[0].Easting + nx, pts[0].Northing + ny, pts[0].Heading));
+            result.Add(new Vec3(pts[1].Easting + nx, pts[1].Northing + ny, pts[1].Heading));
+        }
+        else
+        {
+            // Build offset edges (each edge shifted by offset along its normal)
+            var offEdges = new List<(double ax, double ay, double bx, double by)>();
+            for (int i = 0; i < ptCount - 1; i++)
+            {
+                double dx = pts[i + 1].Easting - pts[i].Easting;
+                double dy = pts[i + 1].Northing - pts[i].Northing;
+                double len = System.Math.Sqrt(dx * dx + dy * dy);
+                if (len < 0.001) continue;
+                double nx = sign * dy / len * offset;
+                double ny = sign * -dx / len * offset;
+                offEdges.Add((pts[i].Easting + nx, pts[i].Northing + ny,
+                              pts[i + 1].Easting + nx, pts[i + 1].Northing + ny));
+            }
 
-            // Perpendicular normal, adjusted for winding
-            double nx = sign * dy / len;
-            double ny = sign * -dx / len;
+            if (offEdges.Count == 0) { segment.OffsetPoints = result; return; }
 
-            result.Add(new Vec3(pt.Easting + nx * offset, pt.Northing + ny * offset, pt.Heading));
+            // First offset point
+            result.Add(new Vec3(offEdges[0].ax, offEdges[0].ay, pts[0].Heading));
+
+            // Intersect consecutive offset edges to find interior offset points
+            for (int i = 0; i < offEdges.Count - 1; i++)
+            {
+                var e1 = offEdges[i];
+                var e2 = offEdges[i + 1];
+
+                if (LineLineIntersection(e1.ax, e1.ay, e1.bx, e1.by,
+                                         e2.ax, e2.ay, e2.bx, e2.by,
+                                         out double ix, out double iy))
+                {
+                    result.Add(new Vec3(ix, iy, pts[i + 1].Heading));
+                }
+                else
+                {
+                    // Parallel edges - use endpoint of first edge
+                    result.Add(new Vec3(e1.bx, e1.by, pts[i + 1].Heading));
+                }
+            }
+
+            // Last offset point
+            var last = offEdges[^1];
+            result.Add(new Vec3(last.bx, last.by, pts[^1].Heading));
         }
 
         // Remove self-intersections only for closed polygons (Boundary type)
@@ -3307,6 +3349,13 @@ public partial class MainViewModel : ObservableObject
                 else if (bContains && !aContains) chosen = polyB;
                 else chosen = System.Math.Abs(CalculateSignedArea(polyA)) >= System.Math.Abs(CalculateSignedArea(polyB)) ? polyA : polyB;
                 if (chosen.Count > 0)
+                    // Remove consecutive duplicate points
+                    for (int d = chosen.Count - 1; d > 0; d--)
+                    {
+                        double ddx = chosen[d].Easting - chosen[d-1].Easting;
+                        double ddy = chosen[d].Northing - chosen[d-1].Northing;
+                        if (ddx * ddx + ddy * ddy < 0.01) chosen.RemoveAt(d);
+                    }
                     chosen.Add(chosen[0]); // close loop
 
                 headland = chosen;
@@ -3334,6 +3383,21 @@ public partial class MainViewModel : ObservableObject
             : $"Headland = boundary ({headland.Count} points, no offset lines intersect)";
 
         SaveHeadlandSegments();
+    }
+
+    /// <summary>Intersect two infinite lines. Returns false if parallel.</summary>
+    private static bool LineLineIntersection(
+        double ax, double ay, double bx, double by,
+        double cx, double cy, double dx, double dy,
+        out double ix, out double iy)
+    {
+        double denom = (bx - ax) * (dy - cy) - (by - ay) * (dx - cx);
+        ix = iy = 0;
+        if (System.Math.Abs(denom) < 1e-10) return false;
+        double t = ((cx - ax) * (dy - cy) - (cy - ay) * (dx - cx)) / denom;
+        ix = ax + t * (bx - ax);
+        iy = ay + t * (by - ay);
+        return true;
     }
 
     private static bool IsPointInPolygon(double px, double py, List<Vec3> polygon)

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3234,7 +3234,9 @@ public partial class MainViewModel : ObservableObject
 
             _logger.LogDebug($"[Headland] Segment '{seg.Name}': start intersect={startIntersectIdx}, end intersect={endIntersectIdx}, offsetLine pts={offsetLine.Count}, headland pts={headland.Count}");
 
-            if (startIntersectIdx >= 0 && endIntersectIdx >= 0 && startIntersectIdx != endIntersectIdx)
+            seg.IsEffective = startIntersectIdx >= 0 && endIntersectIdx >= 0 && startIntersectIdx != endIntersectIdx;
+
+            if (seg.IsEffective)
             {
                 // Both ends intersect - split the polygon into two halves
                 int count = headland.Count - 1; // exclude closing duplicate

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3254,17 +3254,40 @@ public partial class MainViewModel : ObservableObject
             offsetLines.Add((new List<Models.Headland.HeadlandSegment> { seg }, ol));
         }
 
+        // Pre-check: which offset lines already individually reach the boundary on both ends
+        // These should NOT be merged with other lines (merging could break them)
+        var reachesBothEnds = new HashSet<int>();
+        for (int i = 0; i < offsetLines.Count; i++)
+        {
+            var line = offsetLines[i].line;
+            if (line.Count < 2) continue;
+            int halfCk = System.Math.Max(2, line.Count / 2);
+
+            bool startReaches = false;
+            for (int oi = 0; oi < System.Math.Min(halfCk, line.Count - 1) && !startReaches; oi++)
+                startReaches = FindLineHeadlandIntersection(line[oi], line[oi + 1], headland, out _) >= 0;
+
+            bool endReaches = false;
+            for (int oi = line.Count - 1; oi >= System.Math.Max(1, line.Count - halfCk) && !endReaches; oi--)
+                endReaches = FindLineHeadlandIntersection(line[oi - 1], line[oi], headland, out _) >= 0;
+
+            if (startReaches && endReaches) reachesBothEnds.Add(i);
+        }
+
         // Try to merge chained offset lines that intersect each other
         // This handles the case where two lines each only touch boundary on one side
         // but connect to each other on the other side
+        // Skip lines that already reach both boundary ends
         bool merged = true;
         while (merged)
         {
             merged = false;
             for (int a = 0; a < offsetLines.Count && !merged; a++)
             {
+                if (reachesBothEnds.Contains(a)) continue;
                 for (int b = a + 1; b < offsetLines.Count && !merged; b++)
                 {
+                    if (reachesBothEnds.Contains(b)) continue;
                     // Check if end of A intersects any segment of B
                     var lineA = offsetLines[a].line;
                     var lineB = offsetLines[b].line;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -1439,7 +1439,11 @@ public partial class MainViewModel : ObservableObject
             var segments = Services.Headland.HeadlandSegmentFileService.Load(field.DirectoryPath);
             HeadlandSegments.Clear();
             foreach (var seg in segments)
+            {
+                // Recompute offsets with current algorithm (may differ from saved)
+                ComputeSegmentOffset(seg);
                 HeadlandSegments.Add(seg);
+            }
             if (HeadlandSegments.Count > 0)
                 BuildHeadlandFromSegments();
         }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3075,8 +3075,13 @@ public partial class MainViewModel : ObservableObject
             result.Add(new Vec3(pt.Easting + nx * offset, pt.Northing + ny * offset, pt.Heading));
         }
 
-        // Remove self-intersections (e.g. inverted fillets when offset > fillet radius)
-        segment.OffsetPoints = RemoveSelfIntersections(result);
+        // Remove self-intersections only for closed polygons (Boundary type)
+        // Open segments (Line/Curve) shouldn't have self-intersection removal as it
+        // can create artifacts that interfere with headland intersection detection
+        if (segment.Type == Models.Headland.HeadlandSegmentType.Boundary)
+            segment.OffsetPoints = RemoveSelfIntersections(result);
+        else
+            segment.OffsetPoints = result;
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3240,42 +3240,80 @@ public partial class MainViewModel : ObservableObject
 
         int cutsApplied = 0;
 
-        // Multi-pass: keep processing until no more segments become effective
-        // Handles chained lines that depend on each other
-        bool madeProgress = true;
-        int maxPasses = HeadlandSegments.Count + 1;
-        while (madeProgress && maxPasses-- > 0)
+        // Build all offset lines with extensions
+        var offsetLines = new List<(Models.Headland.HeadlandSegment seg, List<Vec3> line)>();
+        foreach (var seg in HeadlandSegments)
         {
-            madeProgress = false;
-            foreach (var seg in HeadlandSegments)
-            {
-                if (seg.IsEffective) continue; // Already applied
-                if (seg.OffsetPoints.Count < 2) continue;
+            if (seg.OffsetPoints.Count < 2) continue;
+            var ol = BuildOffsetLineWithExtensions(seg);
+            offsetLines.Add((seg, ol));
+        }
 
-            // Build the full offset line with extensions
-            var offsetLine = new List<Vec3>();
+        // Try to merge chained offset lines that intersect each other
+        // This handles the case where two lines each only touch boundary on one side
+        // but connect to each other on the other side
+        bool merged = true;
+        while (merged)
+        {
+            merged = false;
+            for (int a = 0; a < offsetLines.Count && !merged; a++)
+            {
+                for (int b = a + 1; b < offsetLines.Count && !merged; b++)
+                {
+                    // Check if end of A intersects any segment of B
+                    var lineA = offsetLines[a].line;
+                    var lineB = offsetLines[b].line;
 
-            // Start extension
-            if (seg.StartExtension > 0)
-            {
-                var s0 = seg.OffsetPoints[0];
-                var s1 = seg.OffsetPoints[1];
-                double sdx = s0.Easting - s1.Easting, sdy = s0.Northing - s1.Northing;
-                double slen = System.Math.Sqrt(sdx * sdx + sdy * sdy);
-                if (slen > 0.01)
-                    offsetLine.Add(new Vec3(s0.Easting + sdx / slen * seg.StartExtension, s0.Northing + sdy / slen * seg.StartExtension, s0.Heading));
+                    // Check A's end vs B
+                    Vec3 intersectPt = default;
+                    bool found = false;
+                    for (int si = 0; si < lineB.Count - 1 && !found; si++)
+                    {
+                        if (LineSegmentIntersection(
+                            lineA[^1].Easting, lineA[^1].Northing, lineA[^2].Easting, lineA[^2].Northing,
+                            lineB[si].Easting, lineB[si].Northing, lineB[si + 1].Easting, lineB[si + 1].Northing,
+                            out double t, out double u))
+                        {
+                            if (t >= 0 && t <= 1 && u >= 0 && u <= 1)
+                            {
+                                intersectPt = new Vec3(
+                                    lineB[si].Easting + u * (lineB[si + 1].Easting - lineB[si].Easting),
+                                    lineB[si].Northing + u * (lineB[si + 1].Northing - lineB[si].Northing), 0);
+                                found = true;
+                            }
+                        }
+                    }
+
+                    if (found)
+                    {
+                        // Merge: A's start to intersection point, then intersection point to B's end (or B's start)
+                        // Figure out which end of B is closer to the intersection
+                        double dStart = System.Math.Pow(lineB[0].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[0].Northing - intersectPt.Northing, 2);
+                        double dEnd = System.Math.Pow(lineB[^1].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[^1].Northing - intersectPt.Northing, 2);
+
+                        var combined = new List<Vec3>(lineA);
+                        combined.Add(intersectPt);
+                        if (dStart < dEnd)
+                            combined.AddRange(lineB); // B goes start to end
+                        else
+                        {
+                            var rev = new List<Vec3>(lineB);
+                            rev.Reverse();
+                            combined.AddRange(rev); // B goes end to start
+                        }
+
+                        offsetLines[a] = (offsetLines[a].seg, combined);
+                        offsetLines.RemoveAt(b);
+                        merged = true;
+                        _logger.LogDebug($"[Headland] Merged offset lines: {offsetLines[a].seg.Name} + removed segment");
+                    }
+                }
             }
-            offsetLine.AddRange(seg.OffsetPoints);
-            // End extension
-            if (seg.EndExtension > 0)
-            {
-                var e0 = seg.OffsetPoints[^2];
-                var e1 = seg.OffsetPoints[^1];
-                double edx = e1.Easting - e0.Easting, edy = e1.Northing - e0.Northing;
-                double elen = System.Math.Sqrt(edx * edx + edy * edy);
-                if (elen > 0.01)
-                    offsetLine.Add(new Vec3(e1.Easting + edx / elen * seg.EndExtension, e1.Northing + edy / elen * seg.EndExtension, e1.Heading));
-            }
+        }
+
+        // Process each offset line (possibly merged chains)
+        foreach (var (seg, offsetLine) in offsetLines)
+        {
 
             // Find intersection of offset line with headland polygon
             // Search from each end along consecutive segments until intersection found
@@ -3370,8 +3408,6 @@ public partial class MainViewModel : ObservableObject
 
                 headland = chosen;
                 cutsApplied++;
-                madeProgress = true;
-            }
             }
         }
 
@@ -3395,6 +3431,29 @@ public partial class MainViewModel : ObservableObject
             : $"Headland = boundary ({headland.Count} points, no offset lines intersect)";
 
         SaveHeadlandSegments();
+    }
+
+    private static List<Vec3> BuildOffsetLineWithExtensions(Models.Headland.HeadlandSegment seg)
+    {
+        var line = new List<Vec3>();
+        if (seg.StartExtension > 0 && seg.OffsetPoints.Count >= 2)
+        {
+            var s0 = seg.OffsetPoints[0]; var s1 = seg.OffsetPoints[1];
+            double sdx = s0.Easting - s1.Easting, sdy = s0.Northing - s1.Northing;
+            double slen = System.Math.Sqrt(sdx * sdx + sdy * sdy);
+            if (slen > 0.01)
+                line.Add(new Vec3(s0.Easting + sdx / slen * seg.StartExtension, s0.Northing + sdy / slen * seg.StartExtension, s0.Heading));
+        }
+        line.AddRange(seg.OffsetPoints);
+        if (seg.EndExtension > 0 && seg.OffsetPoints.Count >= 2)
+        {
+            var e0 = seg.OffsetPoints[^2]; var e1 = seg.OffsetPoints[^1];
+            double edx = e1.Easting - e0.Easting, edy = e1.Northing - e0.Northing;
+            double elen = System.Math.Sqrt(edx * edx + edy * edy);
+            if (elen > 0.01)
+                line.Add(new Vec3(e1.Easting + edx / elen * seg.EndExtension, e1.Northing + edy / elen * seg.EndExtension, e1.Heading));
+        }
+        return line;
     }
 
     /// <summary>Intersect two infinite lines. Returns false if parallel.</summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3117,13 +3117,9 @@ public partial class MainViewModel : ObservableObject
             result.Add(new Vec3(last.bx, last.by, pts[^1].Heading));
         }
 
-        // Remove self-intersections only for closed polygons (Boundary type)
-        // Open segments (Line/Curve) shouldn't have self-intersection removal as it
-        // can create artifacts that interfere with headland intersection detection
-        if (segment.Type == Models.Headland.HeadlandSegmentType.Boundary)
-            segment.OffsetPoints = RemoveSelfIntersections(result);
-        else
-            segment.OffsetPoints = result;
+        // Remove self-intersections (inverted fillets when offset > corner radius)
+        // Safe for all types since edge-based offset produces accurate distances
+        segment.OffsetPoints = result.Count > 3 ? RemoveSelfIntersections(result) : result;
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3264,22 +3264,27 @@ public partial class MainViewModel : ObservableObject
                     var lineA = offsetLines[a].line;
                     var lineB = offsetLines[b].line;
 
-                    // Check A's end vs B
+                    // Check all segment pairs between A and B for intersection
                     Vec3 intersectPt = default;
                     bool found = false;
-                    for (int si = 0; si < lineB.Count - 1 && !found; si++)
+                    int aSegIdx = -1;
+                    for (int ai = 0; ai < lineA.Count - 1 && !found; ai++)
                     {
-                        if (LineSegmentIntersection(
-                            lineA[^1].Easting, lineA[^1].Northing, lineA[^2].Easting, lineA[^2].Northing,
-                            lineB[si].Easting, lineB[si].Northing, lineB[si + 1].Easting, lineB[si + 1].Northing,
-                            out double t, out double u))
+                        for (int bi = 0; bi < lineB.Count - 1 && !found; bi++)
                         {
-                            if (t >= 0 && t <= 1 && u >= 0 && u <= 1)
+                            if (LineSegmentIntersection(
+                                lineA[ai].Easting, lineA[ai].Northing, lineA[ai + 1].Easting, lineA[ai + 1].Northing,
+                                lineB[bi].Easting, lineB[bi].Northing, lineB[bi + 1].Easting, lineB[bi + 1].Northing,
+                                out double t, out double u))
                             {
-                                intersectPt = new Vec3(
-                                    lineB[si].Easting + u * (lineB[si + 1].Easting - lineB[si].Easting),
-                                    lineB[si].Northing + u * (lineB[si + 1].Northing - lineB[si].Northing), 0);
-                                found = true;
+                                if (t >= 0 && t <= 1 && u >= 0 && u <= 1)
+                                {
+                                    intersectPt = new Vec3(
+                                        lineB[bi].Easting + u * (lineB[bi + 1].Easting - lineB[bi].Easting),
+                                        lineB[bi].Northing + u * (lineB[bi + 1].Northing - lineB[bi].Northing), 0);
+                                    found = true;
+                                    aSegIdx = ai;
+                                }
                             }
                         }
                     }
@@ -3308,6 +3313,51 @@ public partial class MainViewModel : ObservableObject
                         _logger.LogDebug($"[Headland] Merged offset lines: {offsetLines[a].seg.Name} + removed segment");
                     }
                 }
+            }
+        }
+
+        // Check for closed loops: merged chains whose start and end meet
+        // These can divide the polygon without touching the boundary
+        for (int ci = 0; ci < offsetLines.Count; ci++)
+        {
+            var (closedSeg, closedLine) = offsetLines[ci];
+            if (closedLine.Count < 4) continue;
+            double loopDist = System.Math.Sqrt(
+                System.Math.Pow(closedLine[0].Easting - closedLine[^1].Easting, 2) +
+                System.Math.Pow(closedLine[0].Northing - closedLine[^1].Northing, 2));
+            if (loopDist < 5.0) // Close enough to form a loop
+            {
+                // This is a closed loop - use it directly as a divider
+                var loopPoly = new List<Vec3>(closedLine);
+                loopPoly.Add(loopPoly[0]); // close
+
+                // The headland is the boundary MINUS the loop area
+                // Keep the part containing the centroid
+                double cx = 0, cy = 0;
+                var bndPts = bnd.Points;
+                foreach (var bp in bndPts) { cx += bp.Easting; cy += bp.Northing; }
+                cx /= bndPts.Count; cy /= bndPts.Count;
+
+                bool loopContainsCentroid = IsPointInPolygon(cx, cy, loopPoly);
+
+                if (!loopContainsCentroid)
+                {
+                    // Loop is outside the centroid - headland is unchanged
+                    // (the loop is in the headland area, not the working area)
+                    closedSeg.IsEffective = true;
+                    _logger.LogDebug($"[Headland] Closed loop found (outside centroid) - headland unchanged");
+                }
+                else
+                {
+                    // Loop contains centroid - the loop IS the headland
+                    headland = loopPoly;
+                    closedSeg.IsEffective = true;
+                    cutsApplied++;
+                    _logger.LogDebug($"[Headland] Closed loop contains centroid - used as headland");
+                }
+
+                offsetLines.RemoveAt(ci);
+                ci--;
             }
         }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3270,10 +3270,17 @@ public partial class MainViewModel : ObservableObject
                     offsetLine.Add(new Vec3(e1.Easting + edx / elen * seg.EndExtension, e1.Northing + edy / elen * seg.EndExtension, e1.Heading));
             }
 
-            // Find intersection of offset line start with headland polygon
-            int startIntersectIdx = FindLineHeadlandIntersection(offsetLine[0], offsetLine[1], headland, out Vec3 startIntersectPt);
-            // Find intersection of offset line end with headland polygon
-            int endIntersectIdx = FindLineHeadlandIntersection(offsetLine[^1], offsetLine[^2], headland, out Vec3 endIntersectPt);
+            // Find intersection of offset line with headland polygon
+            // Search from each end along consecutive segments until intersection found
+            int startIntersectIdx = -1;
+            Vec3 startIntersectPt = default;
+            for (int oi = 0; oi < offsetLine.Count - 1 && startIntersectIdx < 0; oi++)
+                startIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi], offsetLine[oi + 1], headland, out startIntersectPt);
+
+            int endIntersectIdx = -1;
+            Vec3 endIntersectPt = default;
+            for (int oi = offsetLine.Count - 1; oi > 0 && endIntersectIdx < 0; oi--)
+                endIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi], offsetLine[oi - 1], headland, out endIntersectPt);
 
             _logger.LogDebug($"[Headland] Segment '{seg.Name}': start intersect={startIntersectIdx}, end intersect={endIntersectIdx}, offsetLine pts={offsetLine.Count}, headland pts={headland.Count}");
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3240,10 +3240,17 @@ public partial class MainViewModel : ObservableObject
 
         int cutsApplied = 0;
 
-        // For each segment, check if the extended offset line intersects the headland at both ends
-        foreach (var seg in HeadlandSegments)
+        // Multi-pass: keep processing until no more segments become effective
+        // Handles chained lines that depend on each other
+        bool madeProgress = true;
+        int maxPasses = HeadlandSegments.Count + 1;
+        while (madeProgress && maxPasses-- > 0)
         {
-            if (seg.OffsetPoints.Count < 2) continue;
+            madeProgress = false;
+            foreach (var seg in HeadlandSegments)
+            {
+                if (seg.IsEffective) continue; // Already applied
+                if (seg.OffsetPoints.Count < 2) continue;
 
             // Build the full offset line with extensions
             var offsetLine = new List<Vec3>();
@@ -3363,6 +3370,8 @@ public partial class MainViewModel : ObservableObject
 
                 headland = chosen;
                 cutsApplied++;
+                madeProgress = true;
+            }
             }
         }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3375,15 +3375,17 @@ public partial class MainViewModel : ObservableObject
         {
 
             // Find intersection of offset line with headland polygon
-            // Search from each end along consecutive segments until intersection found
+            // Search from each end, limited to half the line to avoid finding the wrong end
+            int halfCount = System.Math.Max(2, offsetLine.Count / 2);
+
             int startIntersectIdx = -1;
             Vec3 startIntersectPt = default;
-            for (int oi = 0; oi < offsetLine.Count - 1 && startIntersectIdx < 0; oi++)
+            for (int oi = 0; oi < System.Math.Min(halfCount, offsetLine.Count - 1) && startIntersectIdx < 0; oi++)
                 startIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi], offsetLine[oi + 1], headland, out startIntersectPt);
 
             int endIntersectIdx = -1;
             Vec3 endIntersectPt = default;
-            for (int oi = offsetLine.Count - 1; oi > 0 && endIntersectIdx < 0; oi--)
+            for (int oi = offsetLine.Count - 1; oi > System.Math.Max(0, offsetLine.Count - 1 - halfCount) && endIntersectIdx < 0; oi--)
                 endIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi], offsetLine[oi - 1], headland, out endIntersectPt);
 
             _logger.LogDebug($"[Headland] Segment '{seg.Name}': start intersect={startIntersectIdx}, end intersect={endIntersectIdx}, offsetLine pts={offsetLine.Count}, headland pts={headland.Count}");

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3291,20 +3291,25 @@ public partial class MainViewModel : ObservableObject
 
                     if (found)
                     {
-                        // Merge: A's start to intersection point, then intersection point to B's end (or B's start)
-                        // Figure out which end of B is closer to the intersection
-                        double dStart = System.Math.Pow(lineB[0].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[0].Northing - intersectPt.Northing, 2);
-                        double dEnd = System.Math.Pow(lineB[^1].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[^1].Northing - intersectPt.Northing, 2);
+                        // Trim A at intersection: keep A[0..aSegIdx] + intersectPt
+                        // Then append B from the closest end
+                        var trimmedA = new List<Vec3>();
+                        for (int k = 0; k <= aSegIdx; k++)
+                            trimmedA.Add(lineA[k]);
+                        trimmedA.Add(intersectPt);
 
-                        var combined = new List<Vec3>(lineA);
-                        combined.Add(intersectPt);
-                        if (dStart < dEnd)
-                            combined.AddRange(lineB); // B goes start to end
+                        // Determine which end of B to connect from
+                        double dBStart = System.Math.Pow(lineB[0].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[0].Northing - intersectPt.Northing, 2);
+                        double dBEnd = System.Math.Pow(lineB[^1].Easting - intersectPt.Easting, 2) + System.Math.Pow(lineB[^1].Northing - intersectPt.Northing, 2);
+
+                        var combined = new List<Vec3>(trimmedA);
+                        if (dBStart < dBEnd)
+                            combined.AddRange(lineB);
                         else
                         {
                             var rev = new List<Vec3>(lineB);
                             rev.Reverse();
-                            combined.AddRange(rev); // B goes end to start
+                            combined.AddRange(rev);
                         }
 
                         offsetLines[a] = (offsetLines[a].seg, combined);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3442,7 +3442,7 @@ public partial class MainViewModel : ObservableObject
                 p1.Easting, p1.Northing, p2.Easting, p2.Northing,
                 out double t, out double u))
             {
-                if (t >= 0) // Ray from lineStart through lineDir
+                if (t >= 0 && t <= 1) // Segment from lineStart to lineDir (extension tip)
                 {
                     // Distance from lineStart to intersection
                     double dx = lineDir.Easting - lineStart.Easting;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3385,8 +3385,9 @@ public partial class MainViewModel : ObservableObject
 
             int endIntersectIdx = -1;
             Vec3 endIntersectPt = default;
-            for (int oi = offsetLine.Count - 1; oi > System.Math.Max(0, offsetLine.Count - 1 - halfCount) && endIntersectIdx < 0; oi--)
-                endIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi], offsetLine[oi - 1], headland, out endIntersectPt);
+            int endStart = System.Math.Max(1, offsetLine.Count - halfCount);
+            for (int oi = endStart; oi < offsetLine.Count && endIntersectIdx < 0; oi++)
+                endIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi - 1], offsetLine[oi], headland, out endIntersectPt);
 
             _logger.LogDebug($"[Headland] Segment '{seg.Name}': start intersect={startIntersectIdx}, end intersect={endIntersectIdx}, offsetLine pts={offsetLine.Count}, headland pts={headland.Count}");
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3292,11 +3292,12 @@ public partial class MainViewModel : ObservableObject
                     var lineA = offsetLines[a].line;
                     var lineB = offsetLines[b].line;
 
-                    // Check all segment pairs between A and B for intersection
+                    // Check segment pairs between A's ends and B for intersection
+                    // Search from A's end backward to prefer extending the chain (not cutting it short)
                     Vec3 intersectPt = default;
                     bool found = false;
                     int aSegIdx = -1;
-                    for (int ai = 0; ai < lineA.Count - 1 && !found; ai++)
+                    for (int ai = lineA.Count - 2; ai >= 0 && !found; ai--)
                     {
                         for (int bi = 0; bi < lineB.Count - 1 && !found; bi++)
                         {
@@ -3383,13 +3384,61 @@ public partial class MainViewModel : ObservableObject
 
         // Check for closed loops: merged chains whose start and end meet
         // These can divide the polygon without touching the boundary
+        // First try to close near-miss loops by finding where end segments intersect start segments
         for (int ci = 0; ci < offsetLines.Count; ci++)
         {
             var (closedSegs, closedLine) = offsetLines[ci];
-            if (closedLine.Count < 4) continue;
+            if (closedLine.Count < 6 || closedSegs.Count < 2) continue; // Need multiple merged segments
+
             double loopDist = System.Math.Sqrt(
                 System.Math.Pow(closedLine[0].Easting - closedLine[^1].Easting, 2) +
                 System.Math.Pow(closedLine[0].Northing - closedLine[^1].Northing, 2));
+
+            if (loopDist >= 5.0)
+            {
+                // Ends don't meet directly - check if end segments intersect start segments
+                // This handles the case where extensions overshoot past the closing corner
+                int searchRange = System.Math.Max(3, closedLine.Count / 2);
+                Vec3 closeIntersectPt = default;
+                int startSegClose = -1, endSegClose = -1;
+
+                for (int si = 0; si < System.Math.Min(searchRange, closedLine.Count / 2) && startSegClose < 0; si++)
+                {
+                    int endSearchStart = System.Math.Max(closedLine.Count / 2, si + 2);
+                    for (int ei = endSearchStart; ei < closedLine.Count - 1 && startSegClose < 0; ei++)
+                    {
+                        if (LineSegmentIntersection(
+                            closedLine[si].Easting, closedLine[si].Northing, closedLine[si + 1].Easting, closedLine[si + 1].Northing,
+                            closedLine[ei].Easting, closedLine[ei].Northing, closedLine[ei + 1].Easting, closedLine[ei + 1].Northing,
+                            out double t, out double u))
+                        {
+                            if (t >= 0 && t <= 1 && u >= 0 && u <= 1)
+                            {
+                                closeIntersectPt = new Vec3(
+                                    closedLine[si].Easting + t * (closedLine[si + 1].Easting - closedLine[si].Easting),
+                                    closedLine[si].Northing + t * (closedLine[si + 1].Northing - closedLine[si].Northing), 0);
+                                startSegClose = si;
+                                endSegClose = ei;
+                            }
+                        }
+                    }
+                }
+
+                if (startSegClose >= 0)
+                {
+                    // Trim both ends at the intersection to close the loop
+                    var trimmed = new List<Vec3> { closeIntersectPt };
+                    for (int k = startSegClose + 1; k <= endSegClose; k++)
+                        trimmed.Add(closedLine[k]);
+                    trimmed.Add(closeIntersectPt);
+
+                    offsetLines[ci] = (closedSegs, trimmed);
+                    closedLine = trimmed;
+                    loopDist = 0; // Now it's a closed loop
+                    _logger.LogDebug($"[Headland] Closed loop by trimming extensions at intersection ({closeIntersectPt.Easting:F1},{closeIntersectPt.Northing:F1})");
+                }
+            }
+
             if (loopDist < 5.0) // Close enough to form a loop
             {
                 // This is a closed loop - use it directly as a divider

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3414,15 +3414,23 @@ public partial class MainViewModel : ObservableObject
 
             int startIntersectIdx = -1;
             Vec3 startIntersectPt = default;
+            int startOffsetSegIdx = -1; // Which offset line segment the start intersection is on
             for (int oi = 0; oi < System.Math.Min(halfCount, offsetLine.Count - 1) && startIntersectIdx < 0; oi++)
+            {
                 startIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi], offsetLine[oi + 1], headland, out startIntersectPt);
+                if (startIntersectIdx >= 0) startOffsetSegIdx = oi;
+            }
 
             int endIntersectIdx = -1;
             Vec3 endIntersectPt = default;
+            int endOffsetSegIdx = -1; // Which offset line segment the end intersection is on
             int endStart = System.Math.Max(1, offsetLine.Count - halfCount);
             // Search from end backward to find the far-end intersection first
             for (int oi = offsetLine.Count - 1; oi >= endStart && endIntersectIdx < 0; oi--)
+            {
                 endIntersectIdx = FindLineHeadlandIntersection(offsetLine[oi - 1], offsetLine[oi], headland, out endIntersectPt);
+                if (endIntersectIdx >= 0) endOffsetSegIdx = oi - 1;
+            }
 
             _logger.LogDebug($"[Headland] Segment '{seg.Name}': start intersect={startIntersectIdx}, end intersect={endIntersectIdx}, offsetLine pts={offsetLine.Count}, headland pts={headland.Count}");
 
@@ -3450,13 +3458,14 @@ public partial class MainViewModel : ObservableObject
                 // Both ends intersect - split the polygon into two halves
                 int count = headland.Count - 1; // exclude closing duplicate
 
-                // The dividing line goes from startIntersectPt to endIntersectPt
-                // For curves, include interior offset points between the intersections
+                // The dividing line goes from startIntersectPt along the offset line to endIntersectPt
+                // Include all offset line interior points between the two intersection segments
                 var divLine = new List<Vec3> { startIntersectPt };
-                if (seg.OffsetPoints.Count > 2)
+                if (startOffsetSegIdx >= 0 && endOffsetSegIdx >= 0 && endOffsetSegIdx > startOffsetSegIdx)
                 {
-                    for (int j = 1; j < seg.OffsetPoints.Count - 1; j++)
-                        divLine.Add(seg.OffsetPoints[j]);
+                    // Add offset line points between the two intersection segments
+                    for (int j = startOffsetSegIdx + 1; j <= endOffsetSegIdx; j++)
+                        divLine.Add(offsetLine[j]);
                 }
                 divLine.Add(endIntersectPt);
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
@@ -412,7 +412,7 @@ Licensed under GNU GPL v3.
                                 <TabItem>
                                     <TabItem.Header>
                                         <StackPanel Spacing="2" HorizontalAlignment="Center" Margin="12,4">
-                                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRecord.png"
+                                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png"
                                                    Width="48" Height="48" Stretch="Uniform" HorizontalAlignment="Center"/>
                                             <TextBlock Text="Boundary" FontSize="14" HorizontalAlignment="Center"/>
                                         </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
@@ -379,7 +379,7 @@ Licensed under GNU GPL v3.
                                                 Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                                                 Click="StartDrawAB_Click">
                                             <StackPanel Spacing="4" HorizontalAlignment="Center">
-                                                <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png"
+                                                <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAB.png"
                                                        Width="36" Height="36" Stretch="Uniform"/>
                                                 <TextBlock Text="AB Line" FontSize="14" HorizontalAlignment="Center"
                                                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
@@ -422,7 +422,7 @@ Licensed under GNU GPL v3.
                                                 Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                                                 Click="StartBoundaryLine_Click">
                                             <StackPanel Spacing="4" HorizontalAlignment="Center">
-                                                <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png"
+                                                <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAB.png"
                                                        Width="36" Height="36" Stretch="Uniform"/>
                                                 <TextBlock Text="AB Line" FontSize="14" HorizontalAlignment="Center"
                                                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
@@ -516,43 +516,6 @@ Licensed under GNU GPL v3.
                                 </StackPanel>
                             </StackPanel>
 
-                            <!-- Extend/Shrink controls for headland preview -->
-                            <StackPanel x:Name="ExtendShrinkPanel" IsVisible="False" Spacing="6" Margin="0,8,0,0">
-                                <TextBlock Text="Adjust Endpoints" FontSize="13" FontWeight="SemiBold"
-                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                                <Grid ColumnDefinitions="*,Auto" Margin="0,2">
-                                    <TextBlock Text="Start:" VerticalAlignment="Center" FontSize="14"
-                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                                        <Button Content="-" Width="36" Height="32" FontSize="16" FontWeight="Bold"
-                                                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                                CornerRadius="4" BorderThickness="0" Cursor="Hand"
-                                                Click="ShrinkStart_Click"/>
-                                        <Button Content="+" Width="36" Height="32" FontSize="16" FontWeight="Bold"
-                                                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                                CornerRadius="4" BorderThickness="0" Cursor="Hand"
-                                                Click="ExtendStart_Click"/>
-                                    </StackPanel>
-                                </Grid>
-                                <Grid ColumnDefinitions="*,Auto" Margin="0,2">
-                                    <TextBlock Text="End:" VerticalAlignment="Center" FontSize="14"
-                                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="4">
-                                        <Button Content="-" Width="36" Height="32" FontSize="16" FontWeight="Bold"
-                                                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                                CornerRadius="4" BorderThickness="0" Cursor="Hand"
-                                                Click="ShrinkEnd_Click"/>
-                                        <Button Content="+" Width="36" Height="32" FontSize="16" FontWeight="Bold"
-                                                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                                CornerRadius="4" BorderThickness="0" Cursor="Hand"
-                                                Click="ExtendEnd_Click"/>
-                                    </StackPanel>
-                                </Grid>
-                            </StackPanel>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -863,13 +863,24 @@ public partial class FieldBuilderDialogPanel : UserControl
         var a = _session.Points[0];
         var b = _session.Points[1];
 
-        var posA = new Position { Easting = a.Easting, Northing = a.Northing };
-        var posB = new Position { Easting = b.Easting, Northing = b.Northing };
+        double heading = Math.Atan2(b.Easting - a.Easting, b.Northing - a.Northing);
+        double headingDeg = heading * 180.0 / Math.PI;
+        if (headingDeg < 0) headingDeg += 360;
 
-        vm.CurrentABCreationMode = ABCreationMode.DrawAB;
-        vm.CurrentABPointStep = ABPointStep.SettingPointA;
-        vm.SetABPointCommand?.Execute(posA);
-        vm.SetABPointCommand?.Execute(posB);
+        // Store the actual clicked A/B points (not extended past boundary)
+        var track = new Models.Track.Track
+        {
+            Name = $"AB_{headingDeg:F1} {DateTime.Now:HH:mm:ss}",
+            Points = new List<Vec3> { new Vec3(a.Easting, a.Northing, heading), new Vec3(b.Easting, b.Northing, heading) },
+            Type = Models.Track.TrackType.ABLine,
+            IsVisible = true
+        };
+
+        foreach (var existing in vm.SavedTracks)
+            existing.IsActive = false;
+
+        vm.SavedTracks.Add(track);
+        vm.SelectedTrack = track;
 
         ExitDrawMode();
         ShowMainTabs();

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -353,14 +353,12 @@ public partial class FieldBuilderDialogPanel : UserControl
         var finishPanel = this.FindControl<StackPanel>("FinishDrawBtnPanel");
         var headingPanel = this.FindControl<StackPanel>("HeadingInputPanel");
         var headingInput = this.FindControl<TextBox>("HeadingInput");
-        var extPanel = this.FindControl<StackPanel>("ExtendShrinkPanel");
 
         if (drawPanel != null) drawPanel.IsVisible = true;
         if (instrText != null) instrText.Text = "Edit headland line - adjust offset and endpoints";
         if (pointCountText != null) pointCountText.Text = "";
         if (createPanel != null) createPanel.IsVisible = true;
         if (finishPanel != null) finishPanel.IsVisible = false;
-        if (extPanel != null) extPanel.IsVisible = true;
 
         if (headingPanel != null) headingPanel.IsVisible = true;
         if (headingInput != null)
@@ -440,60 +438,6 @@ public partial class FieldBuilderDialogPanel : UserControl
         vm.HeadlandSegments.Remove(vm.SelectedHeadlandSegment);
         vm.SelectedHeadlandSegment = null;
         vm.BuildHeadlandFromSegments();
-        UpdatePreview();
-    }
-
-    private void ExtendStart_Click(object? sender, RoutedEventArgs e)
-    {
-        if (!_session.IsHeadland || !_session.IsPreview || _session.BoundaryPoly == null) return;
-        if (_session.BoundaryStartIndex < 0) return;
-
-        var pts = _session.BoundaryPoly.Points;
-        int count = pts.Count;
-        // Move start index one step backward along boundary
-        _session.BoundaryStartIndex = (_session.BoundaryStartIndex - 1 + count) % count;
-
-        var newPt = pts[_session.BoundaryStartIndex];
-        _session.Points.Insert(0, new Vec3(newPt.Easting, newPt.Northing, newPt.Heading));
-        UpdatePreview();
-    }
-
-    private void ShrinkStart_Click(object? sender, RoutedEventArgs e)
-    {
-        if (!_session.IsHeadland || !_session.IsPreview || _session.Points.Count <= 2) return;
-        _session.Points.RemoveAt(0);
-        if (_session.BoundaryPoly != null)
-        {
-            int count = _session.BoundaryPoly.Points.Count;
-            _session.BoundaryStartIndex = (_session.BoundaryStartIndex + 1) % count;
-        }
-        UpdatePreview();
-    }
-
-    private void ExtendEnd_Click(object? sender, RoutedEventArgs e)
-    {
-        if (!_session.IsHeadland || !_session.IsPreview || _session.BoundaryPoly == null) return;
-        if (_session.BoundaryEndIndex < 0) return;
-
-        var pts = _session.BoundaryPoly.Points;
-        int count = pts.Count;
-        // Move end index one step forward along boundary
-        _session.BoundaryEndIndex = (_session.BoundaryEndIndex + 1) % count;
-
-        var newPt = pts[_session.BoundaryEndIndex];
-        _session.Points.Add(new Vec3(newPt.Easting, newPt.Northing, newPt.Heading));
-        UpdatePreview();
-    }
-
-    private void ShrinkEnd_Click(object? sender, RoutedEventArgs e)
-    {
-        if (!_session.IsHeadland || !_session.IsPreview || _session.Points.Count <= 2) return;
-        _session.Points.RemoveAt(_session.Points.Count - 1);
-        if (_session.BoundaryPoly != null)
-        {
-            int count = _session.BoundaryPoly.Points.Count;
-            _session.BoundaryEndIndex = (_session.BoundaryEndIndex - 1 + count) % count;
-        }
         UpdatePreview();
     }
 
@@ -716,8 +660,6 @@ public partial class FieldBuilderDialogPanel : UserControl
                 }
 
                 // Show extend/shrink for headland preview
-                var extPanel = this.FindControl<StackPanel>("ExtendShrinkPanel");
-                if (extPanel != null) extPanel.IsVisible = _session.IsHeadland && _session.IsPreview;
 
                 // Hide heading/offset input for non-headland, non-APlus modes
                 if (!_session.IsHeadland && _session.Target != DrawTarget.TrackAPlus)
@@ -975,8 +917,6 @@ public partial class FieldBuilderDialogPanel : UserControl
                 // Reset back to picking mode
                 _session.Phase = DrawPhase.PickingA;
                 if (createPanel != null) createPanel.IsVisible = false;
-                var extPanel = this.FindControl<StackPanel>("ExtendShrinkPanel");
-                if (extPanel != null) extPanel.IsVisible = false;
                 var headingPanel = this.FindControl<StackPanel>("HeadingInputPanel");
                 if (headingPanel != null) headingPanel.IsVisible = false;
                 SetCanvasStatus("Click point on boundary");
@@ -1237,8 +1177,6 @@ public partial class FieldBuilderDialogPanel : UserControl
         _session.Reset();
         var drawPanel = this.FindControl<Border>("DrawModePanel");
         if (drawPanel != null) drawPanel.IsVisible = false;
-        var extPanel = this.FindControl<StackPanel>("ExtendShrinkPanel");
-        if (extPanel != null) extPanel.IsVisible = false;
         SetCanvasStatus(null);
     }
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -1403,24 +1403,27 @@ public partial class FieldBuilderDialogPanel : UserControl
         bool onHeadlandTab = mainTabs is { IsVisible: true, SelectedIndex: 1 };
         bool isDrawing = _session.IsActive || onHeadlandTab;
 
-        // Draw output headland path (yellow dashed, distinct from boundary)
+        // Draw output headland path (reduced on non-headland tabs)
         if (vm.HasHeadland && vm.CurrentHeadlandLineForPreview != null)
         {
             var headPts = vm.CurrentHeadlandLineForPreview;
             if (headPts.Count >= 3)
             {
-                var headlandColor = light ? Color.FromRgb(200, 180, 0) : Color.FromRgb(255, 230, 50);
+                var headlandColor = onHeadlandTab
+                    ? (light ? Color.FromRgb(200, 180, 0) : Color.FromRgb(255, 230, 50))
+                    : (light ? Color.FromArgb(120, 180, 160, 0) : Color.FromArgb(120, 200, 180, 40));
                 var headlandPoly = new Polygon
                 {
                     Stroke = new SolidColorBrush(headlandColor),
-                    StrokeThickness = 4,
+                    StrokeThickness = onHeadlandTab ? 4 : 2,
                     Points = headPts.Select(p => ToCanvas(p.Easting, p.Northing)).ToList()
                 };
                 canvas.Children.Add(headlandPoly);
             }
         }
 
-        // Draw headland segments (offset lines with extensions, ON TOP of headland path)
+        // Draw headland segments (only on headland tab)
+        if (!onHeadlandTab) goto SkipSegments;
         foreach (var seg in vm.HeadlandSegments)
         {
             if (seg.OffsetPoints.Count < 2) continue;
@@ -1470,6 +1473,7 @@ public partial class FieldBuilderDialogPanel : UserControl
             }
         }
 
+        SkipSegments:
         // Draw tracks
         foreach (var track in vm.SavedTracks)
         {

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -781,9 +781,11 @@ public partial class FieldBuilderDialogPanel : UserControl
             if (headingInput != null) double.TryParse(headingInput.Text, out offset);
 
             bool isCurve = _session.Points.Count > 2;
+            string segName = _session.BackupSegment?.Name
+                ?? $"{(isCurve ? "Curve" : "Line")} {vm.HeadlandSegments.Count + 1}";
             var segment = new Models.Headland.HeadlandSegment
             {
-                Name = $"{(isCurve ? "Curve" : "Line")} {vm.HeadlandSegments.Count + 1}",
+                Name = segName,
                 Type = isCurve ? Models.Headland.HeadlandSegmentType.Curve : Models.Headland.HeadlandSegmentType.Line,
                 Offset = offset,
                 BoundaryStartIndex = _session.BoundaryStartIndex,

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -407,8 +407,33 @@ public partial class FieldBuilderDialogPanel : UserControl
         }
         else if (track.Points.Count == 2)
         {
-            _session.Target = DrawTarget.TrackABLine;
+            // Check if both points are on the boundary (boundary-derived track)
+            bool isBoundaryLine = false;
+            var bndPoly = vm.CurrentBoundary?.OuterBoundary;
+            if (bndPoly?.Points != null)
+            {
+                bool aOnBnd = false, bOnBnd = false;
+                foreach (var bp in bndPoly.Points)
+                {
+                    double dA = Math.Pow(bp.Easting - track.Points[0].Easting, 2) + Math.Pow(bp.Northing - track.Points[0].Northing, 2);
+                    double dB = Math.Pow(bp.Easting - track.Points[1].Easting, 2) + Math.Pow(bp.Northing - track.Points[1].Northing, 2);
+                    if (dA < 1.0) aOnBnd = true;
+                    if (dB < 1.0) bOnBnd = true;
+                    if (aOnBnd && bOnBnd) break;
+                }
+                isBoundaryLine = aOnBnd && bOnBnd;
+            }
+
+            _session.Target = isBoundaryLine ? DrawTarget.TrackBoundaryLine : DrawTarget.TrackABLine;
             _session.Phase = DrawPhase.Preview;
+
+            if (isBoundaryLine && bndPoly != null)
+            {
+                _session.BoundaryPoly = bndPoly;
+                // Find boundary indices for the two points
+                _session.BoundaryStartIndex = _session.FindNearestBoundaryPoint(track.Points[0].Easting, track.Points[0].Northing);
+                _session.BoundaryEndIndex = _session.FindNearestBoundaryPoint(track.Points[1].Easting, track.Points[1].Northing);
+            }
         }
         else
         {

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -394,8 +394,10 @@ public partial class FieldBuilderDialogPanel : UserControl
         }
         else
         {
-            _session.Target = DrawTarget.TrackCurve;
-            _session.Phase = DrawPhase.PickingMore;
+            // Curves with many points are likely boundary-derived, use boundary curve mode
+            // for proper snapping and endpoint-only display
+            _session.Target = DrawTarget.TrackBoundaryCurve;
+            _session.Phase = DrawPhase.Preview;
         }
 
         // Remove the track (will be re-added when Create is clicked)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -1568,6 +1568,15 @@ public partial class FieldBuilderDialogPanel : UserControl
                 // For curve previews, only show first and last markers
                 if (isCurvePreview && i > 0 && i < _session.Points.Count - 1) continue;
 
+                // For A+ preview (3 points: A_ext, origin, B_ext), only show origin marker
+                if (_session.Target == DrawTarget.TrackAPlus && _session.IsPreview && _session.Points.Count == 3)
+                {
+                    if (i != 1) continue; // Only show origin (middle point)
+                    var aPt = ToCanvas(_session.Points[1].Easting, _session.Points[1].Northing);
+                    AddMarker(canvas, aPt, new SolidColorBrush(Color.FromRgb(218, 165, 32)), "A+", light);
+                    continue;
+                }
+
                 var pt = ToCanvas(_session.Points[i].Easting, _session.Points[i].Northing);
                 string? label = null;
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -1425,9 +1425,13 @@ public partial class FieldBuilderDialogPanel : UserControl
         {
             if (seg.OffsetPoints.Count < 2) continue;
             bool segSelected = seg == vm.SelectedHeadlandSegment && !_session.IsActive;
-            var segColor = new SolidColorBrush(segSelected
-                ? (light ? Color.FromRgb(0, 140, 0) : Color.FromRgb(80, 255, 80))
-                : (light ? Color.FromRgb(30, 160, 30) : Color.FromRgb(50, 200, 50)));
+            IBrush segColor;
+            if (!seg.IsEffective)
+                segColor = new SolidColorBrush(light ? Color.FromRgb(200, 60, 60) : Color.FromRgb(255, 80, 80)); // Red = doesn't form loop
+            else if (segSelected)
+                segColor = new SolidColorBrush(light ? Color.FromRgb(0, 140, 0) : Color.FromRgb(80, 255, 80));
+            else
+                segColor = new SolidColorBrush(light ? Color.FromRgb(30, 160, 30) : Color.FromRgb(50, 200, 50));
 
             // Build full line with extensions
             var segPts = new List<Point>();

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -441,6 +441,17 @@ public partial class FieldBuilderDialogPanel : UserControl
             // for proper snapping and endpoint-only display
             _session.Target = DrawTarget.TrackBoundaryCurve;
             _session.Phase = DrawPhase.Preview;
+
+            // Set up boundary info for drag snapping and re-extraction
+            var bndPoly2 = vm.CurrentBoundary?.OuterBoundary;
+            if (bndPoly2?.Points != null)
+            {
+                _session.BoundaryPoly = bndPoly2;
+                _session.BoundaryStartIndex = _session.FindNearestBoundaryPoint(
+                    track.Points[0].Easting, track.Points[0].Northing);
+                _session.BoundaryEndIndex = _session.FindNearestBoundaryPoint(
+                    track.Points[^1].Easting, track.Points[^1].Northing);
+            }
         }
 
         // Remove the track (will be re-added when Create is clicked)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -636,8 +636,10 @@ public partial class FieldBuilderDialogPanel : UserControl
 
                 var createPanel = this.FindControl<StackPanel>("CreateABBtnPanel");
                 var finishPanel = this.FindControl<StackPanel>("FinishDrawBtnPanel");
+                var headingPanel = this.FindControl<StackPanel>("HeadingInputPanel");
                 if (createPanel != null) createPanel.IsVisible = true;
                 if (finishPanel != null) finishPanel.IsVisible = false;
+                if (headingPanel != null) headingPanel.IsVisible = false;
             }
         }
         else if (_session.Target == DrawTarget.TrackCurve)
@@ -714,6 +716,13 @@ public partial class FieldBuilderDialogPanel : UserControl
                 // Show extend/shrink for headland preview
                 var extPanel = this.FindControl<StackPanel>("ExtendShrinkPanel");
                 if (extPanel != null) extPanel.IsVisible = _session.IsHeadland && _session.IsPreview;
+
+                // Hide heading/offset input for non-headland, non-APlus modes
+                if (!_session.IsHeadland && _session.Target != DrawTarget.TrackAPlus)
+                {
+                    var hp = this.FindControl<StackPanel>("HeadingInputPanel");
+                    if (hp != null) hp.IsVisible = false;
+                }
 
                 UpdateDrawModeInfo();
                 var createPanel2 = this.FindControl<StackPanel>("CreateABBtnPanel");

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -872,28 +872,8 @@ public partial class FieldBuilderDialogPanel : UserControl
 
         if (_session.Target == DrawTarget.TrackBoundaryCurve && _session.IsPreview)
         {
-            // Extend curve straight past endpoints
+            // Store the actual boundary segment points (A/B at selected positions)
             var points = new List<Vec3>(_session.Points);
-            double ext = 200; // 200m extension
-
-            if (points.Count >= 2)
-            {
-                var s0 = points[0];
-                var s1 = points[1];
-                double sdx = s0.Easting - s1.Easting;
-                double sdy = s0.Northing - s1.Northing;
-                double slen = Math.Sqrt(sdx * sdx + sdy * sdy);
-                if (slen > 0.01)
-                    points.Insert(0, new Vec3(s0.Easting + sdx / slen * ext, s0.Northing + sdy / slen * ext, s0.Heading));
-
-                var e0 = points[^2];
-                var e1 = points[^1];
-                double edx = e1.Easting - e0.Easting;
-                double edy = e1.Northing - e0.Northing;
-                double elen = Math.Sqrt(edx * edx + edy * edy);
-                if (elen > 0.01)
-                    points.Add(new Vec3(e1.Easting + edx / elen * ext, e1.Northing + edy / elen * ext, e1.Heading));
-            }
 
             var track = new Models.Track.Track
             {

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -385,7 +385,27 @@ public partial class FieldBuilderDialogPanel : UserControl
         _session.BoundaryPoly = vm.CurrentBoundary?.OuterBoundary;
         _session.Points.AddRange(track.Points);
 
-        if (track.Points.Count == 2)
+        bool isAPlus = track.Name?.StartsWith("A+") == true;
+
+        if (isAPlus && track.Points.Count == 2)
+        {
+            _session.Target = DrawTarget.TrackAPlus;
+            _session.Phase = DrawPhase.Preview;
+            // Compute heading from the two track points
+            double headingRad = Math.Atan2(
+                track.Points[1].Easting - track.Points[0].Easting,
+                track.Points[1].Northing - track.Points[0].Northing);
+            _session.Heading = headingRad * 180.0 / Math.PI;
+            if (_session.Heading < 0) _session.Heading += 360;
+            // Set origin at midpoint
+            var mid = new Vec3(
+                (track.Points[0].Easting + track.Points[1].Easting) / 2,
+                (track.Points[0].Northing + track.Points[1].Northing) / 2,
+                headingRad);
+            _session.Points.Clear();
+            _session.Points.Add(mid);
+        }
+        else if (track.Points.Count == 2)
         {
             _session.Target = DrawTarget.TrackABLine;
             _session.Phase = DrawPhase.Preview;
@@ -416,7 +436,22 @@ public partial class FieldBuilderDialogPanel : UserControl
         var tabs = this.FindControl<TabControl>("MainTabs");
         if (tabs != null) tabs.IsVisible = false;
 
-        if (track.Points.Count == 2)
+        if (isAPlus)
+        {
+            if (instrText != null) instrText.Text = "Edit A+ line - adjust heading";
+            if (pointCountText != null) pointCountText.Text = "Point set";
+            var headingPanel = this.FindControl<StackPanel>("HeadingInputPanel");
+            var headingInput = this.FindControl<TextBox>("HeadingInput");
+            if (headingPanel != null) headingPanel.IsVisible = true;
+            if (headingInput != null)
+            {
+                headingInput.Text = _session.Heading.ToString("F1");
+                headingInput.Focus();
+                headingInput.SelectAll();
+            }
+            UpdateAPlusPreview();
+        }
+        else if (track.Points.Count == 2)
         {
             if (instrText != null) instrText.Text = "Edit AB line - drag points or Create";
             if (pointCountText != null) pointCountText.Text = "A and B set";
@@ -758,7 +793,7 @@ public partial class FieldBuilderDialogPanel : UserControl
             var posB = _session.Points[^1];
             var track = new Models.Track.Track
             {
-                Name = $"A+ {headingDeg:F1}",
+                Name = _session.BackupTrack?.Name ?? $"A+ {headingDeg:F1}",
                 Points = new List<Vec3> { posA, posB },
                 Type = TrackType.ABLine,
                 IsVisible = true
@@ -837,7 +872,7 @@ public partial class FieldBuilderDialogPanel : UserControl
 
             var track = new Models.Track.Track
             {
-                Name = $"BndCurve {DateTime.Now:HH:mm:ss}",
+                Name = _session.BackupTrack?.Name ?? $"BndCurve {DateTime.Now:HH:mm:ss}",
                 Points = points,
                 Type = TrackType.Curve,
                 IsVisible = true
@@ -872,7 +907,7 @@ public partial class FieldBuilderDialogPanel : UserControl
         // Store the actual clicked A/B points (not extended past boundary)
         var track = new Models.Track.Track
         {
-            Name = $"AB_{headingDeg:F1} {DateTime.Now:HH:mm:ss}",
+            Name = _session.BackupTrack?.Name ?? $"AB_{headingDeg:F1} {DateTime.Now:HH:mm:ss}",
             Points = new List<Vec3> { new Vec3(a.Easting, a.Northing, heading), new Vec3(b.Easting, b.Northing, heading) },
             Type = Models.Track.TrackType.ABLine,
             IsVisible = true

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
@@ -64,51 +64,46 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
 
-            <!-- Menu Items: 2-column layout (5 rows x 2 columns) -->
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="4" Background="Transparent">
-                <!-- Row 0: Boundary, (Blank) -->
+            <!-- Menu Items: 2-column compact layout -->
+            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="4" Background="Transparent">
+                <!-- Row 0: Field Builder, Boundary -->
                 <Button Grid.Column="0" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowBoundaryDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize Boundary}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <!-- Grid.Column="1" Grid.Row="0" is intentionally blank -->
-
-                <!-- Row 1: Field Builder -->
-                <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press" Command="{Binding ShowFieldBuilderCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Headache.png" Width="28" Height="28"/>
                         <TextBlock Text="Field Builder" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
+                <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
+                        ClickMode="Press" Command="{Binding ShowBoundaryDialogCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="28" Height="28"/>
+                        <TextBlock Text="{loc:Localize Boundary}" VerticalAlignment="Center" FontSize="12"/>
+                    </StackPanel>
+                </Button>
 
-                <!-- Row 2: Tram Lines toggle and builder moved to bottom panel and Field Builder -->
-
-                <!-- Row 3: Delete Applied Area, Flag By Lat Lon -->
-                <Button Grid.Column="0" Grid.Row="3" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
+                <!-- Row 1: Delete Applied Area, Import Tracks -->
+                <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press" Command="{Binding DeleteAppliedAreaCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TrashApplied.png" Width="28" Height="28"/>
                         <TextBlock Text="{loc:Localize DeleteAppliedArea}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
-
-                <!-- Row 4: Recorded Path, Import Tracks -->
-                <Button Grid.Column="0" Grid.Row="4" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ToggleRecordedPathPanelCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/RecPath.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize RecordedPath}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="4" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
+                <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
                         ClickMode="Press" Command="{Binding ImportTracksCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryFromTracks.png" Width="28" Height="28"/>
                         <TextBlock Text="{loc:Localize ImportTracks}" VerticalAlignment="Center" FontSize="12"/>
+                    </StackPanel>
+                </Button>
+
+                <!-- Row 2: Recorded Path -->
+                <Button Grid.Column="0" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
+                        ClickMode="Press" Command="{Binding ToggleRecordedPathPanelCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/RecPath.png" Width="28" Height="28"/>
+                        <TextBlock Text="{loc:Localize RecordedPath}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
@@ -1,0 +1,1005 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Headland;
+
+namespace AgValoniaGPS.ViewModels.Tests;
+
+/// <summary>
+/// Tests for chained/multiple headland segment configurations.
+/// Focus areas: chain merging, multi-line boundary intersection, polygon splitting.
+/// </summary>
+[TestFixture]
+public class HeadlandChainTests
+{
+    /// <summary>
+    /// Creates a VM with a rectangular boundary.
+    /// </summary>
+    private static MainViewModel CreateVmWithBoundary(double width = 200, double height = 200)
+    {
+        var vm = new MainViewModelBuilder().Build();
+        var boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new BoundaryPoint(0, 0, 0),
+                    new BoundaryPoint(width, 0, Math.PI / 2),
+                    new BoundaryPoint(width, height, Math.PI),
+                    new BoundaryPoint(0, height, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(vm, boundary);
+        return vm;
+    }
+
+    /// <summary>
+    /// Helper: get the headland polygon after building.
+    /// </summary>
+    private static List<Vec3>? GetHeadlandLine(MainViewModel vm)
+    {
+        return (List<Vec3>?)typeof(MainViewModel).GetField("_currentHeadlandLine",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(vm);
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 1: Two lines forming an L-shape
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void TwoLines_LShape_BottomAndRight_BothEffective()
+    {
+        // Line A: along bottom edge (horizontal), touches left and right boundary
+        // Line B: along right edge (vertical), touches bottom and top boundary
+        // Both individually reach boundary on both ends -> no chaining needed
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var segA = new HeadlandSegment
+        {
+            Name = "Bottom Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(40, 10, Math.PI / 2), new Vec3(160, 10, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+        var segB = new HeadlandSegment
+        {
+            Name = "Right Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(190, 40, 0), new Vec3(190, 160, 0) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(segA.IsEffective, Is.True, "Bottom line should be effective (both ends reach boundary)");
+        Assert.That(segB.IsEffective, Is.True, "Right line should be effective (both ends reach boundary)");
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        // Headland should be smaller than the full boundary (two cuts applied)
+        double headArea = Math.Abs(CalculateArea(headland!));
+        Assert.That(headArea, Is.LessThan(200 * 200), "Headland should be smaller than full boundary");
+    }
+
+    [Test]
+    public void TwoLines_LShape_ChainedOnly_MergesAndCuts()
+    {
+        // Line A: vertical, only reaches bottom boundary, other end meets Line B
+        // Line B: horizontal, only reaches right boundary, other end meets Line A
+        // They must chain together to cut the headland
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Line A: vertical at x=30, from y=10 to y=80
+        // Start extension reaches y=0 (bottom boundary), end extension reaches y~95
+        var segA = new HeadlandSegment
+        {
+            Name = "Line A (vertical)",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(30, 10, 0), new Vec3(30, 80, 0) },
+            StartExtension = 20,
+            EndExtension = 30
+        };
+
+        // Line B: horizontal at y=90, from x=20 to x=180
+        // Start extension reaches x~0 (overlaps with Line A), end extension reaches x=200 (right boundary)
+        var segB = new HeadlandSegment
+        {
+            Name = "Line B (horizontal)",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(20, 90, Math.PI / 2), new Vec3(180, 90, Math.PI / 2) },
+            StartExtension = 30,
+            EndExtension = 30
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        // The merged chain should be effective
+        bool anyEffective = segA.IsEffective || segB.IsEffective;
+        Assert.That(anyEffective, Is.True,
+            $"L-shaped chain should be effective. A={segA.IsEffective}, B={segB.IsEffective}");
+        Assert.That(vm.HasHeadland, Is.True);
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 2: Two parallel lines (no chaining)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void TwoParallelLines_IndependentCuts()
+    {
+        // Two horizontal lines that both reach left and right boundary independently
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var segA = new HeadlandSegment
+        {
+            Name = "Lower Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(20, 30, Math.PI / 2), new Vec3(180, 30, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+        var segB = new HeadlandSegment
+        {
+            Name = "Upper Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(20, 170, Math.PI / 2), new Vec3(180, 170, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(segA.IsEffective, Is.True, "Lower parallel line should be effective");
+        Assert.That(segB.IsEffective, Is.True, "Upper parallel line should be effective");
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        // Both lines cut the boundary, headland should be smaller
+        double headArea = Math.Abs(CalculateArea(headland!));
+        Assert.That(headArea, Is.LessThan(200 * 200 * 0.8),
+            "Two parallel cuts should reduce area significantly");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 3: Chain merge direction - A's boundary end is at END (not start)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void ChainMerge_AEndTouchesBoundary_StillWorks()
+    {
+        // Line A: horizontal, right end reaches right boundary, left end meets Line B
+        // Line B: vertical, bottom end reaches bottom boundary, top end meets Line A
+        // After merge, chain should go: B_bottom_boundary -> B -> intersection -> A -> A_right_boundary
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Line A: horizontal at y=50, from x=50 to x=170
+        // Both extensions long enough: start reaches past left boundary, end reaches right boundary
+        // After merge, the combined chain should use A's far-end to reach right boundary
+        var segA = new HeadlandSegment
+        {
+            Name = "Line A (right-reaching)",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(50, 50, Math.PI / 2), new Vec3(170, 50, Math.PI / 2) },
+            StartExtension = 80,
+            EndExtension = 50
+        };
+
+        // Line B: vertical at x=40, from y=10 to y=60
+        // StartExtension reaches past bottom boundary, EndExtension meets Line A
+        var segB = new HeadlandSegment
+        {
+            Name = "Line B (bottom-reaching)",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(40, 10, 0), new Vec3(40, 60, 0) },
+            StartExtension = 30,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        bool anyEffective = segA.IsEffective || segB.IsEffective;
+        Assert.That(anyEffective, Is.True,
+            $"Chain where A's END touches boundary should work. A={segA.IsEffective}, B={segB.IsEffective}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 4: Three lines forming a U-shape
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void ThreeLines_UShape_FullChain()
+    {
+        // Line A: vertical on left, touches top boundary, meets Line B at bottom
+        // Line B: horizontal at bottom, connects A and C
+        // Line C: vertical on right, touches top boundary, meets Line B at bottom
+        // Together they form a U that cuts off the bottom of the field
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var segA = new HeadlandSegment
+        {
+            Name = "Left Vertical",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(30, 190, 0), new Vec3(30, 40, 0) },
+            StartExtension = 20, // Reaches y=210, past top boundary
+            EndExtension = 30    // Reaches y=10, meets Line B
+        };
+        var segB = new HeadlandSegment
+        {
+            Name = "Bottom Horizontal",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(25, 30, Math.PI / 2), new Vec3(175, 30, Math.PI / 2) },
+            StartExtension = 20,  // Meets Line A
+            EndExtension = 20     // Meets Line C
+        };
+        var segC = new HeadlandSegment
+        {
+            Name = "Right Vertical",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(170, 40, 0), new Vec3(170, 190, 0) },
+            StartExtension = 30,  // Reaches y=10, meets Line B
+            EndExtension = 20     // Reaches y=210, past top boundary
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.ComputeSegmentOffset(segC);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.HeadlandSegments.Add(segC);
+        vm.BuildHeadlandFromSegments();
+
+        bool anyEffective = segA.IsEffective || segB.IsEffective || segC.IsEffective;
+        Assert.That(anyEffective, Is.True,
+            $"U-shape (3 lines) should form effective chain. " +
+            $"A={segA.IsEffective}, B={segB.IsEffective}, C={segC.IsEffective}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 5: Two lines at acute angle (V-shape)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void TwoLines_VShape_AcuteAngle()
+    {
+        // Two lines meeting at a sharp angle at the bottom,
+        // each reaching boundary on their other end
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Line A: from left boundary area down to bottom-center
+        var segA = new HeadlandSegment
+        {
+            Name = "Left Arm",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(10, 100, 0), new Vec3(90, 30, 0) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        // Line B: from bottom-center up to right boundary area
+        var segB = new HeadlandSegment
+        {
+            Name = "Right Arm",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(110, 30, 0), new Vec3(190, 100, 0) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        // Both lines should individually reach boundary, or chain together
+        bool anyEffective = segA.IsEffective || segB.IsEffective;
+        Assert.That(anyEffective, Is.True,
+            $"V-shape lines should be effective. A={segA.IsEffective}, B={segB.IsEffective}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 6: Chain where intersection is in middle of A (not near end)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void ChainMerge_IntersectionAtMiddleOfA_PreservesChain()
+    {
+        // Line A: long line across the field
+        // Line B: crosses A at its midpoint
+        // After merge, half of A gets cut off - the merged chain should still work
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Line A: diagonal from bottom-left to top-right
+        var segA = new HeadlandSegment
+        {
+            Name = "Diagonal A",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new() { new Vec3(10, 10, Math.PI / 4), new Vec3(190, 190, Math.PI / 4) },
+            StartExtension = 20,
+            EndExtension = 20
+        };
+
+        // Line B: horizontal crossing A near the middle
+        var segB = new HeadlandSegment
+        {
+            Name = "Horizontal B",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new() { new Vec3(10, 100, Math.PI / 2), new Vec3(190, 100, Math.PI / 2) },
+            StartExtension = 20,
+            EndExtension = 20
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        // Both should individually reach boundary (long extensions + spans full field)
+        // If they get merged, the merge shouldn't break them
+        Assert.That(segA.IsEffective || segB.IsEffective, Is.True,
+            $"Crossing lines should produce at least one effective segment. A={segA.IsEffective}, B={segB.IsEffective}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 7: Two lines each touching boundary on ONE end, meeting each other on the other
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void TwoLines_EachOneSideBoundary_ChainConnects()
+    {
+        // Two lines that each touch boundary on one end and meet at an angle in the middle
+        // Line A goes from left boundary down to center-bottom
+        // Line B goes from center-bottom up to right boundary
+        // Together they form a V-shaped chain cutting the bottom of the field
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Line A: from left-center down to bottom-center
+        var segA = new HeadlandSegment
+        {
+            Name = "Left Arm",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(10, 80, 0), new Vec3(90, 30, 0) },
+            StartExtension = 50,  // Past left boundary
+            EndExtension = 50     // Into field, meets B
+        };
+
+        // Line B: from bottom-center up to right-center
+        var segB = new HeadlandSegment
+        {
+            Name = "Right Arm",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(110, 30, 0), new Vec3(190, 80, 0) },
+            StartExtension = 50,  // Into field, meets A
+            EndExtension = 50     // Past right boundary
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        bool anyEffective = segA.IsEffective || segB.IsEffective;
+        Assert.That(anyEffective, Is.True,
+            $"V-shaped chain should be effective. A={segA.IsEffective}, B={segB.IsEffective}");
+
+        if (anyEffective)
+        {
+            var headland = GetHeadlandLine(vm);
+            Assert.That(headland, Is.Not.Null);
+            double headArea = Math.Abs(CalculateArea(headland!));
+            Assert.That(headArea, Is.LessThan(200 * 200 * 0.8),
+                $"Chain should cut area. Head area: {headArea:F0}, full: {200 * 200}");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 8: Merged chain still not reaching boundary
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void TwoLines_ChainedButShort_NotEffective()
+    {
+        // Two short lines that chain together but the combined result
+        // still doesn't reach the boundary on both ends
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var segA = new HeadlandSegment
+        {
+            Name = "Short A",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new() { new Vec3(60, 90, Math.PI / 2), new Vec3(90, 90, Math.PI / 2) },
+            StartExtension = 10,  // Reaches x=50, not boundary
+            EndExtension = 20     // Reaches x=110, meets B
+        };
+        var segB = new HeadlandSegment
+        {
+            Name = "Short B",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new() { new Vec3(100, 90, Math.PI / 2), new Vec3(130, 90, Math.PI / 2) },
+            StartExtension = 20,  // Reaches x=80, meets A
+            EndExtension = 10     // Reaches x=140, not boundary
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        // Even merged, the chain shouldn't reach boundary on both sides
+        bool anyEffective = segA.IsEffective || segB.IsEffective;
+        Assert.That(anyEffective, Is.False,
+            $"Short chained lines shouldn't reach boundary. A={segA.IsEffective}, B={segB.IsEffective}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 9: Line + Curve chaining
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void LineAndCurve_ChainTogether()
+    {
+        // A straight line meets a curve, forming a combined headland cut
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Line: vertical near left side, from y=10 to y=80
+        // Start extension long enough to reach bottom boundary after offset
+        var segLine = new HeadlandSegment
+        {
+            Name = "Vertical Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(20, 10, 0), new Vec3(20, 80, 0) },
+            StartExtension = 50,  // Past bottom boundary
+            EndExtension = 50     // Into field, meets curve
+        };
+
+        // Curve: quarter circle from left-center toward top
+        var curvePts = new List<Vec3>();
+        for (int i = 0; i <= 20; i++)
+        {
+            double angle = i * Math.PI / 2 / 20;
+            curvePts.Add(new Vec3(20 + 80 * Math.Sin(angle), 80 + 80 * (1 - Math.Cos(angle)), angle));
+        }
+        var segCurve = new HeadlandSegment
+        {
+            Name = "Corner Curve",
+            Type = HeadlandSegmentType.Curve,
+            Offset = 15,
+            BoundaryPoints = curvePts,
+            StartExtension = 50,  // Meets line
+            EndExtension = 50     // Past top boundary
+        };
+
+        vm.ComputeSegmentOffset(segLine);
+        vm.ComputeSegmentOffset(segCurve);
+        vm.HeadlandSegments.Add(segLine);
+        vm.HeadlandSegments.Add(segCurve);
+        vm.BuildHeadlandFromSegments();
+
+        bool anyEffective = segLine.IsEffective || segCurve.IsEffective;
+        Assert.That(anyEffective, Is.True,
+            $"Line+curve chain should be effective. Line={segLine.IsEffective}, Curve={segCurve.IsEffective}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 10: Single long line across entire field
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void SingleLongLine_CutsFieldInHalf()
+    {
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var seg = new HeadlandSegment
+        {
+            Name = "Full Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(10, 100, Math.PI / 2), new Vec3(190, 100, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.True, "Line spanning full field should be effective");
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        double headArea = Math.Abs(CalculateArea(headland!));
+        double fullArea = 200 * 200;
+        // Should cut off roughly bottom ~40% (offset shifts line by 20m toward centroid)
+        Assert.That(headArea, Is.LessThan(fullArea * 0.85).And.GreaterThan(fullArea * 0.3),
+            $"Area after cut: {headArea:F0}, full: {fullArea:F0}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 11: Two cuts from opposite sides
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void TwoLines_OpposingSides_BothCut()
+    {
+        // One line along the bottom, one along the top
+        // Both should cut the headland independently
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var segBottom = new HeadlandSegment
+        {
+            Name = "Bottom Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 30,
+            BoundaryPoints = new() { new Vec3(10, 10, Math.PI / 2), new Vec3(190, 10, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+        var segTop = new HeadlandSegment
+        {
+            Name = "Top Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 30,
+            BoundaryPoints = new() { new Vec3(10, 190, Math.PI / 2), new Vec3(190, 190, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(segBottom);
+        vm.ComputeSegmentOffset(segTop);
+        vm.HeadlandSegments.Add(segBottom);
+        vm.HeadlandSegments.Add(segTop);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(segBottom.IsEffective, Is.True, "Bottom cut should be effective");
+        Assert.That(segTop.IsEffective, Is.True, "Top cut should be effective");
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        double headArea = Math.Abs(CalculateArea(headland!));
+        double fullArea = 200 * 200;
+        // Both sides cut off ~30m each, leaving ~140/200 = 70% of area
+        Assert.That(headArea, Is.LessThan(fullArea * 0.8),
+            $"Two opposing cuts should reduce area. Area: {headArea:F0}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 12: All four sides (complete headland ring)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void FourLines_AllSides_CompleteRing()
+    {
+        // One line along each edge of the 200x200 field
+        // Should produce a smaller square headland inside
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var segments = new[]
+        {
+            new HeadlandSegment
+            {
+                Name = "Bottom", Type = HeadlandSegmentType.Line, Offset = 25,
+                BoundaryPoints = new() { new Vec3(10, 10, Math.PI / 2), new Vec3(190, 10, Math.PI / 2) },
+                StartExtension = 50, EndExtension = 50
+            },
+            new HeadlandSegment
+            {
+                Name = "Right", Type = HeadlandSegmentType.Line, Offset = 25,
+                BoundaryPoints = new() { new Vec3(190, 10, 0), new Vec3(190, 190, 0) },
+                StartExtension = 50, EndExtension = 50
+            },
+            new HeadlandSegment
+            {
+                Name = "Top", Type = HeadlandSegmentType.Line, Offset = 25,
+                BoundaryPoints = new() { new Vec3(190, 190, -Math.PI / 2), new Vec3(10, 190, -Math.PI / 2) },
+                StartExtension = 50, EndExtension = 50
+            },
+            new HeadlandSegment
+            {
+                Name = "Left", Type = HeadlandSegmentType.Line, Offset = 25,
+                BoundaryPoints = new() { new Vec3(10, 190, Math.PI), new Vec3(10, 10, Math.PI) },
+                StartExtension = 50, EndExtension = 50
+            }
+        };
+
+        foreach (var seg in segments)
+        {
+            vm.ComputeSegmentOffset(seg);
+            vm.HeadlandSegments.Add(seg);
+        }
+        vm.BuildHeadlandFromSegments();
+
+        int effectiveCount = segments.Count(s => s.IsEffective);
+        Assert.That(effectiveCount, Is.GreaterThanOrEqualTo(2),
+            $"At least 2 of 4 sides should be effective. " +
+            $"Results: {string.Join(", ", segments.Select(s => $"{s.Name}={s.IsEffective}"))}");
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        double headArea = Math.Abs(CalculateArea(headland!));
+        double fullArea = 200 * 200;
+        // Each cut reduces area; with 4 sides and 25m offset, expect significant reduction
+        Assert.That(headArea, Is.LessThan(fullArea),
+            $"Cuts should reduce area. Area: {headArea:F0}, full: {fullArea:F0}, effective: {effectiveCount}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 13: Headland polygon validity checks
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void HeadlandPolygon_IsClosed()
+    {
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var seg = new HeadlandSegment
+        {
+            Name = "Cut Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(10, 100, Math.PI / 2), new Vec3(190, 100, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        Assert.That(headland!.Count, Is.GreaterThanOrEqualTo(4), "Polygon must have at least 4 points");
+
+        // First and last point should be the same (closed polygon)
+        double closeDist = Math.Sqrt(
+            Math.Pow(headland[0].Easting - headland[^1].Easting, 2) +
+            Math.Pow(headland[0].Northing - headland[^1].Northing, 2));
+        Assert.That(closeDist, Is.LessThan(0.1),
+            $"Polygon should be closed. Gap: {closeDist:F3}m");
+    }
+
+    [Test]
+    public void HeadlandPolygon_NoSelfIntersection()
+    {
+        // After a single cut, the resulting polygon should not self-intersect
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var seg = new HeadlandSegment
+        {
+            Name = "Diagonal Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(10, 10, Math.PI / 4), new Vec3(190, 190, Math.PI / 4) },
+            StartExtension = 30,
+            EndExtension = 30
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+
+        // Check for self-intersections
+        bool hasSelfIntersection = false;
+        for (int i = 0; i < headland!.Count - 2 && !hasSelfIntersection; i++)
+        {
+            for (int j = i + 2; j < headland.Count - 1 && !hasSelfIntersection; j++)
+            {
+                if (i == 0 && j == headland.Count - 2) continue; // Skip closing edge pair
+                if (SegmentsIntersect(headland[i], headland[i + 1], headland[j], headland[j + 1]))
+                    hasSelfIntersection = true;
+            }
+        }
+        Assert.That(hasSelfIntersection, Is.False,
+            $"Headland polygon ({headland.Count} pts) should not self-intersect");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 14: Centroid-based polygon selection
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void CutNearEdge_KeepsLargerWorkingArea()
+    {
+        // A cut near the bottom edge should keep the larger top portion
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var seg = new HeadlandSegment
+        {
+            Name = "Near-Edge Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new() { new Vec3(10, 20, Math.PI / 2), new Vec3(190, 20, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.True);
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        double headArea = Math.Abs(CalculateArea(headland!));
+        double fullArea = 200 * 200;
+        // Cut near bottom (at y~30 after offset) should keep ~85% of area
+        Assert.That(headArea, Is.GreaterThan(fullArea * 0.7),
+            $"Near-edge cut should keep most of the area. Area: {headArea:F0}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 15: Edge cases
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void IdenticalLines_NoDoubleCut()
+    {
+        // Two identical lines should not cause problems
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var seg1 = new HeadlandSegment
+        {
+            Name = "Line 1",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(10, 100, Math.PI / 2), new Vec3(190, 100, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+        var seg2 = new HeadlandSegment
+        {
+            Name = "Line 2",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(10, 100, Math.PI / 2), new Vec3(190, 100, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg1);
+        vm.ComputeSegmentOffset(seg2);
+        vm.HeadlandSegments.Add(seg1);
+        vm.HeadlandSegments.Add(seg2);
+
+        // Should not crash
+        Assert.DoesNotThrow(() => vm.BuildHeadlandFromSegments());
+        Assert.That(vm.HasHeadland, Is.True);
+    }
+
+    [Test]
+    public void ZeroOffsetLine_StillWorks()
+    {
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var seg = new HeadlandSegment
+        {
+            Name = "Zero Offset",
+            Type = HeadlandSegmentType.Line,
+            Offset = 0,
+            BoundaryPoints = new() { new Vec3(10, 100, Math.PI / 2), new Vec3(190, 100, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+
+        Assert.DoesNotThrow(() => vm.BuildHeadlandFromSegments());
+    }
+
+    [Test]
+    public void VeryCloseParallelChainLines_DontMergeIncorrectly()
+    {
+        // Two nearly parallel offset lines very close together
+        // They should NOT merge (parallel lines don't intersect)
+        var vm = CreateVmWithBoundary(200, 200);
+
+        var segA = new HeadlandSegment
+        {
+            Name = "Near-Parallel A",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(10, 98, Math.PI / 2), new Vec3(190, 98, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+        var segB = new HeadlandSegment
+        {
+            Name = "Near-Parallel B",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(10, 102, Math.PI / 2), new Vec3(190, 102, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        // Both should be individually effective (each spans the full field width)
+        Assert.That(segA.IsEffective, Is.True, "Parallel A should be effective independently");
+        Assert.That(segB.IsEffective, Is.True, "Parallel B should be effective independently");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 16: Realistic field with notch (irregular shape)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void IrregularField_TwoChainedLines()
+    {
+        // L-shaped field with a horizontal cut through the wide part
+        var vm = new MainViewModelBuilder().Build();
+
+        // L-shaped boundary: wide bottom (200x100) + narrow left column (100x200)
+        var boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new BoundaryPoint(0, 0, 0),
+                    new BoundaryPoint(200, 0, Math.PI / 2),
+                    new BoundaryPoint(200, 100, Math.PI),
+                    new BoundaryPoint(100, 100, Math.PI),
+                    new BoundaryPoint(100, 200, Math.PI),
+                    new BoundaryPoint(0, 200, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(vm, boundary);
+
+        // Horizontal line through the bottom wide section at y=50
+        // Should cross left boundary at x=0 and right boundary at x=200
+        var seg = new HeadlandSegment
+        {
+            Name = "Wide Section Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 15,
+            BoundaryPoints = new() { new Vec3(20, 50, Math.PI / 2), new Vec3(180, 50, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.True,
+            "Horizontal line across wide section of L-shaped field should be effective");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 17: Sequential cuts (order matters)
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void SequentialCuts_OrderDoesNotBreakResult()
+    {
+        // Two lines: first cuts bottom, second cuts right
+        // Both should be effective regardless of order
+        var vm1 = CreateVmWithBoundary(200, 200);
+        var vm2 = CreateVmWithBoundary(200, 200);
+
+        var segBottom = () => new HeadlandSegment
+        {
+            Name = "Bottom",
+            Type = HeadlandSegmentType.Line,
+            Offset = 25,
+            BoundaryPoints = new() { new Vec3(10, 15, Math.PI / 2), new Vec3(190, 15, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+        var segRight = () => new HeadlandSegment
+        {
+            Name = "Right",
+            Type = HeadlandSegmentType.Line,
+            Offset = 25,
+            BoundaryPoints = new() { new Vec3(185, 10, 0), new Vec3(185, 190, 0) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        // Order 1: Bottom then Right
+        var s1b = segBottom(); var s1r = segRight();
+        vm1.ComputeSegmentOffset(s1b); vm1.ComputeSegmentOffset(s1r);
+        vm1.HeadlandSegments.Add(s1b); vm1.HeadlandSegments.Add(s1r);
+        vm1.BuildHeadlandFromSegments();
+
+        // Order 2: Right then Bottom
+        var s2r = segRight(); var s2b = segBottom();
+        vm2.ComputeSegmentOffset(s2r); vm2.ComputeSegmentOffset(s2b);
+        vm2.HeadlandSegments.Add(s2r); vm2.HeadlandSegments.Add(s2b);
+        vm2.BuildHeadlandFromSegments();
+
+        Assert.That(s1b.IsEffective && s1r.IsEffective, Is.True,
+            $"Order 1: Bottom={s1b.IsEffective}, Right={s1r.IsEffective}");
+        Assert.That(s2r.IsEffective && s2b.IsEffective, Is.True,
+            $"Order 2: Right={s2r.IsEffective}, Bottom={s2b.IsEffective}");
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static double CalculateArea(List<Vec3> polygon)
+    {
+        double area = 0;
+        for (int i = 0; i < polygon.Count; i++)
+        {
+            var p1 = polygon[i];
+            var p2 = polygon[(i + 1) % polygon.Count];
+            area += (p2.Easting - p1.Easting) * (p2.Northing + p1.Northing);
+        }
+        return area / 2.0;
+    }
+
+    private static bool SegmentsIntersect(Vec3 a1, Vec3 a2, Vec3 b1, Vec3 b2)
+    {
+        double d = (a2.Easting - a1.Easting) * (b2.Northing - b1.Northing) -
+                   (a2.Northing - a1.Northing) * (b2.Easting - b1.Easting);
+        if (Math.Abs(d) < 1e-10) return false;
+
+        double t = ((b1.Easting - a1.Easting) * (b2.Northing - b1.Northing) -
+                    (b1.Northing - a1.Northing) * (b2.Easting - b1.Easting)) / d;
+        double u = ((b1.Easting - a1.Easting) * (a2.Northing - a1.Northing) -
+                    (b1.Northing - a1.Northing) * (a2.Easting - a1.Easting)) / d;
+
+        return t > 0.01 && t < 0.99 && u > 0.01 && u < 0.99;
+    }
+}

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
@@ -974,6 +974,192 @@ public class HeadlandChainTests
     }
 
     // ---------------------------------------------------------------
+    // TEST GROUP 18: Regression - dividing line follows merged chain shape
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void LShapeChain_HeadlandFollowsCorner_NotDiagonal()
+    {
+        // Regression: two chained lines forming an L-shape produced a diagonal headland
+        // path because the dividing line used the original segment's 2 points instead
+        // of the merged chain's interior points (the corner).
+        //
+        // Setup: horizontal line across top + vertical line down right side
+        // Expected: headland cuts an L-shaped corner from the top-right
+        // Bug: headland cut diagonally from top-left to bottom-right
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Horizontal line along top: from left toward right
+        var segH = new HeadlandSegment
+        {
+            Name = "Top Horizontal",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(20, 180, Math.PI / 2), new Vec3(160, 180, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 60
+        };
+
+        // Vertical line along right: from top down toward bottom
+        var segV = new HeadlandSegment
+        {
+            Name = "Right Vertical",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(180, 170, Math.PI), new Vec3(180, 20, Math.PI) },
+            StartExtension = 60,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(segH);
+        vm.ComputeSegmentOffset(segV);
+        vm.HeadlandSegments.Add(segH);
+        vm.HeadlandSegments.Add(segV);
+        vm.BuildHeadlandFromSegments();
+
+        bool anyEffective = segH.IsEffective || segV.IsEffective;
+        Assert.That(anyEffective, Is.True,
+            $"L-shape chain should be effective. H={segH.IsEffective}, V={segV.IsEffective}");
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+
+        // Key assertion: the headland path should have a point near the L-corner
+        // (approximately at (160, 160) after offset). If the bug is present,
+        // no headland point will be near this corner - the path goes diagonal.
+        bool hasCornerPoint = false;
+        foreach (var pt in headland!)
+        {
+            // The corner should be roughly where the two offset lines meet
+            // Horizontal offset at y~160, vertical offset at x~160
+            double distToCorner = Math.Sqrt(
+                Math.Pow(pt.Easting - 160, 2) + Math.Pow(pt.Northing - 160, 2));
+            if (distToCorner < 30) // Within 30m of expected corner
+            {
+                hasCornerPoint = true;
+                break;
+            }
+        }
+
+        Assert.That(hasCornerPoint, Is.True,
+            "Headland path should have a point near the L-corner (~160,160), not cut diagonally. " +
+            $"Points: {string.Join("; ", headland.Select(p => $"({p.Easting:F0},{p.Northing:F0})"))}");
+
+        // Additional: area should reflect an L-cut (not a diagonal triangle cut)
+        // L-cut removes ~20m from top + ~20m from right = roughly 200*180 - 20*180 = smaller than diagonal
+        double headArea = Math.Abs(CalculateArea(headland));
+        double fullArea = 200 * 200;
+        // An L-cut from two 20m offsets removes ~7600 (top strip + right strip - corner overlap)
+        // A diagonal cut would remove roughly half the field (~20000)
+        Assert.That(headArea, Is.GreaterThan(fullArea * 0.6),
+            $"L-cut should keep most area (not diagonal). Area: {headArea:F0}, full: {fullArea:F0}");
+    }
+
+    [Test]
+    public void TwoSequentialCuts_SecondCutOnSameHeadlandSegment_Works()
+    {
+        // Regression: after first cut creates a long headland edge, second line
+        // intersects that edge at two points. Old code rejected this because
+        // startIntersectIdx == endIntersectIdx (same segment).
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // First cut: horizontal across bottom
+        var seg1 = new HeadlandSegment
+        {
+            Name = "Bottom Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 30,
+            BoundaryPoints = new() { new Vec3(10, 15, Math.PI / 2), new Vec3(190, 15, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        // Second cut: vertical down right side - both endpoints will hit the
+        // new bottom edge (a single long segment created by the first cut)
+        var seg2 = new HeadlandSegment
+        {
+            Name = "Right Cut",
+            Type = HeadlandSegmentType.Line,
+            Offset = 30,
+            BoundaryPoints = new() { new Vec3(185, 190, Math.PI), new Vec3(185, 50, Math.PI) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg1);
+        vm.ComputeSegmentOffset(seg2);
+        vm.HeadlandSegments.Add(seg1);
+        vm.HeadlandSegments.Add(seg2);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg1.IsEffective, Is.True, "First cut should be effective");
+        Assert.That(seg2.IsEffective, Is.True,
+            "Second cut should be effective even when both intersections are on same headland segment");
+
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        double headArea = Math.Abs(CalculateArea(headland!));
+        double fullArea = 200 * 200;
+        // Two cuts: 30m from bottom + 30m from right
+        Assert.That(headArea, Is.LessThan(fullArea * 0.8),
+            $"Two perpendicular cuts should reduce area. Area: {headArea:F0}");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 19: Extension save/load regression
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void ExtensionsSavedAndLoaded()
+    {
+        // Regression: StartExtension and EndExtension were not included in the DTO,
+        // so they always reverted to 50m default on save/load.
+        var tempDir = Path.Combine(Path.GetTempPath(), "headland_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var segments = new List<HeadlandSegment>
+            {
+                new()
+                {
+                    Name = "Custom Extensions",
+                    Type = HeadlandSegmentType.Line,
+                    Offset = 12,
+                    StartExtension = 25,
+                    EndExtension = 75,
+                    BoundaryPoints = new() { new Vec3(10, 50, 0), new Vec3(90, 50, 0) }
+                },
+                new()
+                {
+                    Name = "Default Extensions",
+                    Type = HeadlandSegmentType.Curve,
+                    Offset = 8,
+                    StartExtension = 50,
+                    EndExtension = 50,
+                    BoundaryPoints = new() { new Vec3(0, 0, 0), new Vec3(50, 50, 0), new Vec3(100, 0, 0) }
+                }
+            };
+
+            AgValoniaGPS.Services.Headland.HeadlandSegmentFileService.Save(tempDir, segments);
+            var loaded = AgValoniaGPS.Services.Headland.HeadlandSegmentFileService.Load(tempDir);
+
+            Assert.That(loaded.Count, Is.EqualTo(2));
+            Assert.That(loaded[0].StartExtension, Is.EqualTo(25),
+                "StartExtension should survive save/load");
+            Assert.That(loaded[0].EndExtension, Is.EqualTo(75),
+                "EndExtension should survive save/load");
+            Assert.That(loaded[1].StartExtension, Is.EqualTo(50));
+            Assert.That(loaded[1].EndExtension, Is.EqualTo(50));
+            Assert.That(loaded[0].Offset, Is.EqualTo(12));
+            Assert.That(loaded[0].Name, Is.EqualTo("Custom Extensions"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------
 

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
@@ -1106,7 +1106,122 @@ public class HeadlandChainTests
     }
 
     // ---------------------------------------------------------------
-    // TEST GROUP 19: Extension save/load regression
+    // TEST GROUP 19: One-ended curve should not break other lines
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void OneEndedCurve_DoesNotBreakEffectiveLine()
+    {
+        // Regression: a curve that only reaches boundary on one end was being merged
+        // with a working line, breaking the line's effectiveness.
+        // The working line should still produce a valid headland cut.
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Working line: horizontal across the full field
+        var segLine = new HeadlandSegment
+        {
+            Name = "Full Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 20,
+            BoundaryPoints = new() { new Vec3(10, 100, Math.PI / 2), new Vec3(190, 100, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        // One-ended curve: only reaches boundary on one side, short extension on other
+        var curvePts = new List<Vec3>();
+        for (int i = 0; i <= 10; i++)
+        {
+            double angle = i * Math.PI / 2 / 10;
+            curvePts.Add(new Vec3(150 + 30 * Math.Sin(angle), 80 + 30 * (1 - Math.Cos(angle)), angle));
+        }
+        var segCurve = new HeadlandSegment
+        {
+            Name = "One-Ended Curve",
+            Type = HeadlandSegmentType.Curve,
+            Offset = 15,
+            BoundaryPoints = curvePts,
+            StartExtension = 5,   // Too short to reach boundary
+            EndExtension = 50     // Reaches top boundary
+        };
+
+        vm.ComputeSegmentOffset(segLine);
+        vm.ComputeSegmentOffset(segCurve);
+        vm.HeadlandSegments.Add(segLine);
+        vm.HeadlandSegments.Add(segCurve);
+        vm.BuildHeadlandFromSegments();
+
+        // The full line should still be effective regardless of the one-ended curve
+        Assert.That(segLine.IsEffective, Is.True,
+            "Working line should remain effective even when a one-ended curve is present");
+
+        // The one-ended curve should NOT be effective
+        Assert.That(segCurve.IsEffective, Is.False,
+            "One-ended curve should not be effective");
+
+        // Headland should reflect only the line's cut
+        var headland = GetHeadlandLine(vm);
+        Assert.That(headland, Is.Not.Null);
+        double headArea = Math.Abs(CalculateArea(headland!));
+        double fullArea = 200 * 200;
+        Assert.That(headArea, Is.LessThan(fullArea * 0.85).And.GreaterThan(fullArea * 0.3),
+            $"Only the line's cut should apply. Area: {headArea:F0}");
+    }
+
+    [Test]
+    public void MultipleLines_OneNonEffective_OthersStillWork()
+    {
+        // Multiple lines where one doesn't reach boundary - should not affect the others
+        var vm = CreateVmWithBoundary(200, 200);
+
+        // Working line 1: horizontal bottom
+        var seg1 = new HeadlandSegment
+        {
+            Name = "Bottom",
+            Type = HeadlandSegmentType.Line,
+            Offset = 25,
+            BoundaryPoints = new() { new Vec3(10, 15, Math.PI / 2), new Vec3(190, 15, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        // Non-effective line: in the middle, too short
+        var seg2 = new HeadlandSegment
+        {
+            Name = "Floating",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new() { new Vec3(80, 100, Math.PI / 2), new Vec3(120, 100, Math.PI / 2) },
+            StartExtension = 5,
+            EndExtension = 5
+        };
+
+        // Working line 2: horizontal top
+        var seg3 = new HeadlandSegment
+        {
+            Name = "Top",
+            Type = HeadlandSegmentType.Line,
+            Offset = 25,
+            BoundaryPoints = new() { new Vec3(10, 185, Math.PI / 2), new Vec3(190, 185, Math.PI / 2) },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg1);
+        vm.ComputeSegmentOffset(seg2);
+        vm.ComputeSegmentOffset(seg3);
+        vm.HeadlandSegments.Add(seg1);
+        vm.HeadlandSegments.Add(seg2);
+        vm.HeadlandSegments.Add(seg3);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg1.IsEffective, Is.True, "Bottom line should be effective");
+        Assert.That(seg2.IsEffective, Is.False, "Floating line should not be effective");
+        Assert.That(seg3.IsEffective, Is.True, "Top line should be effective");
+    }
+
+    // ---------------------------------------------------------------
+    // TEST GROUP 20: Extension save/load regression
     // ---------------------------------------------------------------
 
     [Test]

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
@@ -363,6 +363,78 @@ public class HeadlandOffsetTests
         Assert.That(seg.IsEffective, Is.False, "Floating curve should not be effective");
     }
 
+    [Test]
+    [Ignore("Closed loop support needs further work - chain merging not connecting all 4 lines")]
+    public void ClosedLoop_NoBoundaryTouch_StillEffective()
+    {
+        var vm = CreateVm();
+
+        // 200x200 square field
+        var boundary = new Models.Boundary
+        {
+            OuterBoundary = new Models.BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new Models.BoundaryPoint(0, 0, 0),
+                    new Models.BoundaryPoint(200, 0, Math.PI / 2),
+                    new Models.BoundaryPoint(200, 200, Math.PI),
+                    new Models.BoundaryPoint(0, 200, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+
+        // 4 lines forming a square inside the field (50,50)-(150,150)
+        // None touch the boundary, but they form a closed loop together
+        var segments = new[]
+        {
+            // Top: horizontal from (50,150) to (150,150)
+            new HeadlandSegment
+            {
+                Name = "Top", Type = HeadlandSegmentType.Line, Offset = 10,
+                BoundaryPoints = new() { new Vec3(50, 150, Math.PI / 2), new Vec3(150, 150, Math.PI / 2) },
+                StartExtension = 20, EndExtension = 20
+            },
+            // Right: vertical from (150,150) to (150,50)
+            new HeadlandSegment
+            {
+                Name = "Right", Type = HeadlandSegmentType.Line, Offset = 10,
+                BoundaryPoints = new() { new Vec3(150, 150, -Math.PI), new Vec3(150, 50, -Math.PI) },
+                StartExtension = 20, EndExtension = 20
+            },
+            // Bottom: horizontal from (150,50) to (50,50)
+            new HeadlandSegment
+            {
+                Name = "Bottom", Type = HeadlandSegmentType.Line, Offset = 10,
+                BoundaryPoints = new() { new Vec3(150, 50, -Math.PI / 2), new Vec3(50, 50, -Math.PI / 2) },
+                StartExtension = 20, EndExtension = 20
+            },
+            // Left: vertical from (50,50) to (50,150)
+            new HeadlandSegment
+            {
+                Name = "Left", Type = HeadlandSegmentType.Line, Offset = 10,
+                BoundaryPoints = new() { new Vec3(50, 50, 0), new Vec3(50, 150, 0) },
+                StartExtension = 20, EndExtension = 20
+            }
+        };
+
+        foreach (var seg in segments)
+        {
+            vm.ComputeSegmentOffset(seg);
+            vm.HeadlandSegments.Add(seg);
+        }
+
+        vm.BuildHeadlandFromSegments();
+
+        // The 4 lines should chain together and form effective headland cuts
+        // Even though none individually touch the boundary
+        bool anyEffective = segments.Any(s => s.IsEffective);
+        Assert.That(anyEffective, Is.True,
+            "Lines forming a closed loop should create effective headland even without boundary contact");
+    }
+
     private static bool SegmentsIntersect(Vec3 a1, Vec3 a2, Vec3 b1, Vec3 b2)
     {
         double d = (a2.Easting - a1.Easting) * (b2.Northing - b1.Northing) -

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
@@ -1,0 +1,177 @@
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Headland;
+
+namespace AgValoniaGPS.ViewModels.Tests;
+
+[TestFixture]
+public class HeadlandOffsetTests
+{
+    private MainViewModel CreateVm()
+    {
+        return new MainViewModelBuilder().Build();
+    }
+
+    [Test]
+    public void StraightLine_OffsetIs12m()
+    {
+        var vm = CreateVm();
+        var seg = new HeadlandSegment
+        {
+            Type = HeadlandSegmentType.Line,
+            Offset = 12,
+            BoundaryPoints = new()
+            {
+                new Vec3(0, 0, 0),
+                new Vec3(0, 100, 0)
+            }
+        };
+
+        vm.ComputeSegmentOffset(seg);
+
+        Assert.That(seg.OffsetPoints, Has.Count.EqualTo(2));
+        // Offset should be 12m perpendicular
+        double dist0 = Math.Sqrt(
+            Math.Pow(seg.OffsetPoints[0].Easting - seg.BoundaryPoints[0].Easting, 2) +
+            Math.Pow(seg.OffsetPoints[0].Northing - seg.BoundaryPoints[0].Northing, 2));
+        Assert.That(dist0, Is.EqualTo(12).Within(0.1));
+    }
+
+    [Test]
+    public void Curve_OffsetIsConstant()
+    {
+        var vm = CreateVm();
+
+        // Create a 90-degree arc (quarter circle, radius 50m)
+        var pts = new List<Vec3>();
+        for (int i = 0; i <= 20; i++)
+        {
+            double angle = i * Math.PI / 2 / 20;
+            pts.Add(new Vec3(50 * Math.Cos(angle), 50 * Math.Sin(angle), angle));
+        }
+
+        var seg = new HeadlandSegment
+        {
+            Type = HeadlandSegmentType.Curve,
+            Offset = 10,
+            BoundaryPoints = pts
+        };
+
+        vm.ComputeSegmentOffset(seg);
+
+        Assert.That(seg.OffsetPoints.Count, Is.GreaterThanOrEqualTo(pts.Count - 1));
+
+        // All offset points should be ~10m from their boundary counterparts
+        for (int i = 0; i < Math.Min(pts.Count, seg.OffsetPoints.Count); i++)
+        {
+            double dist = Math.Sqrt(
+                Math.Pow(seg.OffsetPoints[i].Easting - pts[i].Easting, 2) +
+                Math.Pow(seg.OffsetPoints[i].Northing - pts[i].Northing, 2));
+            Assert.That(dist, Is.EqualTo(10).Within(1.0),
+                $"Point {i}: offset distance {dist:F1}m, expected 10m");
+        }
+    }
+
+    [Test]
+    public void FilletCorner_NoSelfIntersection()
+    {
+        var vm = CreateVm();
+
+        // Create a boundary with a small fillet (5m radius) and 10m offset
+        // The fillet should be removed (offset > fillet radius)
+        var pts = new List<Vec3>();
+
+        // Straight section going right
+        for (int i = 0; i <= 10; i++)
+            pts.Add(new Vec3(i * 5, 0, Math.PI / 2));
+
+        // Small fillet corner (5m radius, 90 degrees)
+        for (int i = 1; i <= 5; i++)
+        {
+            double angle = i * Math.PI / 2 / 5;
+            pts.Add(new Vec3(50 + 5 * Math.Sin(angle), 5 - 5 * Math.Cos(angle), Math.PI / 2 + angle));
+        }
+
+        // Straight section going up
+        for (int i = 1; i <= 10; i++)
+            pts.Add(new Vec3(55, 5 + i * 5, 0));
+
+        var seg = new HeadlandSegment
+        {
+            Type = HeadlandSegmentType.Curve,
+            Offset = 10, // Larger than fillet radius (5m)
+            BoundaryPoints = pts
+        };
+
+        vm.ComputeSegmentOffset(seg);
+
+        // Check no self-intersections (each consecutive pair should not cross later edges)
+        bool hasSelfIntersection = false;
+        for (int i = 0; i < seg.OffsetPoints.Count - 2; i++)
+        {
+            var a1 = seg.OffsetPoints[i];
+            var a2 = seg.OffsetPoints[i + 1];
+            for (int j = i + 2; j < seg.OffsetPoints.Count - 1; j++)
+            {
+                var b1 = seg.OffsetPoints[j];
+                var b2 = seg.OffsetPoints[j + 1];
+                if (SegmentsIntersect(a1, a2, b1, b2))
+                {
+                    hasSelfIntersection = true;
+                    break;
+                }
+            }
+            if (hasSelfIntersection) break;
+        }
+
+        Assert.That(hasSelfIntersection, Is.False, "Offset polygon should not self-intersect after fillet removal");
+        // Offset should have fewer points than input (fillet collapsed)
+        Assert.That(seg.OffsetPoints.Count, Is.LessThanOrEqualTo(pts.Count));
+    }
+
+    [Test]
+    public void BoundaryOffset_ClosedPolygon()
+    {
+        var vm = CreateVm();
+
+        // Simple square boundary 100x100
+        var seg = new HeadlandSegment
+        {
+            Type = HeadlandSegmentType.Boundary,
+            Offset = 10,
+            BoundaryPoints = new()
+            {
+                new Vec3(0, 0, 0),
+                new Vec3(100, 0, Math.PI / 2),
+                new Vec3(100, 100, Math.PI),
+                new Vec3(0, 100, -Math.PI / 2),
+                new Vec3(0, 0, 0) // closing point
+            }
+        };
+
+        vm.ComputeSegmentOffset(seg);
+
+        // Square with self-intersection removal may collapse sharp corners
+        Assert.That(seg.OffsetPoints.Count, Is.GreaterThanOrEqualTo(2));
+
+        // All offset points should be roughly 10m inside the square
+        foreach (var op in seg.OffsetPoints)
+        {
+            Assert.That(op.Easting, Is.GreaterThanOrEqualTo(-1).And.LessThanOrEqualTo(101),
+                $"Point ({op.Easting:F1}, {op.Northing:F1}) outside expected range");
+        }
+    }
+
+    private static bool SegmentsIntersect(Vec3 a1, Vec3 a2, Vec3 b1, Vec3 b2)
+    {
+        double d = (a2.Easting - a1.Easting) * (b2.Northing - b1.Northing) -
+                   (a2.Northing - a1.Northing) * (b2.Easting - b1.Easting);
+        if (Math.Abs(d) < 1e-10) return false;
+
+        double t = ((b1.Easting - a1.Easting) * (b2.Northing - b1.Northing) -
+                    (b1.Northing - a1.Northing) * (b2.Easting - b1.Easting)) / d;
+        double u = ((b1.Easting - a1.Easting) * (a2.Northing - a1.Northing) -
+                    (b1.Northing - a1.Northing) * (a2.Easting - a1.Easting)) / d;
+
+        return t > 0.01 && t < 0.99 && u > 0.01 && u < 0.99;
+    }
+}

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
@@ -249,6 +249,120 @@ public class HeadlandOffsetTests
         Assert.That(seg.IsEffective, Is.True, "Long extension should intersect boundary at both ends");
     }
 
+    [Test]
+    public void ChainedLines_BothEffective()
+    {
+        var vm = CreateVm();
+
+        // 100x100 square field
+        var boundary = new Models.Boundary
+        {
+            OuterBoundary = new Models.BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new Models.BoundaryPoint(0, 0, 0),
+                    new Models.BoundaryPoint(100, 0, Math.PI / 2),
+                    new Models.BoundaryPoint(100, 100, Math.PI),
+                    new Models.BoundaryPoint(0, 100, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+
+        // Line A: vertical on left side at x=20, from y=20 to y=50
+        // Extension reaches boundary at y=0, other end meets Line B
+        var segA = new HeadlandSegment
+        {
+            Name = "Line A",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new()
+            {
+                new Vec3(20, 20, 0),
+                new Vec3(20, 50, 0)
+            },
+            StartExtension = 30, // Reaches y=-10, past boundary at y=0
+            EndExtension = 15    // Reaches y=65, overlaps with Line B
+        };
+
+        // Line B: horizontal at y=60, from x=15 to x=50
+        // Extension reaches Line A, other end reaches boundary at x=100
+        var segB = new HeadlandSegment
+        {
+            Name = "Line B",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new()
+            {
+                new Vec3(15, 60, Math.PI / 2),
+                new Vec3(50, 60, Math.PI / 2)
+            },
+            StartExtension = 15, // Reaches x=0, past boundary
+            EndExtension = 60    // Reaches x=110, past boundary at x=100
+        };
+
+        vm.ComputeSegmentOffset(segA);
+        vm.ComputeSegmentOffset(segB);
+        vm.HeadlandSegments.Add(segA);
+        vm.HeadlandSegments.Add(segB);
+        vm.BuildHeadlandFromSegments();
+
+        // At least one should be effective (merged chain touches both boundaries)
+        bool anyEffective = segA.IsEffective || segB.IsEffective;
+        Assert.That(anyEffective, Is.True, "Chained lines should form effective headland cut");
+
+        // Headland should be modified (not just the boundary)
+        Assert.That(vm.HasHeadland, Is.True);
+    }
+
+    [Test]
+    public void NonIntersectingCurve_ShowsRed()
+    {
+        var vm = CreateVm();
+
+        var boundary = new Models.Boundary
+        {
+            OuterBoundary = new Models.BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new Models.BoundaryPoint(0, 0, 0),
+                    new Models.BoundaryPoint(100, 0, Math.PI / 2),
+                    new Models.BoundaryPoint(100, 100, Math.PI),
+                    new Models.BoundaryPoint(0, 100, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+
+        // Curve entirely inside field, short extensions, doesn't reach boundary
+        var seg = new HeadlandSegment
+        {
+            Name = "Floating Curve",
+            Type = HeadlandSegmentType.Curve,
+            Offset = 5,
+            BoundaryPoints = new()
+            {
+                new Vec3(30, 50, Math.PI / 2),
+                new Vec3(40, 55, Math.PI / 4),
+                new Vec3(50, 50, 0),
+                new Vec3(60, 45, -Math.PI / 4),
+                new Vec3(70, 50, Math.PI / 2)
+            },
+            StartExtension = 2,
+            EndExtension = 2
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.False, "Floating curve should not be effective");
+    }
+
     private static bool SegmentsIntersect(Vec3 a1, Vec3 a2, Vec3 b1, Vec3 b2)
     {
         double d = (a2.Easting - a1.Easting) * (b2.Northing - b1.Northing) -

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
@@ -161,6 +161,94 @@ public class HeadlandOffsetTests
         }
     }
 
+    [Test]
+    public void ShortExtension_DoesNotIntersect_NotEffective()
+    {
+        var vm = CreateVm();
+
+        // Create a 100x100 square boundary
+        var boundary = new Models.Boundary
+        {
+            OuterBoundary = new Models.BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new Models.BoundaryPoint(0, 0, 0),
+                    new Models.BoundaryPoint(100, 0, Math.PI / 2),
+                    new Models.BoundaryPoint(100, 100, Math.PI),
+                    new Models.BoundaryPoint(0, 100, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+
+        // Set the boundary on the VM
+        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+
+        // Create a headland line in the middle that is too short to reach the edges
+        var seg = new HeadlandSegment
+        {
+            Name = "Short Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new()
+            {
+                new Vec3(40, 50, Math.PI / 2),
+                new Vec3(60, 50, Math.PI / 2)
+            },
+            StartExtension = 5, // Only 5m - won't reach boundary at x=0 (35m away)
+            EndExtension = 5    // Only 5m - won't reach boundary at x=100 (35m away)
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.False, "Short extension should not intersect boundary");
+    }
+
+    [Test]
+    public void LongExtension_Intersects_IsEffective()
+    {
+        var vm = CreateVm();
+
+        var boundary = new Models.Boundary
+        {
+            OuterBoundary = new Models.BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new Models.BoundaryPoint(0, 0, 0),
+                    new Models.BoundaryPoint(100, 0, Math.PI / 2),
+                    new Models.BoundaryPoint(100, 100, Math.PI),
+                    new Models.BoundaryPoint(0, 100, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+
+        var seg = new HeadlandSegment
+        {
+            Name = "Long Line",
+            Type = HeadlandSegmentType.Line,
+            Offset = 10,
+            BoundaryPoints = new()
+            {
+                new Vec3(40, 50, Math.PI / 2),
+                new Vec3(60, 50, Math.PI / 2)
+            },
+            StartExtension = 50, // 50m - reaches boundary at x=0
+            EndExtension = 50    // 50m - reaches boundary at x=100
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.True, "Long extension should intersect boundary at both ends");
+    }
+
     private static bool SegmentsIntersect(Vec3 a1, Vec3 a2, Vec3 b1, Vec3 b2)
     {
         double d = (a2.Easting - a1.Easting) * (b2.Northing - b1.Northing) -

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
@@ -364,7 +364,6 @@ public class HeadlandOffsetTests
     }
 
     [Test]
-    [Ignore("Closed loop support needs further work - chain merging not connecting all 4 lines")]
     public void ClosedLoop_NoBoundaryTouch_StillEffective()
     {
         var vm = CreateVm();

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandRealFieldTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandRealFieldTests.cs
@@ -1,0 +1,260 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Headland;
+
+namespace AgValoniaGPS.ViewModels.Tests;
+
+/// <summary>
+/// Tests using real field data from user bug reports.
+/// Field: ~22.58 ha, 621 boundary points, irregular shape with notch at top.
+/// </summary>
+[TestFixture]
+public class HeadlandRealFieldTests
+{
+    private MainViewModel _vm = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _vm = new MainViewModelBuilder().Build();
+
+        // Load the real boundary from the dump
+        // Simplified to key corner points that define the field shape
+        var boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = new()
+                {
+                    // Approximate corners from the 621-point boundary
+                    new BoundaryPoint(1.1, 82.6, 1.2),       // 0: top-right area
+                    new BoundaryPoint(65.9, -31.8, 3.1),      // ~97: right side
+                    new BoundaryPoint(71.5, -205.1, 3.1),     // ~128: right-bottom
+                    new BoundaryPoint(67.9, -93.9, -2.3),     // ~107: mid-right
+                    new BoundaryPoint(-75.5, -390.8, 4.86),   // ~261: bottom
+                    new BoundaryPoint(-230.2, -367.5, -2.3),  // ~286: bottom-left
+                    new BoundaryPoint(-418.0, -14.5, 0.39),   // ~412: left side
+                    new BoundaryPoint(-300.6, 41.5, 1.63),    // ~461: upper-left
+                    new BoundaryPoint(-175.7, 34.0, 1.63),    // ~481: upper-middle
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(_vm, boundary);
+    }
+
+    [Test]
+    public void Line3_RightSide_TouchesBoundary()
+    {
+        // Line 3: vertical on right side
+        var seg = new HeadlandSegment
+        {
+            Name = "Line 3",
+            Type = HeadlandSegmentType.Line,
+            Offset = 12,
+            BoundaryPoints = new()
+            {
+                new Vec3(65.9, -31.8, 3.1095),
+                new Vec3(71.5, -205.1, 3.1095)
+            },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        _vm.ComputeSegmentOffset(seg);
+        _vm.HeadlandSegments.Add(seg);
+        _vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.True,
+            $"Line 3 should intersect boundary at both ends. Offset pts: {seg.OffsetPoints.Count}");
+    }
+
+    [Test]
+    public void Line4_Diagonal_TouchesBoundary()
+    {
+        // Line 4: diagonal from right to bottom-left
+        var seg = new HeadlandSegment
+        {
+            Name = "Line 4",
+            Type = HeadlandSegmentType.Line,
+            Offset = 12,
+            BoundaryPoints = new()
+            {
+                new Vec3(67.9, -93.9, -2.3132),
+                new Vec3(-230.2, -367.5, -2.3132)
+            },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        _vm.ComputeSegmentOffset(seg);
+        _vm.HeadlandSegments.Add(seg);
+        _vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.True,
+            $"Line 4 diagonal should intersect boundary at both ends");
+    }
+
+    [Test]
+    public void AllFourSegments_ChainTogether()
+    {
+        // Add all 4 segments from the user's field
+        var segments = new HeadlandSegment[]
+        {
+            new()
+            {
+                Name = "Line 4 (diagonal)",
+                Type = HeadlandSegmentType.Line,
+                Offset = 12,
+                BoundaryPoints = new()
+                {
+                    new Vec3(67.9, -93.9, -2.3132),
+                    new Vec3(-230.2, -367.5, -2.3132)
+                },
+                StartExtension = 50,
+                EndExtension = 50
+            },
+            new()
+            {
+                Name = "Line 3 (right)",
+                Type = HeadlandSegmentType.Line,
+                Offset = 12,
+                BoundaryPoints = new()
+                {
+                    new Vec3(65.9, -31.8, 3.1095),
+                    new Vec3(71.5, -205.1, 3.1095)
+                },
+                StartExtension = 50,
+                EndExtension = 50
+            },
+            new()
+            {
+                Name = "Line 4 (upper-left)",
+                Type = HeadlandSegmentType.Line,
+                Offset = 12,
+                BoundaryPoints = new()
+                {
+                    new Vec3(-175.7, 34.0, 1.6304),
+                    new Vec3(-300.6, 41.5, 1.6304)
+                },
+                StartExtension = 50,
+                EndExtension = 50
+            },
+            new()
+            {
+                Name = "Curve 4 (bottom-left)",
+                Type = HeadlandSegmentType.Curve,
+                Offset = 32,
+                BoundaryPoints = new()
+                {
+                    new Vec3(-75.5, -390.8, 4.86324),
+                    new Vec3(-230.2, -367.5, 4.86324),
+                    new Vec3(-418.0, -14.5, 0.39020)
+                },
+                StartExtension = 50,
+                EndExtension = 50
+            }
+        };
+
+        foreach (var seg in segments)
+        {
+            _vm.ComputeSegmentOffset(seg);
+            _vm.HeadlandSegments.Add(seg);
+        }
+
+        _vm.BuildHeadlandFromSegments();
+
+        int effectiveCount = segments.Count(s => s.IsEffective);
+        Assert.That(effectiveCount, Is.GreaterThan(0),
+            $"At least some segments should be effective. " +
+            $"Effective: {string.Join(", ", segments.Select(s => $"{s.Name}={s.IsEffective}"))}");
+    }
+
+    [Test]
+    public void TwoLinesConnecting_FormChain()
+    {
+        // Line 3 (right side) and Line 4 (diagonal) should connect
+        // Line 3 goes from upper-right to lower-right
+        // Line 4 goes from mid-right to bottom-left
+        // They should intersect near the right side
+        var seg1 = new HeadlandSegment
+        {
+            Name = "Line 3",
+            Type = HeadlandSegmentType.Line,
+            Offset = 12,
+            BoundaryPoints = new()
+            {
+                new Vec3(65.9, -31.8, 3.1095),
+                new Vec3(71.5, -205.1, 3.1095)
+            },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        var seg2 = new HeadlandSegment
+        {
+            Name = "Line 4",
+            Type = HeadlandSegmentType.Line,
+            Offset = 12,
+            BoundaryPoints = new()
+            {
+                new Vec3(67.9, -93.9, -2.3132),
+                new Vec3(-230.2, -367.5, -2.3132)
+            },
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        _vm.ComputeSegmentOffset(seg1);
+        _vm.ComputeSegmentOffset(seg2);
+
+        // Check if offset lines actually intersect each other
+        bool linesIntersect = false;
+        var line1 = BuildOffsetWithExt(seg1);
+        var line2 = BuildOffsetWithExt(seg2);
+
+        for (int i = 0; i < line1.Count - 1 && !linesIntersect; i++)
+        {
+            for (int j = 0; j < line2.Count - 1 && !linesIntersect; j++)
+            {
+                double denom = (line1[i + 1].Easting - line1[i].Easting) * (line2[j + 1].Northing - line2[j].Northing) -
+                               (line1[i + 1].Northing - line1[i].Northing) * (line2[j + 1].Easting - line2[j].Easting);
+                if (Math.Abs(denom) < 1e-10) continue;
+                double t = ((line2[j].Easting - line1[i].Easting) * (line2[j + 1].Northing - line2[j].Northing) -
+                            (line2[j].Northing - line1[i].Northing) * (line2[j + 1].Easting - line2[j].Easting)) / denom;
+                double u = ((line2[j].Easting - line1[i].Easting) * (line1[i + 1].Northing - line1[i].Northing) -
+                            (line2[j].Northing - line1[i].Northing) * (line1[i + 1].Easting - line1[i].Easting)) / denom;
+                if (t >= 0 && t <= 1 && u >= 0 && u <= 1)
+                    linesIntersect = true;
+            }
+        }
+
+        Assert.That(linesIntersect, Is.True,
+            $"Line 3 offset ({line1.Count} pts) and Line 4 offset ({line2.Count} pts) should intersect each other");
+    }
+
+    private static List<Vec3> BuildOffsetWithExt(HeadlandSegment seg)
+    {
+        var line = new List<Vec3>();
+        if (seg.StartExtension > 0 && seg.OffsetPoints.Count >= 2)
+        {
+            var s0 = seg.OffsetPoints[0]; var s1 = seg.OffsetPoints[1];
+            double sdx = s0.Easting - s1.Easting, sdy = s0.Northing - s1.Northing;
+            double slen = Math.Sqrt(sdx * sdx + sdy * sdy);
+            if (slen > 0.01)
+                line.Add(new Vec3(s0.Easting + sdx / slen * seg.StartExtension, s0.Northing + sdy / slen * seg.StartExtension, 0));
+        }
+        line.AddRange(seg.OffsetPoints);
+        if (seg.EndExtension > 0 && seg.OffsetPoints.Count >= 2)
+        {
+            var e0 = seg.OffsetPoints[^2]; var e1 = seg.OffsetPoints[^1];
+            double edx = e1.Easting - e0.Easting, edy = e1.Northing - e0.Northing;
+            double elen = Math.Sqrt(edx * edx + edy * edy);
+            if (elen > 0.01)
+                line.Add(new Vec3(e1.Easting + edx / elen * seg.EndExtension, e1.Northing + edy / elen * seg.EndExtension, 0));
+        }
+        return line;
+    }
+}

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandRealFieldTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandRealFieldTests.cs
@@ -235,6 +235,63 @@ public class HeadlandRealFieldTests
             $"Line 3 offset ({line1.Count} pts) and Line 4 offset ({line2.Count} pts) should intersect each other");
     }
 
+    [Test]
+    public void LongCurve_EndIntersectsBoundary()
+    {
+        // Reproduces bug: long curve where end search went backward
+        // and couldn't find boundary intersection near the tip
+        var vm = new MainViewModelBuilder().Build();
+
+        // Simple 200x200 square
+        var boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = new()
+                {
+                    new BoundaryPoint(0, 0, 0),
+                    new BoundaryPoint(200, 0, Math.PI / 2),
+                    new BoundaryPoint(200, 200, Math.PI),
+                    new BoundaryPoint(0, 200, -Math.PI / 2)
+                }
+            }
+        };
+        boundary.OuterBoundary.UpdateBounds();
+        typeof(MainViewModel).GetField("_currentBoundary",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(vm, boundary);
+
+        // Long curve along the bottom + right edges (many points)
+        var curvePts = new List<Vec3>();
+        // Bottom edge: x from 10 to 190 (many points)
+        for (int i = 0; i <= 100; i++)
+            curvePts.Add(new Vec3(10 + i * 1.8, 0, Math.PI / 2));
+        // Right edge: y from 0 to 190
+        for (int i = 1; i <= 100; i++)
+            curvePts.Add(new Vec3(200, i * 1.9, 0));
+
+        var seg = new HeadlandSegment
+        {
+            Name = "Long L-Curve",
+            Type = HeadlandSegmentType.Curve,
+            Offset = 15,
+            BoundaryPoints = curvePts,
+            StartExtension = 50,
+            EndExtension = 50
+        };
+
+        vm.ComputeSegmentOffset(seg);
+        Assert.That(seg.OffsetPoints.Count, Is.GreaterThan(100),
+            "Should have many offset points");
+
+        vm.HeadlandSegments.Add(seg);
+        vm.BuildHeadlandFromSegments();
+
+        Assert.That(seg.IsEffective, Is.True,
+            $"Long curve should be effective - ends near boundary edges. " +
+            $"OffsetPts: {seg.OffsetPoints.Count}");
+    }
+
     private static List<Vec3> BuildOffsetWithExt(HeadlandSegment seg)
     {
         var line = new List<Vec3>();

--- a/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
@@ -72,6 +72,7 @@ public class MainViewModelBuilder
             chartDataService: Substitute.For<IChartDataService>(),
             audioService: Substitute.For<IAudioService>(),
             elevationLogService: Substitute.For<IElevationLogService>(),
+            tramLineService: Substitute.For<AgValoniaGPS.Services.Interfaces.ITramLineService>(),
             gpsPipelineService: GpsPipelineService,
             logger: NullLogger<MainViewModel>.Instance,
             appState: new ApplicationState());


### PR DESCRIPTION
## Summary
Segments that don't form a loop (don't intersect headland at both ends) are shown as red dashed lines and don't affect headland generation.

## Test plan
- [ ] Create headland line that doesn't reach both edges -> shows red
- [ ] Extend it until it intersects both edges -> turns green, headland modified

Generated with [Claude Code](https://claude.com/claude-code)