### PR TITLE
Free-drive: guidance line follows a lookahead point (#261)

### DIFF
--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -30,6 +30,10 @@ namespace AgValoniaGPS.Services.Pipeline;
 /// </summary>
 public sealed class GpsPipelineService : IGpsPipelineService
 {
+    // Lookahead time (seconds) used for auto-track-select in free-drive mode.
+    // Matches AgOpen's setAS_guidanceLookAheadTime default. See #261.
+    private const double GuidanceLookAheadSeconds = 2.0;
+
     // ── Dependencies ────────────────────────────────────────────────────
     private readonly IGpsService _gpsService;
     private readonly IToolPositionService _toolPositionService;
@@ -589,8 +593,20 @@ public sealed class GpsPipelineService : IGpsPipelineService
             // through SyncGuidanceStateToPipeline — two writers fighting each
             // other and causing a per-cycle oscillation (see commit 57920e0).
             // One writer now — the cycle.
+            //
+            // #261: match AgOpen — project a *lookahead* point (pivot + heading * lookDist)
+            // onto the reference line instead of the raw pivot. Produces the "track jumps
+            // ahead of the tractor" behavior operators expect in free-drive.
+            double lookDist = Math.Max(
+                ConfigurationStore.Instance.ActualToolWidth * 0.5,
+                pos.Speed * GuidanceLookAheadSeconds);
+            double hRad = pos.Heading * Math.PI / 180.0;
+            double lookE = driftedEasting + Math.Sin(hRad) * lookDist;
+            double lookN = driftedNorthing + Math.Cos(hRad) * lookDist;
             var (nearestPass, nearestDisplayTrack) = UpdateDisplayTrack(
-                pos, track!, passNumber, nudgeOffset, driftedEasting, driftedNorthing);
+                pos, track!, passNumber, nudgeOffset,
+                driftedEasting, driftedNorthing,
+                lookE, lookN);
             if (nearestDisplayTrack != null)
             {
                 displayTrack = nearestDisplayTrack;
@@ -912,14 +928,23 @@ public sealed class GpsPipelineService : IGpsPipelineService
     /// </summary>
     private (int nearestPass, Models.Track.Track? displayTrack) UpdateDisplayTrack(
         Position pos, Models.Track.Track track, int passNumber, double nudgeOffset,
-        double driftedEasting, double driftedNorthing)
+        double pivotEasting, double pivotNorthing,
+        double sampleEasting, double sampleNorthing)
     {
         var config = ConfigurationStore.Instance;
         double widthMinusOverlap = config.ActualToolWidth - config.Tool.Overlap;
         if (widthMinusOverlap < 0.1) widthMinusOverlap = 1.0;
 
-        double perpDist = CalculatePerpendicularDistance(track, driftedEasting, driftedNorthing);
-        int nearestPass = (int)Math.Round(perpDist / widthMinusOverlap);
+        // Nearest-pass selection uses the *lookahead* sample (hysteresis: line jumps
+        // ahead of the tractor in free-drive). XTE display uses the *pivot* (actual
+        // cross-track error from the tractor position). See #261.
+        double sampleDist = CalculatePerpendicularDistance(track, sampleEasting, sampleNorthing);
+
+        // Match AgOpen CABLine.BuildCurrentABLineList — subtract the accumulated nudge
+        // before rounding to the nearest pass. Without this, nudging the line perpendicular
+        // can cause the auto-select to fight the nudge each cycle.
+        double refDist = (sampleDist - nudgeOffset) / widthMinusOverlap;
+        int nearestPass = refDist < 0 ? (int)(refDist - 0.5) : (int)(refDist + 0.5);
         double distAway = widthMinusOverlap * nearestPass + nudgeOffset;
 
         Models.Track.Track? resultTrack = null;
@@ -941,8 +966,9 @@ public sealed class GpsPipelineService : IGpsPipelineService
             };
         }
 
-        // Update XTE display
-        double xte = perpDist - (nearestPass * widthMinusOverlap);
+        // Update XTE display — actual pivot distance to the selected pass line.
+        double pivotPerp = CalculatePerpendicularDistance(track, pivotEasting, pivotNorthing);
+        double xte = pivotPerp - distAway;
         if (track.Points.Count >= 2)
         {
             var a = track.Points[0];

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 37
+#define VERSION_PATCH 38
 
-#define VERSION "26.4.37"
-#define VERSION_DATE "2026-04-22"
+#define VERSION "26.4.38"
+#define VERSION_DATE "2026-04-23"


### PR DESCRIPTION
## Summary

Closes #261. In free-drive (autosteer disengaged), the active pass line now jumps to whichever parallel offset is closest to a **lookahead point** projected ahead of the tractor rather than to the raw pivot. Matches AgOpen-original's `CABLine.BuildCurrentABLineList` behavior.

## Behavior

The lookahead point is computed as:

```
lookDist = max(toolWidth * 0.5, speed_m_s * 2.0)
lookPos  = pivot + heading * lookDist
```

At typical field speeds with a 16 m tool the lookahead sits 8–25 m ahead of the pivot, so driving across a pass causes the active line to snap to the neighboring offset well before the pivot crosses — the "track jumps ahead" behavior operators expect.

Autosteer-on behavior is unchanged: the line remains locked to whatever pass was active when the operator engaged.

## Also fixes

A pre-existing bug in `UpdateDisplayTrack`: nearest-pass rounding now subtracts the accumulated `NudgeOffset` before rounding, so nudges aren't washed out by the auto-select each cycle. AgOpen's implementation does the same correction. Without this, a user who nudged the line 2 m to the left could have auto-select "snap back" on the next tick.

XTE display continues to use the actual pivot distance (not the lookahead), so cross-track readout reflects the operator's real deviation.

Bumps patch version to 26.4.38.

## Test plan

Tested live on Desktop simulator:

- [x] Drive across AB line perpendicular, autosteer off — active line jumps ahead as expected
- [x] Drive backward across line — symmetric snap rearward
- [x] Engage autosteer — line locks to current pass, stops tracking
- [x] Disengage autosteer — resumes tracking
- [x] Nudge the line, then drive — nudge sticks, not washed out
- [x] Varying speeds — higher speed → lookahead farther → line jumps sooner

🤖 Generated with [Claude Code](https://claude.com/claude-code)