### PR TITLE
Simulator improvements, bug fixes, and UI polish

### DIFF
--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -348,7 +348,7 @@ public class AutoSteerService : IAutoSteerService
         NotifyStateUpdated();
 
         _cycleCount++;
-        Debug.WriteLine($"[AutoSteer] cycle={_cycleCount} E={_state.Easting:F2} N={_state.Northing:F2} H={_state.Heading:F1}");
+        Console.WriteLine($"[AutoSteer] cycle={_cycleCount} E={_state.Easting:F2} N={_state.Northing:F2} H={_state.Heading:F1}");
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -348,6 +348,8 @@ public class AutoSteerService : IAutoSteerService
         NotifyStateUpdated();
 
         _cycleCount++;
+        if (_cycleCount % 10 == 0)
+            Debug.WriteLine($"[AutoSteer] cycle={_cycleCount} E={_state.Easting:F2} N={_state.Northing:F2} H={_state.Heading:F1}");
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -348,8 +348,7 @@ public class AutoSteerService : IAutoSteerService
         NotifyStateUpdated();
 
         _cycleCount++;
-        if (_cycleCount % 10 == 0)
-            Debug.WriteLine($"[AutoSteer] cycle={_cycleCount} E={_state.Easting:F2} N={_state.Northing:F2} H={_state.Heading:F1}");
+        Debug.WriteLine($"[AutoSteer] cycle={_cycleCount} E={_state.Easting:F2} N={_state.Northing:F2} H={_state.Heading:F1}");
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/GpsService.cs
+++ b/Shared/AgValoniaGPS.Services/GpsService.cs
@@ -93,6 +93,14 @@ public class GpsService : IGpsService
     {
         var vehicle = ConfigurationStore.Instance.Vehicle;
 
+        // Skip coordinate-space transforms when Easting/Northing are still 0
+        // (not yet converted to local coordinates). Applying offsets to zeros
+        // produces small non-zero values that break the local plane auto-creation
+        // check in GpsPipelineService, causing a teleport to origin.
+        if (Math.Abs(gpsData.CurrentPosition.Easting) < 0.001
+            && Math.Abs(gpsData.CurrentPosition.Northing) < 0.001)
+            return;
+
         // Convert heading to radians
         double headingRadians = gpsData.CurrentPosition.Heading * Math.PI / 180.0;
 

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -215,6 +215,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
         if (Interlocked.CompareExchange(ref _processing, 1, 0) != 0)
         {
             _gpsDroppedCount++;
+            System.Diagnostics.Debug.WriteLine($"[Pipeline] DROPPED #{_gpsReceivedCount} (total dropped: {_gpsDroppedCount})");
             return;
         }
 
@@ -233,9 +234,8 @@ public sealed class GpsPipelineService : IGpsPipelineService
             {
                 Volatile.Write(ref _processing, 0);
                 sw.Stop();
-                if (_gpsReceivedCount % 10 == 0)
-                    System.Diagnostics.Debug.WriteLine(
-                        $"[Pipeline] received={_gpsReceivedCount} dropped={_gpsDroppedCount} cycleMs={sw.ElapsedMilliseconds}");
+                System.Diagnostics.Debug.WriteLine(
+                    $"[Pipeline] received={_gpsReceivedCount} dropped={_gpsDroppedCount} cycleMs={sw.ElapsedMilliseconds}");
             }
         });
     }

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -215,7 +215,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
         if (Interlocked.CompareExchange(ref _processing, 1, 0) != 0)
         {
             _gpsDroppedCount++;
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] DROPPED #{_gpsReceivedCount} (total dropped: {_gpsDroppedCount})");
+            Console.WriteLine($"[Pipeline] DROPPED #{_gpsReceivedCount} (total dropped: {_gpsDroppedCount})");
             return;
         }
 
@@ -234,7 +234,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
             {
                 Volatile.Write(ref _processing, 0);
                 sw.Stop();
-                System.Diagnostics.Debug.WriteLine(
+                Console.WriteLine(
                     $"[Pipeline] received={_gpsReceivedCount} dropped={_gpsDroppedCount} cycleMs={sw.ElapsedMilliseconds}");
             }
         });

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -204,14 +204,23 @@ public sealed class GpsPipelineService : IGpsPipelineService
     // GPS event handler
     // ══════════════════════════════════════════════════════════════════════
 
+    private long _gpsReceivedCount;
+    private long _gpsDroppedCount;
+
     private void OnGpsDataUpdated(object? sender, GpsData data)
     {
+        _gpsReceivedCount++;
+
         // Skip if previous cycle is still running (back-pressure)
         if (Interlocked.CompareExchange(ref _processing, 1, 0) != 0)
+        {
+            _gpsDroppedCount++;
             return;
+        }
 
         Task.Run(() =>
         {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             try
             {
                 ProcessCycle(data);
@@ -223,6 +232,10 @@ public sealed class GpsPipelineService : IGpsPipelineService
             finally
             {
                 Volatile.Write(ref _processing, 0);
+                sw.Stop();
+                if (_gpsReceivedCount % 10 == 0)
+                    System.Diagnostics.Debug.WriteLine(
+                        $"[Pipeline] received={_gpsReceivedCount} dropped={_gpsDroppedCount} cycleMs={sw.ElapsedMilliseconds}");
             }
         });
     }

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -308,6 +308,40 @@ public sealed class GpsPipelineService : IGpsPipelineService
             }
         }
 
+        // ── (1b) Apply antenna-to-pivot transforms (roll, antenna offset) ──
+        // These operate in local coordinates and were previously in
+        // GpsService.TransformAntennaToPivot, but that runs BEFORE local
+        // plane conversion (E/N still 0), so they had no effect.
+        {
+            var vehicle = ConfigurationStore.Instance.Vehicle;
+            double hdgRad = pos.Heading * Math.PI / 180.0;
+
+            // Fore/aft offset (AntennaPivot)
+            if (Math.Abs(vehicle.AntennaPivot) > 0.001)
+            {
+                posEasting -= Math.Sin(hdgRad) * vehicle.AntennaPivot;
+                posNorthing -= Math.Cos(hdgRad) * vehicle.AntennaPivot;
+            }
+
+            // Lateral offset (AntennaOffset)
+            if (Math.Abs(vehicle.AntennaOffset) > 0.001)
+            {
+                double perpHeading = hdgRad + Math.PI / 2.0;
+                posEasting -= Math.Sin(perpHeading) * vehicle.AntennaOffset;
+                posNorthing -= Math.Cos(perpHeading) * vehicle.AntennaOffset;
+            }
+
+            // Roll correction
+            double imuRoll = SensorState.Instance.ImuRoll;
+            if (Math.Abs(imuRoll) > 0.01 && Math.Abs(vehicle.AntennaHeight) > 0.01)
+            {
+                double rollRadians = imuRoll * Math.PI / 180.0;
+                double rollCorrectionDistance = Math.Sin(rollRadians) * -vehicle.AntennaHeight;
+                posEasting += Math.Cos(-hdgRad) * rollCorrectionDistance;
+                posNorthing += Math.Sin(-hdgRad) * rollCorrectionDistance;
+            }
+        }
+
         // ── (2) Apply drift compensation ────────────────────────────────
         double driftedEasting = posEasting + driftE;
         double driftedNorthing = posNorthing + driftN;

--- a/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
+++ b/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
@@ -51,6 +51,14 @@ public class ToolPositionService : IToolPositionService
     // Jackknife protection threshold (~115 degrees)
     private const double JACKKNIFE_THRESHOLD = 2.0;
 
+    // Heading smoothing (circular EMA) to reduce GPS heading noise
+    // amplified by hitch length. At 10Hz GPS with alpha=0.4, this gives
+    // ~2.5 frame effective window - enough to damp jitter without
+    // noticeable lag.
+    private const double HEADING_SMOOTH_ALPHA = 0.4;
+    private double _smoothedHeading;
+    private bool _headingSmoothed;
+
     public Vec3 ToolPosition => _toolPosition;
     public Vec3 ToolPivotPosition => _toolPivotPosition;
     public double ToolHeading => _toolHeading;
@@ -69,7 +77,27 @@ public class ToolPositionService : IToolPositionService
     {
         var tool = ConfigurationStore.Instance.Tool;
 
-        // Calculate hitch point on vehicle
+        // Smooth heading to reduce GPS noise amplified by hitch length.
+        // Uses circular EMA to handle 0/2pi wrapping correctly.
+        double smoothedHeading;
+        if (!_headingSmoothed)
+        {
+            _smoothedHeading = vehicleHeading;
+            _headingSmoothed = true;
+            smoothedHeading = vehicleHeading;
+        }
+        else
+        {
+            // Circular interpolation: find shortest angular path
+            double diff = vehicleHeading - _smoothedHeading;
+            // Wrap to [-pi, pi]
+            while (diff > Math.PI) diff -= 2 * Math.PI;
+            while (diff < -Math.PI) diff += 2 * Math.PI;
+            _smoothedHeading += HEADING_SMOOTH_ALPHA * diff;
+            smoothedHeading = _smoothedHeading;
+        }
+
+        // Calculate hitch point on vehicle using smoothed heading
         // HitchLength is stored as positive distance; sign determined by tool type
         // Front tools: positive direction (ahead of pivot)
         // Rear tools: negative direction (behind pivot)
@@ -81,9 +109,9 @@ public class ToolPositionService : IToolPositionService
         // Front fixed keeps positive (ahead of vehicle)
 
         _hitchPosition = new Vec3(
-            vehiclePivot.Easting + Math.Sin(vehicleHeading) * hitchDistance,
-            vehiclePivot.Northing + Math.Cos(vehicleHeading) * hitchDistance,
-            vehicleHeading
+            vehiclePivot.Easting + Math.Sin(smoothedHeading) * hitchDistance,
+            vehiclePivot.Northing + Math.Cos(smoothedHeading) * hitchDistance,
+            smoothedHeading
         );
 
         if (tool.IsToolFrontFixed || tool.IsToolRearFixed)

--- a/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
+++ b/Shared/AgValoniaGPS.Services/Tool/ToolPositionService.cs
@@ -77,27 +77,36 @@ public class ToolPositionService : IToolPositionService
     {
         var tool = ConfigurationStore.Instance.Tool;
 
-        // Smooth heading to reduce GPS noise amplified by hitch length.
-        // Uses circular EMA to handle 0/2pi wrapping correctly.
-        double smoothedHeading;
-        if (!_headingSmoothed)
+        // For fixed tools, smooth heading to reduce GPS noise amplified by
+        // hitch length (circular EMA). For trailing/TBT tools, use raw heading
+        // because Torriem's algorithm already smooths via the movement vector.
+        // Smoothing trailing tools causes the hitch point to lag then snap,
+        // making the implement jump forward.
+        bool useSmoothing = tool.IsToolFrontFixed || tool.IsToolRearFixed;
+        double hitchHeading;
+
+        if (useSmoothing)
         {
-            _smoothedHeading = vehicleHeading;
-            _headingSmoothed = true;
-            smoothedHeading = vehicleHeading;
+            if (!_headingSmoothed)
+            {
+                _smoothedHeading = vehicleHeading;
+                _headingSmoothed = true;
+            }
+            else
+            {
+                double diff = vehicleHeading - _smoothedHeading;
+                while (diff > Math.PI) diff -= 2 * Math.PI;
+                while (diff < -Math.PI) diff += 2 * Math.PI;
+                _smoothedHeading += HEADING_SMOOTH_ALPHA * diff;
+            }
+            hitchHeading = _smoothedHeading;
         }
         else
         {
-            // Circular interpolation: find shortest angular path
-            double diff = vehicleHeading - _smoothedHeading;
-            // Wrap to [-pi, pi]
-            while (diff > Math.PI) diff -= 2 * Math.PI;
-            while (diff < -Math.PI) diff += 2 * Math.PI;
-            _smoothedHeading += HEADING_SMOOTH_ALPHA * diff;
-            smoothedHeading = _smoothedHeading;
+            hitchHeading = vehicleHeading;
         }
 
-        // Calculate hitch point on vehicle using smoothed heading
+        // Calculate hitch point on vehicle
         // HitchLength is stored as positive distance; sign determined by tool type
         // Front tools: positive direction (ahead of pivot)
         // Rear tools: negative direction (behind pivot)
@@ -109,9 +118,9 @@ public class ToolPositionService : IToolPositionService
         // Front fixed keeps positive (ahead of vehicle)
 
         _hitchPosition = new Vec3(
-            vehiclePivot.Easting + Math.Sin(smoothedHeading) * hitchDistance,
-            vehiclePivot.Northing + Math.Cos(smoothedHeading) * hitchDistance,
-            smoothedHeading
+            vehiclePivot.Easting + Math.Sin(hitchHeading) * hitchDistance,
+            vehiclePivot.Northing + Math.Cos(hitchHeading) * hitchDistance,
+            hitchHeading
         );
 
         if (tool.IsToolFrontFixed || tool.IsToolRearFixed)

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -1417,11 +1417,11 @@ public partial class ConfigurationViewModel : ObservableObject
             Config.MarkChanged();
         });
 
-        // Set roll zero to current roll value (would need access to current sensor data)
-        // For now, this just resets to 0
+        // Set roll zero: capture current roll reading as the new level reference.
+        // Matches legacy: rollZero = imuRoll + rollZero
         SetRollZeroCommand = new RelayCommand(() =>
         {
-            Ahrs.RollZero = 0;
+            Ahrs.RollZero = SensorState.Instance.ImuRoll + Ahrs.RollZero;
             Config.MarkChanged();
         });
     }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -28,9 +28,8 @@ public partial class MainViewModel
     public void ApplyGpsCycleResult(GpsCycleResult result)
     {
         _applyResultCount++;
-        if (_applyResultCount % 10 == 0)
-            System.Diagnostics.Debug.WriteLine(
-                $"[ApplyResult] count={_applyResultCount} E={result.Easting:F2} N={result.Northing:F2} tool=({result.ToolEasting:F2},{result.ToolNorthing:F2})");
+        System.Diagnostics.Debug.WriteLine(
+            $"[ApplyResult] #{_applyResultCount} E={result.Easting:F2} N={result.Northing:F2} tool=({result.ToolEasting:F2},{result.ToolNorthing:F2})");
 
         // Mark GPS as received (updates timeout tracking for connection status)
         if (result.GpsValid)

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -28,7 +28,7 @@ public partial class MainViewModel
     public void ApplyGpsCycleResult(GpsCycleResult result)
     {
         _applyResultCount++;
-        System.Diagnostics.Debug.WriteLine(
+        Console.WriteLine(
             $"[ApplyResult] #{_applyResultCount} E={result.Easting:F2} N={result.Northing:F2} tool=({result.ToolEasting:F2},{result.ToolNorthing:F2})");
 
         // Mark GPS as received (updates timeout tracking for connection status)

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -23,8 +23,15 @@ public partial class MainViewModel
     /// Called on the UI thread after the service pipeline computes results on a background thread.
     /// This is the ONLY place where GPS-derived properties are set during normal operation.
     /// </summary>
+    private long _applyResultCount;
+
     public void ApplyGpsCycleResult(GpsCycleResult result)
     {
+        _applyResultCount++;
+        if (_applyResultCount % 10 == 0)
+            System.Diagnostics.Debug.WriteLine(
+                $"[ApplyResult] count={_applyResultCount} E={result.Easting:F2} N={result.Northing:F2} tool=({result.ToolEasting:F2},{result.ToolNorthing:F2})");
+
         // Mark GPS as received (updates timeout tracking for connection status)
         if (result.GpsValid)
             _gpsService.MarkGpsReceived();

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -3319,7 +3319,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                     double diagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2 + 100.0;
                     drawingContext.FillRectangle(
                         new ImmutableSolidColorBrush(bgColor),
-                        new Rect(s.CameraX - diagonal, -(s.CameraY + diagonal), diagonal * 2, diagonal * 2));
+                        new Rect(s.CameraX - diagonal, s.CameraY - diagonal, diagonal * 2, diagonal * 2));
                 }
 
                 t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
@@ -3501,10 +3501,13 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             // non-distinct so the stretched version is visually indistinguishable
             // from the tiled version in practice. One draw call at any zoom,
             // constant cost.
+            //
+            // Coordinates are in world space (camera transform handles Y-flip).
+            // Use world coords directly like the grid does, not manual Y-flip.
             double centerX = s.CameraX;
             double centerY = s.CameraY;
             double diagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2 + 100.0;
-            var viewRect = new Rect(centerX - diagonal, -(centerY + diagonal), diagonal * 2, diagonal * 2);
+            var viewRect = new Rect(centerX - diagonal, centerY - diagonal, diagonal * 2, diagonal * 2);
             dc.DrawBitmap(s.GroundTexture!, viewRect);
         }
 

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -2078,6 +2078,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         double zoomFactor = e.Delta.Y > 0 ? 1.1 : 0.9;
         _zoom *= zoomFactor;
         _zoom = Math.Clamp(_zoom, 0.02, 100.0);  // Min zoom 0.02 = 10km view height for large fields
+        SendStateToHandler();
         e.Handled = true;
     }
 

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -3300,15 +3300,6 @@ public class DrawingContextMapControl : Control, ISharedMapControl
 
             try
             {
-                // Background fill (screen space) — ImmediateDrawingContext only, no SKCanvas lease
-                var bgColor = s.IsDayMode
-                    ? Color.FromRgb(69, 102, 179)
-                    : Color.FromRgb(10, 10, 10);
-                drawingContext.FillRectangle(
-                    new ImmutableSolidColorBrush(bgColor),
-                    new Rect(0, 0, s.BoundsWidth, s.BoundsHeight));
-
-
                 // Calculate view transform
                 double aspect = s.BoundsWidth / s.BoundsHeight;
                 double viewWidth = 200.0 * aspect / s.Zoom;
@@ -3316,6 +3307,19 @@ public class DrawingContextMapControl : Control, ISharedMapControl
 
                 var cameraMatrix = GetCameraTransform(s, viewWidth, viewHeight);
                 using var cameraScope = drawingContext.PushPreTransform(cameraMatrix);
+
+                // Background fill drawn in camera space so it rotates with the grid
+                // in HeadingUp mode. Uses a large rect centered on camera to always
+                // cover the viewport regardless of rotation.
+                {
+                    var bgColor = s.IsDayMode
+                        ? Color.FromRgb(69, 102, 179)
+                        : Color.FromRgb(10, 10, 10);
+                    double diagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2 + 100.0;
+                    drawingContext.FillRectangle(
+                        new ImmutableSolidColorBrush(bgColor),
+                        new Rect(s.CameraX - diagonal, -(s.CameraY + diagonal), diagonal * 2, diagonal * 2));
+                }
 
                 t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
                 // Ground texture

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -3131,7 +3131,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         private SKBitmap? _coverageSnapshotSource;    // last source reference (for identity checks)
         private DateTime _coverageSnapshotTime = DateTime.MinValue;
         private int _coverageSnapshotInFlight;        // 0 = idle, 1 = bg task running
-        private const double CoverageSnapshotIntervalMs = 200.0;
+        private const double CoverageSnapshotIntervalMs = 500.0;
         private static readonly SKSamplingOptions _coverageSampling =
             new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
 
@@ -3754,7 +3754,9 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                 && System.Threading.Interlocked.CompareExchange(ref _coverageSnapshotInFlight, 1, 0) == 0)
             {
                 _coverageSnapshotSource = bitmap;
-                _coverageSnapshotTime = now;
+                // Don't set _coverageSnapshotTime here - set it AFTER the bg task
+                // completes. Otherwise the 500ms throttle counts from dispatch time,
+                // not completion time, and a 200ms bg task triggers immediately again.
                 var capturedBitmap = bitmap;
                 System.Threading.Tasks.Task.Run(() =>
                 {
@@ -3778,6 +3780,9 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                     }
                     finally
                     {
+                        // Set timestamp AFTER completion so the 500ms throttle
+                        // starts from when this refresh finished, not when it started.
+                        _coverageSnapshotTime = DateTime.UtcNow;
                         System.Threading.Volatile.Write(ref _coverageSnapshotInFlight, 0);
                     }
                 });

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
@@ -73,7 +73,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="{loc:Localize SteerWizard}" VerticalAlignment="Center" FontSize="12"/>
                     </StackPanel>
                 </Button>
