### PR TITLE
Introduce FloatingPanel reusable component

### DIFF
--- a/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
+++ b/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
@@ -44,5 +44,11 @@
     <AvaloniaResource Include="Assets\Images\**\*.png" />
     <AvaloniaResource Include="Assets\Sounds\**\*.wav" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Controls\FloatingPanel.axaml.cs">
+      <DependentUpon>FloatingPanel.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
 
 </Project>

--- a/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml
@@ -1,0 +1,107 @@
+﻿<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:AgValoniaGPS.Views.Controls"
+             xmlns:localc="using:AgValoniaGPS.Views.Converters"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
+             x:Class="AgValoniaGPS.Views.Controls.FloatingPanel">
+
+    <UserControl.Styles>
+        <Style Selector="Border.FloatingPanelBorder">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Padding" Value="8"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+
+        <Style Selector="Button.ModernButton">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Padding" Value="8,6"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+            <Setter Property="Height" Value="44"/>
+            <Setter Property="Margin" Value="0,2"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </Style>
+
+        <Style Selector="Button.ModernButton:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+        </Style>
+    </UserControl.Styles>
+  <UserControl.Content>
+    <Border Classes="FloatingPanelBorder">
+        <StackPanel Spacing="4">
+
+            <!-- Title bar / drag handle -->
+            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                  Cursor="Hand" ToolTip.Tip="Drag to move">
+                <TextBlock Grid.Column="0" Text="=" VerticalAlignment="Center"
+                           Margin="8,0" IsHitTestVisible="False"
+                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                           FontSize="20" FontWeight="Bold"/>
+                <TextBlock Grid.Column="1"
+                           Text="{Binding Title, RelativeSource={RelativeSource AncestorType=local:FloatingPanel}}"
+                           FontWeight="Bold" VerticalAlignment="Center"
+                           IsHitTestVisible="False"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                           FontSize="16"/>
+                <Button Grid.Column="2" Content="X"
+                        Width="24" Height="24" Padding="0" BorderThickness="0"
+                        Background="Transparent" FontSize="16" Cursor="Hand"
+                        Margin="8,0"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        Command="{Binding CloseCommand, RelativeSource={RelativeSource AncestorType=local:FloatingPanel}}"/>
+            </Grid>
+
+            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
+
+            <!-- Menu items mode: 2-column UniformGrid for ModernButton panels -->
+            <ItemsControl ItemsSource="{Binding MenuItems, RelativeSource={RelativeSource AncestorType=local:FloatingPanel}}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <UniformGrid Columns="2"/>
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
+              <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="local:MenuButton">
+                  <Button Classes="ModernButton"
+                          Command="{Binding Command}"
+                          IsEnabled="{Binding IsEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+                      <Image Source="{Binding Icon, Converter={x:Static localc:StringToImageConverter.Instance}}" Width="28" Height="28"/>
+                      <TextBlock Text="{Binding Text}" VerticalAlignment="Center" FontSize="12"/>
+                    </StackPanel>
+                  </Button>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <!-- Custom content mode: charts, simulator, forms etc. -->
+            <ContentPresenter Content="{Binding PanelContent, RelativeSource={RelativeSource AncestorType=local:FloatingPanel}}"/>
+
+        </StackPanel>
+    </Border>
+  </UserControl.Content>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Metadata;
+
+namespace AgValoniaGPS.Views.Controls;
+
+// Simple data class for menu buttons
+public class MenuButton : AvaloniaObject
+{
+    public static readonly StyledProperty<string> IconProperty =
+        AvaloniaProperty.Register<MenuButton, string>(nameof(Icon), "");
+
+    public static readonly StyledProperty<string> TextProperty =
+        AvaloniaProperty.Register<MenuButton, string>(nameof(Text), "");
+
+    public static readonly StyledProperty<ICommand?> CommandProperty =
+        AvaloniaProperty.Register<MenuButton, ICommand?>(nameof(Command));
+
+    public static readonly StyledProperty<bool> IsEnabledProperty =
+        AvaloniaProperty.Register<MenuButton, bool>(nameof(IsEnabled), true);
+
+    public static readonly StyledProperty<string?> ToolTipProperty =
+        AvaloniaProperty.Register<MenuButton, string?>(nameof(ToolTip));
+
+    public string Icon
+    {
+        get => GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+
+    public string Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    public bool IsEnabled
+    {
+        get => GetValue(IsEnabledProperty);
+        set => SetValue(IsEnabledProperty, value);
+    }
+
+    public string? ToolTip
+    {
+        get => GetValue(ToolTipProperty);
+        set => SetValue(ToolTipProperty, value);
+    }
+}
+
+public partial class FloatingPanel : UserControl
+{
+    private bool _isDragging = false;
+    private Point _lastScreenPoint;
+
+    public event EventHandler<PointerPressedEventArgs>? DragStarted;
+    public event EventHandler<Vector>? DragMoved;
+    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
+
+    // Title
+    public static readonly StyledProperty<string> TitleProperty =
+        AvaloniaProperty.Register<FloatingPanel, string>(nameof(Title), "Untitled");
+
+    public string Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    // Close Command
+    public static readonly StyledProperty<ICommand?> CloseCommandProperty =
+        AvaloniaProperty.Register<FloatingPanel, ICommand?>(nameof(CloseCommand));
+
+    public ICommand? CloseCommand
+    {
+        get => GetValue(CloseCommandProperty);
+        set => SetValue(CloseCommandProperty, value);
+    }
+
+    // Menu items — default [Content] property
+    public static readonly StyledProperty<IList<MenuButton>> MenuItemsProperty =
+        AvaloniaProperty.Register<FloatingPanel, IList<MenuButton>>(nameof(MenuItems));
+
+    [Content]
+    public IList<MenuButton> MenuItems
+    {
+        get => GetValue(MenuItemsProperty);
+        set => SetValue(MenuItemsProperty, value);
+    }
+
+    // Custom content for non-menu panels (charts, simulator etc.)
+    public static readonly StyledProperty<object?> PanelContentProperty =
+        AvaloniaProperty.Register<FloatingPanel, object?>(nameof(PanelContent));
+
+    public object? PanelContent
+    {
+        get => GetValue(PanelContentProperty);
+        set => SetValue(PanelContentProperty, value);
+    }
+
+    public FloatingPanel()
+    {
+        SetValue(MenuItemsProperty, new List<MenuButton>());
+        InitializeComponent();
+        Loaded += (s, e) => AttachDragHandler();
+    }
+
+    private void AttachDragHandler()
+    {
+        var dragHandle = this.FindControl<Grid>("DragHandle");
+        if (dragHandle != null)
+        {
+            dragHandle.PointerPressed += DragHandle_PointerPressed;
+            dragHandle.PointerMoved += DragHandle_PointerMoved;
+            dragHandle.PointerReleased += DragHandle_PointerReleased;
+        }
+    }
+
+    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is Grid handle)
+        {
+            _isDragging = false;
+            var root = this.VisualRoot as Visual;
+            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            e.Pointer.Capture(handle);
+        }
+    }
+
+    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            var root = this.VisualRoot as Visual;
+            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            var dx = currentPoint.X - _lastScreenPoint.X;
+            var dy = currentPoint.Y - _lastScreenPoint.Y;
+
+            if (!_isDragging && (dx * dx + dy * dy) > 25.0)
+            {
+                _isDragging = true;
+                DragStarted?.Invoke(this, null!);
+            }
+
+            if (_isDragging)
+            {
+                var delta = currentPoint - _lastScreenPoint;
+                DragMoved?.Invoke(this, delta);
+                _lastScreenPoint = currentPoint;
+            }
+            e.Handled = true;
+        }
+    }
+
+    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            if (_isDragging)
+                DragEnded?.Invoke(this, e);
+            _isDragging = false;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
@@ -17,163 +17,135 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.BoundaryPlayerPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsBoundaryPlayerPanelVisible}"
              IsHitTestVisible="{Binding IsBoundaryPlayerPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-    </UserControl.Styles>
+    <controls:FloatingPanel x:Name="FP"
+                            MinWidth="250"
+                            Title="Stop Record Pause Boundary">
+        <controls:FloatingPanel.PanelContent>
+            <StackPanel Spacing="4">
 
-    <Border Classes="FloatingPanel" MinWidth="250" IsVisible="{Binding IsBoundaryPlayerPanelVisible}" IsHitTestVisible="True">
-        <StackPanel Spacing="4" Background="Transparent">
-            <!-- Header: Drag handle + Title -->
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*" Height="32" Margin="0,0,0,4"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" FontSize="18" FontWeight="Bold"
-                           Foreground="#FFFFFF" VerticalAlignment="Center" Margin="8,0,0,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Stop Record Pause Boundary" FontSize="12" FontWeight="SemiBold"
-                           Foreground="#1ABC9C" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-            </Grid>
+                <!-- Offset Distance Input -->
+                <Grid ColumnDefinitions="Auto,*" Margin="8,4">
+                    <Button Grid.Column="0" Background="AliceBlue" CornerRadius="4" Padding="8,4" MinWidth="100"
+                            ClickMode="Press" Command="{Binding ShowBoundaryOffsetDialogCommand}" Cursor="Hand"
+                            ToolTip.Tip="Click to enter offset distance">
+                        <TextBlock Text="{Binding BoundaryOffset, StringFormat={}{0:F0}}" FontSize="22" FontWeight="Bold"
+                                   Foreground="Black" HorizontalAlignment="Center" IsHitTestVisible="False"/>
+                    </Button>
+                    <TextBlock Grid.Column="1" Text="cm" FontSize="14" FontWeight="Bold"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                               VerticalAlignment="Center" Margin="8,0,0,0"/>
+                </Grid>
 
