### PR TITLE
1-click bug report dialog with file attachments (#249)

### DIFF
--- a/Plans/ONE_CLICK_BUG_REPORT_PLAN.md
+++ b/Plans/ONE_CLICK_BUG_REPORT_PLAN.md
@@ -1,0 +1,119 @@
+# 1-Click Bug Report Feature
+
+## Context
+
+As AgValoniaGPS approaches beta testing, structured bug reports from testers are critical. Currently, `DebugDumpService` silently creates a diagnostic zip in the temp directory — the user never gets to describe the problem, and the zip is hard to find. The goal is a 1-click experience: user taps a button, sees a dialog to describe the issue, and gets a zip they can attach to a GitHub issue. A future phase will auto-create GitHub issues and upload the data, enabling AI triage.
+
+## Phase 1: 1-Click Bug Report Dialog (this implementation)
+
+**User flow:**
+1. User taps "Bug Report" in File menu (replaces current "Bug Report Dump" button)
+2. Screenshot is captured immediately (before dialog obscures the screen)
+3. Dialog appears with:
+   - Title: "Report a Bug"
+   - Read-only summary of what will be included (system info, config, GPS state, field data, logs, screenshot)
+   - Text area for user to describe the issue (required — placeholder: "What happened? What did you expect?")
+   - **File drop area** — dashed-border zone where users can drag & drop their own screenshots, screen recordings, videos, log files, or any other supporting files. On mobile, an "Add Files" button opens the system file picker instead. Attached files are shown in a list below with filename, size, and a remove button. All user-attached files get bundled into an `attachments/` folder inside the zip.
+   - "Submit" button (creates zip, saves to Documents/AgValoniaGPS/BugReports/, shows success with path)
+   - "Cancel" button
+4. On submit: busy overlay while zip is created, then status message with the file path
+
+**Save location:** `Documents/AgValoniaGPS/BugReports/bugreport_{timestamp}.zip` — visible to the user in their file browser, not buried in temp.
+
+### Files to Modify
+
+#### 1. Add InMemoryLoggerProvider to iOS and Android DI
+Currently only Desktop captures logs. Bug reports from mobile devices would be useless without them.
+
+- `Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs` — add `builder.AddProvider(new InMemoryLoggerProvider());`
+- `Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs` — same
+
+#### 2. Add `BugReport` dialog type to UIState
+- `Shared/AgValoniaGPS.Models/State/UIState.cs`
+  - Add `BugReport` to `DialogType` enum
+  - Add `IsBugReportDialogVisible` computed property
+  - Add `RaisePropertyChanged` call in `ShowDialog`/`CloseDialog`
+
+#### 3. Create BugReportDialogPanel
+- `Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml` — new dialog
+  - Semi-transparent backdrop (standard pattern)
+  - Centered card with:
+    - "Report a Bug" title
+    - Info text listing what gets captured
+    - TextBox for description (multiline, placeholder text)
+    - File drop area — dashed border zone where users can drag & drop screenshots, videos, or other files to include. Uses Avalonia's `DragDrop` API. Shows attached file list with filename, size, and a remove button for each.
+    - Submit + Cancel buttons
+  - Binds `IsVisible` to `State.UI.IsBugReportDialogVisible`
+- `Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml.cs` — code-behind
+  - Backdrop click handler to close
+  - DragOver/Drop event handlers to accept file drops
+  - On mobile (iOS/Android): include an "Add Files" button as alternative to drag & drop (touch doesn't support drag from outside the app easily)
+
+#### 4. Register dialog in DialogOverlayHost
+- `Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml` — add BugReportDialogPanel
+
+#### 5. Update DebugDumpService for user-friendly output
+- `Shared/AgValoniaGPS.Services/DebugDumpService.cs`
+  - Add overload or parameter for custom output directory (default to `Documents/AgValoniaGPS/BugReports/`)
+  - Rename output file pattern from `debug_dump_` to `bugreport_`
+  - Add `userAttachments` parameter (list of file paths) — copies each into `attachments/` folder in the zip
+
+#### 6. Wire up commands in MainViewModel
+- `Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs`
+  - Replace `CreateDebugDumpCommand` with `ShowBugReportDialogCommand` (opens dialog)
+  - Add `CloseBugReportDialogCommand`
+  - Add `SubmitBugReportCommand`:
+    1. Capture screenshot (already done before dialog opened, stored in field)
+    2. Call `DebugDumpService.CreateDump()` with user's description
+    3. Save to Documents/AgValoniaGPS/BugReports/
+    4. Close dialog, show status message with path
+  - Add `BugReportDescription` string property for TextBox binding
+  - Add `BugReportAttachments` ObservableCollection<BugReportAttachment> (filename + path) for the file list
+  - Add `RemoveBugReportAttachmentCommand` to remove items from the list
+  - Add `AddBugReportFilesCommand` for the mobile "Add Files" button (opens file picker via Avalonia StorageProvider)
+  - Add `_bugReportScreenshot` byte[] field to hold pre-captured screenshot
+- `Shared/AgValoniaGPS.ViewModels/MainViewModel.cs` — add command property declarations
+
+#### 7. Update File menu button
+- `Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml`
+  - Change `CreateDebugDumpCommand` to `ShowBugReportDialogCommand`
+  - Keep localization key or update to match
+
+### Key design decisions
+
+- **Screenshot captured BEFORE dialog opens** — otherwise the bug report screenshot just shows the dialog itself, not the state the user is reporting about
+- **Save to Documents, not temp** — users can find the zip in Finder/Files and drag it into a GitHub issue
+- **Keep existing `CreateDebugDumpCommand` as internal** — the silent dump is still useful for integration tests and automated diagnostics
+- **User description is the only input** — everything else is automated. Minimize friction.
+
+## Phase 2: Auto-create GitHub Issue (future)
+
+- Add `Octokit` NuGet package for GitHub API
+- After creating the zip, offer "Post to GitHub" button
+- Creates an issue with structured body (system info, GPS state, field name, user description)
+- Uploads the zip as an issue attachment
+- Requires a GitHub personal access token — store in AppSettings (or use a bot token baked into the app for the beta program)
+- Opens the created issue URL in the browser
+
+## Phase 3: AI Bug Triage (future)
+
+- GitHub Action triggered on new issues with "bug-report" label
+- Downloads the zip, extracts structured data
+- AI agent analyzes: is this a real bug, duplicate, user error, or feature request?
+- Adds triage labels and a comment with analysis
+- Escalates genuine bugs with reproduction steps extracted from the data
+
+## Verification
+
+1. Build all platforms (Desktop, iOS, Android)
+2. Run `dotnet test Tests/` — existing tests should pass
+3. On each platform:
+   - Open File menu, tap "Bug Report"
+   - Verify screenshot captured is of the screen BEFORE the dialog
+   - Enter a description, tap Submit
+   - Verify zip appears in Documents/AgValoniaGPS/BugReports/
+   - Open zip, confirm it contains: system_info.txt, appsettings.json, configuration.json, runtime_state.json, logs.txt, screenshot.png, user_notes.txt, field/ directory (if field open)
+   - Drag & drop a file onto the drop area (Desktop), or tap "Add Files" (mobile) — verify it appears in the attached list
+   - Remove an attachment, verify it disappears
+   - Submit with attachments — verify zip contains `attachments/` folder with the user's files
+4. Verify the old `CreateDebugDumpCommand` still works for integration tests

--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ using AgValoniaGPS.ViewModels;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Android.Services;
+using AgValoniaGPS.Services.Logging;
 
 namespace AgValoniaGPS.Android.DependencyInjection;
 
@@ -45,6 +46,7 @@ public static class ServiceCollectionExtensions
         {
             builder.AddConsole();
             builder.AddDebug();
+            builder.AddProvider(new InMemoryLoggerProvider());
             builder.SetMinimumLevel(LogLevel.Debug);
         });
 

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ using AgValoniaGPS.ViewModels;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.iOS.Services;
+using AgValoniaGPS.Services.Logging;
 
 namespace AgValoniaGPS.iOS.DependencyInjection;
 
@@ -45,6 +46,7 @@ public static class ServiceCollectionExtensions
         {
             builder.AddConsole();
             builder.AddDebug();
+            builder.AddProvider(new InMemoryLoggerProvider());
             builder.SetMinimumLevel(LogLevel.Debug);
         });
 

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -72,6 +72,7 @@ public class UIState : ObservableObject
                 OnPropertyChanged(nameof(IsRecordedPathDialogVisible));
                 OnPropertyChanged(nameof(IsTramSettingsDialogVisible));
                 OnPropertyChanged(nameof(IsFieldBuilderDialogVisible));