-                <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
+                <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
+                        Command="{Binding ShowLogViewerDialogCommand}">
                     <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png" Width="28" Height="28"/>
                         <TextBlock Text="{loc:Localize LogViewer}" VerticalAlignment="Center" FontSize="12"/>

--- a/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
+++ b/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
@@ -26,13 +26,15 @@ namespace AgValoniaGPS.Views.Converters;
 
 public class BoolToColorConverter : IValueConverter
 {
+    private static readonly IBrush DisconnectedBrush = new SolidColorBrush(Color.FromRgb(180, 60, 60));
+
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is bool boolValue)
         {
-            return boolValue ? Brushes.LimeGreen : Brushes.Gray;
+            return boolValue ? Brushes.LimeGreen : DisconnectedBrush;
         }
-        return Brushes.Gray;
+        return DisconnectedBrush;
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
@@ -152,22 +152,22 @@ public class VirtualGpsReceiver : IDisposable
         return sb.ToString();
     }
 
-    /// <summary>Format latitude as DDMM.MMMM</summary>
+    /// <summary>Format latitude as DDMM.MMMMM (5 decimal places = 0.019m resolution)</summary>
     private static string FormatLatitude(double lat)
     {
         lat = Math.Abs(lat);
         int degrees = (int)lat;
         double minutes = (lat - degrees) * 60.0;
-        return string.Format(CultureInfo.InvariantCulture, "{0:D2}{1:00.0000}", degrees, minutes);
+        return string.Format(CultureInfo.InvariantCulture, "{0:D2}{1:00.00000}", degrees, minutes);
     }
 
-    /// <summary>Format longitude as DDDMM.MMMM</summary>
+    /// <summary>Format longitude as DDDMM.MMMMM (5 decimal places = 0.019m resolution)</summary>
     private static string FormatLongitude(double lon)
     {
         lon = Math.Abs(lon);
         int degrees = (int)lon;
         double minutes = (lon - degrees) * 60.0;
-        return string.Format(CultureInfo.InvariantCulture, "{0:D3}{1:00.0000}", degrees, minutes);
+        return string.Format(CultureInfo.InvariantCulture, "{0:D3}{1:00.00000}", degrees, minutes);
     }
 
     public void Dispose()

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -40,7 +40,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private double _commandedAngle;
     private byte _pwmDisplay;
     private bool _steerSwitchOn = true;
-    private bool _autoSteerActive;
+    private bool _autoSteerEngaged;
     private string _statusText = "Stopped";
 
     public double Speed
@@ -115,10 +115,10 @@ public class MainWindowViewModel : INotifyPropertyChanged
         set { _steerSwitchOn = value; OnPropertyChanged(); }
     }
 
-    public bool AutoSteerActive
+    public bool AutoSteerEngaged
     {
-        get => _autoSteerActive;
-        set { _autoSteerActive = value; OnPropertyChanged(); }
+        get => _autoSteerEngaged;
+        private set { _autoSteerEngaged = value; OnPropertyChanged(); }
     }
 
     public string StatusText
@@ -202,8 +202,11 @@ public class MainWindowViewModel : INotifyPropertyChanged
     {
         if (_hub == null) return;
 
-        // When autosteer is active, WAS follows the commanded angle with response lag
-        if (_autoSteerActive)
+        // Read autosteer engaged state from PGN 254 Status byte (set by the main app)
+        AutoSteerEngaged = _hub.Steer.LastCommand?.IsEngaged ?? false;
+
+        // When autosteer is engaged by the app, WAS follows the commanded angle with response lag
+        if (_autoSteerEngaged)
         {
             double commanded = _hub.Steer.CommandedSteerAngleDeg;
             double responseRate = 0.3; // lag factor per tick

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -1,11 +1,12 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:AgValoniaGPS.VehicleSimulator.ViewModels"
+        xmlns:views="using:AgValoniaGPS.VehicleSimulator.Views"
         x:Class="AgValoniaGPS.VehicleSimulator.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="AgValoniaGPS Vehicle Simulator"
-        Width="750" Height="480"
-        MinWidth="650" MinHeight="400">
+        Width="750" Height="520"
+        MinWidth="650" MinHeight="440">
 
     <Design.DataContext>
         <vm:MainWindowViewModel />
@@ -97,7 +98,16 @@
 
                     <TextBlock Text="{Binding SteerSwitchOn, StringFormat='Steer Switch: {0}'}" />
 
-                    <Separator Margin="0,8" />
+                    <Separator Margin="0,4" />
+
+                    <!-- Top-down vehicle with steered front wheels -->
+                    <views:VehicleTopView
+                        WheelAngle="{Binding WasAngle}"
+                        CommandedAngle="{Binding CommandedAngle}"
+                        AutoSteerEngaged="{Binding AutoSteerEngaged}"
+                        Height="140" Margin="0,4" />
+
+                    <Separator Margin="0,4" />
 
                     <TextBlock Text="UDP Ports" FontWeight="SemiBold" />
                     <TextBlock Text="GPS out: 127.0.0.1:9999" FontSize="12"

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -76,8 +76,8 @@
                                    Minimum="0" Maximum="30" />
 
                     <CheckBox Content="Steer Switch ON" IsChecked="{Binding SteerSwitchOn}" />
-                    <CheckBox Content="AutoSteer Active" IsChecked="{Binding AutoSteerActive}"
-                              ToolTip.Tip="When enabled, WAS follows the commanded steer angle from the main app" />
+                    <TextBlock Text="{Binding AutoSteerEngaged, StringFormat='AutoSteer Engaged: {0}'}"
+                               ToolTip.Tip="Controlled by the main app via PGN 254 Status byte" />
                 </StackPanel>
             </Border>
 
@@ -87,6 +87,9 @@
                     BorderThickness="1" CornerRadius="4">
                 <StackPanel Spacing="8">
                     <TextBlock Text="Module Status" FontWeight="SemiBold" FontSize="14" />
+
+                    <TextBlock Text="{Binding AutoSteerEngaged, StringFormat='AutoSteer Engaged: {0}'}"
+                               FontWeight="SemiBold" />
 
                     <TextBlock Text="{Binding CommandedAngle, StringFormat='Commanded Angle: {0:F1} deg'}" />
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/VehicleTopView.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/VehicleTopView.cs
@@ -1,0 +1,132 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace AgValoniaGPS.VehicleSimulator.Views;
+
+/// <summary>
+/// Top-down vehicle visualization showing body, rear wheels (fixed),
+/// and front wheels (steered by WAS angle).
+/// </summary>
+public class VehicleTopView : Control
+{
+    public static readonly StyledProperty<double> WheelAngleProperty =
+        AvaloniaProperty.Register<VehicleTopView, double>(nameof(WheelAngle));
+
+    public static readonly StyledProperty<double> CommandedAngleProperty =
+        AvaloniaProperty.Register<VehicleTopView, double>(nameof(CommandedAngle));
+
+    public static readonly StyledProperty<bool> AutoSteerEngagedProperty =
+        AvaloniaProperty.Register<VehicleTopView, bool>(nameof(AutoSteerEngaged));
+
+    public double WheelAngle
+    {
+        get => GetValue(WheelAngleProperty);
+        set => SetValue(WheelAngleProperty, value);
+    }
+
+    public double CommandedAngle
+    {
+        get => GetValue(CommandedAngleProperty);
+        set => SetValue(CommandedAngleProperty, value);
+    }
+
+    public bool AutoSteerEngaged
+    {
+        get => GetValue(AutoSteerEngagedProperty);
+        set => SetValue(AutoSteerEngagedProperty, value);
+    }
+
+    static VehicleTopView()
+    {
+        AffectsRender<VehicleTopView>(WheelAngleProperty, CommandedAngleProperty, AutoSteerEngagedProperty);
+    }
+
+    // Colors
+    private static readonly IBrush BodyBrush = new SolidColorBrush(Color.FromRgb(80, 80, 80));
+    private static readonly IBrush WheelBrush = new SolidColorBrush(Color.FromRgb(40, 40, 40));
+    private static readonly IBrush CommandedBrush = new SolidColorBrush(Color.FromArgb(100, 0, 180, 0));
+    private static readonly IPen BodyPen = new Pen(Brushes.Gray, 1);
+    private static readonly IPen WheelPen = new Pen(Brushes.Black, 1);
+    private static readonly IPen CommandedPen = new Pen(new SolidColorBrush(Color.FromRgb(0, 180, 0)), 1.5);
+    private static readonly IPen CenterPen = new Pen(Brushes.Yellow, 1, DashStyle.Dash);
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+
+        double w = Bounds.Width;
+        double h = Bounds.Height;
+        if (w < 10 || h < 10) return;
+
+        // Vehicle dimensions relative to control size
+        double bodyW = w * 0.3;
+        double bodyH = h * 0.7;
+        double wheelW = bodyW * 0.2;
+        double wheelH = bodyW * 0.55;
+        double axleOffset = bodyW * 0.65; // wheel center offset from body center
+        double frontAxleY = (h - bodyH) / 2 + bodyH * 0.15; // front axle position
+        double rearAxleY = (h - bodyH) / 2 + bodyH * 0.85;  // rear axle position
+
+        double cx = w / 2;
+        double bodyTop = (h - bodyH) / 2;
+
+        // Draw body
+        var bodyRect = new Rect(cx - bodyW / 2, bodyTop, bodyW, bodyH);
+        context.DrawRectangle(BodyBrush, BodyPen, bodyRect, 4, 4);
+
+        // Draw centerline
+        context.DrawLine(CenterPen, new Point(cx, bodyTop + 5), new Point(cx, bodyTop + bodyH - 5));
+
+        // Draw front direction indicator (triangle)
+        var triangleTop = new Point(cx, bodyTop - 5);
+        var triangleLeft = new Point(cx - 8, bodyTop + 8);
+        var triangleRight = new Point(cx + 8, bodyTop + 8);
+        var triGeo = new StreamGeometry();
+        using (var ctx = triGeo.Open())
+        {
+            ctx.BeginFigure(triangleTop, true);
+            ctx.LineTo(triangleLeft);
+            ctx.LineTo(triangleRight);
+            ctx.EndFigure(true);
+        }
+        context.DrawGeometry(Brushes.Yellow, null, triGeo);
+
+        // Draw rear wheels (fixed)
+        DrawWheel(context, cx - axleOffset, rearAxleY, wheelW, wheelH, 0, WheelBrush, WheelPen);
+        DrawWheel(context, cx + axleOffset, rearAxleY, wheelW, wheelH, 0, WheelBrush, WheelPen);
+
+        // Draw commanded angle ghost wheels (if autosteer engaged)
+        if (AutoSteerEngaged)
+        {
+            DrawWheel(context, cx - axleOffset, frontAxleY, wheelW, wheelH, CommandedAngle, CommandedBrush, CommandedPen);
+            DrawWheel(context, cx + axleOffset, frontAxleY, wheelW, wheelH, CommandedAngle, CommandedBrush, CommandedPen);
+        }
+
+        // Draw front wheels (steered by WAS angle)
+        DrawWheel(context, cx - axleOffset, frontAxleY, wheelW, wheelH, WheelAngle, WheelBrush, WheelPen);
+        DrawWheel(context, cx + axleOffset, frontAxleY, wheelW, wheelH, WheelAngle, WheelBrush, WheelPen);
+    }
+
+    private static void DrawWheel(DrawingContext context, double cx, double cy,
+        double width, double height, double angleDeg, IBrush fill, IPen pen)
+    {
+        using (context.PushTransform(
+            Matrix.CreateTranslation(-cx, -cy) *
+            Matrix.CreateRotation(angleDeg * Math.PI / 180.0) *
+            Matrix.CreateTranslation(cx, cy)))
+        {
+            var rect = new Rect(cx - width / 2, cy - height / 2, width, height);
+            context.DrawRectangle(fill, pen, rect, 2, 2);
+        }
+    }
+}

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
@@ -152,22 +152,22 @@ public class VirtualGpsReceiver : IDisposable
         return sb.ToString();
     }
 
-    /// <summary>Format latitude as DDMM.MMMM</summary>
+    /// <summary>Format latitude as DDMM.MMMMM (5 decimal places = 0.019m resolution)</summary>
     private static string FormatLatitude(double lat)
     {
         lat = Math.Abs(lat);
         int degrees = (int)lat;
         double minutes = (lat - degrees) * 60.0;
-        return string.Format(CultureInfo.InvariantCulture, "{0:D2}{1:00.0000}", degrees, minutes);
+        return string.Format(CultureInfo.InvariantCulture, "{0:D2}{1:00.00000}", degrees, minutes);
     }
 
-    /// <summary>Format longitude as DDDMM.MMMM</summary>
+    /// <summary>Format longitude as DDDMM.MMMMM (5 decimal places = 0.019m resolution)</summary>
     private static string FormatLongitude(double lon)
     {
         lon = Math.Abs(lon);
         int degrees = (int)lon;
         double minutes = (lon - degrees) * 60.0;
-        return string.Format(CultureInfo.InvariantCulture, "{0:D3}{1:00.0000}", degrees, minutes);
+        return string.Format(CultureInfo.InvariantCulture, "{0:D3}{1:00.00000}", degrees, minutes);
     }
 
     public void Dispose()