-            <!-- Offset Distance Input (clickable to open numeric keypad) -->
-            <Grid ColumnDefinitions="Auto,*" Margin="8,4">
-                <Button Grid.Column="0" Background="AliceBlue" CornerRadius="4" Padding="8,4" MinWidth="100"
-                        ClickMode="Press" Command="{Binding ShowBoundaryOffsetDialogCommand}" Cursor="Hand"
-                        ToolTip.Tip="Click to enter offset distance">
-                    <TextBlock Text="{Binding BoundaryOffset, StringFormat={}{0:F0}}" FontSize="22" FontWeight="Bold"
-                               Foreground="Black" HorizontalAlignment="Center" IsHitTestVisible="False"/>
-                </Button>
-                <TextBlock Grid.Column="1" Text="cm" FontSize="14" FontWeight="Bold"
-                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center" Margin="8,0,0,0"/>
-            </Grid>
+                <!-- Button Grid -->
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" Margin="4">
 
-            <!-- Two Column Layout -->
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" Margin="4" Background="Transparent">
-                <!-- Row 0: Trash (restart) | Section Control -->
-                <Button Grid.Column="0" Grid.Row="0" Classes="ModernButton"
-                        Margin="2" Height="56" ClickMode="Press" Command="{Binding ClearBoundaryCommand}"
-                        ToolTip.Tip="Delete all points and restart">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Trash.png" Width="40" Height="40"
-                           IsHitTestVisible="False"/>
-                </Button>
-                <ToggleButton Grid.Column="1" Grid.Row="0"
-                              Margin="2" Height="56" ClickMode="Press"
-                              IsChecked="{Binding IsBoundarySectionControlOn}"
-                              ToolTip.Tip="Record boundary when section is on">
-                    <ToggleButton.Styles>
-                        <Style Selector="ToggleButton">
-                            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-                            <Setter Property="CornerRadius" Value="6"/>
-                            <Setter Property="Cursor" Value="Hand"/>
-                            <Setter Property="BorderThickness" Value="0"/>
-                            <Setter Property="Padding" Value="12,6"/>
-                        </Style>
-                        <Style Selector="ToggleButton:pointerover">
-                            <Setter Property="Background" Value="#2980B9"/>
-                        </Style>
-                        <Style Selector="ToggleButton:checked">
-                            <Setter Property="Background" Value="#1ABC9C"/>
-                        </Style>
-                        <Style Selector="ToggleButton:checked:pointerover">
-                            <Setter Property="Background" Value="#16A085"/>
-                        </Style>
-                    </ToggleButton.Styles>
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundarySectionControlOnOff.png" Width="40" Height="40"
-                           IsHitTestVisible="False"/>
-                </ToggleButton>
+                    <!-- Row 0: Clear | Section Control -->
+                    <Button Grid.Column="0" Grid.Row="0" Classes="ModernButton"
+                            Margin="2" Height="56" ClickMode="Press"
+                            Command="{Binding ClearBoundaryCommand}"
+                            ToolTip.Tip="Delete all points and restart">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Trash.png" Width="40" Height="40" IsHitTestVisible="False"/>
+                    </Button>
+                    <ToggleButton Grid.Column="1" Grid.Row="0"
+                                  Margin="2" Height="56" ClickMode="Press"
+                                  IsChecked="{Binding IsBoundarySectionControlOn}"
+                                  ToolTip.Tip="Record boundary when section is on">
+                        <ToggleButton.Styles>
+                            <Style Selector="ToggleButton">
+                                <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+                                <Setter Property="CornerRadius" Value="6"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                                <Setter Property="Padding" Value="12,6"/>
+                            </Style>
+                            <Style Selector="ToggleButton:pointerover">
+                                <Setter Property="Background" Value="#2980B9"/>
+                            </Style>
+                            <Style Selector="ToggleButton:checked">
+                                <Setter Property="Background" Value="#1ABC9C"/>
+                            </Style>
+                            <Style Selector="ToggleButton:checked:pointerover">
+                                <Setter Property="Background" Value="#16A085"/>
+                            </Style>
+                        </ToggleButton.Styles>
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundarySectionControlOnOff.png" Width="40" Height="40" IsHitTestVisible="False"/>
+                    </ToggleButton>
 
-                <!-- Row 1: Delete Last Point | Add Point -->
-                <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton"
-                        Margin="2" Height="56" ClickMode="Press" Command="{Binding UndoBoundaryPointCommand}"
-                        ToolTip.Tip="Delete last point">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/PointDelete.png" Width="40" Height="40"
-                           IsHitTestVisible="False"/>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton"
-                        Margin="2" Height="56" ClickMode="Press" Command="{Binding AddBoundaryPointCommand}"
-                        ToolTip.Tip="Add point manually">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/PointAdd.png" Width="40" Height="40"
-                           IsHitTestVisible="False"/>
-                </Button>
+                    <!-- Row 1: Delete Last Point | Add Point -->
+                    <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton"
+                            Margin="2" Height="56" ClickMode="Press"
+                            Command="{Binding UndoBoundaryPointCommand}"
+                            ToolTip.Tip="Delete last point">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/PointDelete.png" Width="40" Height="40" IsHitTestVisible="False"/>
+                    </Button>
+                    <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton"
+                            Margin="2" Height="56" ClickMode="Press"
+                            Command="{Binding AddBoundaryPointCommand}"
+                            ToolTip.Tip="Add point manually">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/PointAdd.png" Width="40" Height="40" IsHitTestVisible="False"/>
+                    </Button>
 
-                <!-- Row 2: Left/Right toggle | Antenna/Tool toggle -->
-                <Button Grid.Column="0" Grid.Row="2" Classes="ModernButton"
-                        Margin="2" Height="56" ClickMode="Press"
-                        Command="{Binding ToggleBoundaryLeftRightCommand}"
-                        ToolTip.Tip="Toggle left/right side">
-                    <Panel IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRight.png" Width="40" Height="40"
-                               IsVisible="{Binding IsDrawRightSide}"/>
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryLeft.png" Width="40" Height="40"
-                               IsVisible="{Binding !IsDrawRightSide}"/>
-                    </Panel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="2" Classes="ModernButton"
-                        Margin="2" Height="56" ClickMode="Press"
-                        Command="{Binding ToggleBoundaryAntennaToolCommand}"
-                        ToolTip.Tip="Toggle antenna/tool position">
-                    <Panel IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRecordPivot.png" Width="40" Height="40"
-                               IsVisible="{Binding IsDrawAtPivot}"/>
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRecordTool.png" Width="40" Height="40"
-                               IsVisible="{Binding !IsDrawAtPivot}"/>
-                    </Panel>
-                </Button>
+                    <!-- Row 2: Left/Right | Antenna/Tool -->
+                    <Button Grid.Column="0" Grid.Row="2" Classes="ModernButton"
+                            Margin="2" Height="56" ClickMode="Press"
+                            Command="{Binding ToggleBoundaryLeftRightCommand}"
+                            ToolTip.Tip="Toggle left/right side">
+                        <Panel IsHitTestVisible="False">
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRight.png" Width="40" Height="40" IsVisible="{Binding IsDrawRightSide}"/>
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryLeft.png"  Width="40" Height="40" IsVisible="{Binding !IsDrawRightSide}"/>
+                        </Panel>
+                    </Button>
+                    <Button Grid.Column="1" Grid.Row="2" Classes="ModernButton"
+                            Margin="2" Height="56" ClickMode="Press"
+                            Command="{Binding ToggleBoundaryAntennaToolCommand}"
+                            ToolTip.Tip="Toggle antenna/tool position">
+                        <Panel IsHitTestVisible="False">
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRecordPivot.png" Width="40" Height="40" IsVisible="{Binding IsDrawAtPivot}"/>
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRecordTool.png"  Width="40" Height="40" IsVisible="{Binding !IsDrawAtPivot}"/>
+                        </Panel>
+                    </Button>
 
-                <!-- Row 3: Points display | Area display -->
-                <StackPanel Grid.Column="0" Grid.Row="3" Margin="4">
-                    <TextBlock Text="Points:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
-                    <TextBlock Text="{Binding BoundaryPointCount}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                               FontSize="16" FontWeight="Bold"/>
-                </StackPanel>
-                <StackPanel Grid.Column="1" Grid.Row="3" Margin="4">
-                    <TextBlock Text="Area:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
-                    <TextBlock Text="{Binding BoundaryAreaHectares, StringFormat={}{0:F2} Ha}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                               FontSize="16" FontWeight="Bold"/>
-                </StackPanel>
+                    <!-- Row 3: Points | Area -->
+                    <StackPanel Grid.Column="0" Grid.Row="3" Margin="4">
+                        <TextBlock Text="Points:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                        <TextBlock Text="{Binding BoundaryPointCount}"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   FontSize="16" FontWeight="Bold"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Grid.Row="3" Margin="4">
+                        <TextBlock Text="Area:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12"/>
+                        <TextBlock Text="{Binding BoundaryAreaHectares, StringFormat={}{0:F2} Ha}"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   FontSize="16" FontWeight="Bold"/>
+                    </StackPanel>
 
