### PR TITLE
Fix background texture drift as tractor moves (#262)

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -3496,10 +3496,17 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             // non-distinct so the stretched version is visually indistinguishable
             // from the tiled version in practice. One draw call at any zoom,
             // constant cost.
+            //
+            // The rect is in world coordinates (the camera transform is already
+            // pushed on dc). Center on the camera so the texture tracks the
+            // viewport rather than drifting relative to fixed world features.
+            // The earlier tile-loop fallback used `-(centerY + diagonal)` here,
+            // which mirrored the Y axis incorrectly and caused the texture to
+            // appear to slide south as the tractor moved north (issue #262).
             double centerX = s.CameraX;
             double centerY = s.CameraY;
             double diagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2 + 100.0;
-            var viewRect = new Rect(centerX - diagonal, -(centerY + diagonal), diagonal * 2, diagonal * 2);
+            var viewRect = new Rect(centerX - diagonal, centerY - diagonal, diagonal * 2, diagonal * 2);
             dc.DrawBitmap(s.GroundTexture!, viewRect);
         }
 


### PR DESCRIPTION
Closes #262.

## Summary

The always-stretched ground-texture rect introduced in #255 was Y-mirrored in world coordinates. As the camera moved north, the rect drifted south, causing the aerial texture to appear to slide south relative to fixed world features (boundary, headland, guidance lines).

## Root cause

Pre-existing tile-loop fallback used `Rect(centerX - d, -(centerY + d), 2d, 2d)`. The `-(centerY + d)` Y offset was wrong but only exercised at extreme zoom (>50 tiles-per-axis) where the texture's homogeneous pattern hid the drift. PR #255 made the stretched rect the always-on default, exposing the dormant bug at all zoom levels.

## Fix

One-line change: center the rect on the camera in world coords, matching every other world-space draw in this method.

```diff
- var viewRect = new Rect(centerX - diagonal, -(centerY + diagonal), diagonal * 2, diagonal * 2);
+ var viewRect = new Rect(centerX - diagonal, centerY - diagonal, diagonal * 2, diagonal * 2);
```

## Test plan

- [x] Desktop: open "Bing Test" field with aerial imagery, drive simulator north, confirm texture stays locked to world coords ✓
- [ ] Android tablet: same test
- [ ] iPad: same test

🤖 Generated with [Claude Code](https://claude.com/claude-code)