--- a/Tests/AgValoniaGPS.Services.Tests/NmeaEncodingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/NmeaEncodingTests.cs
@@ -1,0 +1,225 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AgValoniaGPS.IntegrationTests.VirtualModules;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Unit tests for NMEA sentence encoding in VirtualGpsReceiver.
+/// Verifies that $PANDA sentences have correct format, checksum,
+/// and sufficient coordinate precision.
+/// </summary>
+[TestFixture]
+public class NmeaEncodingTests
+{
+    /// <summary>
+    /// Capture the raw $PANDA string from VirtualGpsReceiver via UDP.
+    /// </summary>
+    private static string CapturePanda(double lat, double lon,
+        double heading = 0, double speedKnots = 5, int fixQuality = 4,
+        double roll = 0, double pitch = 0, double yawRate = 0)
+    {
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+        listener.Client.ReceiveTimeout = 2000;
+
+        using var gps = new VirtualGpsReceiver(targetPort: port);
+        gps.Latitude = lat;
+        gps.Longitude = lon;
+        gps.HeadingDegrees = heading;
+        gps.SpeedKnots = speedKnots;
+        gps.FixQuality = fixQuality;
+        gps.Satellites = 12;
+        gps.Hdop = 0.7;
+        gps.RollDegrees = roll;
+        gps.PitchDegrees = pitch;
+        gps.YawRateDegPerSec = yawRate;
+
+        gps.SendOnce();
+        IPEndPoint? remote = null;
+        var bytes = listener.Receive(ref remote);
+        return Encoding.ASCII.GetString(bytes).Trim();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Format tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void PandaSentence_StartsWithDollarPANDA()
+    {
+        var sentence = CapturePanda(42.0, -93.0);
+        Assert.That(sentence, Does.StartWith("$PANDA,"),
+            "Sentence must start with $PANDA,");
+    }
+
+    [Test]
+    public void PandaSentence_HasCorrectFieldCount()
+    {
+        var sentence = CapturePanda(42.0, -93.0);
+        int asterisk = sentence.IndexOf('*');
+        string body = sentence.Substring(0, asterisk);
+        string[] fields = body.Split(',');
+
+        // $PANDA,time,lat,N/S,lon,E/W,fix,sats,hdop,alt,age,speed,heading,roll,pitch,yaw
+        Assert.That(fields.Length, Is.EqualTo(16),
+            $"$PANDA should have 16 fields, got {fields.Length}: {body}");
+    }
+
+    [Test]
+    public void PandaSentence_HasValidChecksum()
+    {
+        var sentence = CapturePanda(42.0, -93.0);
+        int asterisk = sentence.IndexOf('*');
+        Assert.That(asterisk, Is.GreaterThan(0), "Sentence must contain *");
+
+        // Calculate XOR checksum of chars between $ and *
+        byte computed = 0;
+        for (int i = 1; i < asterisk; i++)
+            computed ^= (byte)sentence[i];
+
+        string providedHex = sentence.Substring(asterisk + 1, 2);
+        byte provided = byte.Parse(providedHex, NumberStyles.HexNumber);
+
+        Assert.That(computed, Is.EqualTo(provided),
+            $"Checksum mismatch: computed 0x{computed:X2}, sentence has 0x{provided:X2}");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Coordinate precision tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void LatitudeFormat_HasAtLeast5DecimalPlaces()
+    {
+        var sentence = CapturePanda(42.123456, -93.0);
+        var fields = sentence.Split(',');
+        string latField = fields[2]; // DDMM.MMMMM
+
+        // Find decimal point
+        int dot = latField.IndexOf('.');
+        Assert.That(dot, Is.GreaterThan(0), "Latitude must contain decimal point");
+
+        int decimalPlaces = latField.Length - dot - 1;
+        TestContext.Out.WriteLine($"Latitude field: {latField} ({decimalPlaces} decimal places)");
+
+        Assert.That(decimalPlaces, Is.GreaterThanOrEqualTo(5),
+            $"Latitude has {decimalPlaces} decimal places, need >= 5 for sub-5cm resolution. " +
+            $"4 places = 0.185m resolution (causes stepping at low speed).");
+    }
+
+    [Test]
+    public void LongitudeFormat_HasAtLeast5DecimalPlaces()
+    {
+        var sentence = CapturePanda(42.0, -93.654321);
+        var fields = sentence.Split(',');
+        string lonField = fields[4]; // DDDMM.MMMMM
+
+        int dot = lonField.IndexOf('.');
+        Assert.That(dot, Is.GreaterThan(0), "Longitude must contain decimal point");
+
+        int decimalPlaces = lonField.Length - dot - 1;
+        TestContext.Out.WriteLine($"Longitude field: {lonField} ({decimalPlaces} decimal places)");
+
+        Assert.That(decimalPlaces, Is.GreaterThanOrEqualTo(5),
+            $"Longitude has {decimalPlaces} decimal places, need >= 5 for sub-5cm resolution.");
+    }
+
+    [Test]
+    public void LatitudeEncoding_PreservesSubMeterDifferences()
+    {
+        // Two positions 0.05m apart
+        double lat1 = 42.0;
+        double lat2 = lat1 + 0.05 / 111320.0;
+
+        var s1 = CapturePanda(lat1, -93.0);
+        var s2 = CapturePanda(lat2, -93.0);
+
+        string latField1 = s1.Split(',')[2];
+        string latField2 = s2.Split(',')[2];
+
+        TestContext.Out.WriteLine($"Position 1: {latField1}");
+        TestContext.Out.WriteLine($"Position 2: {latField2}");
+        TestContext.Out.WriteLine($"Input difference: 0.05m");
+
+        Assert.That(latField1, Is.Not.EqualTo(latField2),
+            "Two positions 5cm apart must encode to different NMEA strings. " +
+            "If identical, the NMEA format resolution is too low.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Hemisphere and sign tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void NorthernLatitude_HasN()
+    {
+        var sentence = CapturePanda(42.0, -93.0);
+        Assert.That(sentence.Split(',')[3], Is.EqualTo("N"));
+    }
+
+    [Test]
+    public void SouthernLatitude_HasS()
+    {
+        var sentence = CapturePanda(-33.5, -93.0);
+        Assert.That(sentence.Split(',')[3], Is.EqualTo("S"));
+    }
+
+    [Test]
+    public void EasternLongitude_HasE()
+    {
+        var sentence = CapturePanda(42.0, 11.5);
+        Assert.That(sentence.Split(',')[5], Is.EqualTo("E"));
+    }
+
+    [Test]
+    public void WesternLongitude_HasW()
+    {
+        var sentence = CapturePanda(42.0, -93.0);
+        Assert.That(sentence.Split(',')[5], Is.EqualTo("W"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Data field tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void FixQuality_EncodedCorrectly()
+    {
+        var sentence = CapturePanda(42.0, -93.0, fixQuality: 4);
+        Assert.That(sentence.Split(',')[6], Is.EqualTo("4"));
+    }
+
+    [Test]
+    public void ImuFields_EncodedWithInvariantCulture()
+    {
+        // Roll=1.5, pitch=-0.3, yaw=0.2 must use dot decimal, not comma
+        var sentence = CapturePanda(42.0, -93.0, roll: 1.5, pitch: -0.3, yawRate: 0.2);
+        var fields = sentence.Split(',');
+
+        // Last field has checksum: "0.20*XX"
+        string yawField = fields[15].Split('*')[0];
+
+        Assert.That(fields[13], Is.EqualTo("1.50"), $"Roll should be 1.50, got {fields[13]}");
+        Assert.That(fields[14], Is.EqualTo("-0.30"), $"Pitch should be -0.30, got {fields[14]}");
+        Assert.That(yawField, Is.EqualTo("0.20"), $"Yaw should be 0.20, got {yawField}");
+    }
+
+    [Test]
+    public void SpeedField_UsesInvariantCulture()
+    {
+        var sentence = CapturePanda(42.0, -93.0, speedKnots: 5.5);
+        var fields = sentence.Split(',');
+
+        Assert.That(fields[11], Is.EqualTo("5.50"),
+            $"Speed should use dot decimal: expected 5.50, got {fields[11]}");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/NmeaPrecisionTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/NmeaPrecisionTests.cs
@@ -1,0 +1,268 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AgValoniaGPS.IntegrationTests.VirtualModules;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Tests that GPS data survives the NMEA encode -> transmit -> decode round trip
+/// with sufficient precision for real-time navigation. These tests catch resolution
+/// bugs like DDMM.MMMM (0.185m) vs DDMM.MMMMM (0.019m) formatting.
+///
+/// Root cause of the "tractor stepping" bug: the VirtualGpsReceiver formatted
+/// coordinates with only 4 decimal places on NMEA minutes, giving 0.185m
+/// resolution. At 1 km/h the position only changed once every ~0.7 seconds.
+/// </summary>
+[TestFixture]
+public class NmeaPrecisionTests
+{
+    private AutoSteerService _autoSteer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var configStore = new ConfigurationStore();
+        ConfigurationStore.SetInstance(configStore);
+
+        _autoSteer = new AutoSteerService(
+            Substitute.For<ITrackGuidanceService>(),
+            Substitute.For<IUdpCommunicationService>());
+        _autoSteer.Start();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _autoSteer.Stop();
+    }
+
+    /// <summary>
+    /// Send a GPS position via VirtualGpsReceiver, receive via UDP,
+    /// parse through AutoSteerService, return the parsed lat/lon.
+    /// </summary>
+    private (double lat, double lon) RoundTrip(double lat, double lon)
+    {
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+        listener.Client.ReceiveTimeout = 2000;
+
+        using var gps = new VirtualGpsReceiver(targetPort: port);
+        gps.Latitude = lat;
+        gps.Longitude = lon;
+        gps.HeadingDegrees = 0;
+        gps.SpeedKnots = 5;
+        gps.FixQuality = 4;
+        gps.Satellites = 12;
+
+        gps.SendOnce();
+        IPEndPoint? remote = null;
+        var bytes = listener.Receive(ref remote);
+
+        VehicleStateSnapshot? snap = null;
+        _autoSteer.StateUpdated += (_, s) => snap = s;
+        _autoSteer.ProcessGpsBuffer(bytes, bytes.Length);
+
+        Assert.That(snap, Is.Not.Null, "AutoSteer should produce a snapshot");
+        return (snap!.Value.Latitude, snap.Value.Longitude);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Round-trip precision tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void NmeaRoundTrip_LatitudePrecision_BetterThan5cm()
+    {
+        double inputLat = 42.123456789;
+        double inputLon = -93.654321;
+
+        var (parsedLat, _) = RoundTrip(inputLat, inputLon);
+
+        double errorMeters = Math.Abs(parsedLat - inputLat) * 111320; // deg to meters
+        TestContext.Out.WriteLine($"Latitude round-trip error: {errorMeters:F4}m");
+        TestContext.Out.WriteLine($"  Input:  {inputLat:F10}");
+        TestContext.Out.WriteLine($"  Parsed: {parsedLat:F10}");
+
+        Assert.That(errorMeters, Is.LessThan(0.05),
+            $"Latitude round-trip error ({errorMeters:F4}m) exceeds 5cm. " +
+            "Check NMEA minute format decimal places (need >= 5 for sub-5cm).");
+    }
+
+    [Test]
+    public void NmeaRoundTrip_LongitudePrecision_BetterThan5cm()
+    {
+        double inputLat = 42.0;
+        double inputLon = -93.654321789;
+
+        var (_, parsedLon) = RoundTrip(inputLat, inputLon);
+
+        double cosLat = Math.Cos(inputLat * Math.PI / 180.0);
+        double errorMeters = Math.Abs(parsedLon - inputLon) * 111320 * cosLat;
+        TestContext.Out.WriteLine($"Longitude round-trip error: {errorMeters:F4}m");
+        TestContext.Out.WriteLine($"  Input:  {inputLon:F10}");
+        TestContext.Out.WriteLine($"  Parsed: {parsedLon:F10}");
+
+        Assert.That(errorMeters, Is.LessThan(0.05),
+            $"Longitude round-trip error ({errorMeters:F4}m) exceeds 5cm. " +
+            "Check NMEA minute format decimal places (need >= 5 for sub-5cm).");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Resolution tests: can the system distinguish nearby positions?
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void TwoPositions_10cmApart_ProduceDifferentCoordinates()
+    {
+        // 10cm north = 0.10 / 111320 = 0.000000898 degrees
+        double baseLat = 42.0;
+        double offsetDeg = 0.10 / 111320.0;
+
+        var (lat1, _) = RoundTrip(baseLat, -93.0);
+        var (lat2, _) = RoundTrip(baseLat + offsetDeg, -93.0);
+
+        double deltaMeters = Math.Abs(lat2 - lat1) * 111320;
+        TestContext.Out.WriteLine($"10cm test: delta = {deltaMeters:F4}m (expected ~0.10m)");
+
+        Assert.That(lat2, Is.Not.EqualTo(lat1).Within(1e-10),
+            "Two positions 10cm apart must produce different parsed coordinates. " +
+            "If they're identical, NMEA resolution is too low.");
+        Assert.That(deltaMeters, Is.EqualTo(0.10).Within(0.05),
+            $"Parsed delta ({deltaMeters:F4}m) should be close to 0.10m");
+    }
+
+    [Test]
+    public void TwoPositions_3cmApart_ProduceDifferentCoordinates()
+    {
+        // 3cm = 0.03m. This is the RTK precision target.
+        double baseLat = 42.0;
+        double offsetDeg = 0.03 / 111320.0;
+
+        var (lat1, _) = RoundTrip(baseLat, -93.0);
+        var (lat2, _) = RoundTrip(baseLat + offsetDeg, -93.0);
+
+        double deltaMeters = Math.Abs(lat2 - lat1) * 111320;
+        TestContext.Out.WriteLine($"3cm test: delta = {deltaMeters:F4}m (expected ~0.03m)");
+
+        Assert.That(lat2, Is.Not.EqualTo(lat1).Within(1e-10),
+            "Two positions 3cm apart must produce different coordinates for RTK guidance.");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Low-speed smoothness: verify position changes every GPS cycle
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void LowSpeedDriving_1kmh_PositionChangesEveryCycle()
+    {
+        // At 1 km/h heading north, 10Hz GPS:
+        // distance per cycle = (1000/3600) * 0.1 = 0.0278m per 100ms
+        // The NMEA format must resolve this without stalling.
+
+        double lat = 42.0;
+        double speedMs = 1000.0 / 3600.0; // 1 km/h in m/s
+        double stepTime = 0.1; // 10Hz
+        double stepMeters = speedMs * stepTime; // 0.0278m
+        double stepDeg = stepMeters / 111320.0;
+
+        var positions = new List<double>();
+        for (int i = 0; i < 20; i++)
+        {
+            var (parsedLat, _) = RoundTrip(lat + i * stepDeg, -93.0);
+            positions.Add(parsedLat);
+        }
+
+        // Count how many consecutive positions are identical (stalls)
+        int stalls = 0;
+        int maxConsecutiveStall = 0;
+        int currentStall = 0;
+
+        for (int i = 1; i < positions.Count; i++)
+        {
+            if (Math.Abs(positions[i] - positions[i - 1]) < 1e-10)
+            {
+                stalls++;
+                currentStall++;
+                maxConsecutiveStall = Math.Max(maxConsecutiveStall, currentStall);
+            }
+            else
+            {
+                currentStall = 0;
+            }
+        }
+
+        TestContext.Out.WriteLine($"=== Low-Speed Smoothness (1 km/h, 10Hz) ===");
+        TestContext.Out.WriteLine($"Step distance: {stepMeters:F4}m per cycle");
+        TestContext.Out.WriteLine($"Total cycles: {positions.Count}");
+        TestContext.Out.WriteLine($"Stalled cycles: {stalls} (position unchanged from previous)");
+        TestContext.Out.WriteLine($"Max consecutive stall: {maxConsecutiveStall}");
+
+        for (int i = 0; i < positions.Count; i++)
+        {
+            string marker = (i > 0 && Math.Abs(positions[i] - positions[i - 1]) < 1e-10) ? " STALL" : "";
+            TestContext.Out.WriteLine($"  [{i:D2}] lat={positions[i]:F10}{marker}");
+        }
+
+        // At 0.028m per cycle with 0.019m resolution, we expect movement every cycle
+        // Allow at most 1 stall (rounding at LSB boundary)
+        Assert.That(maxConsecutiveStall, Is.LessThanOrEqualTo(1),
+            $"At 1 km/h, position should change nearly every cycle. " +
+            $"Got {maxConsecutiveStall} consecutive stalls. " +
+            "NMEA resolution is likely too low (need 5+ decimal places on minutes).");
+    }
+
+    [Test]
+    public void LowSpeedDriving_05kmh_NoMoreThan2ConsecutiveStalls()
+    {
+        // At 0.5 km/h: 0.0139m per cycle. With 0.019m resolution,
+        // expect movement every 1-2 cycles.
+        double lat = 42.0;
+        double speedMs = 500.0 / 3600.0;
+        double stepTime = 0.1;
+        double stepDeg = speedMs * stepTime / 111320.0;
+
+        var positions = new List<double>();
+        for (int i = 0; i < 30; i++)
+        {
+            var (parsedLat, _) = RoundTrip(lat + i * stepDeg, -93.0);
+            positions.Add(parsedLat);
+        }
+
+        int maxConsecutiveStall = 0;
+        int currentStall = 0;
+        for (int i = 1; i < positions.Count; i++)
+        {
+            if (Math.Abs(positions[i] - positions[i - 1]) < 1e-10)
+            {
+                currentStall++;
+                maxConsecutiveStall = Math.Max(maxConsecutiveStall, currentStall);
+            }
+            else
+            {
+                currentStall = 0;
+            }
+        }
+
+        TestContext.Out.WriteLine($"=== Low-Speed Smoothness (0.5 km/h, 10Hz) ===");
+        TestContext.Out.WriteLine($"Step distance: {speedMs * stepTime:F4}m per cycle");
+        TestContext.Out.WriteLine($"Max consecutive stall: {maxConsecutiveStall}");
+
+        // At 0.014m per cycle with 0.019m resolution, max 2 consecutive stalls
+        Assert.That(maxConsecutiveStall, Is.LessThanOrEqualTo(2),
+            $"At 0.5 km/h, got {maxConsecutiveStall} consecutive stalls. " +
+            "NMEA resolution too low for smooth low-speed display.");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
@@ -732,4 +732,167 @@ public class PipelineThroughputTests
         realAutoSteer.Stop();
         realGpsService.Stop();
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test 7: Real UDP sockets (VirtualGpsReceiver -> UdpCommunicationService)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task RealUdp_VirtualGpsToUdpService_MeasureThroughput()
+    {
+        // Stop the test-level pipeline
+        _pipeline.Stop();
+
+        var appState = new ApplicationState();
+
+        // Real services
+        var realGpsService = new GpsService();
+        realGpsService.Start();
+        var realNmeaParser = new NmeaParserService(realGpsService);
+
+        var realToolPosition = new AgValoniaGPS.Services.Tool.ToolPositionService();
+        var realGuidance = new TrackGuidanceService();
+        var realCoverage = new CoverageMapService();
+        var realSectionControl = new SectionControlService(
+            realToolPosition, realCoverage, appState);
+
+        // Real UdpCommunicationService
+        var udpService = new UdpCommunicationService();
+
+        // Real AutoSteerService wired to the UDP service
+        var realAutoSteer = new AutoSteerService(realGuidance, udpService);
+
+        // Wire AutoSteer into UDP service for zero-copy path
+        udpService.SetAutoSteerService(realAutoSteer);
+
+        var realPipeline = new GpsPipelineService(
+            realGpsService, realToolPosition, realGuidance,
+            realSectionControl, realCoverage, realAutoSteer,
+            new YouTurnGuidanceService(),
+            Substitute.For<IAudioService>(),
+            NullLogger<GpsPipelineService>.Instance, appState);
+
+        // Wire the old parser path: UDP DataReceived -> NmeaParser -> GpsService
+        udpService.DataReceived += (_, e) =>
+        {
+            if (e.PGN == 0) // NMEA text
+            {
+                string sentence = Encoding.ASCII.GetString(e.Data);
+                realNmeaParser.ParseSentence(sentence);
+            }
+        };
+
+        // Counters
+        long autoSteerCycles = 0;
+        long pipelineCycles = 0;
+        var pipelineResults = new List<GpsCycleResult>();
+
+        realAutoSteer.StateUpdated += (_, _) =>
+            Interlocked.Increment(ref autoSteerCycles);
+
+        realPipeline.CycleCompleted += result =>
+        {
+            Interlocked.Increment(ref pipelineCycles);
+            lock (pipelineResults) pipelineResults.Add(result);
+        };
+
+        // Start everything
+        realAutoSteer.Start();
+        realPipeline.Start();
+
+        try
+        {
+            await udpService.StartAsync();
+        }
+        catch (Exception ex)
+        {
+            Assert.Ignore($"Cannot bind to port 9999: {ex.Message}");
+            return;
+        }
+
+        try
+        {
+            // VirtualGpsReceiver sending to localhost:9999
+            using var gps = new VirtualGpsReceiver(targetPort: 9999, targetIp: "127.0.0.1");
+            gps.Latitude = 42.0;
+            gps.Longitude = -93.0;
+            gps.HeadingDegrees = 0;
+            gps.SpeedKnots = 5;
+            gps.FixQuality = 4;
+            gps.Satellites = 12;
+
+            // Send 50 GPS updates at 10Hz
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < 50; i++)
+            {
+                gps.Latitude = 42.0 + i * 0.00001;
+                gps.SendOnce();
+                if (i < 49)
+                    await Task.Delay(100);
+            }
+            sw.Stop();
+
+            // Wait for pipeline to process
+            await Task.Delay(1000);
+
+            long asCycles = Interlocked.Read(ref autoSteerCycles);
+            long plCycles = Interlocked.Read(ref pipelineCycles);
+
+            List<GpsCycleResult> results;
+            lock (pipelineResults) results = new List<GpsCycleResult>(pipelineResults);
+
+            TestContext.Out.WriteLine($"=== REAL UDP: VirtualGpsReceiver -> UdpCommunicationService ===");
+            TestContext.Out.WriteLine($"GPS packets sent:    50");
+            TestContext.Out.WriteLine($"AutoSteer cycles:    {asCycles}");
+            TestContext.Out.WriteLine($"Pipeline cycles:     {plCycles}");
+            TestContext.Out.WriteLine($"Pipeline drops:      {asCycles - plCycles}");
+            TestContext.Out.WriteLine($"AutoSteer rate:      {asCycles / sw.Elapsed.TotalSeconds:F1} Hz");
+            TestContext.Out.WriteLine($"Pipeline rate:       {plCycles / sw.Elapsed.TotalSeconds:F1} Hz");
+            TestContext.Out.WriteLine($"Wall time:           {sw.Elapsed.TotalSeconds:F1}s");
+
+            if (results.Count >= 2)
+            {
+                TestContext.Out.WriteLine($"\nPositions received: {results.Count}");
+                TestContext.Out.WriteLine($"  First: lat={results[0].Latitude:F6} E={results[0].Easting:F2} N={results[0].Northing:F2}");
+                TestContext.Out.WriteLine($"  Last:  lat={results[^1].Latitude:F6} E={results[^1].Easting:F2} N={results[^1].Northing:F2}");
+
+                var dists = new List<double>();
+                for (int i = 1; i < results.Count; i++)
+                {
+                    double dE = results[i].Easting - results[i - 1].Easting;
+                    double dN = results[i].Northing - results[i - 1].Northing;
+                    dists.Add(Math.Sqrt(dE * dE + dN * dN));
+                }
+                if (dists.Count > 0)
+                {
+                    dists.Sort();
+                    TestContext.Out.WriteLine($"  Steps: min={dists[0]:F3}m avg={dists.Average():F3}m max={dists[^1]:F3}m");
+                }
+            }
+
+            TestContext.Out.WriteLine();
+            if (plCycles < asCycles * 0.8)
+            {
+                TestContext.Out.WriteLine($">>> PIPELINE DROPS: {asCycles - plCycles} updates lost between AutoSteer and Pipeline");
+            }
+            else if (asCycles < 40)
+            {
+                TestContext.Out.WriteLine($">>> UDP RECEIVE DROPS: Only {asCycles}/50 reached AutoSteer");
+            }
+            else
+            {
+                TestContext.Out.WriteLine($">>> Full UDP stack delivers {plCycles}/50 at {plCycles / sw.Elapsed.TotalSeconds:F1}Hz");
+            }
+
+            Assert.That(asCycles, Is.GreaterThan(0), "AutoSteer should receive GPS data via UDP");
+        }
+        finally
+        {
+            await udpService.StopAsync();
+            realPipeline.Stop();
+            realAutoSteer.Stop();
+            realGpsService.Stop();
+            udpService.Dispose();
+        }
+    }
 }

--- a/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
@@ -349,7 +349,117 @@ public class PipelineThroughputTests
     }
 
     // ═══════════════════════════════════════════════════════════════════════
-    // Test 4: Position delta verification
+    // Test 4: Full receive path (AutoSteerService + Pipeline on same thread)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task FullReceivePath_WithAutoSteer_MeasureBlockingTime()
+    {
+        // Create a real AutoSteerService (same as production receive path)
+        var realAutoSteer = new AutoSteerService(
+            Substitute.For<ITrackGuidanceService>(),
+            Substitute.For<IUdpCommunicationService>());
+        realAutoSteer.Start();
+
+        // Pre-build raw GPS bytes (same as what UDP delivers)
+        var gpsBytePairs = new (byte[] bytes, string sentence)[50];
+        for (int i = 0; i < 50; i++)
+        {
+            using var listener = new UdpClient(0);
+            int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+            listener.Client.ReceiveTimeout = 2000;
+
+            using var gps = new VirtualGpsReceiver(targetPort: port);
+            gps.Latitude = 42.0 + i * 0.00001;
+            gps.Longitude = -93.0;
+            gps.HeadingDegrees = 0;
+            gps.SpeedKnots = 5;
+            gps.FixQuality = 4;
+            gps.Satellites = 12;
+
+            gps.SendOnce();
+            IPEndPoint? remote = null;
+            var bytes = listener.Receive(ref remote);
+            gpsBytePairs[i] = (bytes, Encoding.ASCII.GetString(bytes));
+        }
+
+        // Simulate the REAL receive callback path at 10Hz:
+        // 1. AutoSteerService.ProcessGpsBuffer (blocking, on receive thread)
+        // 2. NmeaParser.ParseSentence (blocking, on receive thread)
+        var autoSteerTimes = new List<double>();
+        var parseTimes = new List<double>();
+
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < gpsBytePairs.Length; i++)
+        {
+            var (bytes, sentence) = gpsBytePairs[i];
+
+            // Step 1: AutoSteerService (blocking - this is the suspected bottleneck)
+            var t1 = Stopwatch.GetTimestamp();
+            realAutoSteer.ProcessGpsBuffer(bytes, bytes.Length);
+            var t2 = Stopwatch.GetTimestamp();
+
+            // Step 2: Old parser path (blocking)
+            _nmeaParser.ParseSentence(sentence);
+            var t3 = Stopwatch.GetTimestamp();
+
+            autoSteerTimes.Add((t2 - t1) * 1000.0 / Stopwatch.Frequency);
+            parseTimes.Add((t3 - t2) * 1000.0 / Stopwatch.Frequency);
+
+            if (i < gpsBytePairs.Length - 1)
+                await Task.Delay(100); // 10Hz
+        }
+        sw.Stop();
+
+        // Wait for pipeline to drain
+        await Task.Delay(500);
+
+        long completed = Interlocked.Read(ref _cycleCompletedCount);
+        long parsed = Interlocked.Read(ref _gpsDataUpdatedCount);
+        long dropped = parsed - completed;
+
+        // Analyze AutoSteer timing
+        autoSteerTimes.Sort();
+        parseTimes.Sort();
+
+        TestContext.Out.WriteLine($"=== Full Receive Path (AutoSteer + Pipeline) ===");
+        TestContext.Out.WriteLine($"Sentences:           {gpsBytePairs.Length}");
+        TestContext.Out.WriteLine($"GpsDataUpdated:      {parsed}");
+        TestContext.Out.WriteLine($"CycleCompleted:      {completed}");
+        TestContext.Out.WriteLine($"Dropped:             {dropped} ({(double)dropped / parsed * 100:F1}%)");
+        TestContext.Out.WriteLine($"Effective Hz:        {completed / sw.Elapsed.TotalSeconds:F1}");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"AutoSteerService.ProcessGpsBuffer timing:");
+        TestContext.Out.WriteLine($"  Min:    {autoSteerTimes[0]:F2}ms");
+        TestContext.Out.WriteLine($"  Avg:    {autoSteerTimes.Average():F2}ms");
+        TestContext.Out.WriteLine($"  Median: {autoSteerTimes[autoSteerTimes.Count / 2]:F2}ms");
+        TestContext.Out.WriteLine($"  P95:    {autoSteerTimes[(int)(autoSteerTimes.Count * 0.95)]:F2}ms");
+        TestContext.Out.WriteLine($"  Max:    {autoSteerTimes[^1]:F2}ms");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"NmeaParser.ParseSentence timing:");
+        TestContext.Out.WriteLine($"  Min:    {parseTimes[0]:F2}ms");
+        TestContext.Out.WriteLine($"  Avg:    {parseTimes.Average():F2}ms");
+        TestContext.Out.WriteLine($"  Median: {parseTimes[parseTimes.Count / 2]:F2}ms");
+        TestContext.Out.WriteLine($"  Max:    {parseTimes[^1]:F2}ms");
+
+        double totalBlockingAvg = autoSteerTimes.Average() + parseTimes.Average();
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"Total receive thread blocking: {totalBlockingAvg:F2}ms avg");
+        TestContext.Out.WriteLine($"Budget at 10Hz: 100ms");
+        TestContext.Out.WriteLine($"Headroom: {100 - totalBlockingAvg:F1}ms");
+
+        if (totalBlockingAvg > 50)
+        {
+            TestContext.Out.WriteLine($"\n>>> RECEIVE THREAD BLOCKING {totalBlockingAvg:F0}ms — over 50% of 10Hz budget");
+            TestContext.Out.WriteLine($">>> This delays packet reception and starves the pipeline");
+        }
+
+        Assert.That(parsed, Is.EqualTo(50), "All sentences should parse");
+        realAutoSteer.Stop();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test 5: Position delta verification
     // ═══════════════════════════════════════════════════════════════════════
 
     [Test]

--- a/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
@@ -20,6 +20,9 @@ using AgValoniaGPS.Services;
 using AgValoniaGPS.Services.AutoSteer;
 using AgValoniaGPS.Services.Interfaces;
 using AgValoniaGPS.Services.Pipeline;
+using AgValoniaGPS.Services.Coverage;
+using AgValoniaGPS.Services.Section;
+using AgValoniaGPS.Services.Track;
 using AgValoniaGPS.Services.YouTurn;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -530,5 +533,203 @@ public class PipelineThroughputTests
         }
 
         Assert.That(completed, Is.GreaterThan(0), "At least some cycles should complete");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test 6: Full stack via real UDP (closest to production)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task FullStack_RealUdp_RealServices_MeasureThroughput()
+    {
+        // This test wires the FULL production stack minus the UI:
+        // VirtualGpsReceiver -> UDP -> UdpCommunicationService
+        //   -> AutoSteerService.ProcessGpsBuffer (real, with real guidance)
+        //   -> NmeaParserService -> GpsService -> GpsPipelineService (real services)
+        //
+        // Uses real: ToolPositionService, TrackGuidanceService, CoverageMapService,
+        //            SectionControlService, AutoSteerService
+
+        // Stop the test-level pipeline (we'll build our own full stack)
+        _pipeline.Stop();
+
+        // --- Build real services ---
+        var realGpsService = new GpsService();
+        realGpsService.Start();
+        var realNmeaParser = new NmeaParserService(realGpsService);
+
+        var realToolPosition = new AgValoniaGPS.Services.Tool.ToolPositionService();
+        var realGuidance = new TrackGuidanceService();
+        var realCoverage = new CoverageMapService();
+        var realSectionControl = new SectionControlService(
+            realToolPosition, realCoverage, _appState);
+        var realAutoSteer = new AutoSteerService(realGuidance,
+            Substitute.For<IUdpCommunicationService>());
+
+        var realPipeline = new GpsPipelineService(
+            realGpsService,
+            realToolPosition,
+            realGuidance,
+            realSectionControl,
+            realCoverage,
+            realAutoSteer,
+            new YouTurnGuidanceService(),
+            Substitute.For<IAudioService>(),
+            NullLogger<GpsPipelineService>.Instance,
+            _appState);
+
+        // Wire up UdpCommunicationService on ephemeral ports
+        var udpService = new UdpCommunicationService();
+
+        // We can't easily bind UdpCommunicationService to a custom port,
+        // so instead simulate its receive callback behavior directly.
+        // This is what happens inside ReceiveCallback:
+        realAutoSteer.Start();
+        realPipeline.Start();
+
+        long fullStackCompleted = 0;
+        var fullStackResults = new List<GpsCycleResult>();
+        realPipeline.CycleCompleted += result =>
+        {
+            Interlocked.Increment(ref fullStackCompleted);
+            lock (fullStackResults) fullStackResults.Add(result);
+        };
+
+        // Pre-build GPS data
+        var gpsPairs = new (byte[] bytes, string sentence)[50];
+        for (int i = 0; i < 50; i++)
+        {
+            using var listener = new UdpClient(0);
+            int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+            listener.Client.ReceiveTimeout = 2000;
+
+            using var gps = new VirtualGpsReceiver(targetPort: port);
+            gps.Latitude = 42.0 + i * 0.00001;
+            gps.Longitude = -93.0;
+            gps.HeadingDegrees = i * 7.2; // Vary heading
+            gps.SpeedKnots = 5;
+            gps.FixQuality = 4;
+            gps.Satellites = 12;
+
+            gps.SendOnce();
+            IPEndPoint? remote = null;
+            var bytes = listener.Receive(ref remote);
+            gpsPairs[i] = (bytes, Encoding.ASCII.GetString(bytes));
+        }
+
+        // Simulate the receive callback at 10Hz with REAL services
+        var autoSteerTimes = new List<double>();
+        var parseTimes = new List<double>();
+        var totalCallbackTimes = new List<double>();
+
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < gpsPairs.Length; i++)
+        {
+            var (bytes, sentence) = gpsPairs[i];
+
+            var tCallback = Stopwatch.GetTimestamp();
+
+            // Step 1: AutoSteerService (real guidance, real PGN build)
+            var t1 = Stopwatch.GetTimestamp();
+            realAutoSteer.ProcessGpsBuffer(bytes, bytes.Length);
+            var t2 = Stopwatch.GetTimestamp();
+
+            // Step 2: Old parser path
+            realNmeaParser.ParseSentence(sentence);
+            var t3 = Stopwatch.GetTimestamp();
+
+            autoSteerTimes.Add((t2 - t1) * 1000.0 / Stopwatch.Frequency);
+            parseTimes.Add((t3 - t2) * 1000.0 / Stopwatch.Frequency);
+            totalCallbackTimes.Add((t3 - tCallback) * 1000.0 / Stopwatch.Frequency);
+
+            if (i < gpsPairs.Length - 1)
+                await Task.Delay(100);
+        }
+        sw.Stop();
+
+        // Wait for pipeline to drain
+        await Task.Delay(1000);
+
+        long completed = Interlocked.Read(ref fullStackCompleted);
+        long dropped = gpsPairs.Length - completed;
+
+        // Sort for percentiles
+        autoSteerTimes.Sort();
+        parseTimes.Sort();
+        totalCallbackTimes.Sort();
+
+        TestContext.Out.WriteLine($"=== FULL STACK: Real Services, Simulated UDP @ 10Hz ===");
+        TestContext.Out.WriteLine($"Sentences sent:      {gpsPairs.Length}");
+        TestContext.Out.WriteLine($"CycleCompleted:      {completed}");
+        TestContext.Out.WriteLine($"Dropped:             {dropped} ({(double)dropped / gpsPairs.Length * 100:F1}%)");
+        TestContext.Out.WriteLine($"Effective Hz:        {completed / sw.Elapsed.TotalSeconds:F1}");
+        TestContext.Out.WriteLine($"Wall time:           {sw.Elapsed.TotalSeconds:F1}s");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"AutoSteerService.ProcessGpsBuffer (REAL guidance):");
+        TestContext.Out.WriteLine($"  Min:    {autoSteerTimes[0]:F2}ms");
+        TestContext.Out.WriteLine($"  Avg:    {autoSteerTimes.Average():F2}ms");
+        TestContext.Out.WriteLine($"  Median: {autoSteerTimes[autoSteerTimes.Count / 2]:F2}ms");
+        TestContext.Out.WriteLine($"  P95:    {autoSteerTimes[(int)(autoSteerTimes.Count * 0.95)]:F2}ms");
+        TestContext.Out.WriteLine($"  Max:    {autoSteerTimes[^1]:F2}ms");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"NmeaParser + GpsService (old path):");
+        TestContext.Out.WriteLine($"  Avg:    {parseTimes.Average():F2}ms");
+        TestContext.Out.WriteLine($"  Median: {parseTimes[parseTimes.Count / 2]:F2}ms");
+        TestContext.Out.WriteLine($"  Max:    {parseTimes[^1]:F2}ms");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine($"Total callback blocking:");
+        TestContext.Out.WriteLine($"  Avg:    {totalCallbackTimes.Average():F2}ms");
+        TestContext.Out.WriteLine($"  Median: {totalCallbackTimes[totalCallbackTimes.Count / 2]:F2}ms");
+        TestContext.Out.WriteLine($"  P95:    {totalCallbackTimes[(int)(totalCallbackTimes.Count * 0.95)]:F2}ms");
+        TestContext.Out.WriteLine($"  Max:    {totalCallbackTimes[^1]:F2}ms");
+        TestContext.Out.WriteLine($"  Budget: 100ms at 10Hz");
+        TestContext.Out.WriteLine($"  Headroom: {100 - totalCallbackTimes.Average():F1}ms");
+
+        // Position analysis
+        List<GpsCycleResult> results;
+        lock (fullStackResults) results = new List<GpsCycleResult>(fullStackResults);
+
+        if (results.Count >= 2)
+        {
+            TestContext.Out.WriteLine();
+            TestContext.Out.WriteLine($"Position verification ({results.Count} cycles):");
+            TestContext.Out.WriteLine($"  First: E={results[0].Easting:F2} N={results[0].Northing:F2}");
+            TestContext.Out.WriteLine($"  Last:  E={results[^1].Easting:F2} N={results[^1].Northing:F2}");
+
+            // Check for gaps (dropped updates = larger position jumps)
+            var dists = new List<double>();
+            for (int i = 1; i < results.Count; i++)
+            {
+                double dE = results[i].Easting - results[i - 1].Easting;
+                double dN = results[i].Northing - results[i - 1].Northing;
+                dists.Add(Math.Sqrt(dE * dE + dN * dN));
+            }
+            if (dists.Count > 0)
+            {
+                dists.Sort();
+                TestContext.Out.WriteLine($"  Step sizes: min={dists[0]:F3}m avg={dists.Average():F3}m max={dists[^1]:F3}m");
+                if (dists[^1] > dists[0] * 3)
+                    TestContext.Out.WriteLine($"  >>> Inconsistent steps detected - some updates dropped mid-stream");
+            }
+        }
+
+        // Verdict
+        TestContext.Out.WriteLine();
+        if (dropped > gpsPairs.Length * 0.1)
+        {
+            TestContext.Out.WriteLine($">>> VERDICT: {dropped} drops ({(double)dropped / gpsPairs.Length * 100:F0}%) with real services");
+            TestContext.Out.WriteLine($">>> The real services ARE the bottleneck (not the pipeline framework)");
+        }
+        else
+        {
+            TestContext.Out.WriteLine($">>> VERDICT: Pipeline keeps up with real services ({completed}/{gpsPairs.Length} delivered)");
+            TestContext.Out.WriteLine($">>> Bottleneck must be in the UI layer (Dispatcher.Post / render contention)");
+        }
+
+        Assert.That(completed, Is.GreaterThan(0), "At least some cycles should complete");
+
+        realPipeline.Stop();
+        realAutoSteer.Stop();
+        realGpsService.Stop();
     }
 }

--- a/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
@@ -1,0 +1,424 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AgValoniaGPS.IntegrationTests.VirtualModules;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Pipeline;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// End-to-end throughput tests for the GPS pipeline.
+/// Wires real NmeaParserService -> GpsService -> GpsPipelineService
+/// with mocked heavy dependencies to measure update rates and identify
+/// where GPS updates are dropped.
+/// </summary>
+[TestFixture]
+public class PipelineThroughputTests
+{
+    // Real services (the pipeline under test)
+    private GpsService _gpsService = null!;
+    private NmeaParserService _nmeaParser = null!;
+    private GpsPipelineService _pipeline = null!;
+
+    // Mocked dependencies for GpsPipelineService
+    private IToolPositionService _mockToolPosition = null!;
+    private ITrackGuidanceService _mockGuidance = null!;
+    private ISectionControlService _mockSectionControl = null!;
+    private ICoverageMapService _mockCoverage = null!;
+    private IAutoSteerService _mockAutoSteer = null!;
+    private IAudioService _mockAudio = null!;
+    private ApplicationState _appState = null!;
+
+    // Counters
+    private long _gpsDataUpdatedCount;
+    private long _cycleCompletedCount;
+    private readonly List<GpsCycleResult> _cycleResults = new();
+    private readonly List<long> _cycleTimestamps = new();
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Fresh singletons for each test
+        var configStore = new ConfigurationStore();
+        ConfigurationStore.SetInstance(configStore);
+        _appState = new ApplicationState();
+
+        // Real services
+        _gpsService = new GpsService();
+        _gpsService.Start();
+        _nmeaParser = new NmeaParserService(_gpsService);
+
+        // Mocks
+        _mockToolPosition = Substitute.For<IToolPositionService>();
+        _mockToolPosition.ToolPosition.Returns(new Vec3(0, 0, 0));
+        _mockToolPosition.ToolPivotPosition.Returns(new Vec3(0, 0, 0));
+        _mockToolPosition.HitchPosition.Returns(new Vec3(0, 0, 0));
+        _mockToolPosition.IsToolPositionReady.Returns(true);
+        _mockToolPosition.GetToolEdgePositions().Returns((new Vec3(-3, 0, 0), new Vec3(3, 0, 0)));
+        _mockToolPosition.GetSectionEdgePositions(Arg.Any<double>(), Arg.Any<double>())
+            .Returns((new Vec3(-3, 0, 0), new Vec3(3, 0, 0)));
+
+        _mockGuidance = Substitute.For<ITrackGuidanceService>();
+        _mockSectionControl = Substitute.For<ISectionControlService>();
+        _mockSectionControl.SectionStates.Returns(Array.Empty<SectionControlState>());
+        _mockSectionControl.NumSections.Returns(0);
+
+        _mockCoverage = Substitute.For<ICoverageMapService>();
+        _mockAutoSteer = Substitute.For<IAutoSteerService>();
+        _mockAudio = Substitute.For<IAudioService>();
+
+        // Construct the real pipeline
+        _pipeline = new GpsPipelineService(
+            _gpsService,
+            _mockToolPosition,
+            _mockGuidance,
+            _mockSectionControl,
+            _mockCoverage,
+            _mockAutoSteer,
+            new YouTurnGuidanceService(),
+            _mockAudio,
+            NullLogger<GpsPipelineService>.Instance,
+            _appState);
+
+        // Wire up counters
+        _gpsDataUpdatedCount = 0;
+        _cycleCompletedCount = 0;
+        _cycleResults.Clear();
+        _cycleTimestamps.Clear();
+
+        _gpsService.GpsDataUpdated += (_, _) =>
+            Interlocked.Increment(ref _gpsDataUpdatedCount);
+
+        _pipeline.CycleCompleted += result =>
+        {
+            Interlocked.Increment(ref _cycleCompletedCount);
+            lock (_cycleResults) _cycleResults.Add(result);
+            lock (_cycleTimestamps) _cycleTimestamps.Add(Stopwatch.GetTimestamp());
+        };
+
+        _pipeline.Start();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _pipeline.Stop();
+        _gpsService.Stop();
+    }
+
+    /// <summary>
+    /// Build a $PANDA sentence string for a given position.
+    /// Uses VirtualGpsReceiver to ensure correct checksum.
+    /// </summary>
+    private static string BuildPandaString(double lat, double lon,
+        double heading = 0, double speedKnots = 5, int fixQuality = 4)
+    {
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+        listener.Client.ReceiveTimeout = 2000;
+
+        using var gps = new VirtualGpsReceiver(targetPort: port);
+        gps.Latitude = lat;
+        gps.Longitude = lon;
+        gps.HeadingDegrees = heading;
+        gps.SpeedKnots = speedKnots;
+        gps.FixQuality = fixQuality;
+        gps.Satellites = 12;
+        gps.Hdop = 0.7;
+
+        gps.SendOnce();
+        IPEndPoint? remote = null;
+        var bytes = listener.Receive(ref remote);
+        return Encoding.ASCII.GetString(bytes);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test 1: Synchronous throughput (no timing delays)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void SynchronousThroughput_AllUpdatesReachPipeline()
+    {
+        // Pre-build 100 PANDA sentences with incrementing positions
+        var sentences = new string[100];
+        for (int i = 0; i < 100; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001,
+                lon: -93.0,
+                heading: 0,
+                speedKnots: 5);
+        }
+
+        // Feed all 100 synchronously (no timing - fastest possible)
+        var sw = Stopwatch.StartNew();
+        foreach (var sentence in sentences)
+        {
+            _nmeaParser.ParseSentence(sentence);
+        }
+        sw.Stop();
+
+        // Wait for async pipeline cycles to complete (up to 5 seconds)
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (Interlocked.Read(ref _cycleCompletedCount) < Interlocked.Read(ref _gpsDataUpdatedCount)
+               && DateTime.UtcNow < deadline)
+        {
+            Thread.Sleep(10);
+        }
+
+        // Report
+        long parsed = Interlocked.Read(ref _gpsDataUpdatedCount);
+        long completed = Interlocked.Read(ref _cycleCompletedCount);
+        long dropped = parsed - completed;
+
+        TestContext.Out.WriteLine($"=== Synchronous Throughput (no delays) ===");
+        TestContext.Out.WriteLine($"Sentences sent:      {sentences.Length}");
+        TestContext.Out.WriteLine($"GpsDataUpdated:      {parsed}");
+        TestContext.Out.WriteLine($"CycleCompleted:      {completed}");
+        TestContext.Out.WriteLine($"Dropped (backpressure): {dropped}");
+        TestContext.Out.WriteLine($"Drop rate:           {(double)dropped / parsed * 100:F1}%");
+        TestContext.Out.WriteLine($"Total parse time:    {sw.ElapsedMilliseconds}ms");
+        TestContext.Out.WriteLine($"Avg parse time:      {sw.Elapsed.TotalMilliseconds / sentences.Length:F2}ms");
+
+        // All sentences must parse successfully
+        Assert.That(parsed, Is.EqualTo(100),
+            "All 100 sentences should trigger GpsDataUpdated");
+
+        // Log finding
+        TestContext.Out.WriteLine($"\n>>> DROP RATE: {(double)dropped / parsed * 100:F1}% <<<");
+        if (dropped > 0)
+        {
+            TestContext.Out.WriteLine($">>> Back-pressure is dropping {dropped} out of {parsed} updates");
+            TestContext.Out.WriteLine($">>> This confirms GpsPipelineService.ProcessCycle is the bottleneck");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test 2: Timed throughput at 10Hz (reproduces real scenario)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task TimedThroughput_10Hz_MeasureDropRate()
+    {
+        // Pre-build sentences
+        var sentences = new string[50];
+        for (int i = 0; i < 50; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001,
+                lon: -93.0,
+                heading: 0,
+                speedKnots: 5);
+        }
+
+        // Send at 10Hz (100ms intervals) - simulates real GPS rate
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < sentences.Length; i++)
+        {
+            _nmeaParser.ParseSentence(sentences[i]);
+            if (i < sentences.Length - 1)
+                await Task.Delay(100);
+        }
+        sw.Stop();
+
+        // Wait for pipeline to drain
+        await Task.Delay(500);
+
+        long parsed = Interlocked.Read(ref _gpsDataUpdatedCount);
+        long completed = Interlocked.Read(ref _cycleCompletedCount);
+        long dropped = parsed - completed;
+
+        TestContext.Out.WriteLine($"=== Timed Throughput @ 10Hz (5 seconds) ===");
+        TestContext.Out.WriteLine($"Sentences sent:      {sentences.Length}");
+        TestContext.Out.WriteLine($"GpsDataUpdated:      {parsed}");
+        TestContext.Out.WriteLine($"CycleCompleted:      {completed}");
+        TestContext.Out.WriteLine($"Dropped:             {dropped}");
+        TestContext.Out.WriteLine($"Drop rate:           {(double)dropped / parsed * 100:F1}%");
+        TestContext.Out.WriteLine($"Effective Hz:        {completed / sw.Elapsed.TotalSeconds:F1}");
+        TestContext.Out.WriteLine($"Wall time:           {sw.Elapsed.TotalSeconds:F1}s");
+
+        // Verify all parsed
+        Assert.That(parsed, Is.EqualTo(50), "All sentences should parse");
+
+        double dropRate = (double)dropped / parsed;
+        TestContext.Out.WriteLine($"\n>>> EFFECTIVE UPDATE RATE: {completed / sw.Elapsed.TotalSeconds:F1} Hz <<<");
+
+        if (dropRate > 0.2)
+        {
+            TestContext.Out.WriteLine(">>> WARNING: >20% drop rate even with mocked dependencies!");
+            TestContext.Out.WriteLine(">>> ProcessCycle overhead is too high for 10Hz GPS");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test 3: ProcessCycle timing measurement
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task ProcessCycleTiming_MeasureIndividualCycleLatency()
+    {
+        // Pre-build sentences
+        var sentences = new string[30];
+        for (int i = 0; i < 30; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001,
+                lon: -93.0,
+                heading: i * 12.0,
+                speedKnots: 5);
+        }
+
+        // Send at 10Hz
+        for (int i = 0; i < sentences.Length; i++)
+        {
+            _nmeaParser.ParseSentence(sentences[i]);
+            if (i < sentences.Length - 1)
+                await Task.Delay(100);
+        }
+
+        // Wait for pipeline to drain
+        await Task.Delay(500);
+
+        // Analyze cycle intervals from timestamps
+        List<long> timestamps;
+        lock (_cycleTimestamps) timestamps = new List<long>(_cycleTimestamps);
+
+        if (timestamps.Count > 1)
+        {
+            var intervalsMs = new List<double>();
+            for (int i = 1; i < timestamps.Count; i++)
+            {
+                double ms = (timestamps[i] - timestamps[i - 1]) * 1000.0 / Stopwatch.Frequency;
+                intervalsMs.Add(ms);
+            }
+
+            intervalsMs.Sort();
+            double median = intervalsMs[intervalsMs.Count / 2];
+            double p95 = intervalsMs[(int)(intervalsMs.Count * 0.95)];
+            double max = intervalsMs[^1];
+            double min = intervalsMs[0];
+            double avg = 0;
+            foreach (var t in intervalsMs) avg += t;
+            avg /= intervalsMs.Count;
+
+            TestContext.Out.WriteLine($"=== ProcessCycle Interval Analysis ===");
+            TestContext.Out.WriteLine($"Cycles completed:    {timestamps.Count}");
+            TestContext.Out.WriteLine($"Min interval:        {min:F1}ms");
+            TestContext.Out.WriteLine($"Avg interval:        {avg:F1}ms");
+            TestContext.Out.WriteLine($"Median interval:     {median:F1}ms");
+            TestContext.Out.WriteLine($"P95 interval:        {p95:F1}ms");
+            TestContext.Out.WriteLine($"Max interval:        {max:F1}ms");
+            TestContext.Out.WriteLine($"Expected @ 10Hz:     100ms");
+
+            if (median > 200)
+            {
+                TestContext.Out.WriteLine($"\n>>> BOTTLENECK FOUND: Median cycle interval {median:F0}ms >> 100ms target");
+                TestContext.Out.WriteLine($">>> ProcessCycle is too slow, causing back-pressure drops");
+            }
+            else if (median < 150)
+            {
+                TestContext.Out.WriteLine($"\n>>> Pipeline keeps up with 10Hz (median {median:F0}ms)");
+                TestContext.Out.WriteLine($">>> Bottleneck is likely elsewhere (UI thread, receive thread blocking)");
+            }
+        }
+        else
+        {
+            TestContext.Out.WriteLine(">>> Only 0-1 cycles completed - pipeline is severely broken");
+            Assert.Fail("Pipeline produced fewer than 2 cycles from 30 inputs");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test 4: Position delta verification
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task PositionOutput_MatchesInput_NoDrift()
+    {
+        // Send 20 positions heading north with known spacing
+        double startLat = 42.0;
+        double latStep = 0.00001; // ~1.1m per step
+
+        var sentences = new string[20];
+        for (int i = 0; i < 20; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: startLat + i * latStep,
+                lon: -93.0,
+                heading: 0,
+                speedKnots: 5);
+        }
+
+        // Send at 10Hz
+        for (int i = 0; i < sentences.Length; i++)
+        {
+            _nmeaParser.ParseSentence(sentences[i]);
+            if (i < sentences.Length - 1)
+                await Task.Delay(100);
+        }
+
+        // Wait for pipeline to drain
+        await Task.Delay(500);
+
+        long completed = Interlocked.Read(ref _cycleCompletedCount);
+
+        TestContext.Out.WriteLine($"=== Position Delta Verification ===");
+        TestContext.Out.WriteLine($"Sent: {sentences.Length}, Received: {completed}");
+
+        List<GpsCycleResult> results;
+        lock (_cycleResults) results = new List<GpsCycleResult>(_cycleResults);
+
+        // Log each received position
+        for (int i = 0; i < results.Count; i++)
+        {
+            var r = results[i];
+            TestContext.Out.WriteLine(
+                $"  [{i}] lat={r.Latitude:F6} lon={r.Longitude:F6} E={r.Easting:F2} N={r.Northing:F2} " +
+                $"tool=({r.ToolEasting:F2},{r.ToolNorthing:F2}) heading={r.Heading:F1}");
+        }
+
+        // Check position deltas between consecutive results
+        if (results.Count >= 2)
+        {
+            TestContext.Out.WriteLine($"\nPosition deltas:");
+            for (int i = 1; i < results.Count; i++)
+            {
+                double dE = results[i].Easting - results[i - 1].Easting;
+                double dN = results[i].Northing - results[i - 1].Northing;
+                double dist = Math.Sqrt(dE * dE + dN * dN);
+                double dLat = results[i].Latitude - results[i - 1].Latitude;
+                TestContext.Out.WriteLine(
+                    $"  [{i - 1}->{i}] dE={dE:F3} dN={dN:F3} dist={dist:F3}m dLat={dLat:F8}");
+            }
+
+            if (results.Count < sentences.Length)
+            {
+                TestContext.Out.WriteLine(
+                    $"\n>>> {sentences.Length - results.Count} updates dropped " +
+                    $"({(double)(sentences.Length - results.Count) / sentences.Length * 100:F0}% loss)");
+            }
+        }
+
+        Assert.That(completed, Is.GreaterThan(0), "At least some cycles should complete");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/RollCorrectionTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/RollCorrectionTests.cs
@@ -147,13 +147,13 @@ public class RollCorrectionTests
         ConfigurationStore.Instance.Vehicle.AntennaHeight = 4.0;
         SensorState.Instance.ImuRoll = 15.0;
 
-        var gpsData = MakeGpsData(easting: 0, northing: 0, heading: 0);
+        var gpsData = MakeGpsData(easting: 500, northing: 500, heading: 0);
         gpsService.UpdateGpsData(gpsData);
 
         double expected = Math.Sin(15.0 * Math.PI / 180.0) * 4.0; // ~1.035m
         double actualShift = Math.Sqrt(
-            Math.Pow(gpsData.CurrentPosition.Easting, 2) +
-            Math.Pow(gpsData.CurrentPosition.Northing, 2));
+            Math.Pow(gpsData.CurrentPosition.Easting - 500, 2) +
+            Math.Pow(gpsData.CurrentPosition.Northing - 500, 2));
 
         Assert.That(actualShift, Is.EqualTo(expected).Within(0.05),
             $"Total shift should be sin(15)*4 = {expected:F3}m, got {actualShift:F3}m");
@@ -177,6 +177,26 @@ public class RollCorrectionTests
             "Pivot should move position south");
         Assert.That(gpsData.CurrentPosition.Easting, Is.LessThan(100.0),
             "Roll should move position west");
+    }
+
+    [Test]
+    public void RollWithZeroEastingNorthing_SkipsCorrection_NoTeleportToOrigin()
+    {
+        // Regression: when NMEA parser creates GpsData without local plane conversion,
+        // Easting=Northing=0. Roll correction was applied to zeros, producing small
+        // non-zero values that broke GpsPipelineService's auto-conversion check,
+        // teleporting the tractor to the local origin.
+        var gpsService = new GpsService();
+        ConfigurationStore.Instance.Vehicle.AntennaHeight = 3.0;
+        SensorState.Instance.ImuRoll = 10.0;
+
+        var gpsData = MakeGpsData(easting: 0, northing: 0, heading: 45);
+        gpsService.UpdateGpsData(gpsData);
+
+        Assert.That(gpsData.CurrentPosition.Easting, Is.EqualTo(0.0).Within(0.0001),
+            "Easting should remain 0 when no local plane conversion has occurred");
+        Assert.That(gpsData.CurrentPosition.Northing, Is.EqualTo(0.0).Within(0.0001),
+            "Northing should remain 0 when no local plane conversion has occurred");
     }
 
     private static GpsData MakeGpsData(double easting, double northing, double heading)

--- a/Tests/AgValoniaGPS.Services.Tests/SimulatorDataFlowTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SimulatorDataFlowTests.cs
@@ -437,6 +437,66 @@ public class SimulatorDataFlowTests
             "Easting should be near zero (same longitude as field origin)");
     }
 