-                <!-- Row 4: OK (stop/accept) | Record/Pause toggle -->
-                <Button Grid.Column="0" Grid.Row="4" Classes="ModernButton"
-                        Margin="2" Height="64" ClickMode="Press" Command="{Binding StopBoundaryRecordingCommand}"
-                        ToolTip.Tip="Stop recording and save boundary">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png" Width="48" Height="48"
-                           IsHitTestVisible="False"/>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="4" Classes="ModernButton"
-                        Margin="2" Height="64" ClickMode="Press" Command="{Binding ToggleRecordingCommand}"
-                        ToolTip.Tip="Start/Pause recording">
-                    <Panel IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRecord.png" Width="48" Height="48"
-                               IsVisible="{Binding !IsBoundaryRecording}"/>
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/boundaryPause.png" Width="48" Height="48"
-                               IsVisible="{Binding IsBoundaryRecording}"/>
-                    </Panel>
-                </Button>
-            </Grid>
-        </StackPanel>
-    </Border>
+                    <!-- Row 4: Stop/Accept | Record/Pause -->
+                    <Button Grid.Column="0" Grid.Row="4" Classes="ModernButton"
+                            Margin="2" Height="64" ClickMode="Press"
+                            Command="{Binding StopBoundaryRecordingCommand}"
+                            ToolTip.Tip="Stop recording and save boundary">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png" Width="48" Height="48" IsHitTestVisible="False"/>
+                    </Button>
+                    <Button Grid.Column="1" Grid.Row="4" Classes="ModernButton"
+                            Margin="2" Height="64" ClickMode="Press"
+                            Command="{Binding ToggleRecordingCommand}"
+                            ToolTip.Tip="Start/Pause recording">
+                        <Panel IsHitTestVisible="False">
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryRecord.png"  Width="48" Height="48" IsVisible="{Binding !IsBoundaryRecording}"/>
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/boundaryPause.png"   Width="48" Height="48" IsVisible="{Binding IsBoundaryRecording}"/>
+                        </Panel>
+                    </Button>
+
+                </Grid>
+            </StackPanel>
+        </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
+
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml.cs
@@ -14,75 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class BoundaryPlayerPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public BoundaryPlayerPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
@@ -18,10 +18,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.BoundaryRecordingPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsBoundaryPanelVisible}"
@@ -32,144 +30,123 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <SolidColorBrush x:Key="FalseColor" Color="#E74C3C"/>
     </UserControl.Resources>
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-    </UserControl.Styles>
+    <controls:FloatingPanel x:Name="FP"
+                            MinWidth="480"
+                            Title="{Binding BoundaryRecordingHeaderText}"
+                            CloseCommand="{Binding ToggleBoundaryPanelCommand}">
+        <controls:FloatingPanel.PanelContent>
+            <StackPanel Spacing="4">
 
-    <Border Classes="FloatingPanel" MinWidth="480" IsVisible="{Binding IsBoundaryPanelVisible}" IsHitTestVisible="True">
-        <StackPanel Spacing="4" Background="Transparent">
-            <!-- Header: Drag handle + Title + Close button -->
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,4"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" FontSize="18" FontWeight="Bold"
-                           Foreground="#FFFFFF" VerticalAlignment="Center" Margin="8,0,0,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{Binding BoundaryRecordingHeaderText}" FontSize="14" FontWeight="SemiBold"
-                           Foreground="#1ABC9C" HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="28" Height="28" Margin="0,0,4,0"
-                        Background="Transparent" BorderThickness="0" Foreground="#FFFFFF"
-                        Command="{Binding ToggleBoundaryPanelCommand}" Cursor="Hand"
-                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
-            </Grid>
-
-            <!-- Toolbar Row: Delete, KML Import, Bing, Build From Tracks, Drive Around, + Inner, Accept -->
-            <Grid ColumnDefinitions="*,*,*,*,*,*,*" Margin="4,4,4,8" Background="Transparent">
-                <Button Grid.Column="0" Classes="ModernButton" Margin="2" Height="50"
-                        ToolTip.Tip="Delete selected boundary" Command="{Binding DeleteBoundaryCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Trash.png" Width="32" Height="32"
-                           HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                </Button>
-                <Button Grid.Column="1" Classes="ModernButton" Margin="2" Height="50"
-                        ToolTip.Tip="Import boundary from KML file" Command="{Binding ImportKmlBoundaryCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryLoadFromGE.png" Width="32" Height="32"
-                           HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                </Button>
-                <Button Grid.Column="2" Classes="ModernButton" Margin="2" Height="50"
-                        ToolTip.Tip="Draw boundary on satellite map" Command="{Binding DrawMapBoundaryCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryByMap.png" Width="32" Height="32"
-                           HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                </Button>
-                <Button Grid.Column="3" Classes="ModernButton" Margin="2" Height="50"
-                        ToolTip.Tip="Build boundary from driven tracks" Command="{Binding BuildFromTracksCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryFromTracks.png" Width="32" Height="32"
-                           HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                </Button>
-                <Button Grid.Column="4" Classes="ModernButton" Margin="2" Height="50"
-                        ToolTip.Tip="Drive around field to record boundary" Command="{Binding DriveAroundFieldCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ST_SteerTab.png" Width="32" Height="32"
-                           HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                </Button>
-                <Button Grid.Column="5" Classes="ModernButton" Margin="2" Height="50"
-                        ToolTip.Tip="Add inner boundary / obstacle">
-                    <Button.Flyout>
-                        <MenuFlyout Placement="BottomEdgeAlignedLeft">
-                            <MenuItem Header="Drive Around Obstacle" Command="{Binding DriveAroundInnerBoundaryCommand}">
-                                <MenuItem.Icon>
-                                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ST_SteerTab.png" Width="20" Height="20"/>
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="Draw on Satellite Map" Command="{Binding DrawMapInnerBoundaryCommand}">
-                                <MenuItem.Icon>
-                                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryByMap.png" Width="20" Height="20"/>
-                                </MenuItem.Icon>
-                            </MenuItem>
-                        </MenuFlyout>
-                    </Button.Flyout>
-                    <Grid>
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="32" Height="32"
+                <!-- Toolbar Row -->
+                <Grid ColumnDefinitions="*,*,*,*,*,*,*" Margin="4,4,4,8">
+                    <Button Grid.Column="0" Classes="ModernButton" Margin="2" Height="50"
+                            ToolTip.Tip="Delete selected boundary"
+                            Command="{Binding DeleteBoundaryCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Trash.png" Width="32" Height="32"
                                HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                        <TextBlock Text="+" FontSize="16" FontWeight="Bold" Foreground="#F5F54D"
-                                   HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,2,0"
-                                   IsHitTestVisible="False"/>
-                    </Grid>
-                </Button>
-                <Button Grid.Column="6" Classes="ModernButton" Margin="2" Height="50"
-                        ToolTip.Tip="Accept and close" Command="{Binding ToggleBoundaryPanelCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png" Width="32" Height="32"
-                           HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                </Button>
-            </Grid>
+                    </Button>
+                    <Button Grid.Column="1" Classes="ModernButton" Margin="2" Height="50"
+                            ToolTip.Tip="Import boundary from KML file"
+                            Command="{Binding ImportKmlBoundaryCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryLoadFromGE.png" Width="32" Height="32"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
+                    </Button>
+                    <Button Grid.Column="2" Classes="ModernButton" Margin="2" Height="50"
+                            ToolTip.Tip="Draw boundary on satellite map"
+                            Command="{Binding DrawMapBoundaryCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryByMap.png" Width="32" Height="32"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
+                    </Button>
+                    <Button Grid.Column="3" Classes="ModernButton" Margin="2" Height="50"
+                            ToolTip.Tip="Build boundary from driven tracks"
+                            Command="{Binding BuildFromTracksCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryFromTracks.png" Width="32" Height="32"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
+                    </Button>
+                    <Button Grid.Column="4" Classes="ModernButton" Margin="2" Height="50"
+                            ToolTip.Tip="Drive around field to record boundary"
+                            Command="{Binding DriveAroundFieldCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ST_SteerTab.png" Width="32" Height="32"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
+                    </Button>
+                    <Button Grid.Column="5" Classes="ModernButton" Margin="2" Height="50"
+                            ToolTip.Tip="Add inner boundary / obstacle">
+                        <Button.Flyout>
+                            <MenuFlyout Placement="BottomEdgeAlignedLeft">
+                                <MenuItem Header="Drive Around Obstacle" Command="{Binding DriveAroundInnerBoundaryCommand}">
+                                    <MenuItem.Icon>
+                                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ST_SteerTab.png" Width="20" Height="20"/>
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                                <MenuItem Header="Draw on Satellite Map" Command="{Binding DrawMapInnerBoundaryCommand}">
+                                    <MenuItem.Icon>
+                                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryByMap.png" Width="20" Height="20"/>
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                        <Grid>
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="32" Height="32"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
+                            <TextBlock Text="+" FontSize="16" FontWeight="Bold" Foreground="#F5F54D"
+                                       HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,2,0"
+                                       IsHitTestVisible="False"/>
+                        </Grid>
+                    </Button>
+                    <Button Grid.Column="6" Classes="ModernButton" Margin="2" Height="50"
+                            ToolTip.Tip="Accept and close"
+                            Command="{Binding ToggleBoundaryPanelCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png" Width="32" Height="32"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" IsHitTestVisible="False"/>
+                    </Button>
+                </Grid>
 
-            <!-- Column Headers -->
-            <Grid ColumnDefinitions="*,*,*" Background="{DynamicResource SystemControlHighlightAccentBrush}" Margin="4,0,4,0">
-                <TextBlock Grid.Column="0" Text="{loc:Localize Boundary}" HorizontalAlignment="Center"
-                           FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize Area}" HorizontalAlignment="Center"
-                           FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-                <TextBlock Grid.Column="2" Text="{loc:Localize DriveThru}" HorizontalAlignment="Center"
-                           FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-            </Grid>
+                <!-- Column Headers -->
+                <Grid ColumnDefinitions="*,*,*" Background="{DynamicResource SystemControlHighlightAccentBrush}" Margin="4,0,4,0">
+                    <TextBlock Grid.Column="0" Text="{loc:Localize Boundary}" HorizontalAlignment="Center"
+                               FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                    <TextBlock Grid.Column="1" Text="{loc:Localize Area}" HorizontalAlignment="Center"
+                               FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                    <TextBlock Grid.Column="2" Text="{loc:Localize DriveThru}" HorizontalAlignment="Center"
+                               FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                </Grid>
 
