### PR TITLE
Save active field on app exit (#291)

### DIFF
--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -302,16 +302,19 @@ public partial class MainWindow : Window
         // Panel positions are now anchored (no saved positions needed)
     }
 
+    // Set to true while we're re-entering Closing after programmatically calling Close()
+    // at the end of SaveAndCloseAsync. The flag lets that second close proceed without
+    // re-firing the save path.
+    private bool _closeSaveInProgress;
+
     private void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
         if (App.Services == null) return;
 
-        // Save all settings to ConfigurationStore.Display (which then syncs to AppSettings)
+        // Window geometry + UI toggles — capture synchronously on every close attempt.
+        // Cheap and small, never a good reason to skip.
         var display = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Display;
-
-        // Save window state
         display.WindowMaximized = WindowState == WindowState.Maximized;
-
         if (WindowState == WindowState.Normal)
         {
             display.WindowWidth = Width;
@@ -319,32 +322,60 @@ public partial class MainWindow : Window
             display.WindowX = Position.X;
             display.WindowY = Position.Y;
         }
-
-        // Save UI state to ConfigurationStore
         if (ViewModel != null)
-        {
             display.GridVisible = ViewModel.IsGridOn;
+
+        // Second-pass close triggered by SaveAndCloseAsync → let it through.
+        if (_closeSaveInProgress)
+            return;
+
+        // If a field is open, we need to run CloseFieldAsync (saves boundary / tracks /
+        // headland / tram / elevation / coverage) before actually exiting. The old path
+        // only saved coverage via fire-and-forget Task.Run, which (a) missed the rest and
+        // (b) raced the process exit — users who closed without explicit File → Close Field
+        // lost session work (#291).
+        //
+        // Closing is a synchronous event, so we cancel it, run the async save, then call
+        // Close() a second time; the _closeSaveInProgress flag tells this handler to let
+        // the second close proceed.
+        if (ViewModel?.HasActiveField == true)
+        {
+            e.Cancel = true;
+            _closeSaveInProgress = true;
+            _ = SaveAndCloseAsync();
+            return;
         }
 
-        // Save on background thread — don't block the window close
-        var configService = App.Services.GetRequiredService<IConfigurationService>();
-        var fieldService = App.Services.GetRequiredService<IFieldService>();
-        var coverageService = App.Services.GetRequiredService<ICoverageMapService>();
-        var fieldPath = fieldService.ActiveField?.DirectoryPath;
-
-        Task.Run(() =>
+        // No field open — just persist AppSettings (cheap, synchronous).
+        try
         {
-            try
-            {
-                configService.SaveAppSettings();
-                if (!string.IsNullOrEmpty(fieldPath))
-                    coverageService.SaveToFile(fieldPath);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"[Save] Error saving on close: {ex.Message}");
-            }
-        });
+            App.Services.GetRequiredService<IConfigurationService>().SaveAppSettings();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[Save] Error saving settings on close: {ex.Message}");
+        }
+    }
+
+    private async Task SaveAndCloseAsync()
+    {
+        try
+        {
+            if (App.Services != null)
+                App.Services.GetRequiredService<IConfigurationService>().SaveAppSettings();
+
+            if (ViewModel != null)
+                await ViewModel.CloseFieldAsync();
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[Save] Error during SaveAndCloseAsync: {ex.Message}");
+        }
+        finally
+        {
+            // Re-initiate the close; _closeSaveInProgress lets it through.
+            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => Close());
+        }
     }
 
     private void MainWindow_KeyDown(object? sender, KeyEventArgs e)

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 41
+#define VERSION_PATCH 42
 
-#define VERSION "26.4.41"
+#define VERSION "26.4.42"
 #define VERSION_DATE "2026-04-23"


### PR DESCRIPTION
## Summary

Closes #291. Closing the app without first invoking **File → Close Field** was losing session work — coverage, boundary edits, recorded tracks, tram lines, elevation samples all vanished.

## Root cause

`MainWindow_Closing` had two overlapping problems:

1. **Incomplete save.** It only persisted `AppSettings` and coverage directly. `CloseFieldAsync` is what actually saves boundary, tracks, headland, tram lines, elevation, coverage — and nothing was invoking it on a plain window close.
2. **Race condition.** Even the partial save was fire-and-forget `Task.Run(...)` with no await, so the window could close and the process exit before the save committed to disk.

## Fix

Rewired `MainWindow_Closing` to:

- Always capture window geometry + UI toggles synchronously (cheap, no reason to skip).
- If a field is open, **cancel the close**, **await `CloseFieldAsync`** on a new `SaveAndCloseAsync` task, then **programmatically `Close()` again**. A re-entrancy flag lets the second close proceed without re-firing the save path.
- If no field is open, save `AppSettings` inline and let the close proceed normally.

The existing `"Saving field..."` busy overlay inside `CloseFieldAsync` provides visual feedback during save — operator sees progress rather than a frozen window.

## Test plan

Verified on Desktop (macOS):

- [x] Open field, paint coverage (drive 2+ passes), close via window-X (not File → Close). Log shows full `CloseFieldAsync` sequence before exit.
- [x] Reopen the field — coverage renders. Both `coverage_detect.bin` and `coverage_disp.bin` populated (display was previously 472 bytes / empty).
- [x] Close with no field open — AppSettings saved synchronously, app exits without errors.
- [x] No regressions in File → Close Field explicit flow.

## Out of scope

- iOS `AppDelegate.ApplicationWillTerminate` and Android `Activity.OnPause/OnDestroy` wiring. Same field-save intent, platform-specific plumbing. Separate followup.
- AgOpen-parity "files being closed" progress dialog — nice-to-have; current `"Saving field..."` busy overlay is sufficient for now.

Bumps patch version to 26.4.42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)