### PR TITLE
Add inner boundary (obstacle) creation UI

### DIFF
--- a/Plans/INNER_BOUNDARY_PLAN.md
+++ b/Plans/INNER_BOUNDARY_PLAN.md
@@ -1,6 +1,7 @@
 # Inner Boundary (Obstacle) Creation — Implementation Plan
 
 ## Issue #238
+## Status: In Progress (feature/inner-boundary-ui branch)
 
 ## Context
 

--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ public static class ServiceCollectionExtensions
 
         // Boundary recording service
         services.AddSingleton<IBoundaryRecordingService, BoundaryRecordingService>();
+        services.AddSingleton<IBoundaryBuilderService, BoundaryBuilderService>();
 
         // Headland builder services
         services.AddSingleton<IPolygonOffsetService, PolygonOffsetService>();

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -77,6 +77,7 @@ public static class ServiceCollectionExtensions
 
         // Boundary recording service
         services.AddSingleton<IBoundaryRecordingService, BoundaryRecordingService>();
+        services.AddSingleton<IBoundaryBuilderService, BoundaryBuilderService>();
 
         // Headland builder services
         services.AddSingleton<IPolygonOffsetService, PolygonOffsetService>();

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ public static class ServiceCollectionExtensions
 
         // Boundary recording service
         services.AddSingleton<IBoundaryRecordingService, BoundaryRecordingService>();
+        services.AddSingleton<IBoundaryBuilderService, BoundaryBuilderService>();
 
         // Headland builder services
         services.AddSingleton<IPolygonOffsetService, PolygonOffsetService>();