+                OnPropertyChanged(nameof(IsBugReportDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -114,6 +115,7 @@ public class UIState : ObservableObject
     public bool IsRecordedPathDialogVisible => ActiveDialog == DialogType.RecordedPath;
     public bool IsTramSettingsDialogVisible => ActiveDialog == DialogType.TramSettings;
     public bool IsFieldBuilderDialogVisible => ActiveDialog == DialogType.FieldBuilder;
+    public bool IsBugReportDialogVisible => ActiveDialog == DialogType.BugReport;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -244,7 +246,8 @@ public enum DialogType
     Language,
     RecordedPath,
     TramSettings,
-    FieldBuilder
+    FieldBuilder,
+    BugReport
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Services/DebugDumpService.cs
+++ b/Shared/AgValoniaGPS.Services/DebugDumpService.cs
@@ -4,6 +4,7 @@
 // Licensed under GNU GPL v3. See LICENSE.md.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
@@ -37,12 +38,16 @@ public class DebugDumpService
         ISettingsService settingsService,
         ApplicationState appState,
         string? additionalNotes = null,
-        byte[]? screenshotPng = null)
+        byte[]? screenshotPng = null,
+        string? outputDirectory = null,
+        string filePrefix = "debug_dump",
+        IReadOnlyList<string>? userAttachments = null)
     {
         var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-        var dumpDir = Path.Combine(Path.GetTempPath(), "AgValoniaGPS", "dumps");
+        var dumpDir = outputDirectory
+            ?? Path.Combine(Path.GetTempPath(), "AgValoniaGPS", "dumps");
         Directory.CreateDirectory(dumpDir);
-        var zipPath = Path.Combine(dumpDir, $"debug_dump_{timestamp}.zip");
+        var zipPath = Path.Combine(dumpDir, $"{filePrefix}_{timestamp}.zip");
 
         using var zipStream = File.Create(zipPath);
         using var archive = new ZipArchive(zipStream, ZipArchiveMode.Create);
@@ -150,6 +155,29 @@ public class DebugDumpService
         if (!string.IsNullOrEmpty(additionalNotes))
         {
             AddTextEntry(archive, "user_notes.txt", additionalNotes);
+        }
+
+        // 10. User-attached files (screenshots, videos, logs, etc.)
+        if (userAttachments != null)
+        {
+            foreach (var filePath in userAttachments)
+            {
+                try
+                {
+                    if (File.Exists(filePath))
+                    {
+                        var fileName = Path.GetFileName(filePath);
+                        var entry = archive.CreateEntry($"attachments/{fileName}");
+                        using var entryStream = entry.Open();
+                        using var fileStream = File.OpenRead(filePath);
+                        fileStream.CopyTo(entryStream);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    AddTextEntry(archive, $"attachments/{Path.GetFileName(filePath)}_error.txt", ex.ToString());
+                }
+            }
         }
 
         return zipPath;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -175,12 +175,11 @@ public partial class MainViewModel
             }
             State.UI.CloseDialog();
         });