+    // ═══════════════════════════════════════════════════════════════════════
+    // Pipeline Throughput Test
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void PipelineThroughput_OldPath_MeasureDropRate()
+    {
+        // Simulate the full old pipeline path:
+        // NmeaParser -> GpsService -> GpsPipelineService -> CycleCompleted
+        // Measures how many of 50 GPS updates at 10Hz actually make it through.
+
+        var gpsService = new GpsService();
+        gpsService.Start();
+
+        var nmeaParser = new NmeaParserService(gpsService);
+
+        // Count how many GpsDataUpdated events fire
+        int gpsDataUpdatedCount = 0;
+        gpsService.GpsDataUpdated += (_, _) => Interlocked.Increment(ref gpsDataUpdatedCount);
+
+        // Build 50 PANDA sentences with slightly different positions (simulating movement)
+        var sentences = new string[50];
+        for (int i = 0; i < 50; i++)
+        {
+            using var listener = new UdpClient(0);
+            int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+            listener.Client.ReceiveTimeout = 2000;
+
+            using var gps = new VirtualGpsReceiver(targetPort: port);
+            gps.Latitude = 42.0 + i * 0.00001; // ~1.1m steps
+            gps.Longitude = -93.0;
+            gps.HeadingDegrees = 0;
+            gps.SpeedKnots = 5;
+            gps.FixQuality = 4;
+            gps.Satellites = 12;
+
+            gps.SendOnce();
+            IPEndPoint? remote = null;
+            var bytes = listener.Receive(ref remote);
+            sentences[i] = System.Text.Encoding.ASCII.GetString(bytes);
+        }
+
+        // Feed all 50 sentences through the old parser path synchronously
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        foreach (var sentence in sentences)
+        {
+            nmeaParser.ParseSentence(sentence);
+        }
+        sw.Stop();
+
+        TestContext.Out.WriteLine($"NmeaParser: {sentences.Length} sentences in {sw.ElapsedMilliseconds}ms");
+        TestContext.Out.WriteLine($"GpsDataUpdated events fired: {gpsDataUpdatedCount} / {sentences.Length}");
+        TestContext.Out.WriteLine($"Average parse time: {sw.Elapsed.TotalMilliseconds / sentences.Length:F2}ms");
+
+        // All 50 should trigger GpsDataUpdated (parsing shouldn't drop any)
+        Assert.That(gpsDataUpdatedCount, Is.EqualTo(50),
+            $"All 50 sentences should parse successfully and fire GpsDataUpdated. " +
+            $"Only {gpsDataUpdatedCount} fired. Check NmeaParserService checksum validation.");
+    }
+
     /// <summary>Get a random ephemeral port by binding to 0 and reading the assigned port.</summary>
     private static int GetEphemeralPort()
     {

--- a/Tests/AgValoniaGPS.UI.Tests/PipelineUiThroughputTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/PipelineUiThroughputTests.cs
@@ -1,0 +1,224 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Coverage;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Pipeline;
+using AgValoniaGPS.Services.Section;
+using AgValoniaGPS.Services.Tool;
+using AgValoniaGPS.Services.Track;
+using AgValoniaGPS.Services.YouTurn;
+using AgValoniaGPS.ViewModels;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Tests the full GPS pipeline through the Avalonia UI dispatcher.
+/// Uses headless Avalonia to get a real dispatcher, then measures how many
+/// GPS updates actually reach ApplyGpsCycleResult via Dispatcher.Post.
+/// This reproduces the real-app environment where the UI thread processes
+/// both render frames and posted GPS updates.
+/// </summary>
+[TestFixture]
+public class PipelineUiThroughputTests
+{
+    /// <summary>
+    /// Build a $PANDA sentence with correct NMEA checksum.
+    /// Inlined here to avoid dependency on IntegrationTests project.
+    /// </summary>
+    private static string BuildPandaString(double lat, double lon,
+        double heading = 0, double speedKnots = 5)
+    {
+        double absLat = Math.Abs(lat);
+        int latDeg = (int)absLat;
+        double latMin = (absLat - latDeg) * 60.0;
+        string latStr = $"{latDeg:D2}{latMin:00.0000}";
+        string ns = lat >= 0 ? "N" : "S";
+
+        double absLon = Math.Abs(lon);
+        int lonDeg = (int)absLon;
+        double lonMin = (absLon - lonDeg) * 60.0;
+        string lonStr = $"{lonDeg:D3}{lonMin:00.0000}";
+        string ew = lon >= 0 ? "E" : "W";
+
+        string time = DateTime.UtcNow.ToString("HHmmss.ff",
+            System.Globalization.CultureInfo.InvariantCulture);
+        var ci = System.Globalization.CultureInfo.InvariantCulture;
+
+        string body = $"PANDA,{time},{latStr},{ns},{lonStr},{ew},4,12,0.7,100.0,1.0," +
+                       $"{speedKnots.ToString("F2", ci)},{heading.ToString("F2", ci)},0.00,0.00,0.00";
+
+        byte checksum = 0;
+        foreach (char c in body) checksum ^= (byte)c;
+
+        return $"${body}*{checksum:X2}\r\n";
+    }
+
+    [AvaloniaTest]
+    public async Task DispatcherThroughput_MeasureGpsUpdatesReachingUiThread()
+    {
+        // Setup singletons
+        var configStore = new ConfigurationStore();
+        ConfigurationStore.SetInstance(configStore);
+        var appState = new ApplicationState();
+
+        // Build real pipeline stack
+        var gpsService = new GpsService();
+        gpsService.Start();
+        var nmeaParser = new NmeaParserService(gpsService);
+
+        var toolPosition = new ToolPositionService();
+        var guidance = new TrackGuidanceService();
+        var coverage = new CoverageMapService();
+        var sectionControl = new SectionControlService(toolPosition, coverage, appState);
+        var autoSteer = new AutoSteerService(guidance, Substitute.For<IUdpCommunicationService>());
+
+        var pipeline = new GpsPipelineService(
+            gpsService, toolPosition, guidance, sectionControl, coverage,
+            autoSteer, new YouTurnGuidanceService(),
+            Substitute.For<IAudioService>(),
+            NullLogger<GpsPipelineService>.Instance, appState);
+
+        autoSteer.Start();
+        pipeline.Start();
+
+        // Track updates that reach the UI thread via Dispatcher.Post
+        // (this is what ApplyGpsCycleResult does in the real app)
+        long cycleCompletedCount = 0;
+        long uiThreadApplyCount = 0;
+        var uiPositions = new List<(double E, double N)>();
+
+        pipeline.CycleCompleted += result =>
+        {
+            Interlocked.Increment(ref cycleCompletedCount);
+
+            // This mirrors MainViewModel.OnGpsCycleCompleted exactly:
+            Dispatcher.UIThread.Post(() =>
+            {
+                Interlocked.Increment(ref uiThreadApplyCount);
+                lock (uiPositions) uiPositions.Add((result.Easting, result.Northing));
+            });
+        };
+
+        // Pre-build sentences
+        var sentences = new string[50];
+        for (int i = 0; i < 50; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001,
+                lon: -93.0, heading: 0, speedKnots: 5);
+        }
+
+        // Send at 10Hz from a background thread (simulating UDP receive)
+        var sendTask = Task.Run(async () =>
+        {
+            for (int i = 0; i < sentences.Length; i++)
+            {
+                // Simulate receive callback: AutoSteer + NmeaParser
+                var bytes = Encoding.ASCII.GetBytes(sentences[i]);
+                autoSteer.ProcessGpsBuffer(bytes, bytes.Length);
+                nmeaParser.ParseSentence(sentences[i]);
+
+                if (i < sentences.Length - 1)
+                    await Task.Delay(100);
+            }
+        });
+
+        // While sending, pump the dispatcher to process posted updates
+        // This simulates the Avalonia render loop processing queued work
+        var pumpStart = Stopwatch.StartNew();
+        while (!sendTask.IsCompleted || pumpStart.Elapsed.TotalSeconds < 6)
+        {
+            // Process any queued dispatcher work items
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(33); // ~30 FPS render loop timing
+
+            if (pumpStart.Elapsed.TotalSeconds > 7) break;
+        }
+
+        // Final pump to catch stragglers
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+
+        // Report
+        long cycles = Interlocked.Read(ref cycleCompletedCount);
+        long uiApplied = Interlocked.Read(ref uiThreadApplyCount);
+        long uiDropped = cycles - uiApplied;
+
+        List<(double E, double N)> positions;
+        lock (uiPositions) positions = new List<(double E, double N)>(uiPositions);
+
+        TestContext.Out.WriteLine($"=== UI Dispatcher Throughput @ 10Hz ===");
+        TestContext.Out.WriteLine($"Sentences sent:      {sentences.Length}");
+        TestContext.Out.WriteLine($"CycleCompleted:      {cycles}");
+        TestContext.Out.WriteLine($"UI thread applied:   {uiApplied}");
+        TestContext.Out.WriteLine($"UI thread missed:    {uiDropped}");
+        TestContext.Out.WriteLine($"UI drop rate:        {(cycles > 0 ? (double)uiDropped / cycles * 100 : 0):F1}%");
+        TestContext.Out.WriteLine($"Effective UI Hz:     {uiApplied / 5.0:F1}");
+
+        if (positions.Count >= 2)
+        {
+            TestContext.Out.WriteLine($"\nUI position updates received: {positions.Count}");
+            TestContext.Out.WriteLine($"  First: E={positions[0].E:F2} N={positions[0].N:F2}");
+            TestContext.Out.WriteLine($"  Last:  E={positions[^1].E:F2} N={positions[^1].N:F2}");
+
+            var dists = new List<double>();
+            for (int i = 1; i < positions.Count; i++)
+            {
+                double dE = positions[i].E - positions[i - 1].E;
+                double dN = positions[i].N - positions[i - 1].N;
+                dists.Add(Math.Sqrt(dE * dE + dN * dN));
+            }
+            dists.Sort();
+            TestContext.Out.WriteLine($"  Steps: min={dists[0]:F3}m avg={dists.Average():F3}m max={dists[^1]:F3}m");
+            TestContext.Out.WriteLine($"  Expected step: 1.111m (if no drops)");
+
+            if (dists[^1] > 2.0)
+            {
+                TestContext.Out.WriteLine($"  >>> Large steps detected ({dists[^1]:F1}m) - updates dropped at UI layer");
+            }
+        }
+
+        // Verdict
+        TestContext.Out.WriteLine();
+        if (uiDropped > cycles * 0.1)
+        {
+            TestContext.Out.WriteLine($">>> VERDICT: UI dispatcher is the bottleneck");
+            TestContext.Out.WriteLine($">>> {uiDropped}/{cycles} updates lost between CycleCompleted and UI apply");
+            TestContext.Out.WriteLine($">>> Fix: store latest result in volatile field, read from render timer");
+        }
+        else
+        {
+            TestContext.Out.WriteLine($">>> VERDICT: UI dispatcher keeps up ({uiApplied}/{cycles})");
+            TestContext.Out.WriteLine($">>> Headless dispatcher has no render contention");
+            TestContext.Out.WriteLine($">>> Real app may still bottleneck under 30 FPS render load");
+        }
+
+        Assert.That(cycles, Is.GreaterThan(0), "Pipeline should produce cycles");
+        Assert.That(uiApplied, Is.GreaterThan(0), "UI thread should process some updates");
+
+        pipeline.Stop();
+        autoSteer.Stop();
+        gpsService.Stop();
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/PipelineUiThroughputTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/PipelineUiThroughputTests.cs
@@ -221,4 +221,125 @@ public class PipelineUiThroughputTests
         autoSteer.Stop();
         gpsService.Stop();
     }
+
+    [AvaloniaTest]
+    [TestCase(0, TestName = "RenderContention_0ms_NoLoad")]
+    [TestCase(10, TestName = "RenderContention_10ms_LightRender")]
+    [TestCase(20, TestName = "RenderContention_20ms_MediumRender")]
+    [TestCase(30, TestName = "RenderContention_30ms_HeavyRender")]
+    [TestCase(50, TestName = "RenderContention_50ms_OverbudgetRender")]
+    public async Task DispatcherThroughput_WithSimulatedRenderLoad(int renderMs)
+    {
+        // Same pipeline setup as above
+        var configStore = new ConfigurationStore();
+        ConfigurationStore.SetInstance(configStore);
+        var appState = new ApplicationState();
+
+        var gpsService = new GpsService();
+        gpsService.Start();
+        var nmeaParser = new NmeaParserService(gpsService);
+
+        var toolPosition = new ToolPositionService();
+        var guidance = new TrackGuidanceService();
+        var coverage = new CoverageMapService();
+        var sectionControl = new SectionControlService(toolPosition, coverage, appState);
+        var autoSteer = new AutoSteerService(guidance, Substitute.For<IUdpCommunicationService>());
+
+        var pipeline = new GpsPipelineService(
+            gpsService, toolPosition, guidance, sectionControl, coverage,
+            autoSteer, new YouTurnGuidanceService(),
+            Substitute.For<IAudioService>(),
+            NullLogger<GpsPipelineService>.Instance, appState);
+
+        autoSteer.Start();
+        pipeline.Start();
+
+        long cycleCompletedCount = 0;
+        long uiThreadApplyCount = 0;
+
+        pipeline.CycleCompleted += result =>
+        {
+            Interlocked.Increment(ref cycleCompletedCount);
+            Dispatcher.UIThread.Post(() =>
+            {
+                Interlocked.Increment(ref uiThreadApplyCount);
+            });
+        };
+
+        // Pre-build sentences
+        var sentences = new string[50];
+        for (int i = 0; i < 50; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001,
+                lon: -93.0, heading: 0, speedKnots: 5);
+        }
+
+        // Send at 10Hz from background thread
+        var sendTask = Task.Run(async () =>
+        {
+            for (int i = 0; i < sentences.Length; i++)
+            {
+                var bytes = Encoding.ASCII.GetBytes(sentences[i]);
+                autoSteer.ProcessGpsBuffer(bytes, bytes.Length);
+                nmeaParser.ParseSentence(sentences[i]);
+
+                if (i < sentences.Length - 1)
+                    await Task.Delay(100);
+            }
+        });
+
+        // Simulate render loop with contention
+        // At 30 FPS, each frame is ~33ms. If rendering takes renderMs,
+        // only (33 - renderMs)ms is left for Dispatcher.RunJobs.
+        var pumpStart = Stopwatch.StartNew();
+        while (!sendTask.IsCompleted || pumpStart.Elapsed.TotalSeconds < 6)
+        {
+            // Simulate render work (burns CPU on UI thread)
+            if (renderMs > 0)
+            {
+                var renderStart = Stopwatch.StartNew();
+                while (renderStart.ElapsedMilliseconds < renderMs)
+                {
+                    // Busy-wait simulating GPU/draw work
+                    Thread.SpinWait(1000);
+                }
+            }
+
+            // Process queued dispatcher work in remaining frame time
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(33); // 30 FPS frame boundary
+
+            if (pumpStart.Elapsed.TotalSeconds > 7) break;
+        }
+
+        await Task.Delay(200);
+        Dispatcher.UIThread.RunJobs();
+
+        long cycles = Interlocked.Read(ref cycleCompletedCount);
+        long uiApplied = Interlocked.Read(ref uiThreadApplyCount);
+        long uiDropped = cycles - uiApplied;
+
+        TestContext.Out.WriteLine($"=== Render Contention Test: {renderMs}ms render load ===");
+        TestContext.Out.WriteLine($"CycleCompleted:      {cycles}");
+        TestContext.Out.WriteLine($"UI thread applied:   {uiApplied}");
+        TestContext.Out.WriteLine($"UI thread missed:    {uiDropped}");
+        TestContext.Out.WriteLine($"UI drop rate:        {(cycles > 0 ? (double)uiDropped / cycles * 100 : 0):F1}%");
+        TestContext.Out.WriteLine($"Effective UI Hz:     {uiApplied / 5.0:F1}");
+
+        if (uiDropped > cycles * 0.1)
+        {
+            TestContext.Out.WriteLine($">>> {renderMs}ms render: UI starved, {uiDropped}/{cycles} updates lost");
+        }
+        else
+        {
+            TestContext.Out.WriteLine($">>> {renderMs}ms render: UI keeps up ({uiApplied}/{cycles})");
+        }
+
+        Assert.That(cycles, Is.GreaterThan(0));
+
+        pipeline.Stop();
+        autoSteer.Stop();
+        gpsService.Stop();
+    }
 }