--- a/Shared/AgValoniaGPS.Services/BoundaryBuilderService.cs
+++ b/Shared/AgValoniaGPS.Services/BoundaryBuilderService.cs
@@ -1,0 +1,417 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Ported from AgOpenGPS BoundaryBuilder by Brian Tischler.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services;
+
+public class BoundaryBuilderService : IBoundaryBuilderService
+{
+    private const double IntersectionTolerance = 0.01;
+    private const double IntersectionToleranceSq = IntersectionTolerance * IntersectionTolerance;
+    private const double MaxSegmentStep = 1.5;
+    private const double IntersectionSearchRadius = 5.0;
+    private const double TrimSegmentLength = 0.5;
+    private const int MinPolygonPoints = 3;
+
+    public BoundaryPolygon? BuildBoundaryFromTracks(List<Models.Track.Track> tracks, double extendMeters = 20.0)
+    {
+        if (tracks == null || tracks.Count < 2)
+            return null;
+
+        // Get points from each track, extend endpoints
+        var trackPointSets = new List<(List<Vec2> Points, int TrackId)>();
+        for (int i = 0; i < tracks.Count; i++)
+        {
+            var points = GetTrackPoints(tracks[i]);
+            if (points.Count < 2) continue;
+
+            points = ExtendEndpoints(points, extendMeters);
+            points = EnforceMaxStep(points, MaxSegmentStep);
+            trackPointSets.Add((points, i));
+        }
+
+        if (trackPointSets.Count < 2)
+            return null;
+
+        // Build segments from all tracks
+        var segments = new List<Segment>();
+        foreach (var (points, trackId) in trackPointSets)
+        {
+            for (int i = 0; i < points.Count - 1; i++)
+                segments.Add(new Segment(points[i], points[i + 1], trackId));
+        }
+
+        // Find intersections between segments of different tracks
+        FindIntersections(segments);
+
+        // Trim each track to its outermost intersections
+        var trimmedSegments = TrimSegmentsToIntersections(segments, trackPointSets);
+
+        // Build polygon from trimmed segments
+        var polygon = ConvertSegmentsToPolygon(trimmedSegments);
+
+        if (polygon.Count < MinPolygonPoints)
+            return null;
+
+        // Convert to BoundaryPolygon
+        var boundaryPolygon = new BoundaryPolygon();
+        foreach (var point in polygon)
+            boundaryPolygon.Points.Add(new BoundaryPoint(point.Easting, point.Northing, 0));
+
+        return boundaryPolygon;
+    }
+
+    private static List<Vec2> GetTrackPoints(Models.Track.Track track)
+    {
+        return track.Points.Select(p => new Vec2(p.Easting, p.Northing)).ToList();
+    }
+
+    private static List<Vec2> ExtendEndpoints(List<Vec2> points, double extendMeters)
+    {
+        if (points.Count < 2) return points;
+
+        var result = new List<Vec2>(points.Count + 2);
+
+        // Extend start
+        var dir = points[0] - points[1];
+        double length = dir.GetLength();
+        if (length > 1e-6)
+        {
+            var extend = dir * (extendMeters / length);
+            result.Add(points[0] + extend);
+        }
+
+        result.AddRange(points);
+
+        // Extend end
+        dir = points[^1] - points[^2];
+        length = dir.GetLength();
+        if (length > 1e-6)
+        {
+            var extend = dir * (extendMeters / length);
+            result.Add(points[^1] + extend);
+        }
+
+        return result;
+    }
+
+    private static List<Vec2> EnforceMaxStep(List<Vec2> points, double maxStep)
+    {
+        var result = new List<Vec2>();
+        if (points.Count == 0) return result;
+
+        result.Add(points[0]);
+
+        for (int i = 1; i < points.Count; i++)
+        {
+            var prev = points[i - 1];
+            var current = points[i];
+            double distance = GeometryMath.Distance(prev, current);
+
+            if (distance <= maxStep)
+            {
+                result.Add(current);
+                continue;
+            }
+
+            int steps = (int)Math.Ceiling(distance / maxStep);
+            for (int s = 1; s < steps; s++)
+            {
+                double t = (double)s / steps;
+                result.Add(Vec2.Lerp(prev, current, t));
+            }
+            result.Add(current);
+        }
+
+        return result;
+    }
+
+    private static void FindIntersections(List<Segment> segments)
+    {
+        for (int i = 0; i < segments.Count; i++)
+        {
+            var seg1 = segments[i];
+            for (int j = i + 1; j < segments.Count; j++)
+            {
+                var seg2 = segments[j];
+
+                // Only check segments from different tracks
+                if (seg1.TrackId == seg2.TrackId) continue;
+
+                // Bounding box early-out
+                if (!BoundingBoxesOverlap(seg1, seg2, IntersectionSearchRadius)) continue;
+
+                var (intersects, point) = LineSegmentsIntersect(seg1.Start, seg1.End, seg2.Start, seg2.End);
+                if (intersects)
+                {
+                    seg1.AddIntersection(point);
+                    seg2.AddIntersection(point);
+                }
+            }
+        }
+    }
+
+    private static bool BoundingBoxesOverlap(Segment s1, Segment s2, double tolerance)
+    {
+        double minX1 = Math.Min(s1.Start.Easting, s1.End.Easting) - tolerance;
+        double maxX1 = Math.Max(s1.Start.Easting, s1.End.Easting) + tolerance;
+        double minY1 = Math.Min(s1.Start.Northing, s1.End.Northing) - tolerance;
+        double maxY1 = Math.Max(s1.Start.Northing, s1.End.Northing) + tolerance;
+
+        double minX2 = Math.Min(s2.Start.Easting, s2.End.Easting);
+        double maxX2 = Math.Max(s2.Start.Easting, s2.End.Easting);
+        double minY2 = Math.Min(s2.Start.Northing, s2.End.Northing);
+        double maxY2 = Math.Max(s2.Start.Northing, s2.End.Northing);
+
+        return !(maxX1 < minX2 || maxX2 < minX1 || maxY1 < minY2 || maxY2 < minY1);
+    }
+
+    private static (bool Intersects, Vec2 Point) LineSegmentsIntersect(Vec2 p1, Vec2 p2, Vec2 p3, Vec2 p4)
+    {
+        var r = p2 - p1;
+        var s = p4 - p3;
+        var pq = p3 - p1;
+
+        double rxs = Vec2.Cross(r, s);
+        double pqxr = Vec2.Cross(pq, r);
+
+        if (Math.Abs(rxs) < 1e-10)
+        {
+            // Collinear case
+            if (Math.Abs(pqxr) < 1e-10)
+            {
+                double rDotR = Vec2.Dot(r, r);
+                if (rDotR < 1e-10) return (false, default);
+
+                double t0 = Vec2.Dot(pq, r) / rDotR;
+                double t1 = t0 + Vec2.Dot(s, r) / rDotR;
+                if (t0 > t1) (t0, t1) = (t1, t0);
+
+                if (t0 <= 1 && t1 >= 0)
+                {
+                    double intersectionT = Math.Max(0, Math.Min(t0, 1));
+                    return (true, p1 + r * intersectionT);
+                }
+            }
+            return (false, default);
+        }
+
+        double t = Vec2.Cross(pq, s) / rxs;
+        double u = pqxr / rxs;
+
+        if (t >= 0 && t <= 1 && u >= 0 && u <= 1)
+            return (true, p1 + r * t);
+
+        return (false, default);
+    }
+
+    private static List<Segment> TrimSegmentsToIntersections(
+        List<Segment> allSegments,
+        List<(List<Vec2> Points, int TrackId)> trackPointSets)
+    {
+        var trimmed = new List<Segment>();
+
+        foreach (var (points, trackId) in trackPointSets)
+        {
+            var trackSegments = allSegments.Where(s => s.TrackId == trackId).ToList();
+            if (trackSegments.Count == 0) continue;
+
+            var intersections = trackSegments
+                .SelectMany(s => s.Intersections)
+                .Distinct(new Vec2ApproxComparer())
+                .ToList();
+
+            if (intersections.Count < 2) continue;
+
+            var (startDist, endDist) = GetTrimDistances(points, intersections);
+            if (startDist >= endDist) continue;
+
+            var trimmedPoints = ExtractTrimmedPoints(points, startDist, endDist);
+            trimmed.AddRange(CreateUniformSegments(trimmedPoints, trackId, TrimSegmentLength));
+        }
+
+        return trimmed;
+    }
+
+    private static (double StartDist, double EndDist) GetTrimDistances(List<Vec2> points, List<Vec2> intersections)
+    {
+        var distances = new List<double> { 0 };
+        for (int i = 1; i < points.Count; i++)
+            distances.Add(distances[i - 1] + GeometryMath.Distance(points[i - 1], points[i]));
+
+        var intersectionDistances = new List<double>();
+        foreach (var pt in intersections)
+        {
+            for (int i = 0; i < points.Count - 1; i++)
+            {
+                var projected = Vec2.ProjectOnSegment(pt, points[i], points[i + 1]);
+                double distToSeg = GeometryMath.Distance(pt, projected);
+
+                if (distToSeg < IntersectionSearchRadius)
+                {
+                    intersectionDistances.Add(distances[i] + GeometryMath.Distance(points[i], pt));
+                    break;
+                }
+            }
+        }
+
+        if (intersectionDistances.Count < 2) return (0, 0);
+        return (intersectionDistances.Min(), intersectionDistances.Max());
+    }
+
+    private static List<Vec2> ExtractTrimmedPoints(List<Vec2> points, double startDist, double endDist)
+    {
+        var trimmed = new List<Vec2>();
+        double accumulatedDist = 0;
+
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            var a = points[i];
+            var b = points[i + 1];
+            double segmentLength = GeometryMath.Distance(a, b);
+            double segmentStart = accumulatedDist;
+            double segmentEnd = accumulatedDist + segmentLength;
+
+            if (segmentEnd < startDist || segmentStart > endDist)
+            {
+                accumulatedDist = segmentEnd;
+                continue;
+            }
+
+            if (segmentLength < 1e-10)
+            {
+                accumulatedDist = segmentEnd;
+                continue;
+            }
+
+            double t1 = Math.Max(0, (startDist - segmentStart) / segmentLength);
+            double t2 = Math.Min(1, (endDist - segmentStart) / segmentLength);
+
+            var p1 = Vec2.Lerp(a, b, t1);
+            var p2 = Vec2.Lerp(a, b, t2);
+
+            if (trimmed.Count == 0 || GeometryMath.Distance(trimmed[^1], p1) > IntersectionTolerance)
+                trimmed.Add(p1);
+
+            if (GeometryMath.Distance(p1, p2) > IntersectionTolerance)
+                trimmed.Add(p2);
+
+            accumulatedDist = segmentEnd;
+        }
+
+        return trimmed;
+    }
+
+    private static List<Segment> CreateUniformSegments(List<Vec2> points, int trackId, double segmentLength)
+    {
+        var segments = new List<Segment>();
+
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            var start = points[i];
+            var end = points[i + 1];
+            double distance = GeometryMath.Distance(start, end);
+            int steps = Math.Max(1, (int)(distance / segmentLength));
+
+            for (int j = 0; j < steps; j++)
+            {
+                double t1 = (double)j / steps;
+                double t2 = (double)(j + 1) / steps;
+                segments.Add(new Segment(Vec2.Lerp(start, end, t1), Vec2.Lerp(start, end, t2), trackId));
+            }
+        }
+
+        return segments;
+    }
+
+    private static List<Vec2> ConvertSegmentsToPolygon(List<Segment> segments)
+    {
+        if (segments.Count == 0) return new List<Vec2>();
+
+        var polygon = new List<Vec2>();
+        var visited = new HashSet<int>();
+        int currentIdx = 0;
+
+        polygon.Add(segments[0].Start);
+        polygon.Add(segments[0].End);
+        visited.Add(0);
+
+        while (visited.Count < segments.Count)
+        {
+            var connectionPoint = polygon[^1];
+            int nextIdx = -1;
+
+            for (int i = 0; i < segments.Count; i++)
+            {
+                if (visited.Contains(i)) continue;
+
+                if (GeometryMath.Distance(segments[i].Start, connectionPoint) < IntersectionTolerance)
+                {
+                    nextIdx = i;
+                    break;
+                }
+
+                if (GeometryMath.Distance(segments[i].End, connectionPoint) < IntersectionTolerance)
+                {
+                    segments[i].Reverse();
+                    nextIdx = i;
+                    break;
+                }
+            }
+
+            if (nextIdx < 0) break;
+
+            polygon.Add(segments[nextIdx].End);
+            visited.Add(nextIdx);
+        }
+
+        return polygon;
+    }
+
+    private class Segment
+    {
+        public Vec2 Start { get; private set; }
+        public Vec2 End { get; private set; }
+        public int TrackId { get; }
+        public List<Vec2> Intersections { get; } = new();
+
+        public Segment(Vec2 start, Vec2 end, int trackId)
+        {
+            Start = start;
+            End = end;
+            TrackId = trackId;
+        }
+
+        public void Reverse() => (Start, End) = (End, Start);
+
+        public void AddIntersection(Vec2 point)
+        {
+            if (!Intersections.Any(p => (p - point).GetLengthSquared() < IntersectionToleranceSq))
+                Intersections.Add(point);
+        }
+    }
+
+    private class Vec2ApproxComparer : IEqualityComparer<Vec2>
+    {
+        public bool Equals(Vec2 a, Vec2 b) =>
+            (a - b).GetLengthSquared() < IntersectionToleranceSq;
+
+        public int GetHashCode(Vec2 p) =>
+            HashCode.Combine(
+                Math.Round(p.Easting / IntersectionTolerance),
+                Math.Round(p.Northing / IntersectionTolerance));
+    }
+}

