### PR TITLE
Fix: harden Windows UDP receive against ICMP Port Unreachable

### DIFF
--- a/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
+++ b/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
@@ -106,6 +106,16 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
             // Reduce receive buffer to minimize packet buffering/delay
             _udpSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, 8192);
 
+            // Windows: an ICMP Port Unreachable from a peer on a prior Send would
+            // otherwise surface as a SocketException (ConnectionReset) on the next
+            // ReceiveFrom call, breaking the receive loop. SIO_UDP_CONNRESET
+            // disables that surfacing. No-op on non-Windows. (From PR #278.)
+            if (OperatingSystem.IsWindows())
+            {
+                const int SIO_UDP_CONNRESET = -1744830452; // 0x9800000C
+                _udpSocket.IOControl((IOControlCode)SIO_UDP_CONNRESET, new byte[] { 0 }, null);
+            }
+
             _udpSocket.Bind(new IPEndPoint(IPAddress.Any, 9999));
 
             // Discover broadcast endpoints on all network interfaces
@@ -261,7 +271,22 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
                 ProcessReceivedData(data, (IPEndPoint)_remoteEndPoint);
             }
         }
-        catch { }
+        catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+        {
+            // Non-fatal on UDP. Paired with SIO_UDP_CONNRESET above, this should
+            // be rare — but if SIO setup failed (unusual socket state) the
+            // ICMP Port Unreachable can still surface here. From PR #278.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Socket closed during shutdown — stop the receive loop. From PR #278.
+            return;
+        }
+        catch (Exception ex)
+        {
+            // Unexpected — at least trace instead of silently swallowing.
+            System.Diagnostics.Debug.WriteLine($"[UDP] ReceiveCallback unexpected: {ex}");
+        }
 
         // IMMEDIATELY start the next receive operation - this is the key fix!
         if (_udpSocket != null)

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 33
+#define VERSION_PATCH 34
 
-#define VERSION "26.4.33"
+#define VERSION "26.4.34"
 #define VERSION_DATE "2026-04-21"


### PR DESCRIPTION
## Summary
Cherry-picks the robustness fixes from #278 (lansalot) and leaves the risky changes behind, rebased onto the threading-migration-merged develop.

**Kept:**
- **SIO_UDP_CONNRESET** on Windows — prevents ICMP Port Unreachable from surfacing as \`SocketException (ConnectionReset)\` on \`ReceiveFrom\` and breaking the receive loop. Windows-gated, no-op elsewhere.
- **Typed exception handlers in \`ReceiveCallback\`** — specific \`SocketException (ConnectionReset)\` + \`ObjectDisposedException\` branches, and a \`Debug.WriteLine\` on unexpected exceptions instead of silently swallowing them with \`catch { }\`.

**Deliberately NOT included from #278:**
- **\`SynchronizationContext.Post\` dispatch for \`DataReceived\`** — conflicts with the threading migration (PR #259) just merged. The threading pipeline subscribes to \`DataReceived\` from a background cycle worker and explicitly does not want UI-thread hop. Posting every UDP packet through the UI dispatcher would serialize ~100 packets/sec through the UI thread, defeating the purpose of the unified GPS pipeline.
- **Hardcoded \`StartsWith(\"192.168\")\` filter in \`GetLocalIPAddress\`** — breaks setups using 10.x.x.x or 172.16–31.x.x private subnets, or non-standard corporate networks. Original behavior (accept any IPv4 \`InterNetwork\` address) is preserved.
- **Audio serialization changes to \`AudioService.cs\`** — the NetCoreAudio race is real, but sequencing all sounds through a semaphore queues up rapid section-toggle beeps instead of allowing overlap. Worth evaluating separately; leaving for its own discussion.

## Credit
Authored by @lansalot (#278). This PR just brings the safe subset forward.

## Test plan
- [x] Builds clean (Desktop Debug)
- [ ] Windows real-GPS: verify receive loop survives a target-port-unreachable condition (e.g., AIO module powered off mid-session)
- [ ] Non-Windows: verify SIO block doesn't fire (no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)