--- a/docs/debugging/update-rate-investigation.md
+++ b/docs/debugging/update-rate-investigation.md
@@ -1,0 +1,68 @@
+# Tractor Update Rate Investigation
+
+## Problem
+Tractor moves in big steps (~1 per second) instead of smooth 10Hz updates
+when using the vehicle simulator.
+
+## Hypothesis
+GPS updates are being dropped somewhere in the pipeline. The simulator
+sends at 10Hz but only ~1 update per second reaches the map renderer.
+
+## Pipeline stages (each numbered for instrumentation)
+
+```
+[1] Simulator sends $PANDA via UDP (10Hz)
+     |
+[2] UdpCommunicationService.ReceiveCallback
+     |
+     +--[3] AutoSteerService.ProcessGpsBuffer (BLOCKING on receive thread)
+     |       Parse + Guidance + PGN send
+     |
+     +--[4] NmeaParserService.ParseSentence (BLOCKING on receive thread)
+     |       |
+     |       +--[5] GpsService.UpdateGpsData -> GpsDataUpdated event
+     |               |
+     |               +--[6] GpsPipelineService.OnGpsDataUpdated
+     |                       |
+     |                       +-- Back-pressure check (DROPS if busy)
+     |                       |
+     |                       +--[7] Task.Run -> ProcessCycle
+     |                               |
+     |                               +--[8] CycleCompleted event
+     |                                       |
+     |                                       +--[9] Dispatcher.Post -> ApplyGpsCycleResult
+     |                                               |
+     |                                               +--[10] SetAllPositions -> map render
+```
+
+## Potential drop points
+- **[3]**: ProcessGpsBuffer blocks receive thread for 50-200ms, delaying next receive
+- **[6]**: Back-pressure drops update if previous ProcessCycle still running
+- **[7]**: ProcessCycle slow (>100ms) causing back-pressure
+- **[9]**: Dispatcher.Post queued behind render frames
+
+## Instrumentation added (current)
+- [3] AutoSteerService: logs every 10th cycle with E/N/H
+- [6] GpsPipelineService: logs received/dropped counts + cycleMs
+- [9] ApplyGpsCycleResult: logs every 10th apply with positions
+
+## How to diagnose
+1. Run the main app in Debug mode
+2. Start the simulator at 10Hz, set speed to 5 km/h
+3. Watch Debug output for 10 seconds
+4. Check:
+   - [AutoSteer] cycle count: should increment by ~100 in 10s (10Hz)
+   - [Pipeline] dropped count: if high, ProcessCycle is the bottleneck
+   - [Pipeline] cycleMs: if >100ms, this confirms back-pressure drops
+   - [ApplyResult] count: should match Pipeline processed count
+
+## Expected finding
+ProcessGpsBuffer (step 3) blocks the receive thread for too long,
+AND ProcessCycle (step 7) takes >100ms causing back-pressure drops.
+Combined: only a fraction of updates reach the UI.
+
+## Fix options (aligned with THREADING_MIGRATION_PLAN)
+1. **Quick fix**: Make ProcessGpsBuffer only parse, hand off heavy work
+   to Task.Run (Phase B of threading plan)
+2. **Full fix**: Unify pipelines per THREADING_MIGRATION_PLAN Phase B -
+   single cycle worker, receive thread returns immediately