--- a/Shared/AgValoniaGPS.Services/Interfaces/IBoundaryBuilderService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IBoundaryBuilderService.cs
@@ -1,0 +1,30 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System.Collections.Generic;
+using AgValoniaGPS.Models;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// Builds a boundary polygon from a set of tracks by finding their
+/// intersections and trimming to create a closed polygon.
+/// Ported from AgOpenGPS BoundaryBuilder.
+/// </summary>
+public interface IBoundaryBuilderService
+{
+    /// <summary>
+    /// Builds a boundary polygon from the given tracks.
+    /// Tracks are extended, intersections found, segments trimmed,
+    /// and a closed polygon is constructed.
+    /// </summary>
+    /// <param name="tracks">Tracks to build the boundary from (minimum 2)</param>
+    /// <param name="extendMeters">Distance to extend track endpoints (helps find intersections)</param>
+    /// <returns>A BoundaryPolygon if successful, null if insufficient tracks or no valid polygon</returns>
+    BoundaryPolygon? BuildBoundaryFromTracks(List<Models.Track.Track> tracks, double extendMeters = 20.0);
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.BoundaryRecording.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.BoundaryRecording.cs
@@ -98,6 +98,9 @@ public partial class MainViewModel
             BoundaryPointCount = e.PointCount;
             BoundaryAreaHectares = e.AreaHectares;
 
+            // Update header text when recording state changes
+            OnPropertyChanged(nameof(BoundaryRecordingHeaderText));
+
             // Clear recording points from map when recording becomes idle
             if (e.State == BoundaryRecordingState.Idle)
             {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
@@ -52,6 +52,7 @@ public partial class MainViewModel
             BoundaryMapCanSave = false;
             BoundaryMapCoordinateText = string.Empty;
             BoundaryMapResultPoints.Clear();
+            PopulateBoundaryMapExistingPolygons();
             State.UI.ShowDialog(DialogType.BoundaryMap);
         });
 
@@ -92,7 +93,11 @@ public partial class MainViewModel
                         _logger.LogDebug($"[BoundaryMap] Point WGS84: ({lat:F8}, {lon:F8}) -> Local: ({geoCoord.Easting:F2}, {geoCoord.Northing:F2})");
                     }
 
-                    boundary.OuterBoundary = outerPolygon;
+                    if (PendingBoundaryType == BoundaryType.Inner)
+                        boundary.InnerBoundaries.Add(outerPolygon);
+                    else
+                        boundary.OuterBoundary = outerPolygon;
+
                     _boundaryFileService.SaveBoundary(boundary, fieldPath);
 
                     // NOTE: Do NOT overwrite the field origin - it should stay constant!
@@ -101,7 +106,8 @@ public partial class MainViewModel
 
                     SetCurrentBoundary(boundary);
 
-                    if (outerPolygon.Points.Count > 0)
+                    // Pan to boundary center only for outer boundaries
+                    if (PendingBoundaryType == BoundaryType.Outer && outerPolygon.Points.Count > 0)
                     {
                         double minE = double.MaxValue, maxE = double.MinValue;
                         double minN = double.MaxValue, maxN = double.MinValue;
@@ -134,7 +140,9 @@ public partial class MainViewModel
                     }
 
                     RefreshBoundaryList();
-                    StatusMessage = $"Boundary created with {BoundaryMapResultPoints.Count} points";
+                    var mapTypeLabel = PendingBoundaryType == BoundaryType.Inner ? "Inner boundary" : "Boundary";
+                    StatusMessage = $"{mapTypeLabel} created with {BoundaryMapResultPoints.Count} points";
+                    PendingBoundaryType = BoundaryType.Outer; // Reset to default
                 }
                 catch (Exception ex)
                 {
@@ -447,11 +455,17 @@ public partial class MainViewModel
                 {
                     var fieldPath = Path.Combine(_settingsService.Settings.FieldsDirectory, CurrentFieldName);
                     var boundary = _boundaryFileService.LoadBoundary(fieldPath) ?? new Boundary();
-                    boundary.OuterBoundary = polygon;
+
+                    if (_boundaryRecordingService.CurrentBoundaryType == BoundaryType.Inner)
+                        boundary.InnerBoundaries.Add(polygon);
+                    else
+                        boundary.OuterBoundary = polygon;
+
                     _boundaryFileService.SaveBoundary(boundary, fieldPath);
                     SetCurrentBoundary(boundary);
                     RefreshBoundaryList();
-                    StatusMessage = $"Boundary saved with {polygon.Points.Count} points, Area: {polygon.AreaHectares:F2} Ha";
+                    var typeLabel = _boundaryRecordingService.CurrentBoundaryType == BoundaryType.Inner ? "Inner boundary" : "Boundary";
+                    StatusMessage = $"{typeLabel} saved with {polygon.Points.Count} points, Area: {polygon.AreaHectares:F2} Ha";
                 }
                 else
                 {
@@ -584,6 +598,21 @@ public partial class MainViewModel
                 return;
             }
 
+            _kmlImportToExistingField = true;
+            PopulateAvailableKmlFiles();
+            KmlImportFieldName = CurrentFieldName;
+            KmlBoundaryPointCount = 0;
+            KmlCenterLatitude = 0;
+            KmlCenterLongitude = 0;
+            _kmlBoundaryPoints.Clear();
+            _kmlParsedPolygons.Clear();
+            SelectedKmlFile = null;
+
+            if (AvailableKmlFiles.Count > 0)
+            {
+                SelectedKmlFile = AvailableKmlFiles[0];
+            }
+
             State.UI.ShowDialog(DialogType.KmlImport);
         });
 