-        // Debug Dump (#127)
+        // Debug Dump (#127) - silent dump for integration tests
         CreateDebugDumpCommand = new RelayCommand(() =>
         {
             try
             {
-                // Capture screenshot before creating dump (runs on UI thread)
                 byte[]? screenshot = null;
                 try { screenshot = ScreenshotProvider?.Invoke(); }
                 catch { /* screenshot is optional */ }
@@ -194,6 +193,95 @@ public partial class MainViewModel
             {
                 StatusMessage = $"Debug dump failed: {ex.Message}";
                 _logger.LogError(ex, "Debug dump failed");
+            }
+        });
+
+        // Bug Report Dialog (#249)
+        ShowBugReportDialogCommand = new RelayCommand(() =>
+        {
+            // Capture screenshot BEFORE dialog opens (so it shows the actual state)
+            _bugReportScreenshot = null;
+            try { _bugReportScreenshot = ScreenshotProvider?.Invoke(); }
+            catch { /* screenshot is optional */ }
+
+            BugReportTitle = string.Empty;
+            BugReportDescription = string.Empty;
+            BugReportAttachments.Clear();
+            State.UI.ShowDialog(Models.State.DialogType.BugReport);
+        });
+
+        CloseBugReportDialogCommand = new RelayCommand(() =>
+        {
+            _bugReportScreenshot = null;
+            BugReportAttachments.Clear();
+            State.UI.CloseDialog();
+        });
+
+        RemoveBugReportAttachmentCommand = new RelayCommand<BugReportAttachment>(attachment =>
+        {
+            if (attachment != null)
+                BugReportAttachments.Remove(attachment);
+        });
+
+        SubmitBugReportCommand = new AsyncRelayCommand(async () =>
+        {
+            try
+            {
+                State.UI.CloseDialog();
+                State.UI.BusyMessage = "Creating bug report...";
+                State.UI.IsBusy = true;
+
+                // Force UI to render busy overlay
+                await Dispatcher.UIThread.InvokeAsync(() => { }, Avalonia.Threading.DispatcherPriority.Render);
+                await System.Threading.Tasks.Task.Delay(50);
+
+                var bugReportsDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    "AgValoniaGPS", "BugReports");
+
+                // Build filename from title: sanitize, replace spaces with hyphens
+                var titleSlug = string.IsNullOrWhiteSpace(BugReportTitle)
+                    ? "untitled"
+                    : string.Join("-", BugReportTitle.Trim().Split(
+                        Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries))
+                        .Replace(' ', '-').ToLowerInvariant();
+                if (titleSlug.Length > 60) titleSlug = titleSlug[..60];
+
+                var attachmentPaths = BugReportAttachments.Count > 0
+                    ? BugReportAttachments.Select(a => a.FilePath).ToList()
+                    : null;
+
+                // Combine title + description for the notes file
+                var notes = string.IsNullOrWhiteSpace(BugReportTitle)
+                    ? BugReportDescription
+                    : $"# {BugReportTitle}\n\n{BugReportDescription}";
+
+                var zipPath = Services.DebugDumpService.CreateDump(
+                    _settingsService,
+                    _appState,
+                    additionalNotes: notes,
+                    screenshotPng: _bugReportScreenshot,
+                    outputDirectory: bugReportsDir,
+                    filePrefix: $"bugreport_{titleSlug}",
+                    userAttachments: attachmentPaths);
+
+                _bugReportScreenshot = null;
+                BugReportAttachments.Clear();
+
+                _logger.LogInformation("Bug report created: {ZipPath}", zipPath);
+                ShowConfirmationDialog(
+                    "Bug Report Saved",
+                    $"Your bug report has been saved to:\n\n{zipPath}\n\nAttach this file to a GitHub issue.",
+                    () => { });
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = $"Bug report failed: {ex.Message}";
+                _logger.LogError(ex, "Bug report creation failed");
+            }
+            finally
+            {
+                State.UI.IsBusy = false;
             }
         });
 
