### PR TITLE
U-turn geometry + coverage-load fixes (#289)

### DIFF
--- a/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
@@ -1518,6 +1518,17 @@ public class CoverageMapService : ICoverageMapService
             SetPixelBufferCallback(pixels);
 
             Console.WriteLine($"[Coverage] Loaded section display: {nonZeroPixels:N0} covered pixels{(needsScaling ? " (scaled)" : "")}");
+
+            // If the display file decoded to an empty canvas (no covered pixels) but the
+            // caller also has detection bits to draw from, return false so LoadFromFile's
+            // CoverageUpdated event reports PixelsAlreadyLoaded=false and the UI rebuilds
+            // the display from detection bits. Otherwise a truncated / stale / header-only
+            // disp file silently wins over valid detection data and the field opens blank.
+            if (nonZeroPixels == 0)
+            {
+                Console.WriteLine("[Coverage] Section display is empty — treating as no-display so detection bits can rebuild the map");
+                return false;
+            }
             return true;
         }
         catch (Exception ex)

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -88,8 +88,20 @@ public partial class YouTurnCreationService
         {
             var path = output.TurnPath;
 
-            // Spiral / pretzel guard: a clean U-turn is ~180°; anything over ~270° means
-            // the Dubins / Omega algorithm wrapped, so drop to the simple fallback.
+            // Spiral / pretzel guard. The original check summed |ΔHeading| per step and
+            // rejected anything > 1.5π (270°) — but a legit Dubins RLR/LRL arc-arc-arc
+            // solution can accumulate 300°+ of absolute turning while ending at the correct
+            // 180° reversal. That false-rejected valid paths (#289 F2) and dropped the run
+            // to the less-optimal simple fallback.
+            //
+            // New guard:
+            //   - Primary check: start-to-end heading delta should be ~π (180°) for a U-turn.
+            //   - Secondary safety: cumulative |ΔHeading| capped at 4π (720°) to still catch
+            //     actual infinite-loop spirals, without rejecting loopy-but-valid paths.
+            double netHeadingChange = path[^1].Heading - path[0].Heading;
+            while (netHeadingChange > Math.PI) netHeadingChange -= 2 * Math.PI;
+            while (netHeadingChange < -Math.PI) netHeadingChange += 2 * Math.PI;
+
             double totalHeadingChange = 0;
             for (int i = 1; i < path.Count; i++)
             {
@@ -99,17 +111,22 @@ public partial class YouTurnCreationService
                 totalHeadingChange += Math.Abs(delta);
             }
 
-            if (totalHeadingChange > Math.PI * 1.5)
+            // ~π expected for U-turn; tolerate ±30° slack to account for approach angle.
+            bool netIsUTurnLike = Math.Abs(Math.Abs(netHeadingChange) - Math.PI) < Math.PI / 6.0;
+            bool cumulativeRunaway = totalHeadingChange > Math.PI * 4.0;
+
+            if (!netIsUTurnLike || cumulativeRunaway)
             {
-                _logger.LogWarning("[YouTurn] Service path has excessive heading change ({Deg:F0}°) - using simple fallback",
-                    totalHeadingChange * 180 / Math.PI);
+                _logger.LogWarning("[YouTurn] Service path rejected: net={Net:F0}° cumulative={Cum:F0}° - using simple fallback",
+                    netHeadingChange * 180 / Math.PI, totalHeadingChange * 180 / Math.PI);
                 var fallback = SimpleFallback(currentPosition, abHeading, turnLeft, boundary,
                     guidance, turn, uTurnSkipRows, headlandDistance);
                 return new TurnPathResult(fallback.Count > 10 ? fallback : null, UsedFallback: true);
             }
 
             TurnPathSmoothing.Smooth(path, config.Guidance.UTurnSmoothing);
-            _logger.LogDebug("[YouTurn] Path created with {Count} points", path.Count);
+            _logger.LogDebug("[YouTurn] Path created with {Count} points, net={Net:F0}° cumulative={Cum:F0}°",
+                path.Count, netHeadingChange * 180 / Math.PI, totalHeadingChange * 180 / Math.PI);
             return new TurnPathResult(path, UsedFallback: false);
         }
 
@@ -490,11 +507,34 @@ public partial class YouTurnCreationService
         double headlandBoundaryNorthing = currentPosition.Northing + Math.Cos(travelHeading) * distToHeadland;
 
         double distanceFromBoundary = config.Guidance.UTurnDistanceFromBoundary;