-            <!-- Boundary List -->
-            <Border Background="#DD1a252f" Margin="4,0,4,4" MinHeight="60" MaxHeight="150">
-                <ListBox ItemsSource="{Binding BoundaryItems}"
-                         SelectedIndex="{Binding SelectedBoundaryIndex}"
-                         Background="Transparent"
-                         BorderThickness="0">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <Grid ColumnDefinitions="*,*,*">
-                                <TextBlock Grid.Column="0" Text="{Binding BoundaryType}"
-                                           HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-                                <TextBlock Grid.Column="1" Text="{Binding AreaDisplay}"
-                                           HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
-                                <Button Grid.Column="2" Content="{Binding DriveThruDisplay}"
-                                        HorizontalAlignment="Center" Padding="8,6"
-                                        Foreground="{Binding IsDriveThrough, Converter={StaticResource BoolToColorConverter}}"
-                                        Background="Transparent" BorderThickness="0" Cursor="Hand"
-                                        Command="{Binding $parent[ListBox].((vm:MainViewModel)DataContext).ToggleDriveThroughCommand}"/>
-                            </Grid>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                    <ListBox.Styles>
-                        <Style Selector="ListBoxItem">
-                            <Setter Property="Background" Value="#334C566A"/>
-                            <Setter Property="Padding" Value="0"/>
-                            <Setter Property="Margin" Value="0,1,0,0"/>
-                        </Style>
-                        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
-                            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-                        </Style>
-                    </ListBox.Styles>
-                </ListBox>
-            </Border>
-        </StackPanel>
-    </Border>
+                <!-- Boundary List -->
+                <Border Background="#DD1a252f" Margin="4,0,4,4" MinHeight="60" MaxHeight="150">
+                    <ListBox ItemsSource="{Binding BoundaryItems}"
+                             SelectedIndex="{Binding SelectedBoundaryIndex}"
+                             Background="Transparent"
+                             BorderThickness="0">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="*,*,*">
+                                    <TextBlock Grid.Column="0" Text="{Binding BoundaryType}"
+                                               HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding AreaDisplay}"
+                                               HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                                    <Button Grid.Column="2" Content="{Binding DriveThruDisplay}"
+                                            HorizontalAlignment="Center" Padding="8,6"
+                                            Foreground="{Binding IsDriveThrough, Converter={StaticResource BoolToColorConverter}}"
+                                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                                            Command="{Binding $parent[ListBox].((vm:MainViewModel)DataContext).ToggleDriveThroughCommand}"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                        <ListBox.Styles>
+                            <Style Selector="ListBoxItem">
+                                <Setter Property="Background" Value="#334C566A"/>
+                                <Setter Property="Padding" Value="0"/>
+                                <Setter Property="Margin" Value="0,1,0,0"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
+                                <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+                            </Style>
+                        </ListBox.Styles>
+                    </ListBox>
+                </Border>
+
+            </StackPanel>
+        </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
+
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml.cs
@@ -14,75 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class BoundaryRecordingPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public BoundaryRecordingPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
@@ -18,118 +18,83 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.ConfigurationPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsConfigurationPanelVisible}"
              IsHitTestVisible="{Binding IsConfigurationPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-    </UserControl.Styles>
-
     <Grid>
-    <Border Classes="FloatingPanel" MinWidth="360" IsVisible="{Binding IsConfigurationPanelVisible}">
-        <StackPanel Spacing="4">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize VehicleConfiguration}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
-                        Command="{Binding ToggleConfigurationPanelCommand}" Margin="8,0,8,0"/>
-            </Grid>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
+        <!-- Main Panel -->
+        <controls:FloatingPanel x:Name="FP"
+                                Title="{loc:Localize VehicleConfiguration}"
+                                CloseCommand="{Binding ToggleConfigurationPanelCommand}">
 
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="4">
-                <!-- Row 0: Profile Management -->
-                <Button Grid.Column="0" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
-                        Command="{Binding ShowNewProfileDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize NewProfile}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
-                        Command="{Binding ShowLoadProfileDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileOpen.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize LoadProfile}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
+            <controls:FloatingPanel.PanelContent>
+                <Border Background="#DD1E8449" CornerRadius="6" Padding="8,4" Margin="0,8,0,0">
+                    <TextBlock Text="{Binding CurrentProfileName, StringFormat='Profile: {0}'}"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               TextWrapping="Wrap"
+                               HorizontalAlignment="Center"/>
+                </Border>
+            </controls:FloatingPanel.PanelContent>
 
-                <!-- Row 1: Vehicle Settings -->
-                <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
-                        Command="{Binding ShowConfigurationDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Settings48.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize VehicleSettings}" VerticalAlignment="Center" FontSize="12" FontWeight="SemiBold"/>
-                    </StackPanel>
-                </Button>
-            </Grid>
+            <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png"
+                                 Text="{loc:Localize NewProfile}"
+                                 Command="{Binding ShowNewProfileDialogCommand}"/>
+            <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/FileOpen.png"
+                                 Text="{loc:Localize LoadProfile}"
+                                 Command="{Binding ShowLoadProfileDialogCommand}"/>
+            <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/Settings48.png"
+                                 Text="{loc:Localize VehicleSettings}"
+                                 Command="{Binding ShowConfigurationDialogCommand}"/>
 
-            <!-- Current Profile Display -->
-            <Border Background="#DD1E8449" CornerRadius="6" Padding="8,4" Margin="0,8,0,0">
-                <TextBlock Text="{Binding CurrentProfileName, StringFormat='Profile: {0}'}"
+        </controls:FloatingPanel>
+
+        <!-- Profile Selection Popup -->
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="12" Padding="8" BorderThickness="1"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                MinWidth="300"
+                IsVisible="{Binding IsProfileSelectionVisible}"
+                HorizontalAlignment="Center" VerticalAlignment="Center">
+            <StackPanel Spacing="8">
+                <TextBlock Text="{loc:Localize SelectProfile}"
+                           FontSize="16" FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                           FontSize="13"
-                           FontWeight="SemiBold"
-                           TextWrapping="Wrap"
-                           HorizontalAlignment="Center"/>
-            </Border>
-        </StackPanel>
-    </Border>
+                           HorizontalAlignment="Center" Margin="0,4,0,8"/>
+                <ListBox ItemsSource="{Binding AvailableProfiles}"
+                         SelectedItem="{Binding SelectedProfile}"
+                         MaxHeight="200" MinWidth="260"
+                         Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                       FontSize="14" Padding="8,6"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="8" Margin="0,8,0,0">
+                    <Button Grid.Column="0" Content="{loc:Localize Cancel}"
+                            HorizontalContentAlignment="Center"
+                            Background="#E74C3C"
+                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            CornerRadius="6" Height="36"
+                            Command="{Binding CancelProfileSelectionCommand}"/>
+                    <Button Grid.Column="1" Content="{loc:Localize Load}"
+                            HorizontalContentAlignment="Center"
+                            Background="#4A9A7E"
+                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            CornerRadius="6" Height="36"
+                            Command="{Binding LoadSelectedProfileCommand}"/>
+                </Grid>
+            </StackPanel>
+        </Border>
 
-    <!-- Profile Selection Popup -->
-    <Border Classes="FloatingPanel" MinWidth="300" IsVisible="{Binding IsProfileSelectionVisible}"
-            HorizontalAlignment="Center" VerticalAlignment="Center">
-        <StackPanel Spacing="8">
-            <TextBlock Text="{loc:Localize SelectProfile}" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                       HorizontalAlignment="Center" Margin="0,4,0,8"/>
-
-            <ListBox ItemsSource="{Binding AvailableProfiles}"
-                     SelectedItem="{Binding SelectedProfile}"
-                     MaxHeight="200" MinWidth="260" Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" Padding="8,6"/>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
-
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="8" Margin="0,8,0,0">
-                <Button Grid.Column="0" Content="{loc:Localize Cancel}" HorizontalContentAlignment="Center"
-                        Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="6" Height="36"
-                        Command="{Binding CancelProfileSelectionCommand}"/>
-                <Button Grid.Column="1" Content="{loc:Localize Load}" HorizontalContentAlignment="Center"
-                        Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" CornerRadius="6" Height="36"
-                        Command="{Binding LoadSelectedProfileCommand}"/>
-            </Grid>
-        </StackPanel>
-    </Border>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml.cs
@@ -23,66 +23,13 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class ConfigurationPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public ConfigurationPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
@@ -18,95 +18,34 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.FieldToolsPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsFieldToolsPanelVisible}"
              IsHitTestVisible="{Binding IsFieldToolsPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-    </UserControl.Styles>
+  <controls:FloatingPanel x:Name="FP"
+                          Title="{loc:Localize FieldTools}"
+                          CloseCommand="{Binding ToggleFieldToolsPanelCommand}">
 
-    <Border Classes="FloatingPanel" MinWidth="400" IsVisible="{Binding IsFieldToolsPanelVisible}" IsHitTestVisible="True">
-        <StackPanel Spacing="4" Background="Transparent">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize FieldTools}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
-                        Command="{Binding ToggleFieldToolsPanelCommand}" Margin="8,0,8,0"/>
-            </Grid>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/Headache.png"
+                         Text="Field Builder"
+                         Command="{Binding ShowFieldBuilderCommand}"/>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png"
+                         Text="{loc:Localize Boundary}"
+                         Command="{Binding ShowBoundaryDialogCommand}"/>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/TrashApplied.png"
+                         Text="{loc:Localize DeleteAppliedArea}"
+                         Command="{Binding DeleteAppliedAreaCommand}"/>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryFromTracks.png"
+                         Text="{loc:Localize ImportTracks}"
+                         Command="{Binding ImportTracksCommand}"/>
 
-            <!-- Menu Items: 2-column compact layout -->
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="4" Background="Transparent">
-                <!-- Row 0: Field Builder, Boundary -->
-                <Button Grid.Column="0" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowFieldBuilderCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Headache.png" Width="28" Height="28"/>
-                        <TextBlock Text="Field Builder" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowBoundaryDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize Boundary}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/RecPath.png"
+                         Text="{loc:Localize RecordedPath}"
+                         Command="{Binding ToggleRecordedPathPanelCommand}"/>
 
-                <!-- Row 1: Delete Applied Area, Import Tracks -->
-                <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding DeleteAppliedAreaCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TrashApplied.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize DeleteAppliedArea}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ImportTracksCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/BoundaryFromTracks.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize ImportTracks}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Row 2: Recorded Path -->
-                <Button Grid.Column="0" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ToggleRecordedPathPanelCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/RecPath.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize RecordedPath}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-            </Grid>
-        </StackPanel>
-    </Border>
+  </controls:FloatingPanel>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml.cs
@@ -23,66 +23,13 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class FieldToolsPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public FieldToolsPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -18,93 +18,65 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.FileMenuPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsFileMenuPanelVisible}"
              IsHitTestVisible="{Binding IsFileMenuPanelVisible}">