@@ -227,6 +315,45 @@ public partial class MainViewModel
     }
 
     public ICommand? CreateDebugDumpCommand { get; private set; }
+    public ICommand? ShowBugReportDialogCommand { get; private set; }
+    public ICommand? CloseBugReportDialogCommand { get; private set; }
+    public ICommand? SubmitBugReportCommand { get; private set; }
+    public ICommand? RemoveBugReportAttachmentCommand { get; private set; }
+
+    private byte[]? _bugReportScreenshot;
+
+    private string _bugReportTitle = string.Empty;
+    public string BugReportTitle
+    {
+        get => _bugReportTitle;
+        set { _bugReportTitle = value; OnPropertyChanged(); }
+    }
+
+    private string _bugReportDescription = string.Empty;
+    public string BugReportDescription
+    {
+        get => _bugReportDescription;
+        set { _bugReportDescription = value; OnPropertyChanged(); }
+    }
+
+    public ObservableCollection<BugReportAttachment> BugReportAttachments { get; } = new();
+
+    public void AddBugReportAttachment(string filePath)
+    {
+        if (!File.Exists(filePath)) return;
+        // Avoid duplicates
+        if (BugReportAttachments.Any(a => a.FilePath == filePath)) return;
+        var info = new FileInfo(filePath);
+        BugReportAttachments.Add(new BugReportAttachment(
+            info.Name, filePath, FormatFileSize(info.Length)));
+    }
+
+    private static string FormatFileSize(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024.0):F1} MB";
+    }
 
     private void ApplyDrift(double deltaEasting, double deltaNorthing)
     {
@@ -472,3 +599,5 @@ public class AppDirectoryInfo
         Exists = Directory.Exists(path);
     }
 }