-        double headlandLegLength = headlandDistance - turnRadius - distanceFromBoundary;
+
+        // #289 F4: Compute the actual distance from the headland crossing to the outer
+        // boundary along the travel heading, instead of assuming headlandDistance (the
+        // scalar headland-zone width). On non-rectangular fields the available forward
+        // room varies along the headland — near a corner it's tighter than the zone
+        // width, along a long straight edge it's closer to the zone width. The previous
+        // formula `headlandLegLength = headlandDistance - turnRadius - distanceFromBoundary`
+        // produced a tight arc when used as a fallback for a turn that the Dubins service
+        // would have placed deeper. Using the actual ray distance makes the fallback's
+        // apex placement match the service's intent regardless of field shape.
+        double rayToOuter = double.MaxValue;
+        if (boundary?.OuterBoundary != null && boundary.OuterBoundary.IsValid)
+        {
+            rayToOuter = RaycastDistanceToPolygon(
+                headlandBoundaryEasting, headlandBoundaryNorthing,
+                travelHeading, boundary.OuterBoundary.Points);
+        }
+        double availableHeadlandSpan = rayToOuter < double.MaxValue
+            ? rayToOuter
+            : headlandDistance; // fallback to legacy scalar when raycast fails
+
+        double headlandLegLength = availableHeadlandSpan - turnRadius - distanceFromBoundary;
+        if (headlandLegLength < 0) headlandLegLength = 0;
         double fieldLegLength = config.Guidance.UTurnExtension;
 
         _logger.LogDebug("[YouTurn] Simple path: turnOffset={Off:F1}m, turnRadius={Rad:F1}m", turnOffset, turnRadius);
-        _logger.LogDebug("[YouTurn] HeadlandDistance={HD:F1}m, headlandLegLength={HLL:F1}m", headlandDistance, headlandLegLength);
+        _logger.LogDebug("[YouTurn] headlandDist(scalar)={HD:F1}m rayToOuter={RO:F1}m, headlandLegLength={HLL:F1}m",
+            headlandDistance, rayToOuter, headlandLegLength);
 
         double entryStartE = headlandBoundaryEasting - Math.Sin(travelHeading) * fieldLegLength;
         double entryStartN = headlandBoundaryNorthing - Math.Cos(travelHeading) * fieldLegLength;
@@ -693,5 +733,44 @@ public partial class YouTurnCreationService
             path.Count, turnRadius, turnOffset, turnLeft);
 
         return path;
+    }
+
+    /// <summary>
+    /// Distance from (startE, startN) along direction `heading` to the first intersection
+    /// with a closed polygon. Returns double.MaxValue if the ray never hits. Used by
+    /// SimpleFallback to measure the actual forward distance from the headland crossing to
+    /// the outer boundary on non-rectangular fields (#289 F4).
+    /// </summary>
+    private static double RaycastDistanceToPolygon(
+        double startE, double startN, double heading, IReadOnlyList<BoundaryPoint> polygon)
+    {
+        if (polygon.Count < 3) return double.MaxValue;
+
+        double dirE = Math.Sin(heading);
+        double dirN = Math.Cos(heading);
+        double minDist = double.MaxValue;
+        int n = polygon.Count;
+
+        for (int i = 0; i < n; i++)
+        {
+            var p1 = polygon[i];
+            var p2 = polygon[(i + 1) % n];
+
+            double edgeE = p2.Easting - p1.Easting;
+            double edgeN = p2.Northing - p1.Northing;
+            double toP1E = p1.Easting - startE;
+            double toP1N = p1.Northing - startN;
+
+            double cross = dirE * edgeN - dirN * edgeE;
+            if (Math.Abs(cross) < 1e-10) continue;
+
+            double t = (toP1E * edgeN - toP1N * edgeE) / cross;
+            double u = (toP1E * dirN - toP1N * dirE) / cross;
+
+            if (t > 0 && u >= 0 && u <= 1 && t < minDist)
+                minDist = t;
+        }
+
+        return minDist;
     }
 }

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnPathingService.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnPathingService.cs
@@ -122,9 +122,18 @@ public sealed class YouTurnPathingService
     }
 
     /// <summary>