@@ -599,7 +628,41 @@ public partial class MainViewModel
 
         BuildFromTracksCommand = new RelayCommand(() =>
         {
-            StatusMessage = "Build boundary from tracks not yet implemented";
+            if (!IsFieldOpen || string.IsNullOrEmpty(CurrentFieldName))
+            {
+                StatusMessage = "Open a field first";
+                return;
+            }
+
+            var tracks = SavedTracks.Where(t => t.Points.Count >= 2).ToList();
+            if (tracks.Count < 2)
+            {
+                StatusMessage = "Need at least 2 tracks to build a boundary";
+                return;
+            }
+
+            var polygon = _boundaryBuilderService.BuildBoundaryFromTracks(tracks);
+            if (polygon == null || polygon.Points.Count < 3)
+            {
+                StatusMessage = "Could not build boundary - tracks may not intersect";
+                return;
+            }
+
+            var fieldPath = Path.Combine(_settingsService.Settings.FieldsDirectory, CurrentFieldName);
+            var boundary = _boundaryFileService.LoadBoundary(fieldPath) ?? new Boundary();
+
+            if (PendingBoundaryType == BoundaryType.Inner)
+                boundary.InnerBoundaries.Add(polygon);
+            else
+                boundary.OuterBoundary = polygon;
+
+            _boundaryFileService.SaveBoundary(boundary, fieldPath);
+            SetCurrentBoundary(boundary);
+            RefreshBoundaryList();
+
+            var typeLabel = PendingBoundaryType == BoundaryType.Inner ? "Inner boundary" : "Boundary";
+            StatusMessage = $"{typeLabel} built from {tracks.Count} tracks ({polygon.Points.Count} points)";
+            PendingBoundaryType = BoundaryType.Outer;
         });
 
         DriveAroundFieldCommand = new RelayCommand(() =>
@@ -617,6 +680,95 @@ public partial class MainViewModel
             _boundaryRecordingService.PauseRecording();
 
             StatusMessage = "Drive around the field boundary. Click Record to start.";
+        });
+
+        RecordInnerBoundaryCommand = new RelayCommand(() =>
+        {
+            if (!IsFieldOpen || string.IsNullOrEmpty(CurrentFieldName))
+            {
+                StatusMessage = "Open a field first before recording a boundary";
+                return;
+            }
+
+            _boundaryRecordingService.StartRecording(BoundaryType.Inner);
+            StatusMessage = "Recording inner boundary (obstacle)";
+        });
+
+        DriveAroundInnerBoundaryCommand = new RelayCommand(() =>
+        {
+            if (!IsFieldOpen || string.IsNullOrEmpty(CurrentFieldName))
+            {
+                StatusMessage = "Open a field first before recording a boundary";
+                return;
+            }
+
+            IsBoundaryPanelVisible = false;
+            IsBoundaryPlayerPanelVisible = true;
+
+            _boundaryRecordingService.StartRecording(BoundaryType.Inner);
+            _boundaryRecordingService.PauseRecording();
+
+            StatusMessage = "Drive around the obstacle. Click Record to start.";
+        });
+
+        DrawMapInnerBoundaryCommand = new RelayCommand(() =>
+        {
+            if (!IsFieldOpen || string.IsNullOrEmpty(CurrentFieldName))
+            {
+                StatusMessage = "Open a field first to add boundary";
+                return;
+            }
+            PendingBoundaryType = BoundaryType.Inner;
+            ShowBoundaryMapDialogCommand?.Execute(null);
+        });
+
+        ToggleDriveThroughCommand = new RelayCommand(() =>
+        {
+            if (SelectedBoundaryIndex < 0)
+            {
+                StatusMessage = "Select a boundary first";
+                return;
+            }
+
+            if (string.IsNullOrEmpty(CurrentFieldName)) return;
+
+            var fieldPath = Path.Combine(_settingsService.Settings.FieldsDirectory, CurrentFieldName);
+            var boundary = _boundaryFileService.LoadBoundary(fieldPath);
+            if (boundary == null) return;
+
+            // Map selected index to the correct boundary polygon
+            int currentIndex = 0;
+
+            if (boundary.OuterBoundary != null && boundary.OuterBoundary.IsValid)
+            {
+                if (currentIndex == SelectedBoundaryIndex)
+                {
+                    boundary.OuterBoundary.IsDriveThrough = !boundary.OuterBoundary.IsDriveThrough;
+                    _boundaryFileService.SaveBoundary(boundary, fieldPath);
+                    SetCurrentBoundary(boundary);
+                    RefreshBoundaryList();
+                    StatusMessage = $"Outer boundary drive-through: {(boundary.OuterBoundary.IsDriveThrough ? "On" : "Off")}";
+                    return;
+                }
+                currentIndex++;
+            }
+
+            for (int i = 0; i < boundary.InnerBoundaries.Count; i++)
+            {
+                if (boundary.InnerBoundaries[i].IsValid)
+                {
+                    if (currentIndex == SelectedBoundaryIndex)
+                    {
+                        boundary.InnerBoundaries[i].IsDriveThrough = !boundary.InnerBoundaries[i].IsDriveThrough;
+                        _boundaryFileService.SaveBoundary(boundary, fieldPath);
+                        SetCurrentBoundary(boundary);
+                        RefreshBoundaryList();
+                        StatusMessage = $"Inner {i + 1} drive-through: {(boundary.InnerBoundaries[i].IsDriveThrough ? "On" : "Off")}";
+                        return;
+                    }
+                    currentIndex++;
+                }
+            }
         });
     }
 }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -373,12 +373,14 @@ public partial class MainViewModel
         // KML Import Dialog
         ShowKmlImportDialogCommand = new RelayCommand(() =>
         {
+            _kmlImportToExistingField = false;
             PopulateAvailableKmlFiles();
             KmlImportFieldName = string.Empty;
             KmlBoundaryPointCount = 0;
             KmlCenterLatitude = 0;
             KmlCenterLongitude = 0;
             _kmlBoundaryPoints.Clear();
+            _kmlParsedPolygons.Clear();
             SelectedKmlFile = null;
 
             if (AvailableKmlFiles.Count > 0)
@@ -404,16 +406,24 @@ public partial class MainViewModel
                 return;
             }
 
+            if (_kmlParsedPolygons.Count == 0 || _kmlBoundaryPoints.Count < 3)
+            {
+                StatusMessage = "KML file must contain at least 3 boundary points";
+                return;
+            }
+
+            // Import to existing field mode (opened from boundary panel)
+            if (_kmlImportToExistingField)
+            {
+                ImportKmlToExistingField();
+                return;
+            }
+
+            // Create new field mode (opened from field creation)
             var newFieldName = KmlImportFieldName.Trim();
             if (string.IsNullOrWhiteSpace(newFieldName))
             {
                 StatusMessage = "Please enter a field name";
-                return;
-            }
-
-            if (_kmlBoundaryPoints.Count < 3)
-            {
-                StatusMessage = "KML file must contain at least 3 boundary points";
                 return;
             }
 
@@ -443,27 +453,56 @@ public partial class MainViewModel
                 var sharedProps = new SharedFieldProperties();
                 var localPlane = new LocalPlane(origin, sharedProps);
 
-                var outerPolygon = new BoundaryPolygon();
-                foreach (var (lat, lon) in _kmlBoundaryPoints)
+                var boundary = new Boundary();
+
+                // First polygon = outer boundary
+                for (int polyIdx = 0; polyIdx < _kmlParsedPolygons.Count; polyIdx++)
                 {
-                    var wgs84 = new Wgs84(lat, lon);
-                    var geoCoord = localPlane.ConvertWgs84ToGeoCoord(wgs84);
-                    outerPolygon.Points.Add(new BoundaryPoint(geoCoord.Easting, geoCoord.Northing, 0));
+                    var polygon = new BoundaryPolygon();
+                    foreach (var (lat, lon) in _kmlParsedPolygons[polyIdx])
+                    {
+                        var wgs84 = new Wgs84(lat, lon);
+                        var geoCoord = localPlane.ConvertWgs84ToGeoCoord(wgs84);
+                        polygon.Points.Add(new BoundaryPoint(geoCoord.Easting, geoCoord.Northing, 0));
+                    }
+
+                    if (polyIdx == 0)
+                        boundary.OuterBoundary = polygon;
+                    else
+                        boundary.InnerBoundaries.Add(polygon);
                 }
 
-                var boundary = new Boundary { OuterBoundary = outerPolygon };
                 _boundaryFileService.SaveBoundary(boundary, newFieldPath);
+
+                // Set field origin so coordinate conversions work
+                _fieldOriginLatitude = KmlCenterLatitude;
+                _fieldOriginLongitude = KmlCenterLongitude;
+                _simulatorLocalPlane = null;
 
                 CurrentFieldName = newFieldName;
                 FieldsRootDirectory = fieldsDir;
                 IsFieldOpen = true;
 
+                // Load boundary into map renderer
+                SetCurrentBoundary(boundary);
+                CenterMapOnBoundary(boundary);
+
+                // Update boundary area stats
+                var boundaryAreas = new List<double> { boundary.AreaHectares * 10000 };
+                _fieldStatistics.UpdateBoundaryAreas(boundaryAreas);
+                OnPropertyChanged(nameof(BoundaryAreaDisplay));
+
                 _settingsService.Settings.LastOpenedField = newFieldName;
                 _settingsService.Save();
 
+                RefreshBoundaryList();
+                SetSimulatorCoordinates(_fieldOriginLatitude, _fieldOriginLongitude);
+
                 State.UI.CloseDialog();
                 IsJobMenuPanelVisible = false;
-                StatusMessage = $"Imported KML: {newFieldName}";
+                var innerCount = _kmlParsedPolygons.Count - 1;
+                var innerMsg = innerCount > 0 ? $" ({innerCount} inner boundaries)" : "";
+                StatusMessage = $"Imported KML: {newFieldName}{innerMsg}";
             }
             catch (Exception ex)
             {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -53,6 +53,7 @@ public partial class MainViewModel : ObservableObject
     private readonly ISettingsService _settingsService;
     private readonly IMapService _mapService;
     private readonly IBoundaryRecordingService _boundaryRecordingService;
+    private readonly IBoundaryBuilderService _boundaryBuilderService;
     private readonly BoundaryFileService _boundaryFileService;
     private readonly NmeaParserService _nmeaParser;
     private readonly Services.Headland.IHeadlandBuilderService _headlandBuilderService;
@@ -151,6 +152,7 @@ public partial class MainViewModel : ObservableObject
         ISettingsService settingsService,
         IMapService mapService,
         IBoundaryRecordingService boundaryRecordingService,
+        IBoundaryBuilderService boundaryBuilderService,
         BoundaryFileService boundaryFileService,
         Services.Headland.IHeadlandBuilderService headlandBuilderService,
         ITrackGuidanceService trackGuidanceService,
@@ -203,6 +205,7 @@ public partial class MainViewModel : ObservableObject
         _settingsService = settingsService;
         _mapService = mapService;
         _boundaryRecordingService = boundaryRecordingService;
+        _boundaryBuilderService = boundaryBuilderService;
         _boundaryFileService = boundaryFileService;
         _headlandBuilderService = headlandBuilderService;
         _trackGuidanceService = trackGuidanceService;
@@ -2040,6 +2043,13 @@ public partial class MainViewModel : ObservableObject
     }
 
     private List<(double Latitude, double Longitude)> _kmlBoundaryPoints = new();
