### PR TITLE
Fix: resolution switch silently wipes coverage

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -629,10 +629,21 @@ public class DrawingContextMapControl : Control, ISharedMapControl
     {
         if (e.PropertyName == nameof(AgValoniaGPS.Models.Configuration.DisplayConfig.DisplayResolutionMultiplier))
         {
-            // Rebuild bitmap at new resolution using stored bounds.
-            // Can't use UpdateCoverageBitmapIfNeeded — providers may be null on this instance.
-            if (_coverageWriteableBitmap != null && _bitmapWidth > 0)
+            if (_coverageWriteableBitmap == null || _bitmapWidth <= 0) return;
+
+            // Prefer the provider-driven path: UpdateCoverageBitmapIfNeeded recomputes
+            // dimensions at the new multiplier, recreates the bitmap, and repaints from
+            // the coverage providers. Calling InitializeCoverageBitmapWithBounds alone
+            // produces an empty bitmap with no repaint, which looks like the coverage
+            // was wiped.
+            if (_coverageBoundsProvider != null && _coverageAllCellsProvider != null)
             {
+                MarkCoverageFullRebuildNeeded();
+            }
+            else
+            {
+                // Secondary instance (no providers wired). Best we can do is resize
+                // the empty bitmap to the new resolution.
                 InitializeCoverageBitmapWithBounds(_bitmapMinE, _bitmapMaxE, _bitmapMinN, _bitmapMaxN);
             }
         }
@@ -1388,6 +1399,16 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                     cellCount++;
                 }
             }
+        }
+
+        // Step 4: Propagate painted cells to the Bgra8888 display bitmap and the
+        // SKBitmap shadow. Without this, the data bitmap has pixels but the
+        // renderer (which reads _coverageSkBitmap) shows empty — exactly what
+        // happens after a resolution-multiplier change in-session.
+        if (cellCount > 0)
+        {
+            SyncDisplayBitmap();
+            SyncSkBitmapFromDisplay();
         }
 
         return cellCount;

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 31
+#define VERSION_PATCH 32
 
-#define VERSION "26.4.31"
+#define VERSION "26.4.32"
 #define VERSION_DATE "2026-04-21"


### PR DESCRIPTION
## Summary
Discovered during the threading-migration smoke-testing as a develop-side bug that was being mistakenly attributed to the threading branch. Reproduces on develop, desktop and mobile.

Two bugs in the display-resolution-change path, both from painting only to one of three parallel bitmaps:

### Bug 1 — in-session switch uses the wrong rebuild entry point
`OnDisplayConfigChanged` called `InitializeCoverageBitmapWithBounds` directly. That creates a fresh empty bitmap but does not repaint from the coverage providers. After the switch the display looked wiped. Close/reopen didn't restore either — same unrepainted bitmap.

**Fix**: when providers are wired, route through `MarkCoverageFullRebuildNeeded`, which schedules `UpdateCoverageBitmapIfNeeded`. That path recomputes dimensions at the new multiplier, recreates the bitmap, and triggers a full repaint from `_coverageAllCellsProvider`. Fall back to the old path only when providers are null (secondary `MapControl` instance — preserved for AOT/headless cases per the original comment).

### Bug 2 — Full rebuild doesn't sync to render bitmap
`UpdateCoverageBitmapFull` painted only to the Rgb565 data bitmap. The renderer reads `_coverageSkBitmap` (Bgra8888). Without syncing, the data bitmap had pixels but the composition visual showed nothing — same visual symptom as Bug 1.

The pre-existing `Incremental` path wrote to all three bitmaps; `Full` did not. The close/reopen "recovery" worked by accident: `LoadSectionDisplay` took the `SetCoveragePixelBuffer` branch instead of `UpdateCoverageBitmapFull`, and that branch explicitly syncs all three.

**Fix**: call `SyncDisplayBitmap` + `SyncSkBitmapFromDisplay` at the end of `UpdateCoverageBitmapFull` when any cells were written. Gated on `cellCount > 0` to keep the no-op case cheap.

## Test plan
- [x] Desktop: open a field with coverage. Cycle Ultra → High → Med → Low → back to Ultra. Coverage visible at every step, edge detail changes with cell size as expected.
- [x] Confirmed this is the develop-side bug that cost several hours of threading-branch debugging. PR #259 testing benefits from landing this first on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)