--- a/docs/superpowers/plans/2026-04-19-pipeline-throughput-test.md
+++ b/docs/superpowers/plans/2026-04-19-pipeline-throughput-test.md
@@ -1,0 +1,576 @@
+# Pipeline Throughput Test Infrastructure
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an end-to-end test that wires the full GPS pipeline with mocked dependencies, sends GPS updates at 10Hz, and measures how many reach each stage -- reproducing and diagnosing the "tractor moves in big steps" bug.
+
+**Architecture:** A single test class `PipelineThroughputTests` in the existing Services.Tests project. Constructs the real NmeaParserService -> GpsService -> GpsPipelineService chain with NSubstitute mocks for heavy dependencies (sections, coverage, guidance). Sends real $PANDA sentences built by VirtualGpsReceiver. Counts events at each stage, measures ProcessCycle time.
+
+**Tech Stack:** NUnit 4, NSubstitute, VirtualGpsReceiver (from integration tests), Stopwatch, ManualResetEventSlim for async synchronization.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs` | New test class with pipeline throughput measurements |
+
+Only one new file. All service classes used are existing production code.
+
+---
+
+### Task 1: Scaffold test class with full pipeline construction
+
+**Files:**
+- Create: `Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs`
+
+- [ ] **Step 1: Write the test class with SetUp that constructs the full pipeline**
+
+```csharp
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AgValoniaGPS.IntegrationTests.VirtualModules;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Pipeline;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// End-to-end throughput tests for the GPS pipeline.
+/// Wires real NmeaParserService -> GpsService -> GpsPipelineService
+/// with mocked heavy dependencies to measure update rates and identify
+/// where GPS updates are dropped.
+/// </summary>
+[TestFixture]
+public class PipelineThroughputTests
+{
+    // Real services (the pipeline under test)
+    private GpsService _gpsService = null!;
+    private NmeaParserService _nmeaParser = null!;
+    private GpsPipelineService _pipeline = null!;
+
+    // Mocked dependencies for GpsPipelineService
+    private IToolPositionService _mockToolPosition = null!;
+    private ITrackGuidanceService _mockGuidance = null!;
+    private ISectionControlService _mockSectionControl = null!;
+    private ICoverageMapService _mockCoverage = null!;
+    private IAutoSteerService _mockAutoSteer = null!;
+    private IAudioService _mockAudio = null!;
+    private ApplicationState _appState = null!;
+
+    // Counters
+    private long _gpsDataUpdatedCount;
+    private long _cycleCompletedCount;
+    private readonly List<GpsCycleResult> _cycleResults = new();
+    private readonly List<double> _cycleTimes = new();
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Fresh singletons for each test
+        var configStore = new ConfigurationStore();
+        ConfigurationStore.SetInstance(configStore);
+        _appState = new ApplicationState();
+
+        // Real services
+        _gpsService = new GpsService();
+        _gpsService.Start();
+        _nmeaParser = new NmeaParserService(_gpsService);
+
+        // Mocks
+        _mockToolPosition = Substitute.For<IToolPositionService>();
+        _mockToolPosition.ToolPosition.Returns(new Vec3(0, 0, 0));
+        _mockToolPosition.ToolPivotPosition.Returns(new Vec3(0, 0, 0));
+        _mockToolPosition.HitchPosition.Returns(new Vec3(0, 0, 0));
+        _mockToolPosition.IsToolPositionReady.Returns(true);
+        _mockToolPosition.GetToolEdgePositions().Returns((new Vec3(-3, 0, 0), new Vec3(3, 0, 0)));
+        _mockToolPosition.GetSectionEdgePositions(Arg.Any<double>(), Arg.Any<double>())
+            .Returns((new Vec3(-3, 0, 0), new Vec3(3, 0, 0)));
+
+        _mockGuidance = Substitute.For<ITrackGuidanceService>();
+        _mockSectionControl = Substitute.For<ISectionControlService>();
+        _mockSectionControl.SectionStates.Returns(Array.Empty<SectionControlState>());
+        _mockSectionControl.NumSections.Returns(0);
+
+        _mockCoverage = Substitute.For<ICoverageMapService>();
+        _mockAutoSteer = Substitute.For<IAutoSteerService>();
+        _mockAudio = Substitute.For<IAudioService>();
+
+        // Construct the real pipeline
+        _pipeline = new GpsPipelineService(
+            _gpsService,
+            _mockToolPosition,
+            _mockGuidance,
+            _mockSectionControl,
+            _mockCoverage,
+            _mockAutoSteer,
+            new YouTurnGuidanceService(),
+            _mockAudio,
+            NullLogger<GpsPipelineService>.Instance,
+            _appState);
+
+        // Wire up counters
+        _gpsDataUpdatedCount = 0;
+        _cycleCompletedCount = 0;
+        _cycleResults.Clear();
+        _cycleTimes.Clear();
+
+        _gpsService.GpsDataUpdated += (_, _) =>
+            Interlocked.Increment(ref _gpsDataUpdatedCount);
+
+        _pipeline.CycleCompleted += result =>
+        {
+            Interlocked.Increment(ref _cycleCompletedCount);
+            lock (_cycleResults) _cycleResults.Add(result);
+        };
+
+        _pipeline.Start();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _pipeline.Stop();
+        _gpsService.Stop();
+    }
+
+    /// <summary>
+    /// Build a $PANDA sentence string for a given position.
+    /// Uses VirtualGpsReceiver to ensure correct checksum.
+    /// </summary>
+    private static string BuildPandaString(double lat, double lon,
+        double heading = 0, double speedKnots = 5, int fixQuality = 4)
+    {
+        using var listener = new UdpClient(0);
+        int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
+        listener.Client.ReceiveTimeout = 2000;
+
+        using var gps = new VirtualGpsReceiver(targetPort: port);
+        gps.Latitude = lat;
+        gps.Longitude = lon;
+        gps.HeadingDegrees = heading;
+        gps.SpeedKnots = speedKnots;
+        gps.FixQuality = fixQuality;
+        gps.Satellites = 12;
+        gps.Hdop = 0.7;
+
+        gps.SendOnce();
+        IPEndPoint? remote = null;
+        var bytes = listener.Receive(ref remote);
+        return Encoding.ASCII.GetString(bytes);
+    }
+}
+```
+
+- [ ] **Step 2: Verify the test class compiles**
+
+Run: `~/.dotnet/dotnet build Tests/AgValoniaGPS.Services.Tests/`
+Expected: Build succeeded, 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+git commit -m "Scaffold PipelineThroughputTests with full pipeline wiring"
+```
+
+---
+
+### Task 2: Synchronous throughput test (no timing delays)
+
+**Files:**
+- Modify: `Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs`
+
+- [ ] **Step 1: Add the synchronous throughput test**
+
+Add this test method to `PipelineThroughputTests`:
+
+```csharp
+    [Test]
+    public void SynchronousThroughput_AllUpdatesReachPipeline()
+    {
+        // Pre-build 100 PANDA sentences with incrementing positions
+        var sentences = new string[100];
+        for (int i = 0; i < 100; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001, // ~1.1m steps north
+                lon: -93.0,
+                heading: 0,
+                speedKnots: 5);
+        }
+
+        // Feed all 100 synchronously (no timing - fastest possible)
+        var sw = Stopwatch.StartNew();
+        foreach (var sentence in sentences)
+        {
+            _nmeaParser.ParseSentence(sentence);
+        }
+        sw.Stop();
+
+        // Wait for async pipeline cycles to complete (up to 5 seconds)
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (Interlocked.Read(ref _cycleCompletedCount) < Interlocked.Read(ref _gpsDataUpdatedCount)
+               && DateTime.UtcNow < deadline)
+        {
+            Thread.Sleep(10);
+        }
+
+        // Report
+        long parsed = Interlocked.Read(ref _gpsDataUpdatedCount);
+        long completed = Interlocked.Read(ref _cycleCompletedCount);
+        long dropped = parsed - completed;
+
+        TestContext.Out.WriteLine($"=== Synchronous Throughput (no delays) ===");
+        TestContext.Out.WriteLine($"Sentences sent:      {sentences.Length}");
+        TestContext.Out.WriteLine($"GpsDataUpdated:      {parsed}");
+        TestContext.Out.WriteLine($"CycleCompleted:      {completed}");
+        TestContext.Out.WriteLine($"Dropped (backpressure): {dropped}");
+        TestContext.Out.WriteLine($"Drop rate:           {(double)dropped / parsed * 100:F1}%");
+        TestContext.Out.WriteLine($"Total parse time:    {sw.ElapsedMilliseconds}ms");
+        TestContext.Out.WriteLine($"Avg parse time:      {sw.Elapsed.TotalMilliseconds / sentences.Length:F2}ms");
+
+        // All sentences must parse successfully
+        Assert.That(parsed, Is.EqualTo(100),
+            "All 100 sentences should trigger GpsDataUpdated");
+
+        // Report drop rate but don't fail - this test measures, not enforces
+        TestContext.Out.WriteLine($"\n>>> DROP RATE: {(double)dropped / parsed * 100:F1}% <<<");
+        if (dropped > 0)
+        {
+            TestContext.Out.WriteLine($">>> Back-pressure is dropping {dropped} out of {parsed} updates");
+            TestContext.Out.WriteLine($">>> This confirms GpsPipelineService.ProcessCycle is the bottleneck");
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `~/.dotnet/dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "SynchronousThroughput" -v n`
+Expected: PASS. Output shows how many cycles completed vs dropped.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+git commit -m "Add synchronous throughput test measuring pipeline drop rate"
+```
+
+---
+
+### Task 3: Timed throughput test at 10Hz (reproduces real scenario)
+
+**Files:**
+- Modify: `Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs`
+
+- [ ] **Step 1: Add the 10Hz timed throughput test**
+
+Add this test method:
+
+```csharp
+    [Test]
+    public async Task TimedThroughput_10Hz_MeasureDropRate()
+    {
+        // Pre-build sentences
+        var sentences = new string[50];
+        for (int i = 0; i < 50; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001,
+                lon: -93.0,
+                heading: 0,
+                speedKnots: 5);
+        }
+
+        // Send at 10Hz (100ms intervals) - simulates real GPS rate
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < sentences.Length; i++)
+        {
+            _nmeaParser.ParseSentence(sentences[i]);
+            if (i < sentences.Length - 1)
+                await Task.Delay(100); // 10Hz
+        }
+        sw.Stop();
+
+        // Wait for pipeline to drain
+        await Task.Delay(500);
+
+        long parsed = Interlocked.Read(ref _gpsDataUpdatedCount);
+        long completed = Interlocked.Read(ref _cycleCompletedCount);
+        long dropped = parsed - completed;
+
+        TestContext.Out.WriteLine($"=== Timed Throughput @ 10Hz (5 seconds) ===");
+        TestContext.Out.WriteLine($"Sentences sent:      {sentences.Length}");
+        TestContext.Out.WriteLine($"GpsDataUpdated:      {parsed}");
+        TestContext.Out.WriteLine($"CycleCompleted:      {completed}");
+        TestContext.Out.WriteLine($"Dropped:             {dropped}");
+        TestContext.Out.WriteLine($"Drop rate:           {(double)dropped / parsed * 100:F1}%");
+        TestContext.Out.WriteLine($"Effective Hz:        {completed / (sw.Elapsed.TotalSeconds):F1}");
+        TestContext.Out.WriteLine($"Wall time:           {sw.Elapsed.TotalSeconds:F1}s");
+
+        // Verify all parsed
+        Assert.That(parsed, Is.EqualTo(50), "All sentences should parse");
+
+        // At 10Hz with mocked services, most should get through
+        // If drop rate > 20%, pipeline is too slow even with mocks
+        double dropRate = (double)dropped / parsed;
+        TestContext.Out.WriteLine($"\n>>> EFFECTIVE UPDATE RATE: {completed / sw.Elapsed.TotalSeconds:F1} Hz <<<");
+
+        if (dropRate > 0.2)
+        {
+            TestContext.Out.WriteLine(">>> WARNING: >20% drop rate even with mocked dependencies!");
+            TestContext.Out.WriteLine(">>> ProcessCycle overhead is too high for 10Hz GPS");
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `~/.dotnet/dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "TimedThroughput" -v n`
+Expected: PASS. Output shows effective Hz and drop rate at realistic 10Hz.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+git commit -m "Add timed 10Hz throughput test reproducing real GPS rate"
+```
+
+---
+
+### Task 4: ProcessCycle timing measurement
+
+**Files:**
+- Modify: `Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs`
+
+- [ ] **Step 1: Add the ProcessCycle timing test**
+
+Add this test method:
+
+```csharp
+    [Test]
+    public async Task ProcessCycleTiming_MeasureIndividualCycleLatency()
+    {
+        // Pre-build sentences
+        var sentences = new string[30];
+        for (int i = 0; i < 30; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: 42.0 + i * 0.00001,
+                lon: -93.0,
+                heading: i * 12.0, // Vary heading
+                speedKnots: 5);
+        }
+
+        // Track per-cycle timing via CycleCompleted timestamps
+        var cycleTimes = new List<long>();
+        var lastCycleTime = Stopwatch.GetTimestamp();
+
+        _pipeline.CycleCompleted += _ =>
+        {
+            long now = Stopwatch.GetTimestamp();
+            long elapsed = now - Volatile.Read(ref lastCycleTime);
+            Volatile.Write(ref lastCycleTime, now);
+            lock (cycleTimes) cycleTimes.Add(elapsed);
+        };
+
+        // Send at 10Hz
+        for (int i = 0; i < sentences.Length; i++)
+        {
+            _nmeaParser.ParseSentence(sentences[i]);
+            if (i < sentences.Length - 1)
+                await Task.Delay(100);
+        }
+
+        // Wait for pipeline to drain
+        await Task.Delay(500);
+
+        // Analyze cycle intervals
+        if (cycleTimes.Count > 1)
+        {
+            // Skip the first (unreliable initial interval)
+            var intervals = cycleTimes.GetRange(1, cycleTimes.Count - 1);
+            var intervalsMs = intervals.ConvertAll(t =>
+                t * 1000.0 / Stopwatch.Frequency);
+
+            intervalsMs.Sort();
+            double median = intervalsMs[intervalsMs.Count / 2];
+            double p95 = intervalsMs[(int)(intervalsMs.Count * 0.95)];
+            double max = intervalsMs[^1];
+            double min = intervalsMs[0];
+            double avg = 0;
+            foreach (var t in intervalsMs) avg += t;
+            avg /= intervalsMs.Count;
+
+            TestContext.Out.WriteLine($"=== ProcessCycle Interval Analysis ===");
+            TestContext.Out.WriteLine($"Cycles completed:    {cycleTimes.Count}");
+            TestContext.Out.WriteLine($"Min interval:        {min:F1}ms");
+            TestContext.Out.WriteLine($"Avg interval:        {avg:F1}ms");
+            TestContext.Out.WriteLine($"Median interval:     {median:F1}ms");
+            TestContext.Out.WriteLine($"P95 interval:        {p95:F1}ms");
+            TestContext.Out.WriteLine($"Max interval:        {max:F1}ms");
+            TestContext.Out.WriteLine($"Expected @ 10Hz:     100ms");
+
+            // If median interval > 200ms, cycles are running way too slow
+            if (median > 200)
+            {
+                TestContext.Out.WriteLine($"\n>>> BOTTLENECK FOUND: Median cycle interval {median:F0}ms >> 100ms target");
+                TestContext.Out.WriteLine($">>> ProcessCycle is too slow, causing back-pressure drops");
+            }
+            // If intervals are clustered near 100ms, pipeline keeps up fine
+            else if (median < 150)
+            {
+                TestContext.Out.WriteLine($"\n>>> Pipeline keeps up with 10Hz (median {median:F0}ms)");
+                TestContext.Out.WriteLine($">>> Bottleneck is likely elsewhere (UI thread, receive thread blocking)");
+            }
+        }
+        else
+        {
+            TestContext.Out.WriteLine(">>> Only 0-1 cycles completed - pipeline is severely broken");
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `~/.dotnet/dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "ProcessCycleTiming" -v n`
+Expected: PASS. Shows per-cycle latency distribution.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+git commit -m "Add ProcessCycle timing test with latency percentiles"
+```
+
+---
+
+### Task 5: Position delta verification test
+
+**Files:**
+- Modify: `Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs`
+
+- [ ] **Step 1: Add position delta test that verifies output positions match input**
+
+Add this test method:
+
+```csharp
+    [Test]
+    public async Task PositionOutput_MatchesInput_NoDrift()
+    {
+        // Send 20 positions at known intervals heading north
+        double startLat = 42.0;
+        double latStep = 0.00001; // ~1.1m per step
+
+        var sentences = new string[20];
+        for (int i = 0; i < 20; i++)
+        {
+            sentences[i] = BuildPandaString(
+                lat: startLat + i * latStep,
+                lon: -93.0,
+                heading: 0,
+                speedKnots: 5);
+        }
+
+        // Send at 10Hz
+        for (int i = 0; i < sentences.Length; i++)
+        {
+            _nmeaParser.ParseSentence(sentences[i]);
+            if (i < sentences.Length - 1)
+                await Task.Delay(100);
+        }
+
+        // Wait for pipeline to drain
+        await Task.Delay(500);
+
+        long completed = Interlocked.Read(ref _cycleCompletedCount);
+
+        TestContext.Out.WriteLine($"=== Position Delta Verification ===");
+        TestContext.Out.WriteLine($"Sent: {sentences.Length}, Received: {completed}");
+
+        List<GpsCycleResult> results;
+        lock (_cycleResults) results = new List<GpsCycleResult>(_cycleResults);
+
+        // Log each received position
+        for (int i = 0; i < results.Count; i++)
+        {
+            var r = results[i];
+            TestContext.Out.WriteLine(
+                $"  [{i}] lat={r.Latitude:F6} lon={r.Longitude:F6} E={r.Easting:F2} N={r.Northing:F2} " +
+                $"tool=({r.ToolEasting:F2},{r.ToolNorthing:F2}) heading={r.Heading:F1}");
+        }
+
+        // Check position deltas between consecutive results
+        if (results.Count >= 2)
+        {
+            TestContext.Out.WriteLine($"\nPosition deltas:");
+            for (int i = 1; i < results.Count; i++)
+            {
+                double dE = results[i].Easting - results[i - 1].Easting;
+                double dN = results[i].Northing - results[i - 1].Northing;
+                double dist = Math.Sqrt(dE * dE + dN * dN);
+                double dLat = results[i].Latitude - results[i - 1].Latitude;
+                TestContext.Out.WriteLine(
+                    $"  [{i-1}->{i}] dE={dE:F3} dN={dN:F3} dist={dist:F3}m dLat={dLat:F8}");
+            }
+
+            // If positions are incrementing smoothly, distance between consecutive
+            // results should be ~1.1m (latStep * 111320m/deg).
+            // If updates are being dropped, distance will be multiples of 1.1m.
+            var firstDelta = Math.Sqrt(
+                Math.Pow(results[1].Easting - results[0].Easting, 2) +
+                Math.Pow(results[1].Northing - results[0].Northing, 2));
+
+            if (results.Count < sentences.Length)
+            {
+                TestContext.Out.WriteLine(
+                    $"\n>>> {sentences.Length - results.Count} updates dropped " +
+                    $"({(double)(sentences.Length - results.Count) / sentences.Length * 100:F0}% loss)");
+                TestContext.Out.WriteLine(
+                    $">>> Remaining updates have {firstDelta:F1}m gaps " +
+                    $"(expected ~1.1m if no drops)");
+            }
+        }
+
+        Assert.That(completed, Is.GreaterThan(0), "At least some cycles should complete");
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `~/.dotnet/dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "PositionOutput" -v n`
+Expected: PASS. Shows per-position output with deltas and gap analysis.
+
+- [ ] **Step 3: Run all throughput tests together**
+
+Run: `~/.dotnet/dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "PipelineThroughputTests" -v n`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/AgValoniaGPS.Services.Tests/PipelineThroughputTests.cs
+git commit -m "Add position delta verification test for pipeline output"
+```

