### PR TITLE
Manual U-turn: immediate arc at tractor position (#260)

### DIFF
--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -596,4 +596,102 @@ public partial class YouTurnCreationService
 
         return path;
     }
+
+    /// <summary>
+    /// Build an immediate U-turn path anchored at the tractor's current position — no
+    /// entry/exit straight legs, no headland traversal. Just a semicircle from the
+    /// tractor to the next parallel pass, executed the moment it's rendered (#260).
+    ///
+    /// The arc radius is fixed at <c>offset / 2</c> so the endpoint lands exactly on
+    /// the next parallel pass with reversed heading. The configured
+    /// <c>Guidance.UTurnRadius</c> is ignored because any larger radius would overshoot
+    /// the target pass and would need a connector leg to bridge the gap — which would
+    /// defeat the "no legs, immediate" requirement.
+    /// </summary>
+    public List<Vec3> CreateManualArcPath(
+        Position currentPosition,
+        double abHeading,
+        bool turnLeft,
+        Boundary? boundary,
+        GuidanceWorkingState guidance,
+        int uTurnSkipRows)
+    {
+        var path = new List<Vec3>();
+        var config = ConfigurationStore.Instance;
+
+        const double pointSpacing = 0.5;
+        double trackWidth = config.ActualToolWidth - config.Tool.Overlap;
+        double turnOffset = trackWidth * (uTurnSkipRows + 1);
+        if (turnOffset < 0.1)
+        {
+            _logger.LogWarning("[ManualYouTurn] Tool width is zero — cannot compute offset");
+            return path;
+        }
+
+        double turnRadius = turnOffset / 2.0;
+
+        // Travel direction as the tractor is currently heading along the AB line.
+        double travelHeading = abHeading;
+        if (!guidance.IsHeadingSameWay)
+        {
+            travelHeading += Math.PI;
+            if (travelHeading >= Math.PI * 2) travelHeading -= Math.PI * 2;
+        }
+
+        double arcStartE = currentPosition.Easting;
+        double arcStartN = currentPosition.Northing;
+
+        double perpAngle = turnLeft ? (travelHeading - Math.PI / 2) : (travelHeading + Math.PI / 2);
+
+        double arcCenterE = arcStartE + Math.Sin(perpAngle) * turnRadius;
+        double arcCenterN = arcStartN + Math.Cos(perpAngle) * turnRadius;
+
+        double arcEndE = arcStartE + Math.Sin(perpAngle) * (2 * turnRadius);
+        double arcEndN = arcStartN + Math.Cos(perpAngle) * (2 * turnRadius);
+
+        // Refuse to plot a turn whose endpoint lands outside the field.
+        if (boundary?.OuterBoundary != null && boundary.OuterBoundary.IsValid
+            && !boundary.OuterBoundary.IsPointInside(arcEndE, arcEndN))
+        {
+            _logger.LogDebug("[ManualYouTurn] Arc end ({E:F1},{N:F1}) outside boundary — refusing",
+                arcEndE, arcEndN);
+            return path;
+        }
+
+        double startAngle = Math.Atan2(arcStartE - arcCenterE, arcStartN - arcCenterN);
+        int arcPoints = Math.Max((int)(Math.PI * turnRadius / pointSpacing), 20);
+
+        // Include the start point so guidance has a valid t=0 sample at the tractor.
+        path.Add(new Vec3
+        {
+            Easting = arcStartE,
+            Northing = arcStartN,
+            Heading = travelHeading,
+        });
+
+        for (int i = 1; i <= arcPoints; i++)
+        {
+            double t = (double)i / arcPoints;
+            double sweepAngle = turnLeft ? (-Math.PI * t) : (Math.PI * t);
+            double currentAngle = startAngle + sweepAngle;
+
+            double tangentHeading = currentAngle + (turnLeft ? -Math.PI / 2 : Math.PI / 2);
+            if (tangentHeading < 0) tangentHeading += Math.PI * 2;
+            if (tangentHeading >= Math.PI * 2) tangentHeading -= Math.PI * 2;
+
+            path.Add(new Vec3
+            {
+                Easting = arcCenterE + Math.Sin(currentAngle) * turnRadius,
+                Northing = arcCenterN + Math.Cos(currentAngle) * turnRadius,
+                Heading = tangentHeading,
+            });
+        }
+
+        TurnPathSmoothing.Smooth(path, config.Guidance.UTurnSmoothing);
+
+        _logger.LogDebug("[ManualYouTurn] Arc path: {Count} points, radius={Rad:F1}m, offset={Off:F1}m, turnLeft={Left}",
+            path.Count, turnRadius, turnOffset, turnLeft);
+
+        return path;
+    }
 }

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
@@ -250,10 +250,21 @@ public sealed class YouTurnStateMachine
             return effects;
         }
 
