### PR TITLE
Legacy import: confirmation dialog before auto-conversion

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -61,6 +61,28 @@ public partial class MainViewModel
             var fieldPath = Path.Combine(_fieldSelectionDirectory, SelectedFieldInfo.Name);
             var fieldName = SelectedFieldInfo.Name;
 
+            // Check if this is a legacy field that will be auto-converted
+            bool isLegacy = !File.Exists(Path.Combine(fieldPath, "field.geojson")) &&
+                            File.Exists(Path.Combine(fieldPath, "Field.txt"));
+
+            if (isLegacy)
+            {
+                State.UI.CloseDialog();
+                ShowConfirmationDialog(
+                    "Import Legacy Field",
+                    $"'{fieldName}' uses the legacy AgOpenGPS format. " +
+                    "It will be imported and converted to the new format. " +
+                    "The original files will be kept. Continue?",
+                    () =>
+                    {
+                        SelectedFieldInfo = null;
+                        _ = OpenFieldAsync(fieldPath, fieldName).ContinueWith(_ =>
+                            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                                IsJobMenuPanelVisible = false));
+                    });
+                return;
+            }
+
             State.UI.CloseDialog();
             SelectedFieldInfo = null;
 


### PR DESCRIPTION
## Summary
Show confirmation dialog before importing a legacy AgOpenGPS field, preventing accidental auto-conversion.

Fixes #126

## Change
When the user opens a field that has `Field.txt` but no `field.geojson`, a confirmation dialog appears:
- Title: "Import Legacy Field"  
- Message explains the field uses legacy format and will be converted
- Confirms original files are kept
- User can Cancel to abort or Confirm to proceed

Fields already in GeoJSON format open without any prompt.

## Test plan
- [ ] Open a field with only legacy text files - confirmation dialog appears
- [ ] Cancel: field is not opened
- [ ] Confirm: field opens and converts to GeoJSON
- [ ] Open a field with field.geojson - opens directly, no prompt
- [ ] Open the same legacy field again after conversion - no prompt (has geojson now)