--- a/docs/superpowers/plans/2026-04-19-unify-gps-pipeline.md
+++ b/docs/superpowers/plans/2026-04-19-unify-gps-pipeline.md
@@ -52,59 +52,70 @@ UdpCommunicationService.ReceiveCallback
 
 ## Target Architecture
 
+**Threading principle (from Chris):** Receive threads parse only and return
+immediately. All heavy per-cycle work runs on a dedicated background worker
+with single-cycle-in-flight back-pressure. UI thread only applies result
+snapshots.
+
 ```
 UDP Port 9999
     |
     v
-UdpCommunicationService.ReceiveCallback
+UdpCommunicationService.ReceiveCallback        [I/O thread - fast return]
     |
     v
-AutoSteerService.ProcessGpsBuffer (single entry point)
-    -> NmeaParserServiceFast.ParseIntoState (only parser)
-    -> VehicleState
+NmeaParserServiceFast.ParseIntoState (~0.2ms)  [I/O thread - parse only]
+    -> Parsed GPS struct (lat/lon/heading/speed/roll)
+    |
+    v
+Hand off to background worker                  [Task.Run, one-in-flight]
+    |
+    v
+GpsCycleWorker.ProcessCycle                     [Background thread]
     -> Auto-create LocalPlane (single instance, shared)
     -> ConvertWgs84ToGeoCoord (once)
-    -> CalculateGuidance + SendPgns
-    -> Tool position calculation (moved from pipeline)
-    -> Section control update (moved from pipeline)
-    -> Coverage painting (moved from pipeline)
+    -> CalculateGuidance + SendPgns (PGN 254)
+    -> Tool position calculation
+    -> Section control update
+    -> Coverage painting
     -> Emit unified GpsCycleResult
-      -> UI thread: ApplyGpsCycleResult -> all UI updates
+      |
+      v
+    UI thread: ApplyGpsCycleResult -> all UI updates
 ```
 
 ---
 
 ## Implementation Phases
 