-
     <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
+      <Style Selector="Button.MenuListButton">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Padding" Value="8,6"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="Cursor" Value="Hand"/>
+      </Style>
+      <Style Selector="Button.MenuListButton:pointerover">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+      </Style>
     </UserControl.Styles>
+    <controls:FloatingPanel x:Name="FP"
+                            Title="{loc:Localize ApplicationSettings}"
+                            CloseCommand="{Binding ToggleFileMenuPanelCommand}">
+        <controls:FloatingPanel.PanelContent>
+            <StackPanel Spacing="4">
 
-    <Border Classes="FloatingPanel" MinWidth="200" IsVisible="{Binding IsFileMenuPanelVisible}">
-        <StackPanel Spacing="4">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize ApplicationSettings}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
-                        Command="{Binding ToggleFileMenuPanelCommand}" Margin="8,0,8,0"/>
-            </Grid>
+                <!-- General Settings -->
+                <Button Classes="MenuListButton" Content="{loc:Localize Language}"         HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowLanguageDialogCommand}"/>
+                <Button Classes="MenuListButton" Content="{loc:Localize ResetAllSettings}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ResetAllSettingsCommand}"/>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-            <!-- General Settings -->
-            <Button Classes="ModernButton" Content="{loc:Localize Language}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowLanguageDialogCommand}"/>
-            <Button Classes="ModernButton" Content="{loc:Localize ResetAllSettings}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ResetAllSettingsCommand}"/>
+                <!-- App Configuration -->
+                <Button Classes="MenuListButton" Content="{loc:Localize ViewAllSettings}"  HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowViewSettingsDialogCommand}"/>
+                <Button Classes="MenuListButton" Content="{loc:Localize AppDirectories}"   HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowAppDirectoriesDialogCommand}"/>
+                <Button Classes="MenuListButton" Content="{loc:Localize LogViewer}"        HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowLogViewerDialogCommand}"/>
+                <Button Classes="MenuListButton" Content="{loc:Localize Hotkeys}"          HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowHotkeyConfigDialogCommand}"/>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-            <!-- App Configuration -->
-            <Button Classes="ModernButton" Content="{loc:Localize ViewAllSettings}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowViewSettingsDialogCommand}"/>
-            <Button Classes="ModernButton" Content="{loc:Localize AppDirectories}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowAppDirectoriesDialogCommand}"/>
-            <Button Classes="ModernButton" Content="{loc:Localize LogViewer}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowLogViewerDialogCommand}"/>
-            <Button Classes="ModernButton" Content="{loc:Localize Hotkeys}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowHotkeyConfigDialogCommand}"/>
+                <!-- NTRIP Profiles -->
+                <Button Classes="MenuListButton" Content="{loc:Localize NtripProfiles}"    HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowNtripProfilesDialogCommand}"/>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-            <!-- NTRIP Profiles -->
-            <Button Classes="ModernButton" Content="{loc:Localize NtripProfiles}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowNtripProfilesDialogCommand}"/>
+                <!-- Simulator -->
+                <Button Classes="MenuListButton" Content="{loc:Localize Simulator}"        HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ToggleSimulatorPanelCommand}"/>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-            <!-- Simulator -->
-            <Button Classes="ModernButton" Content="{loc:Localize Simulator}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ToggleSimulatorPanelCommand}"/>
+                <!-- Help & Info -->
+                <Button Classes="MenuListButton" Content="{loc:Localize AgShareApi}"       HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowAgShareSettingsDialogCommand}"/>
+                <Button Classes="MenuListButton" Content="{loc:Localize Help}"             HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowHelpDialogCommand}"/>
+                <Button Classes="MenuListButton" Content="{loc:Localize About}"            HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowAboutDialogCommand}"/>
+                <Button Classes="MenuListButton" Content="{loc:Localize BugReportDump}"    HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowBugReportDialogCommand}"/>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+            </StackPanel>
+        </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
 
-            <!-- Help & Info -->
-            <Button Classes="ModernButton" Content="{loc:Localize AgShareApi}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowAgShareSettingsDialogCommand}"/>
-            <Button Classes="ModernButton" Content="{loc:Localize Help}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowHelpDialogCommand}"/>
-            <Button Classes="ModernButton" Content="{loc:Localize About}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowAboutDialogCommand}"/>
-            <Button Classes="ModernButton" Content="{loc:Localize BugReportDump}" HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press"
-                    Command="{Binding ShowBugReportDialogCommand}"/>
-        </StackPanel>
-    </Border>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml.cs
@@ -23,66 +23,13 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class FileMenuPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public FileMenuPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
@@ -18,39 +18,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              xmlns:controls="using:AgValoniaGPS.Views.Controls"
-             mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Panels.HeadingChartPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsHeadingChartPanelVisible}"
              IsHitTestVisible="{Binding IsHeadingChartPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="4"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-    </UserControl.Styles>
+  <controls:FloatingPanel x:Name="FP"
+                          Width="420"
+                          Title="{loc:Localize HeadingChart}"
+                          CloseCommand="{Binding ToggleHeadingChartPanelCommand}">
+    <controls:FloatingPanel.PanelContent>
+      <controls:ChartControl x:Name="HeadingChart" Height="192"/>
+    </controls:FloatingPanel.PanelContent>
+  </controls:FloatingPanel>
 
-    <Border Classes="FloatingPanel" Width="420" Height="240">
-        <Grid RowDefinitions="24,*">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize HeadingChart}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"
-                        Command="{Binding ToggleHeadingChartPanelCommand}" Margin="4,0,4,0"/>
-            </Grid>
-            <controls:ChartControl x:Name="HeadingChart" Grid.Row="1"/>
-        </Grid>
-    </Border>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml.cs
@@ -17,7 +17,6 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 using AgValoniaGPS.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,26 +24,19 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class HeadingChartPanel : UserControl
 {
-    private bool _isDragging;
-    private Point _lastScreenPoint;
     private bool _configured;
 
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public static IServiceProvider? ServiceProvider { get; set; }
 
     public HeadingChartPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
+
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
 
         PropertyChanged += (_, e) =>
         {
@@ -77,49 +69,5 @@ public partial class HeadingChartPanel : UserControl
         chart.AddSeries(chartData.HeadingError);
         chart.AddSeries(chartData.ImuHeading);
         chart.AddSeries(chartData.GpsHeading);
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml
@@ -18,155 +18,67 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.JobMenuPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsJobMenuPanelVisible}"
              IsHitTestVisible="{Binding IsJobMenuPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-    </UserControl.Styles>
+    <controls:FloatingPanel x:Name="FP"
+                            Title="{loc:Localize StartNewField}"
+                            CloseCommand="{Binding ToggleJobMenuPanelCommand}">
 
-    <Border Classes="FloatingPanel" MinWidth="400" IsVisible="{Binding IsJobMenuPanelVisible}" IsHitTestVisible="True">
-        <StackPanel Spacing="4" Background="Transparent">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize StartNewField}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
-                        Command="{Binding ToggleJobMenuPanelCommand}" Margin="8,0,8,0"/>
-            </Grid>
-
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
-
-            <!-- Menu Items: 2-column layout (6 rows x 2 columns) -->
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="4" Background="Transparent">
-                <!-- Row 0: ISO-XML, Close -->
-                <Button Grid.Column="0" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowIsoXmlImportDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ISOXML.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize IsoXml}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding CloseFieldCommand}"
-                        IsEnabled="{Binding IsFieldOpen}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileClose.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize Close}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Row 1: From KML, Drive In -->
-                <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowKmlImportDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/GoogleEarth.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize FromKml}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding DriveInCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SteerDriveOn.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize DriveIn}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Row 2: From Existing, Open -->
-                <Button Grid.Column="0" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowFromExistingFieldDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileExisting.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize FromExisting}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowFieldSelectionDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileOpen.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize Open}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Row 3: New From Default, Resume -->
-                <Button Grid.Column="0" Grid.Row="3" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowNewFieldDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize NewFromDefault}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="3" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ResumeFieldCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FilePrevious.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize Resume}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Row 4: AgShare Download, AgShare Upload -->
-                <Button Grid.Column="0" Grid.Row="4" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowAgShareDownloadDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize AgShareDownload}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="4" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowAgShareUploadDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize AgShareUpload}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Row 5: Offset Fix -->
-                <Button Grid.Column="0" Grid.Row="5" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44"
-                        ClickMode="Press" Command="{Binding ShowOffsetFixDialogCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/YouTurnReverse.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize OffsetFix}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-            </Grid>
-
-            <!-- Current Field Display -->
+        <controls:FloatingPanel.PanelContent>
             <Border Background="#DD1E8449" CornerRadius="6" Padding="8,4" Margin="0,8,0,0"
                     IsVisible="{Binding IsFieldOpen}">
                 <TextBlock Text="{Binding CurrentFieldName, StringFormat='Current Field: {0}'}"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                           FontSize="13"
-                           FontWeight="SemiBold"
+                           FontSize="13" FontWeight="SemiBold"
                            TextWrapping="Wrap"
                            HorizontalAlignment="Center"/>
             </Border>
