### PR TITLE
Fix: preserve field origin through Open → Close cycle

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -1212,6 +1212,40 @@ public partial class MainViewModel : ObservableObject
             try
             {
                 var fieldInfo = _fieldPlaneFileService.LoadField(fieldPath);
+
+                // Recovery: if Field.txt has no origin or a zero origin, fall
+                // back to field.origin — a separate file written at field-
+                // create time and never touched by close-save. Fields
+                // corrupted by the pre-#270 save-with-zero bug can be healed
+                // this way; next close writes the real origin back to both
+                // Field.txt and field.geojson.
+                if (fieldInfo.Origin == null
+                    || (fieldInfo.Origin.Latitude == 0 && fieldInfo.Origin.Longitude == 0))
+                {
+                    var originBackupPath = Path.Combine(fieldPath, "field.origin");
+                    if (File.Exists(originBackupPath))
+                    {
+                        var originLine = File.ReadAllText(originBackupPath).Trim();
+                        var parts = originLine.Split(',');
+                        if (parts.Length == 2
+                            && double.TryParse(parts[0], System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture, out var backupLat)
+                            && double.TryParse(parts[1], System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture, out var backupLon)
+                            && (backupLat != 0 || backupLon != 0)
+                            && backupLat >= -90 && backupLat <= 90
+                            && backupLon >= -180 && backupLon <= 180)
+                        {
+                            fieldInfo.Origin = new Position
+                            {
+                                Latitude = backupLat,
+                                Longitude = backupLon,
+                            };
+                            _logger.LogDebug($"[Field] Recovered origin from field.origin backup: {backupLat}, {backupLon}");
+                        }
+                    }
+                }
+
                 if (fieldInfo.Origin != null)
                 {
                     SetFieldOrigin(fieldInfo.Origin.Latitude, fieldInfo.Origin.Longitude);
@@ -1244,12 +1278,20 @@ public partial class MainViewModel : ObservableObject
             // Load background image
             LoadBackgroundImage(fieldPath, boundary);
 
-            // Create field object and set as active
+            // Create field object and set as active. Origin must be copied from
+            // the loaded Field.txt — otherwise Field.Origin defaults to (0, 0)
+            // and CloseFieldAsync silently overwrites the on-disk Field.txt with
+            // a zero origin, corrupting the field for every future session.
             var field = new Field
             {
                 Name = fieldName,
                 DirectoryPath = fieldPath,
-                Boundary = boundary
+                Boundary = boundary,
+                Origin = new Position
+                {
+                    Latitude = _fieldOriginLatitude,
+                    Longitude = _fieldOriginLongitude,
+                }
             };
 
             // Update field service (triggers OnActiveFieldChanged for state sync only)

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 30
+#define VERSION_PATCH 31
 
-#define VERSION "26.4.30"
-#define VERSION_DATE "2026-04-20"
+#define VERSION "26.4.31"
+#define VERSION_DATE "2026-04-21"


### PR DESCRIPTION
## Summary
- Root cause behind yesterday's iPad "coverage renders ~100 m SW" and "background image missing" symptoms that we initially chased through the threading-migration branch. Not a threading regression — a pre-existing file-corruption bug.
- `OpenFieldAsync` created the `ActiveField` without copying the loaded origin. `Field.Origin` defaulted to `(0, 0)`. `CloseFieldAsync → FieldService.SaveField` then overwrote both `Field.txt` (legacy) and `field.geojson` (new canonical format) with the zero origin, permanently corrupting the field for every future session.
- Companion to #269: that PR prevented the *symptom* (simulator coords clobbered by a 0,0-origin file). This PR prevents the *cause* (0,0 ending up in the file in the first place).

## The cascade, step by step
1. Load `Field.txt` with real origin (e.g. `32.59053818, -87.18024200`).
2. `new Field { Name, DirectoryPath, Boundary }` — `Origin` defaults to `new Position()` i.e. `(0, 0, 0)`.
3. User drives. Rendering is fine — `State.Field.LocalPlane` was set separately by `SetFieldOrigin` and holds the real origin.
4. Close →
   - `FieldPlaneFileService.SaveField` writes `Field.txt` from `field.Origin = (0, 0)`.
   - `GeoJsonFieldService.Save` writes `field.geojson` from `field.Origin = (0, 0)`.
5. Reopen → `LoadField` reads `(0, 0)` → `SetFieldOrigin(0, 0)` → `LocalPlane` at the equator. Coverage / background / boundaries were stored relative to the real origin, so they render offset. Autosteer kept working because it re-computes from live GPS each cycle.

## Fix
Populate `field.Origin` at the `new Field { … }` call in `OpenFieldAsync` using `_fieldOriginLatitude` / `_fieldOriginLongitude`, which `SetFieldOrigin` populates from the loaded file. `SaveField` then round-trips the real origin to both formats.

## Verified
- Opened `Test 1` (legacy format: `Field.txt` only, no `field.geojson`, real origin `32.59053818, -87.18024200`).
- Closed the field.
- Disk check after close:
  - `Field.txt` `StartFix` line: `32.59053818,-87.18024200` ✅ (was being rewritten to `0,0` before the fix).
  - `field.geojson` created fresh with `originLatitude: 32.59053818, originLongitude: -87.180242` ✅.
- Confirms both the legacy-format preservation AND the legacy → new-format conversion path.

## Test plan
- [x] Open a legacy field with valid origin, close, verify `Field.txt` origin preserved
- [x] Verify `field.geojson` is written with the same origin (legacy-to-new conversion)
- [ ] Open a previously-corrupted field (e.g. `Bing Test` on my disk) and re-georeference it via Boundary-by-Map; confirm future saves stick
- [ ] iPad: repeat the open/close cycle and confirm the ~100m offset is gone on a fresh field created post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)