-        if (turn.IsExecuting || turn.TurnPath != null)
+        if (turn.IsExecuting)
         {
+            // Refuse to swap paths while the guidance service is actively following
+            // one — doing so could whip the steering mid-arc.
             effects.StatusMessage = "U-turn already in progress";
             return effects;
+        }
+
+        // If an auto-trigger plotted a path but it hasn't engaged yet, discard it so
+        // the manual trigger's immediate arc takes over.
+        if (turn.TurnPath != null)
+        {
+            turn.TurnPath = null;
+            turn.IsTriggered = false;
+            effects.SyncTurnPathToMap = true;
         }
 
         var track = ctx.SelectedTrack;
@@ -289,10 +300,18 @@ public sealed class YouTurnStateMachine
         effects.SyncNextTrackToMap = true;
         effects.IsInYouTurnMapFlag = true;
 
-        CreatePathAndSync(in ctx, track, headingRadians, abHeading, guidance, turn, effects);
+        // Manual triggers skip the boundary-anchored Dubins pipeline used by auto turns.
+        // The arc starts at the tractor's current position so the turn begins the instant
+        // the path renders — no headland traversal, no entry/exit legs (#260).
+        var path = _creation.CreateManualArcPath(
+            ctx.CurrentPosition, abHeading, turnLeft,
+            ctx.Boundary, guidance, ctx.UTurnSkipRows);
 
-        if (turn.TurnPath != null && turn.TurnPath.Count > 2)
+        if (path.Count > 2)
         {
+            turn.TurnPath = path;
+            turn.YouTurnCounter = 0;
+            effects.SyncTurnPathToMap = true;
             // Manual turns trigger immediately — no proximity check against the turn start.
             turn.IsTriggered = true;
             turn.IsExecuting = true;
@@ -300,7 +319,7 @@ public sealed class YouTurnStateMachine
         }
         else
         {
-            effects.StatusMessage = "Failed to create U-turn path";
+            effects.StatusMessage = "Not enough room — turn would leave the field";
         }
 
         return effects;

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 36
+#define VERSION_PATCH 37
 
-#define VERSION "26.4.36"
+#define VERSION "26.4.37"
 #define VERSION_DATE "2026-04-22"


### PR DESCRIPTION
## Summary

Closes #260. Manual U-turn clicks now plot an immediate semicircle starting at the tractor's current position rather than routing through the boundary-anchored Dubins pipeline used by automatic headland turns. Previously, clicking manual L/R from mid-field would plot the arc at the headland — the tractor drove up to the headland before the turn started.

## What changed

- **New path generator** — `YouTurnCreationService.CreateManualArcPath` — a pure semicircle anchored at the tractor's current position, sized so the endpoint lands exactly on the next parallel pass. Radius is fixed at `offset / 2` where `offset = (skipRows + 1) * (toolWidth - overlap)`; the configured `Guidance.UTurnRadius` is intentionally ignored because any larger radius would overshoot the target pass and require a connector leg, defeating the "no legs, immediate" requirement.
- **Boundary safety** — if the arc endpoint lands outside the outer boundary, the path is rejected with "Not enough room — turn would leave the field" status.
- **`TriggerManual` rewired** — calls the new method directly instead of the shared `CreatePathAndSync`. Automatic proximity-triggered U-turns are unchanged. Both modes coexist.
- **In-progress guard split** — a manual click now supersedes an auto-plotted path that hasn't engaged yet. Mid-execution swaps are still refused (swapping `TurnPath` under the guidance service while the tractor is mid-arc could whip the steering).

Bumps patch version to 26.4.37.

## Test plan

Tested live on Desktop simulator across:

- [x] Manual L/R from straight driving — arc starts at tractor, lands on next pass, tractor executes immediately
- [x] Skip-rows > 0 — offset/radius scale correctly
- [x] Tractor near boundary — path rejected with "Not enough room" status
- [x] Auto-plotted path still pending → manual click — auto plot is discarded, manual arc takes over
- [x] Auto mid-turn → manual click — refused with "U-turn already in progress"
- [x] Sequential manual clicks — each produces its own immediate arc

🤖 Generated with [Claude Code](https://claude.com/claude-code)