-        </StackPanel>
-    </Border>
+        </controls:FloatingPanel.PanelContent>
+
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/ISOXML.png"
+                             Text="{loc:Localize IsoXml}"
+                             Command="{Binding ShowIsoXmlImportDialogCommand}"/>
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/FileClose.png"
+                             Text="{loc:Localize Close}"
+                             Command="{Binding CloseFieldCommand}"
+                             IsEnabled="{Binding IsFieldOpen}"/>
+
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/GoogleEarth.png"
+                             Text="{loc:Localize FromKml}"
+                             Command="{Binding ShowKmlImportDialogCommand}"/>
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/SteerDriveOn.png"
+                             Text="{loc:Localize DriveIn}"
+                             Command="{Binding DriveInCommand}"/>
+
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/FileExisting.png"
+                             Text="{loc:Localize FromExisting}"
+                             Command="{Binding ShowFromExistingFieldDialogCommand}"/>
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/FileOpen.png"
+                             Text="{loc:Localize Open}"
+                             Command="{Binding ShowFieldSelectionDialogCommand}"/>
+
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png"
+                             Text="{loc:Localize NewFromDefault}"
+                             Command="{Binding ShowNewFieldDialogCommand}"/>
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/FilePrevious.png"
+                             Text="{loc:Localize Resume}"
+                             Command="{Binding ResumeFieldCommand}"/>
+
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png"
+                             Text="{loc:Localize AgShareDownload}"
+                             Command="{Binding ShowAgShareDownloadDialogCommand}"/>
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png"
+                             Text="{loc:Localize AgShareUpload}"
+                             Command="{Binding ShowAgShareUploadDialogCommand}"/>
+
+        <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/YouTurnReverse.png"
+                             Text="{loc:Localize OffsetFix}"
+                             Command="{Binding ShowOffsetFixDialogCommand}"/>
+
+    </controls:FloatingPanel>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/JobMenuPanel.axaml.cs
@@ -23,66 +23,14 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class JobMenuPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public JobMenuPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
-    }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
@@ -18,63 +18,28 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.SimulatorPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsSimulatorPanelVisible}"
              IsHitTestVisible="{Binding IsSimulatorPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-    </UserControl.Styles>
-
-    <Border Classes="FloatingPanel" MinWidth="320" IsVisible="{Binding IsSimulatorPanelVisible}">
-        <StackPanel Spacing="4">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize GpsSimulator}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
-                        Command="{Binding ToggleSimulatorPanelCommand}" Margin="8,0,8,0"/>
-            </Grid>
-
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-
-            <!-- Simulator Controls -->
+    <controls:FloatingPanel x:Name="FP"
+                            MinWidth="320"
+                            Title="{loc:Localize GpsSimulator}"
+                            CloseCommand="{Binding ToggleSimulatorPanelCommand}">
+        <controls:FloatingPanel.PanelContent>
             <StackPanel Spacing="8" Margin="12">
-                <!-- Simulator Enable/Disable -->
+
+                <!-- Enable/Disable -->
                 <CheckBox Content="{loc:Localize SimulatorEnabled}"
                           IsChecked="{Binding IsSimulatorEnabled}"
-                          FontWeight="Bold"
-                          FontSize="13"
+                          FontWeight="Bold" FontSize="13"
                           Margin="0,0,0,4"/>
 
-                <!-- Enter Sim Coords (only when simulator is disabled) -->
-                <Button Classes="ModernButton" ClickMode="Press" HorizontalAlignment="Stretch"
+                <!-- Enter Coords -->
+                <Button ClickMode="Press" HorizontalAlignment="Stretch"
                         Command="{Binding ShowSimCoordsDialogCommand}"
                         IsEnabled="{Binding !IsSimulatorEnabled}"
                         ToolTip.Tip="Enter starting GPS coordinates (disable simulator first)">
@@ -83,90 +48,93 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-                <!-- Row 1: Reset Position and Reset Steering -->
+                <!-- Reset / Reset Steering -->
                 <Grid ColumnDefinitions="*,*">
-                    <Button Grid.Column="0" Classes="ModernButton" Margin="0,0,4,0" ClickMode="Press"
+                    <Button Grid.Column="0" Margin="0,0,4,0" ClickMode="Press"
                             Command="{Binding ResetSimulatorCommand}"
                             ToolTip.Tip="Reset to starting position">
-                        <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                            <TextBlock Text="{loc:Localize Reset}" FontSize="12"/>
-                        </StackPanel>
+                        <TextBlock Text="{loc:Localize Reset}" FontSize="12" IsHitTestVisible="False"/>
                     </Button>
-                    <Button Grid.Column="1" Classes="ModernButton" Margin="4,0,0,0" ClickMode="Press"
+                    <Button Grid.Column="1" Margin="4,0,0,0" ClickMode="Press"
                             Command="{Binding ResetSteerAngleCommand}"
                             ToolTip.Tip="Reset steering to 0 (straight ahead)">
                         <TextBlock Text="&gt;0&lt;" FontSize="14" FontWeight="Bold" IsHitTestVisible="False"/>
                     </Button>
                 </Grid>
 
-                <!-- Row 2: Steering Controls -->
+                <!-- Steering L / Slider / R -->
                 <Grid ColumnDefinitions="Auto,*,Auto">
-                    <Button Grid.Column="0" Classes="ModernButton" Width="40" Margin="0,0,8,0" ClickMode="Press"
+                    <Button Grid.Column="0" Width="40" Margin="0,0,8,0" ClickMode="Press"
                             Command="{Binding SimulatorSteerLeftCommand}"
                             ToolTip.Tip="Steer left">
                         <TextBlock Text="L" FontSize="16" IsHitTestVisible="False"/>
                     </Button>
-                    <Slider Grid.Column="1" Margin="0"
+                    <Slider Grid.Column="1"
                             Minimum="-40" Maximum="40"
                             Value="{Binding SimulatorSteerAngle, Mode=TwoWay}"
-                            TickFrequency="5"
-                            IsSnapToTickEnabled="True"
+                            TickFrequency="5" IsSnapToTickEnabled="True"
                             ToolTip.Tip="Steering angle"/>
-                    <Button Grid.Column="2" Classes="ModernButton" Width="40" Margin="8,0,0,0" ClickMode="Press"
+                    <Button Grid.Column="2" Width="40" Margin="8,0,0,0" ClickMode="Press"
                             Command="{Binding SimulatorSteerRightCommand}"
                             ToolTip.Tip="Steer right">
                         <TextBlock Text="R" FontSize="16" IsHitTestVisible="False"/>
                     </Button>
                 </Grid>
 
-                <!-- Row 3: Steer Angle Display -->
+                <!-- Steer Angle Display -->
                 <TextBlock Text="{Binding SimulatorSteerAngleDisplay, Mode=OneWay}"
-                           HorizontalAlignment="Center"
-                           FontSize="12"
-                           Foreground="#DDD"/>
+                           HorizontalAlignment="Center" FontSize="12" Foreground="#DDD"/>
 
-                <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="1" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-                <!-- Row 4: Speed Slider (-10 to +25 kph) -->
+                <!-- Speed label + 10x toggle -->
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Grid.Column="0" Text="{loc:Localize Speed}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                    <CheckBox Grid.Column="1" Content="10x" IsChecked="{Binding IsSimulatorSpeed10x}"
-                              FontSize="10" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,0"
+                    <TextBlock Grid.Column="0" Text="{loc:Localize Speed}"
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                               FontSize="11" HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    <CheckBox Grid.Column="1" Content="10x"
+                              IsChecked="{Binding IsSimulatorSpeed10x}"
+                              FontSize="10"
+                              Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                               ToolTip.Tip="10x speed multiplier for large fields"/>
                 </Grid>
+
+                <!-- Speed -10 / Slider / 25 -->
                 <Grid ColumnDefinitions="Auto,*,Auto">
-                    <TextBlock Grid.Column="0" Text="-10" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                    <Slider Grid.Column="1" Margin="0"
+                    <TextBlock Grid.Column="0" Text="-10"
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                               FontSize="10" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                    <Slider Grid.Column="1"
                             Minimum="-10" Maximum="25"
                             Value="{Binding SimulatorSpeedKph, Mode=TwoWay}"
-                            TickFrequency="5"
-                            IsSnapToTickEnabled="False"
+                            TickFrequency="5" IsSnapToTickEnabled="False"
                             ToolTip.Tip="Speed in kph (-10 reverse to +25 forward)"/>
-                    <TextBlock Grid.Column="2" Text="25" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="10" VerticalAlignment="Center" Margin="4,0,0,0"/>
+                    <TextBlock Grid.Column="2" Text="25"
+                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                               FontSize="10" VerticalAlignment="Center" Margin="4,0,0,0"/>
                 </Grid>
 
                 <!-- Speed Display -->
                 <TextBlock Text="{Binding SimulatorSpeedDisplay, Mode=OneWay}"
-                           HorizontalAlignment="Center"
-                           FontSize="12"
-                           Foreground="#DDD"/>
+                           HorizontalAlignment="Center" FontSize="12" Foreground="#DDD"/>
 
-                <!-- Stop Button -->
-                <Button Classes="ModernButton" ClickMode="Press"
+                <!-- Stop -->
+                <Button ClickMode="Press"
                         Command="{Binding SimulatorStopCommand}"
-                        ToolTip.Tip="Stop (set speed to 0)" HorizontalAlignment="Center" Width="80">
+                        ToolTip.Tip="Stop (set speed to 0)"
+                        HorizontalAlignment="Center" Width="80">
                     <TextBlock Text="STOP" FontSize="14" FontWeight="Bold" IsHitTestVisible="False"/>
                 </Button>
 
-                <!-- Row 5: Reverse Direction -->
-                <Button Classes="ModernButton" ClickMode="Press"
+                <!-- Reverse Direction -->
+                <Button ClickMode="Press"
                         Command="{Binding SimulatorReverseDirectionCommand}"
                         ToolTip.Tip="Reverse direction (180 turn)">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <TextBlock Text="{loc:Localize ReverseDirection}" FontSize="12"/>
-                    </StackPanel>
+                    <TextBlock Text="{loc:Localize ReverseDirection}" FontSize="12" IsHitTestVisible="False"/>
                 </Button>
+
             </StackPanel>
-        </StackPanel>
-    </Border>
+        </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
+
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml.cs
@@ -14,75 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class SimulatorPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public SimulatorPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
@@ -18,39 +18,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              xmlns:controls="using:AgValoniaGPS.Views.Controls"
-             mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Panels.SteerChartPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsSteerChartPanelVisible}"
              IsHitTestVisible="{Binding IsSteerChartPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="4"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-    </UserControl.Styles>