-    /// True if the midpoint of the next pass (as determined by the normal turn rule — turnLeft XOR
-    /// sameWay — with no skip-worked adjustment) lies inside the cultivated area.
+    /// True if *any portion* of the next pass line (as determined by the normal turn rule —
+    /// turnLeft XOR sameWay — with no skip-worked adjustment) crosses the cultivated area.
     /// </summary>
+    /// <remarks>
+    /// Fixes #289 F1. The previous implementation tested only the midpoint of the AB segment
+    /// offset perpendicular — for non-rectangular fields the AB midpoint is not the center of
+    /// every offset pass's usable span, so a midpoint can fall outside the polygon even when
+    /// the offset line still crosses the field somewhere along its 2000 m rendered extent.
+    /// That false-negative stopped U-turns early, leaving unworked strips on the far side of
+    /// non-rectangular fields. New implementation walks the full offset line at fixed spacing
+    /// and returns true if any sample lies inside the cultivated area.
+    /// </remarks>
     public bool WouldNextLineBeInsideBoundary(
         Models.Track.Track currentTrack,
         double abHeading,
@@ -150,13 +159,46 @@ public sealed class YouTurnPathingService
         var pointB = currentTrack.Points[currentTrack.Points.Count - 1];
         double perpAngle = abHeading + Math.PI / 2;
 
+        // Sample the offset pass line along the AB direction across the full rendered extent
+        // (pass lines are drawn 2000 m beyond A and B in each direction — see
+        // DrawingContextMapControl.DrawSingleTrack). Spacing 5 m gives ~800 samples across a
+        // 4 km line — trivial cost, and won't miss a field whose narrowest usable span is > 5 m.
+        const double SampleSpacing = 5.0;
+        const double LineExtent = 2000.0;
+        double abDx = pointB.Easting - pointA.Easting;
+        double abDy = pointB.Northing - pointA.Northing;
+        double abLen = Math.Sqrt(abDx * abDx + abDy * abDy);
+        if (abLen < 0.01) return IsPointInsideCultivatedArea(
+            (pointA.Easting + pointB.Easting) / 2 + Math.Sin(perpAngle) * nextDistAway,
+            (pointA.Northing + pointB.Northing) / 2 + Math.Cos(perpAngle) * nextDistAway,
+            boundary, headlandLine);
+
+        double abNx = abDx / abLen;
+        double abNy = abDy / abLen;
+
         double midEasting = (pointA.Easting + pointB.Easting) / 2 + Math.Sin(perpAngle) * nextDistAway;
         double midNorthing = (pointA.Northing + pointB.Northing) / 2 + Math.Cos(perpAngle) * nextDistAway;
 
-        bool inside = IsPointInsideCultivatedArea(midEasting, midNorthing, boundary, headlandLine);
-        _logger.LogDebug("[NextTrack] currentPath={Cur}, nextPath={Next}, midpoint=({E:F1},{N:F1}) insideCultivated={Inside}",
-            guidance.HowManyPathsAway, nextPathsAway, midEasting, midNorthing, inside);
-        return inside;
+        double totalLength = abLen + 2 * LineExtent;
+        int sampleCount = (int)(totalLength / SampleSpacing);
+        double startOffset = -(totalLength / 2.0);
+
+        for (int i = 0; i <= sampleCount; i++)
+        {
+            double t = startOffset + i * SampleSpacing;
+            double e = midEasting + abNx * t;
+            double n = midNorthing + abNy * t;
+            if (IsPointInsideCultivatedArea(e, n, boundary, headlandLine))
+            {
+                _logger.LogDebug("[NextTrack] currentPath={Cur}, nextPath={Next}, sample at t={T:F0}m hit cultivated area",
+                    guidance.HowManyPathsAway, nextPathsAway, t);
+                return true;
+            }
+        }
+
+        _logger.LogDebug("[NextTrack] currentPath={Cur}, nextPath={Next}, no sample along {N} samples of offset line hit cultivated area",
+            guidance.HowManyPathsAway, nextPathsAway, sampleCount + 1);
+        return false;
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3602,12 +3602,13 @@ public partial class MainViewModel : ObservableObject
         }
         else
         {
-            State.Field.HeadlandLine = null;
-            _currentHeadlandLine = null;
-            _mapService.SetHeadlandLine(null);
-            HasHeadland = false;
-            IsHeadlandOn = false;
-            _logger.LogDebug($"[Headland] No valid HeadlandPolygon - YouTurn headland detection disabled");
+            // Boundary didn't carry a HeadlandPolygon (field.geojson has no headland role).
+            // DO NOT clobber State.Field.HeadlandLine here — the legacy Headlines.txt
+            // loader (LoadHeadland) runs separately on field open and is the authoritative
+            // source for the legacy-format case. Nulling it here races with that loader
+            // and silently disables U-turn headland detection (#289 F3). Field close and
+            // explicit headland removal handle the reset case elsewhere.
+            _logger.LogDebug($"[Headland] Boundary has no HeadlandPolygon — deferring to LoadHeadland / existing state");
         }
 
         // Sync boundary + headland to pipeline for guidance computations

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 39
+#define VERSION_PATCH 41
 