-### Phase 1: Move tool/section/coverage into AutoSteerService
-- Move ToolPositionService calls from GpsPipelineService into AutoSteerService
-- Move SectionControlService.Update from GpsPipelineService into AutoSteerService
-- Move coverage painting trigger from GpsPipelineService into AutoSteerService
+### Phase 1: Split AutoSteerService receive from processing
+- Extract NMEA parsing out of ProcessGpsBuffer into a thin receive handler
+- Receive handler: parse NMEA (~0.2ms), hand off parsed struct, return
+- ProcessCycle: runs on Task.Run with Interlocked back-pressure (same pattern as current GpsPipelineService)
+- ProcessCycle does: coordinate conversion, guidance, PGN send
+- This fixes the current violation where guidance runs on the receive thread
+
+### Phase 2: Merge pipeline work into AutoSteerService.ProcessCycle
+- Move ToolPositionService calls from GpsPipelineService into AutoSteerService.ProcessCycle
+- Move SectionControlService.Update from GpsPipelineService into AutoSteerService.ProcessCycle
+- Move coverage painting trigger from GpsPipelineService into AutoSteerService.ProcessCycle
 - AutoSteerService now emits a complete GpsCycleResult (not just StateUpdated)
 - GpsPipelineService becomes a thin wrapper that just forwards
 
-### Phase 2: Remove GpsPipelineService
+### Phase 3: Remove GpsPipelineService and old parser path
 - MainViewModel subscribes directly to AutoSteerService.CycleCompleted
 - Remove GpsPipelineService class entirely
-- Remove _gpsPipelineService from MainViewModel constructor
-
-### Phase 3: Remove old parser path
 - Remove NmeaParserService (old string-based parser)
 - Remove GpsService.UpdateGpsData (no longer called)
 - Remove DataReceived -> OnUdpDataReceived -> ParseSentence chain
 - GpsService becomes just timeout/connection tracking
 - UdpCommunicationService only routes NMEA to AutoSteerService
 
-### Phase 4: Clean up GpsService
+### Phase 4: Clean up GpsService + single LocalPlane
 - Move timeout tracking into AutoSteerService
 - GpsService either removed or kept as pure status query interface
-- Remove _lastGpsDataReceived, MarkGpsReceived (no longer needed)
-
-### Phase 5: Single LocalPlane
-- Remove auto-create from both AutoSteerService and GpsPipelineService
-- Add auto-create to the unified pipeline (one place)
+- Remove auto-create from both services, add to unified pipeline (one place)
 - LocalPlane shared via ApplicationState.Field.LocalPlane
-- Field open replaces it, field close removes it
 
 ---
 
@@ -133,7 +144,8 @@ AutoSteerService.ProcessGpsBuffer (single entry point)
 ## Risks
 
 - AutoSteerService becomes larger (mitigate: keep tool/section as separate services called from AutoSteerService)
-- Thread safety: everything runs on the UDP receive thread (currently works, just more code there)
+- Thread safety: ProcessCycle runs on background thread, must not touch UI-bound state directly
+- Back-pressure: if ProcessCycle > 100ms, GPS updates will be dropped (same as current GpsPipelineService behavior, but now also affects PGN 254 timing)
 - Test coverage: need to verify all UI properties still update correctly
 - Breaking change for any code subscribing to GpsPipelineService events
 


### PR DESCRIPTION
## Summary
- AutoSteer Active driven by PGN 254 Status byte instead of manual checkbox
- Fix roll != 0 teleporting tractor to local origin (regression test added)
- Add top-down vehicle view with steerable front wheels to simulator
- Fix log viewer button missing Command binding in ToolsPanel
- Fix roll zero calibration to capture current IMU reading (matches legacy)
- Fix dark connection status icons (visible dark red instead of invisible gray)

## Test plan
- [ ] Verify simulator reads autosteer engaged state from main app
- [ ] Verify roll != 0 no longer teleports tractor
- [ ] Verify front wheel visualization rotates with WAS angle
- [ ] Verify log viewer opens from ToolsPanel button
- [ ] Verify roll zero captures current roll as reference
- [ ] Verify module status indicators are visible in both themes