+  <controls:FloatingPanel x:Name="FP"
+                          Width="420"
+                          Title="{loc:Localize SteerChart}"
+                          CloseCommand="{Binding ToggleSteerChartPanelCommand}">
+    <controls:FloatingPanel.PanelContent>
+      <controls:ChartControl x:Name="SteerChart" Height="192"/>
+    </controls:FloatingPanel.PanelContent>
+  </controls:FloatingPanel>
 
-    <Border Classes="FloatingPanel" Width="420" Height="240">
-        <Grid RowDefinitions="24,*">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize SteerChart}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"
-                        Command="{Binding ToggleSteerChartPanelCommand}" Margin="4,0,4,0"/>
-            </Grid>
-            <controls:ChartControl x:Name="SteerChart" Grid.Row="1"/>
-        </Grid>
-    </Border>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml.cs
@@ -25,45 +25,27 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class SteerChartPanel : UserControl
 {
-    private bool _isDragging;
-    private Point _lastScreenPoint;
     private bool _configured;
 
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
-    /// <summary>
-    /// Optional DI service provider for auto-configuration.
-    /// Set by the hosting platform (Desktop App.Services, etc).
-    /// </summary>
     public static IServiceProvider? ServiceProvider { get; set; }
 
     public SteerChartPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
 
-        // Auto-configure when panel becomes visible
         PropertyChanged += (_, e) =>
         {
             if (e.Property.Name == nameof(IsVisible) && e.NewValue is true)
-                TryAutoConfigure();
+            {
+                var chartData = ServiceProvider?.GetService<IChartDataService>();
+                if (chartData != null) ConfigureChart(chartData);
+            }
         };
-    }
-
-    private void TryAutoConfigure()
-    {
-        if (_configured) return;
-        var chartData = ServiceProvider?.GetService<IChartDataService>();
-        if (chartData != null)
-            ConfigureChart(chartData);
     }
 
     public void ConfigureChart(IChartDataService chartData)
@@ -86,49 +68,5 @@ public partial class SteerChartPanel : UserControl
         chart.AddSeries(chartData.SetSteerAngle);
         chart.AddSeries(chartData.ActualSteerAngle);
         chart.AddSeries(chartData.PwmOutput);
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
@@ -18,99 +18,36 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.ToolsPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsToolsPanelVisible}"
              IsHitTestVisible="{Binding IsToolsPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-    </UserControl.Styles>
+  <controls:FloatingPanel x:Name="FP"
+                          Title="Tools"
+                          CloseCommand="{Binding ToggleToolsPanelCommand}">
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png"
+                         Text="{loc:Localize SteerWizard}"
+                         Command="{Binding ShowSteerWizardCommand}"/>
 
-    <Border Classes="FloatingPanel" MinWidth="360" IsVisible="{Binding IsToolsPanelVisible}">
-        <StackPanel Spacing="4">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32" Margin="0,0,0,8"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="20" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize Tools}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" Cursor="Hand"
-                        Command="{Binding ToggleToolsPanelCommand}" Margin="8,0,8,0"/>
-            </Grid>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png"
+                         Text="{loc:Localize LogViewer}"/>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/AutoSteerOn.png"
+                         Text="{loc:Localize SteerChart}"
+                         Command="{Binding ToggleSteerChartPanelCommand}"/>
 
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="4">
-                <!-- Row 0: Wizards -->
-                <Button Grid.Column="0" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
-                        Command="{Binding ShowSteerWizardCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize SteerWizard}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="0" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize LogViewer}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesHeading.png"
+                         Text="{loc:Localize HeadingChart}"
+                         Command="{Binding ToggleHeadingChartPanelCommand}"/>
 
-                <!-- Row 1: Charts -->
-                <Button Grid.Column="0" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
-                        Command="{Binding ToggleSteerChartPanelCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoSteerOn.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize SteerChart}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="1" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
-                        Command="{Binding ToggleHeadingChartPanelCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesHeading.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize HeadingChart}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/AutoManualIsAuto.png"
+                         Text="{loc:Localize XteChart}"
+                         Command="{Binding ToggleXTEChartPanelCommand}"/>
 
-                <!-- Row 2: More Charts + Roll Correction -->
-                <Button Grid.Column="0" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press"
-                        Command="{Binding ToggleXTEChartPanelCommand}">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoManualIsAuto.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize XteChart}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-                <Button Grid.Column="1" Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="0,2" Height="44" ClickMode="Press">
-                    <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesRoll.png" Width="28" Height="28"/>
-                        <TextBlock Text="{loc:Localize RollCorrection}" VerticalAlignment="Center" FontSize="12"/>
-                    </StackPanel>
-                </Button>
-            </Grid>
-        </StackPanel>
-    </Border>
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesRoll.png"
+                         Text="{loc:Localize RollCorrection}"/>
+    </controls:FloatingPanel>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml.cs
@@ -23,66 +23,13 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class ToolsPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public ToolsPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
@@ -18,154 +18,110 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             mc:Ignorable="d"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.ViewSettingsPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsViewSettingsPanelVisible}"
              IsHitTestVisible="{Binding IsViewSettingsPanelVisible}">
 
-    <UserControl.Styles>
-        <!-- Floating Panel Style -->
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
+    <controls:FloatingPanel x:Name="FP"
+                            MinWidth="200"
+                            Title="{loc:Localize ViewSettings}"
+                            CloseCommand="{Binding ToggleViewSettingsPanelCommand}">
+        <controls:FloatingPanel.PanelContent>
+            <StackPanel Spacing="4">
 
-        <!-- Modern Button Style -->
-        <Style Selector="Button.ModernButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="8,6"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.ModernButton:pressed">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
-        </Style>
-    </UserControl.Styles>
+                <StackPanel.Styles>
+                    <Style Selector="Button.VSButton">
+                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+                        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                        <Setter Property="CornerRadius" Value="6"/>
+                        <Setter Property="Padding" Value="8,6"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="FontSize" Value="12"/>
+                        <Setter Property="Cursor" Value="Hand"/>
+                    </Style>
+                    <Style Selector="Button.VSButton:pointerover">
+                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+                    </Style>
+                    <Style Selector="Button.VSButton:pressed">
+                        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
+                    </Style>
+                </StackPanel.Styles>
 