+    private List<List<(double Latitude, double Longitude)>> _kmlParsedPolygons = new();
+
+    /// <summary>
+    /// When true, KML import adds boundaries to the current open field.
+    /// When false (default), KML import creates a new field.
+    /// </summary>
+    private bool _kmlImportToExistingField;
 
     public ICommand? CancelKmlImportDialogCommand { get; private set; }
     public ICommand? ConfirmKmlImportDialogCommand { get; private set; }
@@ -2119,6 +2129,9 @@ public partial class MainViewModel : ObservableObject
         get => _boundaryMapCanSave;
         set => SetProperty(ref _boundaryMapCanSave, value);
     }
+
+    // Existing boundary polygons for reference display in the map dialog (WGS84 coordinates)
+    public List<List<(double Latitude, double Longitude)>> BoundaryMapExistingPolygons { get; } = new();
 
     // Result properties for boundary map dialog
     public List<(double Latitude, double Longitude)> BoundaryMapResultPoints { get; } = new();
@@ -2338,6 +2351,37 @@ public partial class MainViewModel : ObservableObject
             {
                 RefreshBoundaryList();
             }
+        }
+    }
+
+    // Boundary mode: tracks whether next boundary operation targets inner or outer
+    private BoundaryType _pendingBoundaryType = BoundaryType.Outer;
+    public BoundaryType PendingBoundaryType
+    {
+        get => _pendingBoundaryType;
+        set
+        {
+            if (SetProperty(ref _pendingBoundaryType, value))
+            {
+                OnPropertyChanged(nameof(BoundaryRecordingHeaderText));
+                OnPropertyChanged(nameof(IsInnerBoundaryMode));
+            }
+        }
+    }
+
+    public bool IsInnerBoundaryMode => PendingBoundaryType == BoundaryType.Inner;
+
+    public string BoundaryRecordingHeaderText
+    {
+        get
+        {
+            if (_boundaryRecordingService.IsRecording || _boundaryRecordingService.State == BoundaryRecordingState.Paused)
+            {
+                return _boundaryRecordingService.CurrentBoundaryType == BoundaryType.Inner
+                    ? "Recording Inner Boundary"
+                    : "Recording Outer Boundary";
+            }
+            return "Start or Delete Boundary";
         }
     }
 
@@ -2949,6 +2993,10 @@ public partial class MainViewModel : ObservableObject
     public ICommand? DrawMapBoundaryCommand { get; private set; }
     public ICommand? BuildFromTracksCommand { get; private set; }
     public ICommand? DriveAroundFieldCommand { get; private set; }
+    public ICommand? RecordInnerBoundaryCommand { get; private set; }
+    public ICommand? DriveAroundInnerBoundaryCommand { get; private set; }
+    public ICommand? DrawMapInnerBoundaryCommand { get; private set; }
+    public ICommand? ToggleDriveThroughCommand { get; private set; }
     public ICommand? ToggleRecordingCommand { get; private set; }
     public ICommand? ToggleBoundaryLeftRightCommand { get; private set; }
     public ICommand? ToggleBoundaryAntennaToolCommand { get; private set; }
@@ -3562,29 +3610,35 @@ public partial class MainViewModel : ObservableObject
 
     /// <summary>
     /// Parses a KML file to extract boundary coordinates.
