### PR TITLE
Fix roll correction: wire IMU data through GpsData to pipeline

### DIFF
--- a/Shared/AgValoniaGPS.Models/GpsData.cs
+++ b/Shared/AgValoniaGPS.Models/GpsData.cs
@@ -45,6 +45,15 @@ public class GpsData
     /// </summary>
     public double DifferentialAge { get; set; }
 
+    /// <summary>IMU roll angle in degrees (from $PANDA field 13)</summary>
+    public double ImuRoll { get; set; }
+
+    /// <summary>IMU pitch angle in degrees (from $PANDA field 14)</summary>
+    public double ImuPitch { get; set; }
+
+    /// <summary>IMU yaw rate in degrees/second (from $PANDA field 15)</summary>
+    public double ImuYawRate { get; set; }
+
     /// <summary>
     /// Timestamp when data was received
     /// </summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -395,6 +395,9 @@ public class AutoSteerService : IAutoSteerService
             SatellitesInUse = _state.Satellites,
             Hdop = _state.Hdop,
             DifferentialAge = _state.DifferentialAge,
+            ImuRoll = _state.Roll,
+            ImuPitch = _state.Pitch,
+            ImuYawRate = _state.YawRate,
             Timestamp = DateTime.UtcNow,
         };
         _gpsService.UpdateGpsData(gpsData);

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -446,8 +446,9 @@ public sealed class GpsPipelineService : IGpsPipelineService
                 posNorthing -= Math.Cos(perpHeading) * vehicle.AntennaOffset;
             }
 
-            // Roll correction
-            double imuRoll = SensorState.Instance.ImuRoll;
+            // Roll correction (read from GpsData, not SensorState — Phase B
+            // removed NmeaParserService which was the only SensorState writer)
+            double imuRoll = data.ImuRoll;
             if (Math.Abs(imuRoll) > 0.01 && Math.Abs(vehicle.AntennaHeight) > 0.01)
             {
                 double rollRad = imuRoll * Math.PI / 180.0;
@@ -740,7 +741,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
             Northing = driftedNorthing,
             Heading = pos.Heading,
             Speed = pos.Speed,
-            RollDegrees = SensorState.Instance.ImuRoll,
+            RollDegrees = data.ImuRoll,
             SatelliteCount = data.SatellitesInUse,
             FixQuality = data.FixQuality,
             GpsValid = data.IsValid,

--- a/Tests/AgValoniaGPS.Services.Tests/TractorPathTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/TractorPathTests.cs
@@ -151,7 +151,7 @@ public class TractorPathTests
     }
 
     private static byte[] BuildPandaBytes(double lat, double lon,
-        double heading, double speedKnots)
+        double heading, double speedKnots, double roll = 0)
     {
         using var listener = new UdpClient(0);
         int port = ((IPEndPoint)listener.Client.LocalEndPoint!).Port;
@@ -162,6 +162,7 @@ public class TractorPathTests
         gps.Longitude = lon;
         gps.HeadingDegrees = heading;
         gps.SpeedKnots = speedKnots;
+        gps.RollDegrees = roll;
         gps.FixQuality = 4;
         gps.Satellites = 12;
         gps.Hdop = 0.7;
@@ -459,7 +460,8 @@ public class TractorPathTests
         for (int i = 0; i < steps; i++)
         {
             model.Step(0.1);
-            var bytes = BuildPandaBytes(model.Lat, model.Lon, model.HeadingDeg, 10 / 1.852);
+            var bytes = BuildPandaBytes(model.Lat, model.Lon, model.HeadingDeg, 10 / 1.852,
+                roll: SensorState.Instance.ImuRoll);
             _autoSteer.ProcessGpsBuffer(bytes, bytes.Length);
             System.Threading.Thread.Sleep(5);
         }


### PR DESCRIPTION
## Summary
- Phase B removed NmeaParserService which was the only writer of SensorState.Instance.ImuRoll
- Pipeline read roll from SensorState (always 0), so roll correction was silently no-op
- Add ImuRoll/ImuPitch/ImuYawRate to GpsData, wire through PublishGpsData
- Pipeline reads data.ImuRoll instead of SensorState.Instance.ImuRoll
- Also fixes RollDegrees in GpsCycleResult (was always 0)

## Test plan
- [ ] Existing Roll10Deg_ShiftsLaterally_ViaPipeline confirms -0.521m shift
- [ ] Run simulator with roll != 0, verify tractor position shifts laterally
- [ ] `dotnet test Tests/AgValoniaGPS.Services.Tests/` (427 pass)