### PR TITLE
Fix: don't reset sim coords to 0,0 when opening a field without georeference

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -1216,7 +1216,12 @@ public partial class MainViewModel : ObservableObject
                 {
                     SetFieldOrigin(fieldInfo.Origin.Latitude, fieldInfo.Origin.Longitude);
                     _logger.LogDebug($"[Field] Set origin: {_fieldOriginLatitude}, {_fieldOriginLongitude}");
-                    SetSimulatorCoordinates(_fieldOriginLatitude, _fieldOriginLongitude);
+                    // Only reposition the simulator if the field has a real (non-zero)
+                    // georeference. Fields that were never georeferenced persist an
+                    // origin of (0, 0), which otherwise clobbers the user's
+                    // simulator coords (saved to appsettings on window close).
+                    if (_fieldOriginLatitude != 0 || _fieldOriginLongitude != 0)
+                        SetSimulatorCoordinates(_fieldOriginLatitude, _fieldOriginLongitude);
                 }
             }
             catch (Exception ex)

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 29
+#define VERSION_PATCH 30
 
-#define VERSION "26.4.29"
-#define VERSION_DATE "2026-04-18"
+#define VERSION "26.4.30"
+#define VERSION_DATE "2026-04-20"


### PR DESCRIPTION
## Summary
- `OpenFieldAsync` was unconditionally calling `SetSimulatorCoordinates` with the field's `Field.txt` origin. Fields that were never georeferenced persist an origin of `(0, 0)`, so opening one silently zeroed the user's simulator coords — which then got saved to `appsettings.json` on window close, so the user had to re-enter them every launch.
- 2-line guard: only reposition the simulator when the origin is non-zero. Georeferenced fields still follow; locally-referenced fields leave the user's coords alone.
- Cherry-picked verbatim from the threading-migration branch (commit `31edccd`), where it was diagnosed via a temporary stack-trace log on `SettingsService.Save`. Verified on develop baseline (`329165d` + this fix) today — desktop simulator now survives field open/close/reopen.

Closes #264.

## Test plan
- [x] Desktop: open a legacy field with no georeference; confirm simulator coords do not reset to 0,0
- [x] Desktop: open a georeferenced field; confirm simulator still follows the field origin
- [x] Close and relaunch; confirm `appsettings.json` retained the user's sim coords

🤖 Generated with [Claude Code](https://claude.com/claude-code)