+    /// Parses ALL coordinate blocks: first = outer boundary, subsequent = inner boundaries.
+    /// Results stored in both _kmlBoundaryPoints (first polygon, for field-creation flow)
+    /// and _kmlParsedPolygons (all polygons, for import-to-existing flow).
     /// </summary>
     private void ParseKmlFile(string filePath)
     {
         _kmlBoundaryPoints.Clear();
+        _kmlParsedPolygons.Clear();
         KmlBoundaryPointCount = 0;
         KmlCenterLatitude = 0;
         KmlCenterLongitude = 0;
 
         try
         {
-            string? coordinates = null;
-            int startIndex;
-
             using var reader = new StreamReader(filePath);
+            double sumLat = 0, sumLon = 0;
+            int totalValidPoints = 0;
+
             while (!reader.EndOfStream)
             {
                 string? line = reader.ReadLine();
                 if (line == null) continue;
 
-                startIndex = line.IndexOf("<coordinates>");
+                int startIndex = line.IndexOf("<coordinates>");
 
                 if (startIndex != -1)
                 {
+                    string? coordinates = null;
+
                     // Found start of coordinates block
                     while (true)
                     {
@@ -3620,8 +3674,7 @@ public partial class MainViewModel : ObservableObject
 
                     if (numberSets.Length >= 3)
                     {
-                        double sumLat = 0, sumLon = 0;
-                        int validPoints = 0;
+                        var polygonPoints = new List<(double Latitude, double Longitude)>();
 
                         foreach (string item in numberSets)
                         {
@@ -3632,30 +3685,157 @@ public partial class MainViewModel : ObservableObject
                                 double.TryParse(parts[0], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out double lon) &&
                                 double.TryParse(parts[1], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out double lat))
                             {
-                                _kmlBoundaryPoints.Add((lat, lon));
+                                polygonPoints.Add((lat, lon));
                                 sumLat += lat;
                                 sumLon += lon;
-                                validPoints++;
+                                totalValidPoints++;
                             }
                         }
 
-                        if (validPoints > 0)
+                        if (polygonPoints.Count >= 3)
                         {
-                            KmlCenterLatitude = sumLat / validPoints;
-                            KmlCenterLongitude = sumLon / validPoints;
+                            _kmlParsedPolygons.Add(polygonPoints);
+
+                            // First polygon also populates _kmlBoundaryPoints for backwards compatibility
+                            if (_kmlParsedPolygons.Count == 1)
+                            {
+                                _kmlBoundaryPoints.AddRange(polygonPoints);
+                            }
                         }
-
-                        KmlBoundaryPointCount = validPoints;
                     }
+                    // Continue to parse additional coordinate blocks (inner boundaries)
+                }
+            }
 
-                    // Only parse first coordinate block (outer boundary)
-                    break;
+            if (totalValidPoints > 0)
+            {
+                KmlCenterLatitude = sumLat / totalValidPoints;
+                KmlCenterLongitude = sumLon / totalValidPoints;
+            }
+
+            KmlBoundaryPointCount = totalValidPoints;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error parsing KML: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Imports KML boundaries into the currently open field.
+    /// First polygon becomes outer (or inner if PendingBoundaryType is Inner),
+    /// subsequent polygons are added as inner boundaries.
+    /// </summary>
+    /// <summary>
+    /// Converts existing boundary polygons from local coordinates to WGS84
+    /// for display as reference layers in the boundary map dialog.
+    /// </summary>
+    private void PopulateBoundaryMapExistingPolygons()
+    {
+        BoundaryMapExistingPolygons.Clear();
+
+        if (_currentBoundary == null || (_fieldOriginLatitude == 0 && _fieldOriginLongitude == 0))
+            return;
+
+        try
+        {
+            var origin = new Wgs84(_fieldOriginLatitude, _fieldOriginLongitude);
+            var sharedProps = new SharedFieldProperties();
+            var localPlane = new LocalPlane(origin, sharedProps);
+
+            // Add outer boundary
+            if (_currentBoundary.OuterBoundary?.Points != null && _currentBoundary.OuterBoundary.Points.Count >= 3)
+            {
+                var wgs84Points = new List<(double Latitude, double Longitude)>();
+                foreach (var pt in _currentBoundary.OuterBoundary.Points)
+                {
+                    var geoCoord = new GeoCoord(pt.Northing, pt.Easting);
+                    var wgs84 = localPlane.ConvertGeoCoordToWgs84(geoCoord);
+                    wgs84Points.Add((wgs84.Latitude, wgs84.Longitude));
+                }
+                BoundaryMapExistingPolygons.Add(wgs84Points);
+            }
+
+            // Add inner boundaries
+            foreach (var inner in _currentBoundary.InnerBoundaries)
+            {
+                if (inner.Points.Count >= 3)
+                {
+                    var wgs84Points = new List<(double Latitude, double Longitude)>();
+                    foreach (var pt in inner.Points)
+                    {
+                        var geoCoord = new GeoCoord(pt.Northing, pt.Easting);
+                        var wgs84 = localPlane.ConvertGeoCoordToWgs84(geoCoord);
+                        wgs84Points.Add((wgs84.Latitude, wgs84.Longitude));
+                    }
+                    BoundaryMapExistingPolygons.Add(wgs84Points);
                 }
             }
         }
         catch (Exception ex)
         {
-            StatusMessage = $"Error parsing KML: {ex.Message}";
+            _logger.LogDebug($"[BoundaryMap] Failed to populate existing polygons: {ex.Message}");
+        }
+    }
+
+    private void ImportKmlToExistingField()
+    {
+        if (string.IsNullOrEmpty(CurrentFieldName) || _kmlParsedPolygons.Count == 0)
+        {
+            StatusMessage = "No field open or no KML polygons parsed";
+            return;
+        }
+
+        try
+        {
+            var fieldPath = Path.Combine(_settingsService.Settings.FieldsDirectory, CurrentFieldName);
+            var boundary = _boundaryFileService.LoadBoundary(fieldPath) ?? new Boundary();
+
+            var origin = new Wgs84(_fieldOriginLatitude, _fieldOriginLongitude);
+            var sharedProps = new SharedFieldProperties();
+            var localPlane = new LocalPlane(origin, sharedProps);
+
+            for (int polyIdx = 0; polyIdx < _kmlParsedPolygons.Count; polyIdx++)
+            {
+                var polygon = new BoundaryPolygon();
+                foreach (var (lat, lon) in _kmlParsedPolygons[polyIdx])
+                {
+                    var wgs84 = new Wgs84(lat, lon);
+                    var geoCoord = localPlane.ConvertWgs84ToGeoCoord(wgs84);
+                    polygon.Points.Add(new BoundaryPoint(geoCoord.Easting, geoCoord.Northing, 0));
+                }
+
+                // First polygon: respects PendingBoundaryType
+                // Subsequent polygons: always inner
+                if (polyIdx == 0 && PendingBoundaryType == BoundaryType.Outer)
+                    boundary.OuterBoundary = polygon;
+                else
+                    boundary.InnerBoundaries.Add(polygon);
+            }
+
+            _boundaryFileService.SaveBoundary(boundary, fieldPath);
+            SetCurrentBoundary(boundary);
+            CenterMapOnBoundary(boundary);
+            RefreshBoundaryList();
+
+            // Update boundary area stats
+            if (boundary.OuterBoundary != null)
+            {
+                var boundaryAreas = new List<double> { boundary.AreaHectares * 10000 };
+                _fieldStatistics.UpdateBoundaryAreas(boundaryAreas);
+                OnPropertyChanged(nameof(BoundaryAreaDisplay));
+            }
+
+            State.UI.CloseDialog();
+            PendingBoundaryType = BoundaryType.Outer;
+
+            var innerCount = _kmlParsedPolygons.Count > 1 ? _kmlParsedPolygons.Count - 1 : 0;
+            var innerMsg = innerCount > 0 ? $" + {innerCount} inner" : "";
+            StatusMessage = $"KML boundary imported{innerMsg}";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error importing KML boundary: {ex.Message}";
         }
     }
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
@@ -100,6 +100,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="24" Height="24"/>
                                 <TextBlock Text="{loc:Localize DrawFieldBoundary}" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18"/>
+                                <Border Background="#F5F54D" CornerRadius="4" Padding="6,2" VerticalAlignment="Center"
+                                        IsVisible="{Binding IsInnerBoundaryMode}">
+                                    <TextBlock Text="INNER" FontSize="12" FontWeight="Bold" Foreground="#333333"/>
+                                </Border>
                             </StackPanel>
                             <TextBlock Text="{loc:Localize TapOnTheMapToAddBoundaryPointsPanWithDragPinchToZoom}"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,5,0,0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml.cs
@@ -46,6 +46,7 @@ public partial class BoundaryMapDialogPanel : UserControl
 {
     private WritableLayer? _pointsLayer;
     private WritableLayer? _polygonLayer;
+    private WritableLayer? _existingBoundaryLayer;
     private bool _isDrawingMode;
     private bool _mapInitialized;
     private readonly List<(double Lat, double Lon)> _boundaryPoints = new();
@@ -60,10 +61,14 @@ public partial class BoundaryMapDialogPanel : UserControl
 
     private void OnPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
     {
-        if (e.Property.Name == nameof(IsVisible) && IsVisible && !_mapInitialized)
+        if (e.Property.Name == nameof(IsVisible) && IsVisible)
         {
-            SetupMap();
-            _mapInitialized = true;
+            if (!_mapInitialized)
+            {
+                SetupMap();
+                _mapInitialized = true;
+            }
+            UpdateExistingBoundaryLayer();
         }
     }
 
@@ -83,6 +88,11 @@ public partial class BoundaryMapDialogPanel : UserControl
             name: "Bing Satellite");
         map.Layers.Add(new TileLayer(bingTileSource) { Name = "Satellite" });
         Debug.WriteLine("[BoundaryMap] Using Bing Satellite tiles");
+
+        // Create layer for existing boundary reference (below active drawing layers)
+        // Style = null so per-feature styles are used instead of a layer default
+        _existingBoundaryLayer = new WritableLayer { Name = "ExistingBoundaries", Style = null };
+        map.Layers.Add(_existingBoundaryLayer);
 
         // Create layer for polygon (drawn below points)
         _polygonLayer = new WritableLayer
@@ -144,6 +154,56 @@ public partial class BoundaryMapDialogPanel : UserControl
 
         // Handle pointer movement for coordinate display
         MapControl.PointerMoved += OnPointerMoved;
+    }
+
+    /// <summary>
+    /// Renders existing boundary polygons (outer + inner) as reference on the satellite map.
+    /// </summary>
+    private void UpdateExistingBoundaryLayer()
+    {
+        if (_existingBoundaryLayer == null) return;
+        _existingBoundaryLayer.Clear();
+
+        if (DataContext is not AgValoniaGPS.ViewModels.MainViewModel vm) return;
+        if (vm.BoundaryMapExistingPolygons.Count == 0) return;
+
+        var factory = new GeometryFactory();
+
+        for (int polyIdx = 0; polyIdx < vm.BoundaryMapExistingPolygons.Count; polyIdx++)
+        {
+            var wgs84Points = vm.BoundaryMapExistingPolygons[polyIdx];
+            if (wgs84Points.Count < 3) continue;
+
+            // Convert to Mercator coordinates and close the ring
+            var coords = new Coordinate[wgs84Points.Count + 1];
+            for (int i = 0; i < wgs84Points.Count; i++)
+            {
+                var merc = SphericalMercator.FromLonLat(wgs84Points[i].Longitude, wgs84Points[i].Latitude);
+                coords[i] = new Coordinate(merc.x, merc.y);
+            }
+            coords[^1] = coords[0]; // Close ring
+
+            var ring = factory.CreateLinearRing(coords);
+            var polygon = factory.CreatePolygon(ring);
+            var feature = new GeometryFeature(polygon);
+
+            // Outer boundary = orange, inner boundaries = yellow
+            bool isOuter = polyIdx == 0;
+            feature.Styles.Add(new VectorStyle
+            {
+                Fill = new Mapsui.Styles.Brush(isOuter
+                    ? new Mapsui.Styles.Color(242, 112, 89, 40)   // Semi-transparent orange
+                    : new Mapsui.Styles.Color(245, 245, 77, 40)), // Semi-transparent yellow
+                Line = new Mapsui.Styles.Pen(isOuter
+                    ? new Mapsui.Styles.Color(242, 112, 89, 200)  // Orange outline
+                    : new Mapsui.Styles.Color(245, 245, 77, 200), // Yellow outline
+                    2)
+            });
+
+            _existingBoundaryLayer.Add(feature);
+        }
+
+        _existingBoundaryLayer.DataHasChanged();
     }
 
     private void OnMapPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -399,9 +459,10 @@ public partial class BoundaryMapDialogPanel : UserControl
             Directory.CreateDirectory(tempDir);
             var savedBackgroundPath = Path.Combine(tempDir, "BackPic.png");
 
-            // Hide drawing layers before capture
+            // Hide drawing and reference layers before capture
             if (_pointsLayer != null) _pointsLayer.Enabled = false;
             if (_polygonLayer != null) _polygonLayer.Enabled = false;
+            if (_existingBoundaryLayer != null) _existingBoundaryLayer.Enabled = false;
             MapControl.Refresh();
 
             // Wait for tile layer to finish loading
@@ -449,9 +510,10 @@ public partial class BoundaryMapDialogPanel : UserControl
                 renderTarget.Save(savedBackgroundPath);
             }
 
