### PR TITLE
Update CI and docs for Xcode 26.3

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -233,6 +233,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ AgValoniaGPS3/
 | Windows | AgValoniaGPS.Desktop | Same codebase as macOS/Linux |
 | macOS | AgValoniaGPS.Desktop | Same codebase as Windows/Linux |
 | Linux | AgValoniaGPS.Desktop | Same codebase as Windows/macOS |
-| iOS/iPadOS | AgValoniaGPS.iOS | Requires Xcode 26.2+, runs on ARM64 simulator |
+| iOS/iPadOS | AgValoniaGPS.iOS | Requires Xcode 26.3+, runs on ARM64 simulator |
 | Android | AgValoniaGPS.Android | APK build, sideload install |
 
 ## Build Commands
@@ -80,7 +80,7 @@ AgValoniaGPS3/
 dotnet build Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
 dotnet run --project Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
 
-# Build iOS (requires macOS with Xcode 26.2+)
+# Build iOS (requires macOS with Xcode 26.3+)
 dotnet build Platforms/AgValoniaGPS.iOS/AgValoniaGPS.iOS.csproj -c Debug -f net10.0-ios -r iossimulator-arm64
 
 # Deploy and run iOS on simulator


### PR DESCRIPTION
## Summary
- Add `sudo xcode-select -s /Applications/Xcode_26.3.app` to the iOS CI build step — the macos-26 runner now has Xcode 26.3 installed, but the iOS SDK requires it to be explicitly selected
- Update CLAUDE.md Xcode version references from 26.2 to 26.3

## Test plan
- [ ] iOS CI build passes on macos-26 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)