-#define VERSION "26.4.39"
+#define VERSION "26.4.41"
 #define VERSION_DATE "2026-04-23"


### PR DESCRIPTION
## Summary

Closes #289. Five related fixes in the U-turn / coverage pipeline that together eliminate unworked strips, inconsistent turn geometry, and coverage-not-rendering on reload.

## What changed

### F3 — Don't clobber headland state in `SetCurrentBoundary`
When a field's geojson lacks a `headland` role, `SetCurrentBoundary` was nulling `State.Field.HeadlandLine` unconditionally — silently undoing the legacy `Headlines.txt` loader's work from the previous tick. Removed the null-out; `LoadHeadland` and field-close are the authoritative sources for headland state.

### F2 — Smarter Dubins spiral guard
Previous guard summed `|ΔHeading|` per step and rejected paths over 270°, which also rejected valid RLR/LRL arc-arc-arc solutions that accumulate 300°+ of absolute turning while ending at the correct ±180° reversal. New guard checks net start-to-end heading (expect `±π ± π/6` slack) and keeps a 4π runaway safety. On the repro field the 304° and 345° turns now pass — zero fallback invocations this run.

### F1 — Line-sample `WouldNextLineBeInsideBoundary`
Midpoint-of-AB-offset-perpendicular test falsely rejected valid passes on non-rectangular fields where the midpoint projection fell outside the polygon even though the pass line crossed the field somewhere along its 2000 m rendered extent. Replaced with a walk of the full offset line at 5 m spacing; returns true if any sample lies inside the cultivated area. The previously-unworked NW-corner strip now gets turns.

### F4 — Raycast outer-boundary distance in `SimpleFallback`
Fallback was using the scalar headland-zone width to compute `headlandLegLength`, which on non-rectangular fields underestimates the real forward room near long edges and overestimates near corners. Added `RaycastDistanceToPolygon` helper and use the actual travel-direction distance to the outer boundary, so the fallback arc's apex placement matches the Dubins service's intent regardless of field shape. Falls back to the scalar when the raycast misses (degenerate geometry).

### Coverage display empty-file handling
`LoadSectionDisplay` returned true even when the decoded display was entirely zero pixels, causing `CoverageUpdated` to report `PixelsAlreadyLoaded=true` and the UI to skip the rebuild-from-detection-bits path. Result: a field with 180k+ covered cells in detection would open blank if the display file was stale or truncated. Now returns false on zero non-zero pixels so detection bits rebuild the display.

Bumps patch version to 26.4.41 (26.4.40 reserved for PR #288).

## Test plan

Tested live on Desktop simulator with a non-rectangular (diamond-shaped) field:

- [x] Previously-rejected path -4 (NW corner) now has `nextLineInside=True` with `sample at t=XXm hit cultivated area`
- [x] Turn sequence progresses 0 → -1 → -2 → -3 → -4 without early-termination
- [x] Zero `simple fallback` invocations — all turns accepted by new spiral guard (`net=±180° cumulative=304°` and `345°` now pass)
- [x] `deferring to LoadHeadland` message replaces the old `disabled` message; headland stays populated
- [x] Field with 180k+ existing detection-bit cells renders coverage on reload (was blank before)
- [x] Full build + no regressions in other paths (`dotnet build AgValoniaGPS.sln` — 0 errors)

## Out of scope (followup)

Save-on-exit: `CloseFieldAsync` isn't invoked when the app closes without an explicit field-close, so coverage painted during a session is lost on abrupt exit. Filing separately — it's an app-lifecycle fix, not a U-turn/coverage algorithm fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)