+
+public record BugReportAttachment(string FileName, string FilePath, string FileSize);

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -64,6 +64,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:OffsetFixDialogPanel/>
         <dialogs:TramSettingsDialogPanel/>
         <dialogs:FieldBuilderDialogPanel/>
+        <dialogs:BugReportDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml
@@ -1,0 +1,98 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.BugReportDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsBugReportDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsBugReportDialogVisible}">
+
+    <!-- Semi-transparent backdrop -->
+    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="12" Padding="24"
+                MaxWidth="520" MaxHeight="680"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                BoxShadow="0 4 16 #40000000">
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="Report a Bug" FontSize="22" FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+
+                <!-- What gets captured -->
+                <TextBlock TextWrapping="Wrap" FontSize="12"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                           Text="The report will include: screenshot, system info, app settings, GPS state, field data, and recent logs."/>
+                <TextBlock TextWrapping="Wrap" FontSize="11"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                           Text="Saved to: Documents/AgValoniaGPS/BugReports/"/>
+
+                <!-- Title -->
+                <TextBlock Text="Title" FontSize="14" FontWeight="SemiBold"/>
+                <TextBox Text="{Binding BugReportTitle, Mode=TwoWay}"
+                         PlaceholderText="Brief summary, e.g. 'Boundary not closing'"
+                         MaxLength="80"/>
+
+                <!-- Description -->
+                <TextBlock Text="What happened?" FontSize="14" FontWeight="SemiBold"/>
+                <TextBox x:Name="DescriptionBox"
+                         Text="{Binding BugReportDescription, Mode=TwoWay}"
+                         PlaceholderText="Describe the issue. What did you expect to happen?"
+                         AcceptsReturn="True" TextWrapping="Wrap"
+                         MinHeight="100" MaxHeight="180"/>
+
+                <!-- File drop area -->
+                <TextBlock Text="Attachments (optional)" FontSize="14" FontWeight="SemiBold"/>
+                <Border x:Name="DropZone"
+                        BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                        BorderThickness="2" CornerRadius="8"
+                        MinHeight="60" Padding="12"
+                        Background="Transparent"
+                        DragDrop.AllowDrop="True">
+                    <StackPanel Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <TextBlock Text="Drop files here or"
+                                   HorizontalAlignment="Center" FontSize="13"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <Button Content="Browse Files" Classes="ModernButton"
+                                HorizontalAlignment="Center" MinHeight="32"
+                                Click="OnBrowseFilesClick"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Attached file list -->
+                <ItemsControl ItemsSource="{Binding BugReportAttachments}"
+                              IsVisible="{Binding BugReportAttachments.Count}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                                    CornerRadius="4" Padding="8,4" Margin="0,2">
+                                <Grid ColumnDefinitions="*,Auto,Auto">
+                                    <TextBlock Grid.Column="0" Text="{Binding FileName}"
+                                               VerticalAlignment="Center" FontSize="13"
+                                               TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding FileSize}"
+                                               VerticalAlignment="Center" FontSize="12" Margin="8,0"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                    <Button Grid.Column="2" Content="X" FontSize="11"
+                                            MinWidth="24" MinHeight="24" Padding="4,2"
+                                            Command="{Binding $parent[UserControl].((vm:MainViewModel)DataContext).RemoveBugReportAttachmentCommand}"
+                                            CommandParameter="{Binding}"/>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- Buttons -->
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12" Margin="0,8,0,0">
+                    <Button Content="Submit Report" Classes="ModernButton"
+                            MinWidth="140" MinHeight="40"
+                            Command="{Binding SubmitBugReportCommand}"
+                            IsEnabled="{Binding BugReportTitle.Length}"/>
+                    <Button Content="Cancel" Classes="ModernButton"
+                            MinWidth="100" MinHeight="40"
+                            Command="{Binding CloseBugReportDialogCommand}"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml.cs
@@ -1,0 +1,70 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class BugReportDialogPanel : UserControl
+{
+    public BugReportDialogPanel()
+    {
+        InitializeComponent();
+
+        AddHandler(DragDrop.DragOverEvent, DropZone_DragOver);
+        AddHandler(DragDrop.DropEvent, DropZone_Drop);
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+            vm.CloseBugReportDialogCommand?.Execute(null);
+    }
+
+    private void DropZone_DragOver(object? sender, DragEventArgs e)
+    {
+        e.DragEffects = DragDropEffects.Copy;
+    }
+
+    private void DropZone_Drop(object? sender, DragEventArgs e)
+    {
+        if (DataContext is not AgValoniaGPS.ViewModels.MainViewModel vm) return;
+
+        var files = e.DataTransfer.TryGetFiles();
+        if (files == null) return;
+
+        foreach (var file in files)
+        {
+            var path = file.Path.LocalPath;
+            if (!string.IsNullOrEmpty(path))
+                vm.AddBugReportAttachment(path);
+        }
+    }
+
+    private async void OnBrowseFilesClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not AgValoniaGPS.ViewModels.MainViewModel vm) return;
+
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel == null) return;
+
+        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Attach files to bug report",
+            AllowMultiple = true
+        });
+
+        foreach (var file in files)
+        {
+            var path = file.Path.LocalPath;
+            if (!string.IsNullOrEmpty(path))
+                vm.AddBugReportAttachment(path);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -104,7 +104,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Button Classes="ModernButton" Content="{loc:Localize About}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
                     Command="{Binding ShowAboutDialogCommand}"/>
             <Button Classes="ModernButton" Content="{loc:Localize BugReportDump}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding CreateDebugDumpCommand}"/>
+                    Command="{Binding ShowBugReportDialogCommand}"/>
         </StackPanel>
     </Border>
 </UserControl>

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 23
+#define VERSION_PATCH 24
 
-#define VERSION "26.4.23"
+#define VERSION "26.4.24"
 #define VERSION_DATE "2026-04-16"


### PR DESCRIPTION
## Summary
- Replaces the silent "Bug Report Dump" button with an interactive dialog
- **Title** (required) — used in the zip filename for easy identification, e.g. `bugreport_boundary-not-closing_20260416_113045.zip`
- **Description** field for the user to explain the issue
- **File drop area** — drag & drop (Desktop) or "Browse Files" button (mobile) for screenshots, videos, etc.
- Auto-captures screenshot **before** the dialog opens so it shows the actual app state
- Saves to `Documents/AgValoniaGPS/BugReports/` with confirmation dialog showing the path
- Adds `InMemoryLoggerProvider` to iOS and Android DI so mobile bug reports include logs
- Existing silent `CreateDebugDumpCommand` preserved for integration tests

Closes #249

## Test plan
- [x] Desktop builds and all 536 tests pass
- [x] Android builds
- [ ] Open File menu > Bug Report Dump — verify dialog appears
- [ ] Submit without title — verify Submit button is disabled
- [ ] Enter title + description, submit — verify zip created in Documents/AgValoniaGPS/BugReports/
- [ ] Open zip — verify system_info.txt, configuration.json, runtime_state.json, logs.txt, screenshot.png, user_notes.txt
- [ ] Drag & drop a file — verify it appears in attachment list and ends up in attachments/ folder in zip
- [ ] Browse Files button — verify file picker opens and selected files appear in list
- [ ] Test on iOS and Android physical devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)