-            // Re-enable drawing layers
+            // Re-enable drawing and reference layers
             if (_pointsLayer != null) _pointsLayer.Enabled = true;
             if (_polygonLayer != null) _polygonLayer.Enabled = true;
+            if (_existingBoundaryLayer != null) _existingBoundaryLayer.Enabled = true;
             MapControl.Refresh();
 
             // Create geo-reference file content (includes Mercator bounds)
@@ -465,9 +527,10 @@ public partial class BoundaryMapDialogPanel : UserControl
         {
             Debug.WriteLine($"Error capturing background: {ex.Message}");
 
-            // Re-enable drawing layers on error
+            // Re-enable drawing and reference layers on error
             if (_pointsLayer != null) _pointsLayer.Enabled = true;
             if (_polygonLayer != null) _polygonLayer.Enabled = true;
+            if (_existingBoundaryLayer != null) _existingBoundaryLayer.Enabled = true;
             MapControl.Refresh();
 
             return null;

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
@@ -54,14 +54,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <Border Classes="FloatingPanel" MinWidth="420" IsVisible="{Binding IsBoundaryPanelVisible}" IsHitTestVisible="True">
+    <Border Classes="FloatingPanel" MinWidth="480" IsVisible="{Binding IsBoundaryPanelVisible}" IsHitTestVisible="True">
         <StackPanel Spacing="4" Background="Transparent">
             <!-- Header: Drag handle + Title + Close button -->
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,4"
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
                 <TextBlock Grid.Column="0" Text="=" FontSize="18" FontWeight="Bold"
                            Foreground="#FFFFFF" VerticalAlignment="Center" Margin="8,0,0,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize StartOrDeleteBoundary}" FontSize="14" FontWeight="SemiBold"
+                <TextBlock Grid.Column="1" Text="{Binding BoundaryRecordingHeaderText}" FontSize="14" FontWeight="SemiBold"
                            Foreground="#1ABC9C" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
                 <Button Grid.Column="2" Content="X" Width="28" Height="28" Margin="0,0,4,0"
                         Background="Transparent" BorderThickness="0" Foreground="#FFFFFF"
@@ -69,8 +69,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
             </Grid>
 
-            <!-- Toolbar Row: Delete, KML Import, Bing, Build From Tracks, Drive Around, Accept -->
-            <Grid ColumnDefinitions="*,*,*,*,*,*" Margin="4,4,4,8" Background="Transparent">
+            <!-- Toolbar Row: Delete, KML Import, Bing, Build From Tracks, Drive Around, + Inner, Accept -->
+            <Grid ColumnDefinitions="*,*,*,*,*,*,*" Margin="4,4,4,8" Background="Transparent">
                 <Button Grid.Column="0" Classes="ModernButton" Margin="2" Height="50"
                         ToolTip.Tip="Delete selected boundary" Command="{Binding DeleteBoundaryCommand}">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Trash.png" Width="32" Height="32"
@@ -97,6 +97,30 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
                 </Button>
                 <Button Grid.Column="5" Classes="ModernButton" Margin="2" Height="50"
+                        ToolTip.Tip="Add inner boundary / obstacle">
+                    <Button.Flyout>
+                        <MenuFlyout Placement="BottomEdgeAlignedLeft">
+                            <MenuItem Header="Drive Around Obstacle" Command="{Binding DriveAroundInnerBoundaryCommand}">
+                                <MenuItem.Icon>
+                                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ST_SteerTab.png" Width="20" Height="20"/>
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <MenuItem Header="Draw on Satellite Map" Command="{Binding DrawMapInnerBoundaryCommand}">
+                                <MenuItem.Icon>
+                                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryByMap.png" Width="20" Height="20"/>
+                                </MenuItem.Icon>
+                            </MenuItem>
+                        </MenuFlyout>
+                    </Button.Flyout>
+                    <Grid>
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="32" Height="32"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
+                        <TextBlock Text="+" FontSize="16" FontWeight="Bold" Foreground="#F5F54D"
+                                   HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,2,0"
+                                   IsHitTestVisible="False"/>
+                    </Grid>
+                </Button>
+                <Button Grid.Column="6" Classes="ModernButton" Margin="2" Height="50"
                         ToolTip.Tip="Accept and close" Command="{Binding ToggleBoundaryPanelCommand}">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png" Width="32" Height="32"
                            HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
@@ -126,9 +150,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                            HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                                 <TextBlock Grid.Column="1" Text="{Binding AreaDisplay}"
                                            HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-                                <TextBlock Grid.Column="2" Text="{Binding DriveThruDisplay}"
-                                           HorizontalAlignment="Center" Padding="8,6"
-                                           Foreground="{Binding IsDriveThrough, Converter={StaticResource BoolToColorConverter}}"/>
+                                <Button Grid.Column="2" Content="{Binding DriveThruDisplay}"
+                                        HorizontalAlignment="Center" Padding="8,6"
+                                        Foreground="{Binding IsDriveThrough, Converter={StaticResource BoolToColorConverter}}"
+                                        Background="Transparent" BorderThickness="0" Cursor="Hand"
+                                        Command="{Binding $parent[ListBox].((vm:MainViewModel)DataContext).ToggleDriveThroughCommand}"/>
                             </Grid>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -45,6 +45,7 @@ public class MainViewModelBuilder
             settingsService: SettingsService,
             mapService: Substitute.For<IMapService>(),
             boundaryRecordingService: Substitute.For<IBoundaryRecordingService>(),
+            boundaryBuilderService: Substitute.For<IBoundaryBuilderService>(),
             boundaryFileService: new BoundaryFileService(),
             headlandBuilderService: Substitute.For<AgValoniaGPS.Services.Headland.IHeadlandBuilderService>(),
             trackGuidanceService: Substitute.For<ITrackGuidanceService>(),

--- a/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
@@ -54,6 +54,7 @@ public class MainViewModelBuilder
             settingsService: SettingsService,
             mapService: MapService,
             boundaryRecordingService: Substitute.For<IBoundaryRecordingService>(),
+            boundaryBuilderService: Substitute.For<IBoundaryBuilderService>(),
             boundaryFileService: new BoundaryFileService(),
             headlandBuilderService: Substitute.For<AgValoniaGPS.Services.Headland.IHeadlandBuilderService>(),
             trackGuidanceService: TrackGuidanceService,


### PR DESCRIPTION
## Summary

Closes #238. Wires up all boundary creation tools to support inner boundaries (obstacles/holes):

- **Drive around obstacle** — new flyout menu on "+ Inner" button starts inner boundary recording
- **Draw on satellite map** — opens map dialog in inner mode with existing boundaries rendered as reference (orange outer, yellow inner)
- **KML multi-polygon import** — parses all `<coordinates>` blocks; first = outer, rest = inner. Works for both new field creation and importing into existing fields
- **Build from tracks** — ports AgOpenGPS `BoundaryBuilder` as `IBoundaryBuilderService` for building boundaries from intersecting tracks
- **Drive-through toggle** — clickable in boundary list panel
- **Fix KML new-field flow** — now calls `SetCurrentBoundary` so boundaries render immediately after import

## Infrastructure (already existed)
Model, file I/O, rendering, section control, and recording service all supported inner boundaries. Only UI triggers and save logic were missing.

## Test plan
- [x] Record inner boundary via drive-around — appears as "Inner 1" in list
- [x] Draw inner boundary on satellite map — existing boundaries visible as reference
- [x] Import KML with multiple polygons (new field flow)
- [x] Import KML into existing field (boundary panel flow)  
- [x] Delete inner boundary from list
- [x] Toggle drive-through on inner boundary
- [x] All 525 tests pass (85 model + 345 service + 95 UI)
- [x] Outer boundary recording unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)