-    <Border Classes="FloatingPanel" MinWidth="200" IsVisible="{Binding IsViewSettingsPanelVisible}" IsHitTestVisible="True">
-        <StackPanel Spacing="4" Background="Transparent">
-            <!-- Header with drag handle and close button -->
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto"
-                  Height="32"
-                  Margin="0,0,0,8"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                  Cursor="Hand"
-                  ToolTip.Tip="Drag to move">
-                <!-- Drag Handle Icon -->
-                <TextBlock Grid.Column="0"
-                           Text="="
-                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                           FontSize="20"
-                           FontWeight="Bold"
-                           VerticalAlignment="Center"
-                           Margin="8,0,8,0"
-                           IsHitTestVisible="False"/>
-                <!-- Title -->
-                <TextBlock Grid.Column="1"
-                           Text="{loc:Localize ViewSettings}"
-                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                           FontSize="16"
-                           FontWeight="Bold"
-                           VerticalAlignment="Center"
-                           IsHitTestVisible="False"/>
-                <!-- Close Button -->
-                <Button Grid.Column="2"
-                        Content="X"
-                        Width="24" Height="24"
-                        Padding="0"
-                        BorderThickness="0"
-                        Background="Transparent"
-                        Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                        FontSize="16"
-                        Cursor="Hand"
-                        Command="{Binding ToggleViewSettingsPanelCommand}"
-                        ToolTip.Tip="Close"
-                        Margin="8,0,8,0"/>
-            </Grid>
+                <!-- Camera Controls -->
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto">
+                    <Button Grid.Row="0" Grid.Column="0" Classes="VSButton"
+                            Content="{loc:Localize TiltUp}" Margin="2" ClickMode="Press"
+                            Command="{Binding IncreaseCameraPitchCommand}"
+                            ToolTip.Tip="Tilt toward overhead (2D)"/>
+                    <Button Grid.Row="0" Grid.Column="1" Classes="VSButton"
+                            Content="{loc:Localize TiltDown}" Margin="2" ClickMode="Press"
+                            Command="{Binding DecreaseCameraPitchCommand}"
+                            ToolTip.Tip="Tilt toward horizon (3D)"/>
+                    <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                               Text="{Binding CameraPitchDisplay}"
+                               HorizontalAlignment="Center" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                               Margin="0,2"/>
+                    <Button Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Classes="VSButton"
+                            Content="2D/3D" Margin="2" ClickMode="Press"
+                            Command="{Binding Toggle2D3DCommand}"
+                            ToolTip.Tip="Toggle 2D/3D view"/>
+                </Grid>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,0,0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-            <!-- Camera Controls -->
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" Background="Transparent">
-                <Button Grid.Row="0" Grid.Column="0" Classes="ModernButton"
-                        Content="{loc:Localize TiltUp}" Margin="2" ClickMode="Press"
-                        Command="{Binding IncreaseCameraPitchCommand}"
-                        ToolTip.Tip="Tilt toward overhead (2D)"/>
-                <Button Grid.Row="0" Grid.Column="1" Classes="ModernButton"
-                        Content="{loc:Localize TiltDown}" Margin="2" ClickMode="Press"
-                        Command="{Binding DecreaseCameraPitchCommand}"
-                        ToolTip.Tip="Tilt toward horizon (3D)"/>
-                <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                           Text="{Binding CameraPitchDisplay}"
-                           HorizontalAlignment="Center" FontSize="12"
-                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
-                           Margin="0,2"/>
-                <Button Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Classes="ModernButton"
-                        Content="2D/3D" Margin="2" ClickMode="Press"
-                        Command="{Binding Toggle2D3DCommand}"
-                        ToolTip.Tip="Toggle 2D/3D view"/>
-            </Grid>
+                <!-- Display Options -->
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto">
+                    <Button Grid.Row="0" Grid.Column="0" Classes="VSButton"
+                            Content="{loc:Localize North}" Margin="2" ClickMode="Press"
+                            Command="{Binding ToggleNorthUpCommand}"
+                            ToolTip.Tip="North-up/Track-up"/>
+                    <Button Grid.Row="0" Grid.Column="1" Classes="VSButton"
+                            Content="{loc:Localize Grid}" Margin="2" ClickMode="Press"
+                            Command="{Binding ToggleGridCommand}"
+                            ToolTip.Tip="Toggle grid"/>
+                    <Button Grid.Row="1" Grid.Column="0" Classes="VSButton"
+                            Content="{loc:Localize DayNight}" Margin="2" ClickMode="Press"
+                            Command="{Binding ToggleDayNightCommand}"
+                            ToolTip.Tip="Day/Night mode"/>
+                    <TextBlock Grid.Row="1" Grid.Column="1"
+                               Text="10 Hz" Margin="2" Padding="8"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                               FontWeight="Bold" FontSize="12"/>
+                </Grid>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-            <!-- Display Options -->
-            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" Background="Transparent">
-                <Button Grid.Row="0" Grid.Column="0" Classes="ModernButton"
-                        Content="{loc:Localize North}" Margin="2" ClickMode="Press"
-                        Command="{Binding ToggleNorthUpCommand}"
-                        ToolTip.Tip="North-up/Track-up"/>
-                <Button Grid.Row="0" Grid.Column="1" Classes="ModernButton"
-                        Content="{loc:Localize Grid}" Margin="2" ClickMode="Press"
-                        Command="{Binding ToggleGridCommand}"
-                        ToolTip.Tip="Toggle grid"/>
-                <Button Grid.Row="1" Grid.Column="0" Classes="ModernButton"
-                        Content="{loc:Localize DayNight}" Margin="2" ClickMode="Press"
-                        Command="{Binding ToggleDayNightCommand}"
-                        ToolTip.Tip="Day/Night mode"/>
-                <TextBlock Grid.Row="1" Grid.Column="1"
-                           Text="10 Hz" Margin="2" Padding="8"
-                           HorizontalAlignment="Center" VerticalAlignment="Center"
-                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="12"/>
-            </Grid>
+                <!-- Brightness -->
+                <Grid ColumnDefinitions="*,*">
+                    <Button Grid.Column="0" Classes="VSButton"
+                            Content="{Binding BrightnessDisplay, StringFormat='Dim -{0}'}" Margin="2" ClickMode="Press"
+                            Command="{Binding DecreaseBrightnessCommand}"
+                            ToolTip.Tip="Decrease brightness"/>
+                    <Button Grid.Column="1" Classes="VSButton"
+                            Content="Bright +" Margin="2" ClickMode="Press"
+                            Command="{Binding IncreaseBrightnessCommand}"
+                            ToolTip.Tip="Increase brightness"/>
+                </Grid>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-            <!-- Brightness -->
-            <Grid ColumnDefinitions="*,*" Background="Transparent">
-                <Button Grid.Column="0" Classes="ModernButton"
-                        Content="{Binding BrightnessDisplay, StringFormat='Dim -{0}'}" Margin="2" ClickMode="Press"
-                        Command="{Binding DecreaseBrightnessCommand}"
-                        ToolTip.Tip="Decrease brightness"/>
-                <Button Grid.Column="1" Classes="ModernButton"
-                        Content="Bright +" Margin="2" ClickMode="Press"
-                        Command="{Binding IncreaseBrightnessCommand}"
-                        ToolTip.Tip="Increase brightness"/>
-            </Grid>
+                <!-- Display Quality -->
+                <Button Classes="VSButton" Margin="2" ClickMode="Press"
+                        Command="{Binding CycleDisplayResolutionCommand}"
+                        ToolTip.Tip="Cycle coverage display quality (High/Medium/Low). Lower = less memory, better performance on constrained devices.">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="6">
+                        <TextBlock Text="Quality:" VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding DisplayResolutionLabel}" FontWeight="Bold" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
 
-            <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+            </StackPanel>
+        </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
 
-            <!-- Display Quality -->
-            <Button Classes="ModernButton" Margin="2" ClickMode="Press"
-                    Command="{Binding CycleDisplayResolutionCommand}"
-                    ToolTip.Tip="Cycle coverage display quality (High/Medium/Low). Lower = less memory, better performance on constrained devices.">
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="6">
-                    <TextBlock Text="Quality:" VerticalAlignment="Center"/>
-                    <TextBlock Text="{Binding DisplayResolutionLabel}" FontWeight="Bold" VerticalAlignment="Center"/>
-                </StackPanel>
-            </Button>
-        </StackPanel>
-    </Border>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml.cs
@@ -23,76 +23,13 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class ViewSettingsPanel : UserControl
 {
-    private bool _isDragging = false;
-    private Point _lastScreenPoint;
-
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public ViewSettingsPanel()
     {
         InitializeComponent();
-
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-            ToolTip.SetIsOpen(handle, false);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                ToolTip.SetIsOpen(handle, false);
-                DragStarted?.Invoke(this, null!);
-            }
-
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging)
-            {
-                DragEnded?.Invoke(this, e);
-            }
-
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
@@ -18,39 +18,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              xmlns:controls="using:AgValoniaGPS.Views.Controls"
-             mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Panels.XTEChartPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsXTEChartPanelVisible}"
              IsHitTestVisible="{Binding IsXTEChartPanelVisible}">
 
-    <UserControl.Styles>
-        <Style Selector="Border.FloatingPanel">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
-            <Setter Property="Padding" Value="4"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-        </Style>
-    </UserControl.Styles>
+  <controls:FloatingPanel x:Name="FP"
+                          Width="420"
+                          Title="{loc:Localize SteerChart}"
+                          CloseCommand="{Binding ToggleXTEChartPanelCommand}">
+    <controls:FloatingPanel.PanelContent>
+      <controls:ChartControl x:Name="XTEChart" Height="192"/>
+    </controls:FloatingPanel.PanelContent>
+  </controls:FloatingPanel>
 
-    <Border Classes="FloatingPanel" Width="420" Height="240">
-        <Grid RowDefinitions="24,*">
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="24"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="16" FontWeight="Bold"
-                           VerticalAlignment="Center" Margin="6,0,6,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="{loc:Localize CrossTrackError}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12" FontWeight="Bold"
-                           VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="20" Height="20" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Cursor="Hand"
-                        Command="{Binding ToggleXTEChartPanelCommand}" Margin="4,0,4,0"/>
-            </Grid>
-            <controls:ChartControl x:Name="XTEChart" Grid.Row="1"/>
-        </Grid>
-    </Border>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml.cs
@@ -25,26 +25,18 @@ namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class XTEChartPanel : UserControl
 {
-    private bool _isDragging;
-    private Point _lastScreenPoint;
     private bool _configured;
 
-    public event EventHandler<PointerPressedEventArgs>? DragStarted;
     public event EventHandler<Vector>? DragMoved;
-    public event EventHandler<PointerReleasedEventArgs>? DragEnded;
 
     public static IServiceProvider? ServiceProvider { get; set; }
 
     public XTEChartPanel()
     {
         InitializeComponent();
-        var dragHandle = this.FindControl<Grid>("DragHandle");
-        if (dragHandle != null)
-        {
-            dragHandle.PointerPressed += DragHandle_PointerPressed;
-            dragHandle.PointerMoved += DragHandle_PointerMoved;
-            dragHandle.PointerReleased += DragHandle_PointerReleased;
-        }
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
 
         PropertyChanged += (_, e) =>
         {
@@ -75,49 +67,5 @@ public partial class XTEChartPanel : UserControl
             autoScaleY: true);
 
         chart.AddSeries(chartData.CrossTrackError);
-    }
-
-    private void DragHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (sender is Grid handle)
-        {
-            var root = this.VisualRoot as Visual;
-            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            e.Pointer.Capture(handle);
-        }
-    }
-
-    private void DragHandle_PointerMoved(object? sender, PointerEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            var root = this.VisualRoot as Visual;
-            var currentPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
-            var distance = Math.Sqrt(Math.Pow(currentPoint.X - _lastScreenPoint.X, 2) +
-                                    Math.Pow(currentPoint.Y - _lastScreenPoint.Y, 2));
-            if (!_isDragging && distance > 5.0)
-            {
-                _isDragging = true;
-                DragStarted?.Invoke(this, null!);
-            }
-            if (_isDragging)
-            {
-                var delta = currentPoint - _lastScreenPoint;
-                DragMoved?.Invoke(this, delta);
-                _lastScreenPoint = currentPoint;
-            }
-            e.Handled = true;
-        }
-    }
-
-    private void DragHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
-    {
-        if (sender is Grid handle && e.Pointer.Captured == handle)
-        {
-            if (_isDragging) DragEnded?.Invoke(this, e);
-            _isDragging = false;
-            e.Pointer.Capture(null);
-            e.Handled = true;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `FloatingPanel.axaml/cs` — a reusable UserControl providing a shared title bar, drag handle, close button, 2-column `UniformGrid` for `MenuButton` items, and a `PanelContent` slot for custom content
- Convert 11 panels to use `FloatingPanel`: `BoundaryPlayerPanel`, `BoundaryRecordingPanel`, `ConfigurationPanel`, `FieldToolsPanel`, `FileMenuPanel`, `HeadingChartPanel`, `JobMenuPanel`, `SimulatorPanel`, `SteerChartPanel`, `ToolsPanel`, `ViewSettingsPanel`
- Remove ~830 lines of duplicated drag code, border styles, and title bar boilerplate across all converted panels

## What changed
Each converted panel previously had its own copy of: `Border.FloatingPanel` style, `Button.ModernButton` style, `DragHandle` Grid, 3 pointer event handlers (`PointerPressed`, `PointerMoved`, `PointerReleased`), and `_isDragging`/`_lastScreenPoint` fields. All of that now lives only in `FloatingPanel`. Each panel `.cs` file is reduced to just a `DragMoved` event forwarder.
