### PR TITLE
Bump Avalonia 12.0.0 → 12.0.1 to resolve Tmds.DBus.Protocol CVE (#287)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/AgValoniaGPS.Android.csproj
+++ b/Platforms/AgValoniaGPS.Android/AgValoniaGPS.Android.csproj
@@ -19,9 +19,9 @@
 
   <!-- Avalonia packages -->
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Android" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Android" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />

--- a/Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
+++ b/Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj
@@ -38,11 +38,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
     <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>

--- a/Platforms/AgValoniaGPS.iOS/AgValoniaGPS.iOS.csproj
+++ b/Platforms/AgValoniaGPS.iOS/AgValoniaGPS.iOS.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0" />
-    <PackageReference Include="Avalonia.iOS" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.iOS" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />

--- a/Shared/AgValoniaGPS.ViewModels/AgValoniaGPS.ViewModels.csproj
+++ b/Shared/AgValoniaGPS.ViewModels/AgValoniaGPS.ViewModels.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>

--- a/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
+++ b/Shared/AgValoniaGPS.Views/AgValoniaGPS.Views.csproj
@@ -14,8 +14,8 @@
 
   <!-- Avalonia is needed for avares:// resource compilation -->
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Skia" Version="12.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Skia" Version="12.0.1" />
     <PackageReference Include="Mapsui" Version="5.0.2" />
     <PackageReference Include="Mapsui.Rendering.Skia" Version="5.0.2" />
     <PackageReference Include="Mapsui.Tiling" Version="5.0.2" />

--- a/Simulators/AgValoniaGPS.VehicleSimulator/AgValoniaGPS.VehicleSimulator.csproj
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/AgValoniaGPS.VehicleSimulator.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/AgValoniaGPS.IntegrationTests/AgValoniaGPS.IntegrationTests.csproj
+++ b/Tests/AgValoniaGPS.IntegrationTests/AgValoniaGPS.IntegrationTests.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Skia" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Headless" Version="12.0.0" />
+    <PackageReference Include="Avalonia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Skia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Headless" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />

--- a/Tests/AgValoniaGPS.UI.Tests/AgValoniaGPS.UI.Tests.csproj
+++ b/Tests/AgValoniaGPS.UI.Tests/AgValoniaGPS.UI.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless.NUnit" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Skia" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Headless.NUnit" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Skia" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 39
+#define VERSION_PATCH 40
 
-#define VERSION "26.4.39"
+#define VERSION "26.4.40"
 #define VERSION_DATE "2026-04-23"


### PR DESCRIPTION
## Summary

Closes #287. Bumps every `Avalonia.*` package reference from `12.0.0` to `12.0.1`. This pulls in `Tmds.DBus.Protocol 0.92.0` transitively via `Avalonia.FreeDesktop 12.0.1`, resolving **CVE-2026-39959** (GHSA-xrw6-gwf8-vvr9), which CI has been flagging on every build as `NU1903`.

Per the vendor nuspec at `Avalonia.FreeDesktop 12.0.1` — it declares `Tmds.DBus.Protocol 0.92.0` as its dependency. No explicit transitive override is needed.

## Changes

- All `Avalonia.*` package references in the 8 affected `.csproj` files bumped from `12.0.0` to `12.0.1`.
- **Exception:** `Avalonia.Controls.DataGrid` stays at `12.0.0` — 12.0.1 was not released for that package (verified against NuGet). Patch-level mixing within a minor is ABI-safe.
- Bumps app patch version to `26.4.40`.

## Verification

```
$ dotnet restore AgValoniaGPS.sln
All projects are up-to-date for restore.

$ dotnet list AgValoniaGPS.sln package --vulnerable --include-transitive
The given project `AgValoniaGPS.Models` has no vulnerable packages given the current sources.
The given project `AgValoniaGPS.Services` has no vulnerable packages given the current sources.
... (every project) ...
The given project `AgValoniaGPS.UI.Tests` has no vulnerable packages given the current sources.

$ dotnet build AgValoniaGPS.sln | grep NU1903
(empty)

$ dotnet build AgValoniaGPS.sln
Build succeeded.
    258 Warning(s)   # all pre-existing, no new ones
    0 Error(s)
```

Smoke-launched Desktop app on macOS — steady 60 FPS, no exceptions, behavior unchanged.

## Test plan

- [x] Clean restore
- [x] `--vulnerable --include-transitive` reports zero across all projects
- [x] Solution builds with 0 errors and 0 NU1903 warnings
- [x] Desktop smoke launch (macOS) — app runs, renders at 60 FPS
- [ ] CI builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)