### PR TITLE
Fix IMU heading wiring: route through GpsData, fix PANDA scaling

### DIFF
--- a/Plans/IMU_HEADING_WIRING_PLAN.md
+++ b/Plans/IMU_HEADING_WIRING_PLAN.md
@@ -1,0 +1,103 @@
+# IMU Heading Wiring Fix
+
+Branch: `fix/imu-heading-wiring`
+
+## Problem
+
+The IMU/GPS heading-fusion slider in `GpsSubTab.axaml` is user-visible and persists `Connections.HeadingFusionWeight`, but the runtime fusion is unreachable. Investigation also surfaced a separate parser bug for PANDA-format heading.
+
+Three concrete defects:
+
+1. **PANDA heading is parsed at 10× the real value.** The AiO firmware (`AiO_New_Dawn/lib/aio_navigation/NAVProcessor.cpp:157`) emits PANDA field 12 as `(int)(heading * 10.0)` — e.g. 90.5° → `"905"`. AgOpenGPS divides by 0.1 on receive (`UDPComm.Designer.cs:137`). `NmeaParserServiceFast.ParsePandaFieldsIntoState` parses field 12 as a raw double with no scaling, so `_state.Heading = 905.0` for a real heading of 90.5°. PAOGI sends field 12 as a float without scaling, so PAOGI is correct.
+
+2. **No "no IMU" sentinel detection.** AiO sends the literal string `"65535"` in PANDA field 12 when no IMU is present. AgValoniaGPS parses that as `_state.Heading = 65535.0`.
+
+3. **The fusion slider does nothing.** `GpsHeadingFusionService.FuseHeading` gates the IMU blend on `SensorState.Instance.HasValidImu`, which compares `ImuHeading != 99999`. Nothing in production code writes `SensorState.Instance.ImuHeading` (verified across all branches via `git log -S`). So `HasValidImu` is always false and the blend never runs.
+
+The 10× heading bug is masked at speed because `FuseHeading` overrides the value with fix-to-fix above `MinGpsStep`. It only manifests at low speed / standstill — exactly when IMU heading would matter.
+
+None of these are Phase B regressions: the deleted `NmeaParserService` had the same no-scaling, no-sentinel parse, and `SensorState.ImuHeading` has never had a production writer.
+
+## Wire-format reference
+
+From `Firmware_Teensy_AiO_26/lib/aio_navigation/NAVProcessor.cpp`, `IMUProcessor.cpp`, and AgOpenGPS `UDPComm.Designer.cs:133-160`:
+
+| Field | PANDA emits | PAOGI emits | Receive convention |
+|---|---|---|---|
+| 12 (heading) | `(int)(heading*10)`, sentinel `"65535"` | `dualHeading` float, 1 decimal | PANDA: `* 0.1`. PAOGI: as-is. |
+| 13 (roll) | `(int)round(currentData.roll)`, source pre-multiplied — see below | `dualRoll` float, 2 decimals | PANDA: `* 0.1`. PAOGI: as-is. |
+| 14 (pitch) | `(int)round(pitch)` | int via `round(insPitch)` or `round(imuPitch)` | as-is |
+| 15 (yawRate) | `%.2f` float | `yawRate` float, 2 decimals | as-is |
+
+**Roll wire format clarified.** It looked at first like PANDA roll was raw integer degrees because `NAVProcessor.cpp:158` does `(int)round(imuData.roll)` — no ×10. But `IMUProcessor.cpp:255-303` populates `currentData.roll = 10.0f * bnoParser->getRoll()` (and similar for TM171), so the value sitting in `currentData.roll` is already `degrees * 10` despite the misleading `// degrees` comment in `IMUProcessor.h:27`. Net wire format for PANDA roll: same ×10 integer convention as heading. AgOpenGPS's `* 0.1` decode is correct. PR #294's `data.ImuRoll = _state.Roll` is operating on values 10× too large against real firmware — its test passes only because `VirtualGpsReceiver.cs:138` emits roll as float `"5.70"`, not the canonical scaled-int. Both heading and roll need `* 0.1` in the parser; both fixture encoders need to scale.
+
+PGN 211 (binary IMU PGN, `IMUProcessor.cpp:464-498`) over-scales roll by another factor of 10 (`(int16_t)(currentData.roll * 10)` on top of the already-pre-multiplied source). That's a separate firmware bug; AgValoniaGPS doesn't consume PGN 211, so out of scope.
+
+## Goals
+
+- PANDA field 12 parses to correct degrees (÷10).
+- "No IMU" sentinel (65535) maps to "IMU heading invalid" instead of leaking through as a heading value.
+- IMU heading flows through `GpsData` (mirror of PR #294's roll fix), not through `SensorState`.
+- `GpsHeadingFusionService` reads IMU heading from the data parameter; the `SensorState` read goes away.
+- Slider in `GpsSubTab` becomes functional for single-antenna PANDA + IMU users.
+- Existing PAOGI behavior unchanged.
+
+## Non-goals
+
+- Pitch / yaw rate scaling. PANDA pitch is rounded integer degrees (1° resolution baked into wire format); yaw rate is float. Neither needs scaling and neither is currently consumed by guidance — leave alone.
+- External IMU module (PGN 211 / 0xD3) handler. AgValoniaGPS doesn't have one and the AiO ecosystem packs IMU into PANDA anyway.
+- Firmware patches. PGN 211's roll over-scaling and any related `IMUProcessor` cleanups are upstream concerns.
+- Removing `SensorState` entirely. After this PR, `GpsService.cs:133` is the only remaining `SensorState.Instance.ImuRoll` reader, and it lives inside the now-dead `TransformAntennaToPivot` body (already early-returns for the production E/N=0 path). Cleaning that up is a separate trivial PR.
+
+## Architecture
+
+The intent of `HeadingFusionWeight` is to blend two sources for the *single-antenna* case:
+- **IMU heading** — what the AiO IMU reports, available in PANDA field 12.
+- **Fix-to-fix heading** — computed by `GpsHeadingFusionService` from successive Easting/Northing positions.
+
+Currently both inputs collapse into `_state.Heading` / `pos.Heading`, so the blend has nothing to mix. Fix:
+
+1. **Parser stage** — `NmeaParserServiceFast.ParsePandaFieldsIntoState` distinguishes PANDA from PAOGI. The dispatcher already detects sentence type at line 317; pass it in (or split into two methods):
+   - **PANDA**: parse field 12 as int. If `== 65535` → set `state.ImuValid = false`, leave `state.Heading = 0` and `state.ImuHeading = 0`. If valid → `state.ImuHeading = value * 0.1`, `state.ImuValid = true`. For consistency seed `state.Heading = state.ImuHeading` so first-cycle / standstill has a sensible default; pipeline's fix-to-fix overrides at any real speed. Field 13 (roll) `* 0.1` when `ImuValid`, else 0. Field 14 (pitch) raw int. Field 15 (yawRate) raw float.
+   - **PAOGI**: field 12 → `state.Heading` directly. Field 13 (roll) → `state.Roll` directly (already float). `state.ImuValid` stays false — dual antenna is ground truth, no fusion needed; `state.ImuHeading` left at 0.
+
+2. **State** — add `double ImuHeading` to `VehicleState` (struct, `Shared/AgValoniaGPS.Models/VehicleState.cs`). Reuse the existing `ImuValid` flag — PANDA parser sets it based on the 65535 sentinel.
+
+3. **DTO** — add `double ImuHeading` and `bool ImuValid` to `GpsData` (parallel to PR #294's `ImuRoll`).
+
+4. **Publish** — `AutoSteerService.PublishGpsData` forwards `_state.ImuHeading` and `_state.ImuValid`.
+
+5. **Fusion** — `GpsHeadingFusionService.FuseHeading` signature changes:
+   ```csharp
+   double FuseHeading(double rawHeading, double imuHeading, bool imuValid,
+                      double speedMs, double easting, double northing);
+   ```
+   Logic: compute fix-to-fix as before. Then if `imuValid && fusionWeight in (0,1)`, blend `fixToFix` with `imuHeading` using the weight (GPS weight = `fusionWeight`, IMU weight = `1 - fusionWeight`). Drop `SensorState.Instance.HasValidImu` and `.ImuHeading` reads.
+
+6. **Pipeline** — `GpsPipelineService.ProcessCycle` passes `data.ImuHeading` and `data.ImuValid` to `_headingFusion.FuseHeading`.
+
+7. **Tests** — three buckets:
+   - `NmeaParserServiceFastTests`: PANDA heading scaling (`"905"` → 90.5° in `state.ImuHeading`), PANDA roll scaling (`"57"` → 5.7° in `state.Roll`), PANDA 65535 sentinel → `state.ImuValid = false`, PAOGI unchanged (`"90.5"` → 90.5° in `state.Heading`).
+   - `GpsHeadingFusionServiceTests`: blend at 0/50/100% weight with valid IMU; IMU branch skipped when invalid.
+   - `VirtualGpsReceiver`: PANDA emit changes to `(int)(heading * 10)` and `(int)(roll * 10)`. PAOGI emit stays float. The existing `Roll10Deg_ShiftsLaterally_ViaPipeline` test uses PANDA via the fixture; once both ends scale by the same factor, the round-trip math comes out the same as before — assertion target unchanged.
+
+## Phasing
+
+Single PR. Order of edits:
+
+1. Add `ImuHeading` + `ImuHeadingValid` to `VehicleState`, `GpsData`. Build.
+2. `AutoSteerService.PublishGpsData` forwards new fields. Build.
+3. `NmeaParserServiceFast`: split PANDA/PAOGI parsing of field 12; sentinel + scaling. Add unit tests.
+4. `GpsHeadingFusionService.FuseHeading`: new signature; pipeline call site updated. Drop `SensorState` reads. Update tests.
+5. Update `VirtualGpsReceiver` PANDA encoder to AiO format. Run integration tests, fix any fallout.
+6. Run full `dotnet test Tests/`. Manual smoke test with simulator (PAOGI path).
+
+## Risks
+
+- **Behavior change for PAOGI users.** None — PAOGI gets `ImuValid = false`, fusion blend stays skipped (same as before). Heading still flows through field 12 as float decimal degrees.
+
+- **Behavior change for PANDA + IMU users.** Currently they get a 10× heading and 10× roll at low speed (masked at speed by fix-to-fix override and by guidance algorithms that mostly don't care about roll magnitude beyond sign and ratio). After the fix, both arrive in correct degrees, and the slider actually blends fix-to-fix with IMU heading. If anyone tuned slider position around the broken behavior, their preferred value may shift. Acceptable: the broken state isn't a feature.
+
+- **Fix-to-fix at standstill.** When stationary, fix-to-fix has stale data. Blend should still produce a stable output (= IMU heading when fix-to-fix is unavailable). Add a test for `speedMs < MinGpsStep`.
+
+- **PR #294's roll correction shrinks 10×.** Before this PR, `data.ImuRoll` was 10× the real roll (lossless wrong direction — test passed because the test fixture also didn't scale). After this PR, `data.ImuRoll` is real degrees (correct). Roll-correction lateral shift will be 1/10 of what it was on real hardware — but that 1/10 number is the actually-correct correction. Worth re-running the simulator-with-roll smoke test described in PR #294's test plan.

--- a/Shared/AgValoniaGPS.Models/GpsData.cs
+++ b/Shared/AgValoniaGPS.Models/GpsData.cs
@@ -55,6 +55,22 @@ public class GpsData
     public double ImuYawRate { get; set; }
 
     /// <summary>
+    /// IMU heading in degrees (0-360), separate from <see cref="Position.Heading"/>.
+    /// Only populated for PANDA sentences with a valid IMU. PAOGI sets this to 0
+    /// and <see cref="ImuValid"/> to false because dual-antenna heading is ground
+    /// truth and doesn't need fusion. Consumed by <c>GpsHeadingFusionService</c>
+    /// to blend with fix-to-fix using <c>HeadingFusionWeight</c>.
+    /// </summary>
+    public double ImuHeading { get; set; }
+
+    /// <summary>
+    /// True when the IMU block in the most recent NMEA sentence is valid
+    /// (PANDA field 12 != 65535 sentinel). Gates use of <see cref="ImuHeading"/>
+    /// and <see cref="ImuRoll"/>.
+    /// </summary>
+    public bool ImuValid { get; set; }
+
+    /// <summary>
     /// Timestamp when data was received
     /// </summary>
     public DateTime Timestamp { get; set; } = DateTime.Now;

--- a/Shared/AgValoniaGPS.Models/VehicleState.cs
+++ b/Shared/AgValoniaGPS.Models/VehicleState.cs
@@ -74,6 +74,15 @@ public struct VehicleState
     /// <summary>Yaw rate in degrees per second</summary>
     public double YawRate;
 
+    /// <summary>
+    /// IMU heading in degrees (0-360). Distinct from <see cref="Heading"/>:
+    /// <see cref="Heading"/> is the value guidance uses (potentially fused with
+    /// fix-to-fix); <see cref="ImuHeading"/> is the raw IMU input that the
+    /// pipeline blends with fix-to-fix per <c>HeadingFusionWeight</c>.
+    /// Only populated for PANDA sentences with a valid IMU; PAOGI leaves it 0.
+    /// </summary>
+    public double ImuHeading;
+
     // ═══════════════════════════════════════════════════════════════════════
     // Local Coordinates (updated after GPS parse, using LocalPlane)
     // ═══════════════════════════════════════════════════════════════════════

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -398,6 +398,8 @@ public class AutoSteerService : IAutoSteerService
             ImuRoll = _state.Roll,
             ImuPitch = _state.Pitch,
             ImuYawRate = _state.YawRate,
+            ImuHeading = _state.ImuHeading,
+            ImuValid = _state.ImuValid,
             Timestamp = DateTime.UtcNow,
         };
         _gpsService.UpdateGpsData(gpsData);

--- a/Shared/AgValoniaGPS.Services/Gps/GpsHeadingFusionService.cs
+++ b/Shared/AgValoniaGPS.Services/Gps/GpsHeadingFusionService.cs
@@ -27,7 +27,8 @@ public class GpsHeadingFusionService : IGpsHeadingFusionService
     private double _previousHeading;
     private bool _hasPreviousPosition;
 
-    public double FuseHeading(double gpsHeading, double speedMs, double easting, double northing)
+    public double FuseHeading(double gpsHeading, double imuHeading, bool imuValid,
+                              double speedMs, double easting, double northing)
     {
         double finalHeading = gpsHeading;
 
@@ -57,11 +58,12 @@ public class GpsHeadingFusionService : IGpsHeadingFusionService
         }
 
         // IMU fusion when an IMU heading is available and fusion is enabled.
+        // For PANDA, gpsHeading was seeded from the IMU and may have been
+        // overridden by fix-to-fix above; the blend below recovers the IMU
+        // contribution per HeadingFusionWeight.
         double fusionWeight = Connections.HeadingFusionWeight;
-        if (fusionWeight > 0 && fusionWeight < 1.0 && SensorState.Instance.HasValidImu)
+        if (fusionWeight > 0 && fusionWeight < 1.0 && imuValid)
         {
-            double imuHeading = SensorState.Instance.ImuHeading;
-
             double diff = imuHeading - finalHeading;
             if (diff > 180) diff -= 360;
             if (diff < -180) diff += 360;

--- a/Shared/AgValoniaGPS.Services/Interfaces/IGpsHeadingFusionService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IGpsHeadingFusionService.cs
@@ -17,15 +17,21 @@ namespace AgValoniaGPS.Services.Interfaces;
 public interface IGpsHeadingFusionService
 {
     /// <summary>
-    /// Compute the final heading given the raw GPS sentence heading and the
-    /// current fix's position and speed.
+    /// Compute the final heading given the raw GPS sentence heading, the
+    /// IMU heading (when valid), and the current fix's position and speed.
     /// </summary>
-    /// <param name="gpsHeading">Raw heading from the NMEA sentence, degrees 0–360.</param>
+    /// <param name="gpsHeading">Raw heading from the NMEA sentence, degrees 0–360.
+    /// For PANDA this is seeded from the IMU; for PAOGI it's the dual-antenna heading.</param>
+    /// <param name="imuHeading">IMU heading in degrees 0–360. Only meaningful
+    /// when <paramref name="imuValid"/> is true (PANDA + IMU present).</param>
+    /// <param name="imuValid">True when the IMU block in the latest sentence
+    /// is valid. False for PAOGI or PANDA with the 65535 sentinel.</param>
     /// <param name="speedMs">Current speed, m/s.</param>
     /// <param name="easting">Current easting, meters, local frame.</param>
     /// <param name="northing">Current northing, meters, local frame.</param>
     /// <returns>Final heading in degrees, normalized to 0–360.</returns>
-    double FuseHeading(double gpsHeading, double speedMs, double easting, double northing);
+    double FuseHeading(double gpsHeading, double imuHeading, bool imuValid,
+                       double speedMs, double easting, double northing);
 
     /// <summary>
     /// Discard fix-to-fix history. Call on field close or GPS reconnect.

--- a/Shared/AgValoniaGPS.Services/NmeaParserServiceFast.cs
+++ b/Shared/AgValoniaGPS.Services/NmeaParserServiceFast.cs
@@ -100,11 +100,13 @@ public class NmeaParserServiceFast
         var sentenceType = data.Slice(1, 5);
 
         // Check for PANDA or PAOGI
-        if (!sentenceType.SequenceEqual(PANDA) && !sentenceType.SequenceEqual(PAOGI))
-            return false;
+        bool isPanda;
+        if (sentenceType.SequenceEqual(PANDA)) isPanda = true;
+        else if (sentenceType.SequenceEqual(PAOGI)) isPanda = false;
+        else return false;
 
         // Parse the fields (data up to asterisk)
-        return ParsePandaFields(data.Slice(0, asterisk));
+        return ParsePandaFields(data.Slice(0, asterisk), isPanda);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -139,7 +141,7 @@ public class NmeaParserServiceFast
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private bool ParsePandaFields(ReadOnlySpan<byte> data)
+    private bool ParsePandaFields(ReadOnlySpan<byte> data, bool isPanda)
     {
         // Find all comma positions (up to 16 fields)
         Span<int> commas = stackalloc int[20];
@@ -234,11 +236,23 @@ public class NmeaParserServiceFast
             speed *= 0.514444; // knots to m/s
         }
 
-        // Heading (field 12)
+        // Heading (field 12). PANDA: int scaled ×10 with 65535 sentinel.
+        // PAOGI: float decimal degrees.
         var headingField = GetField(data, commas, FIELD_HEADING);
         if (headingField.Length > 0)
         {
-            Utf8Parser.TryParse(headingField, out heading, out _);
+            if (isPanda)
+            {
+                if (Utf8Parser.TryParse(headingField, out int rawHeading, out _)
+                    && rawHeading != 65535)
+                {
+                    heading = rawHeading * 0.1;
+                }
+            }
+            else
+            {
+                Utf8Parser.TryParse(headingField, out heading, out _);
+            }
         }
 
         // Apply hemisphere signs
@@ -313,12 +327,17 @@ public class NmeaParserServiceFast
         // Get sentence type (bytes 1-5 after $)
         var sentenceType = data.Slice(1, 5);
 
-        // Check for PANDA or PAOGI
-        if (!sentenceType.SequenceEqual(PANDA) && !sentenceType.SequenceEqual(PAOGI))
-            return false;
+        // PANDA = single GPS + IMU; field 12 is IMU heading scaled ×10 with
+        // sentinel "65535", field 13 is IMU roll scaled ×10. PAOGI = dual
+        // antenna; field 12 is dual-antenna heading as float, field 13 is
+        // dual roll as float — no IMU fusion needed.
+        bool isPanda;
+        if (sentenceType.SequenceEqual(PANDA)) isPanda = true;
+        else if (sentenceType.SequenceEqual(PAOGI)) isPanda = false;
+        else return false;
 
         // Parse directly into state
-        if (!ParsePandaFieldsIntoState(data.Slice(0, asterisk), ref state))
+        if (!ParsePandaFieldsIntoState(data.Slice(0, asterisk), ref state, isPanda))
             return false;
 
         state.MarkParseEnd();
@@ -326,10 +345,13 @@ public class NmeaParserServiceFast
     }
 
     /// <summary>
-    /// Parse PANDA/PAOGI fields directly into VehicleState.
+    /// Parse PANDA/PAOGI fields directly into VehicleState. Fields 1-11 are
+    /// identical between the two. Fields 12-13 (heading, roll) differ:
+    /// PANDA scales them ×10 as int with a 65535 IMU-invalid sentinel on
+    /// heading; PAOGI sends them as floats with no scaling.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    private static bool ParsePandaFieldsIntoState(ReadOnlySpan<byte> data, ref VehicleState state)
+    private static bool ParsePandaFieldsIntoState(ReadOnlySpan<byte> data, ref VehicleState state, bool isPanda)
     {
         // Find all comma positions (up to 20 fields)
         Span<int> commas = stackalloc int[20];
@@ -416,29 +438,78 @@ public class NmeaParserServiceFast
             state.Speed *= 0.514444; // knots to m/s
         }
 
-        // Heading in degrees (field 12)
+        // Heading (field 12) and roll (field 13) — sentence-type dependent.
         var headingField = GetField(data, commas, FIELD_HEADING);
-        if (headingField.Length > 0)
-        {
-            Utf8Parser.TryParse(headingField, out state.Heading, out _);
-        }
-
-        // Roll angle in degrees (field 13)
         var rollField = GetField(data, commas, FIELD_ROLL);
-        if (rollField.Length > 0)
+
+        if (isPanda)
         {
-            Utf8Parser.TryParse(rollField, out state.Roll, out _);
-            state.ImuValid = true;
+            // PANDA: heading is `(int)(degrees * 10)` with sentinel 65535 for
+            // "no IMU"; roll is `(int)(degrees * 10)` (the firmware's
+            // currentData.roll is pre-multiplied by 10 at the IMU layer —
+            // see Firmware_Teensy_AiO_26/lib/aio_navigation/IMUProcessor.cpp).
+            int rawHeading = 0;
+            bool imuValid = false;
+            if (headingField.Length > 0
+                && Utf8Parser.TryParse(headingField, out rawHeading, out _)
+                && rawHeading != 65535)
+            {
+                state.ImuHeading = rawHeading * 0.1;
+                imuValid = true;
+            }
+            else
+            {
+                state.ImuHeading = 0;
+            }
+            state.ImuValid = imuValid;
+            // Seed primary heading from IMU so first-cycle / standstill has a
+            // sensible default. Pipeline's fix-to-fix overrides at any real speed.
+            state.Heading = imuValid ? state.ImuHeading : 0;
+
+            if (imuValid && rollField.Length > 0
+                && Utf8Parser.TryParse(rollField, out int rawRoll, out _))
+            {
+                state.Roll = rawRoll * 0.1;
+            }
+            else
+            {
+                state.Roll = 0;
+            }
+        }
+        else
+        {
+            // PAOGI: dual-antenna heading and dual roll, both float decimal
+            // degrees. Dual antenna is ground truth — no IMU fusion needed,
+            // so ImuHeading stays 0 and ImuValid stays false.
+            if (headingField.Length > 0)
+            {
+                Utf8Parser.TryParse(headingField, out state.Heading, out _);
+            }
+            else
+            {
+                state.Heading = 0;
+            }
+            state.ImuHeading = 0;
+            state.ImuValid = false;
+
+            if (rollField.Length > 0)
+            {
+                Utf8Parser.TryParse(rollField, out state.Roll, out _);
+            }
+            else
+            {
+                state.Roll = 0;
+            }
         }
 
-        // Pitch angle in degrees (field 14)
+        // Pitch angle in degrees (field 14) — same format both sentences.
         var pitchField = GetField(data, commas, FIELD_PITCH);
         if (pitchField.Length > 0)
         {
             Utf8Parser.TryParse(pitchField, out state.Pitch, out _);
         }
 
-        // Yaw rate in degrees/second (field 15)
+        // Yaw rate in degrees/second (field 15) — same format both sentences.
         var yawField = GetField(data, commas, FIELD_YAW_RATE);
         if (yawField.Length > 0)
         {

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -420,7 +420,9 @@ public sealed class GpsPipelineService : IGpsPipelineService
         // Stage 3 (Phase B C2): Heading fusion. Replaces the raw NMEA heading
         // with the dual-antenna-aware / fix-to-fix / IMU-blended value.
         // Receives real local easting/northing — see TMP-009 in the parking lot.
-        double fusedHeading = _headingFusion.FuseHeading(pos.Heading, pos.Speed, posEasting, posNorthing);
+        double fusedHeading = _headingFusion.FuseHeading(
+            pos.Heading, data.ImuHeading, data.ImuValid,
+            pos.Speed, posEasting, posNorthing);
         pos = pos with { Heading = fusedHeading };
 
         // ── (1b) Antenna-to-pivot transform in local coordinates ────────

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs
@@ -115,11 +115,17 @@ public class VirtualGpsReceiver : IDisposable
     private string BuildPandaSentence()
     {
         // Format: $PANDA,time,lat,N/S,lon,E/W,fix,sats,hdop,alt,age,speed,heading,roll,pitch,yaw*checksum
+        // Heading and roll wire format = (int)(degrees * 10), per AiO firmware
+        // Firmware_Teensy_AiO_26/lib/aio_navigation/NAVProcessor.cpp:157-158
+        // (heading scales explicitly; roll scales because IMUProcessor.cpp pre-multiplies
+        // currentData.roll by 10 before NAVProcessor rounds it).
         string time = DateTime.UtcNow.ToString("HHmmss.ff", CultureInfo.InvariantCulture);
         string lat = FormatLatitude(Latitude);
         string ns = Latitude >= 0 ? "N" : "S";
         string lon = FormatLongitude(Longitude);
         string ew = Longitude >= 0 ? "E" : "W";
+        int headingX10 = (int)Math.Round(HeadingDegrees * 10.0);
+        int rollX10 = (int)Math.Round(RollDegrees * 10.0);
 
         var sb = new StringBuilder();
         sb.Append("$PANDA,");
@@ -134,8 +140,8 @@ public class VirtualGpsReceiver : IDisposable
         sb.Append(Altitude.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(DifferentialAge.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(SpeedKnots.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(HeadingDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(RollDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(headingX10.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(rollX10.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(PitchDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(YawRateDegPerSec.ToString("F2", CultureInfo.InvariantCulture));
 

--- a/Tests/AgValoniaGPS.Services.Tests/AutoSteerUTurnNUnitTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoSteerUTurnNUnitTests.cs
@@ -96,7 +96,8 @@ public class AutoSteerUTurnNUnitTests
         var sectionControl = new SectionControlService(_toolPosition, coverage, _appState);
 
         var headingFusion = Substitute.For<IGpsHeadingFusionService>();
-        headingFusion.FuseHeading(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>())
+        headingFusion.FuseHeading(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<bool>(),
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>())
             .Returns(ci => ci.ArgAt<double>(0));
 
         _autoSteer = new AutoSteerService(guidance,

--- a/Tests/AgValoniaGPS.Services.Tests/Gps/GpsHeadingFusionServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/Gps/GpsHeadingFusionServiceTests.cs
@@ -9,7 +9,7 @@ using AgValoniaGPS.Services.Gps;
 namespace AgValoniaGPS.Services.Tests.Gps;
 
 [TestFixture]
-[NonParallelizable] // ConfigurationStore + SensorState are singletons
+[NonParallelizable] // ConfigurationStore is a singleton
 public class GpsHeadingFusionServiceTests
 {
     private GpsHeadingFusionService _service = null!;
@@ -27,8 +27,6 @@ public class GpsHeadingFusionServiceTests
         c.MinGpsStep = 0.05;
         c.FixToFixDistance = 0.2;
         c.HeadingFusionWeight = 1.0; // all GPS, no IMU
-
-        SensorState.Instance.Reset();
     }
 
     [Test]
@@ -37,7 +35,8 @@ public class GpsHeadingFusionServiceTests
         ConfigurationStore.Instance.Connections.MinGpsStep = 1.0;
 
         double result = _service.FuseHeading(
-            gpsHeading: 45.0, speedMs: 0.1, easting: 0, northing: 0);
+            gpsHeading: 45.0, imuHeading: 0, imuValid: false,
+            speedMs: 0.1, easting: 0, northing: 0);
 
         Assert.That(result, Is.EqualTo(45.0).Within(1e-9));
     }
@@ -50,14 +49,16 @@ public class GpsHeadingFusionServiceTests
 
         // First call primes the fix-to-fix state; no previous position yet so returns raw.
         double first = _service.FuseHeading(
-            gpsHeading: 0.0, speedMs: 10.0, easting: 0, northing: 0);
+            gpsHeading: 0.0, imuHeading: 0, imuValid: false,
+            speedMs: 10.0, easting: 0, northing: 0);
 
         Assert.That(first, Is.EqualTo(0.0).Within(1e-9),
             "first call has no previous position, returns raw heading");
 
         // Second call: moved 10m east — fix-to-fix heading = atan2(10, 0) = 90°.
         double second = _service.FuseHeading(
-            gpsHeading: 0.0, speedMs: 10.0, easting: 10, northing: 0);
+            gpsHeading: 0.0, imuHeading: 0, imuValid: false,
+            speedMs: 10.0, easting: 10, northing: 0);
 
         Assert.That(second, Is.EqualTo(90.0).Within(1e-9),
             "fix-to-fix replaces raw heading when travelling faster than MinGpsStep");
@@ -70,7 +71,8 @@ public class GpsHeadingFusionServiceTests
         ConfigurationStore.Instance.Connections.DualHeadingOffset = 10.0;
 
         double result = _service.FuseHeading(
-            gpsHeading: 355.0, speedMs: 10.0, easting: 0, northing: 0);
+            gpsHeading: 355.0, imuHeading: 0, imuValid: false,
+            speedMs: 10.0, easting: 0, northing: 0);
 
         // 355 + 10 = 365 → normalize to 5.
         Assert.That(result, Is.EqualTo(5.0).Within(1e-9));
@@ -85,11 +87,13 @@ public class GpsHeadingFusionServiceTests
         ConfigurationStore.Instance.Connections.FixToFixDistance = 0.2;
 
         // Prime fix-to-fix state at speed.
-        _service.FuseHeading(gpsHeading: 90, speedMs: 5.0, easting: 0, northing: 0);
+        _service.FuseHeading(gpsHeading: 90, imuHeading: 0, imuValid: false,
+            speedMs: 5.0, easting: 0, northing: 0);
 
         // Now slow down — DualSwitchSpeed kicks in, fix-to-fix should override.
         double result = _service.FuseHeading(
-            gpsHeading: 90, speedMs: 1.0, easting: 0, northing: 10);
+            gpsHeading: 90, imuHeading: 0, imuValid: false,
+            speedMs: 1.0, easting: 0, northing: 10);
 
         // Moved 10m north from origin → heading = atan2(0, 10) = 0°.
         Assert.That(result, Is.EqualTo(0.0).Within(1e-9));
@@ -102,12 +106,14 @@ public class GpsHeadingFusionServiceTests
         ConfigurationStore.Instance.Connections.FixToFixDistance = 1.0;
 
         // Prime
-        _service.FuseHeading(gpsHeading: 45, speedMs: 10.0, easting: 0, northing: 0);
+        _service.FuseHeading(gpsHeading: 45, imuHeading: 0, imuValid: false,
+            speedMs: 10.0, easting: 0, northing: 0);
 
         // Second call: moved only 0.5m (< FixToFixDistance) — fix-to-fix rejected,
         // raw heading stands.
         double result = _service.FuseHeading(
-            gpsHeading: 45, speedMs: 10.0, easting: 0.5, northing: 0);
+            gpsHeading: 45, imuHeading: 0, imuValid: false,
+            speedMs: 10.0, easting: 0.5, northing: 0);
 
         Assert.That(result, Is.EqualTo(45.0).Within(1e-9));
     }
@@ -116,10 +122,10 @@ public class GpsHeadingFusionServiceTests
     public void IMU_fusion_blends_when_weight_is_partial_and_IMU_valid()
     {
         ConfigurationStore.Instance.Connections.HeadingFusionWeight = 0.5; // 50/50
-        SensorState.Instance.ImuHeading = 100.0;                           // makes HasValidImu true
 
         double result = _service.FuseHeading(
-            gpsHeading: 80.0, speedMs: 0.01, easting: 0, northing: 0);
+            gpsHeading: 80.0, imuHeading: 100.0, imuValid: true,
+            speedMs: 0.01, easting: 0, northing: 0);
 
         // diff = imu - final = 100 - 80 = 20; final = 80 + 20 * 0.5 = 90.
         Assert.That(result, Is.EqualTo(90.0).Within(1e-9));
@@ -129,12 +135,26 @@ public class GpsHeadingFusionServiceTests
     public void IMU_fusion_skipped_when_weight_is_1()
     {
         ConfigurationStore.Instance.Connections.HeadingFusionWeight = 1.0;
-        SensorState.Instance.ImuHeading = 180.0;
 
         double result = _service.FuseHeading(
-            gpsHeading: 45.0, speedMs: 0.01, easting: 0, northing: 0);
+            gpsHeading: 45.0, imuHeading: 180.0, imuValid: true,
+            speedMs: 0.01, easting: 0, northing: 0);
 
         Assert.That(result, Is.EqualTo(45.0).Within(1e-9));
+    }
+
+    [Test]
+    public void IMU_fusion_skipped_when_imu_invalid()
+    {
+        // Slider at 50% would normally blend, but the 65535 sentinel means
+        // ImuValid=false — IMU branch must skip and return GPS heading as-is.
+        ConfigurationStore.Instance.Connections.HeadingFusionWeight = 0.5;
+
+        double result = _service.FuseHeading(
+            gpsHeading: 80.0, imuHeading: 0, imuValid: false,
+            speedMs: 0.01, easting: 0, northing: 0);
+
+        Assert.That(result, Is.EqualTo(80.0).Within(1e-9));
     }
 
     [Test]
@@ -143,13 +163,15 @@ public class GpsHeadingFusionServiceTests
         ConfigurationStore.Instance.Connections.MinGpsStep = 0.05;
 
         // Prime: establishes previous position.
-        _service.FuseHeading(gpsHeading: 0, speedMs: 10, easting: 0, northing: 0);
+        _service.FuseHeading(gpsHeading: 0, imuHeading: 0, imuValid: false,
+            speedMs: 10, easting: 0, northing: 0);
         _service.Reset();
 
         // After reset, the next call should behave like the very first — no fix-to-fix,
         // even though easting moved.
         double result = _service.FuseHeading(
-            gpsHeading: 0, speedMs: 10, easting: 10, northing: 0);
+            gpsHeading: 0, imuHeading: 0, imuValid: false,
+            speedMs: 10, easting: 10, northing: 0);
 
         Assert.That(result, Is.EqualTo(0.0).Within(1e-9));
     }

--- a/Tests/AgValoniaGPS.Services.Tests/GuidancePipelineIntegrationTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/GuidancePipelineIntegrationTests.cs
@@ -265,9 +265,11 @@ public class GuidancePipelineIntegrationTests
     private static string BuildPanda(double lat, string latDir, double lon, string lonDir,
         int fix, int sats, double hdop, double alt, double diffAge, double speed, double heading)
     {
+        // Heading wire format = (int)(degrees * 10), per AiO firmware.
+        int headingX10 = (int)System.Math.Round(heading * 10.0);
         string body = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-            "PANDA,123456.00,{0:F3},{1},{2:F3},{3},{4},{5},{6:F1},{7:F1},{8:F1},{9:F1},{10:F1},0,0,0",
-            lat, latDir, lon, lonDir, fix, sats, hdop, alt, diffAge, speed, heading);
+            "PANDA,123456.00,{0:F3},{1},{2:F3},{3},{4},{5},{6:F1},{7:F1},{8:F1},{9:F1},{10},0,0,0",
+            lat, latDir, lon, lonDir, fix, sats, hdop, alt, diffAge, speed, headingX10);
         byte checksum = 0;
         foreach (char c in body) checksum ^= (byte)c;
         return $"${body}*{checksum:X2}";

--- a/Tests/AgValoniaGPS.Services.Tests/NmeaEncodingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/NmeaEncodingTests.cs
@@ -201,14 +201,19 @@ public class NmeaEncodingTests
     [Test]
     public void ImuFields_EncodedWithInvariantCulture()
     {
-        // Roll=1.5, pitch=-0.3, yaw=0.2 must use dot decimal, not comma
+        // PANDA wire format from VirtualGpsReceiver after IMU heading fix:
+        //   Roll  = (int)round(degrees × 10), e.g. 1.5° → "15"   (matches AiO firmware)
+        //   Pitch = float "%.2f", e.g. -0.3° → "-0.30"           (legacy fixture format)
+        //   YawRate = float "%.2f", e.g. 0.2 → "0.20"            (legacy fixture format)
+        // Test name is about culture-correct decimal separators — pitch and
+        // yaw still exercise that. Roll just verifies the scaling.
         var sentence = CapturePanda(42.0, -93.0, roll: 1.5, pitch: -0.3, yawRate: 0.2);
         var fields = sentence.Split(',');
 
         // Last field has checksum: "0.20*XX"
         string yawField = fields[15].Split('*')[0];
 
-        Assert.That(fields[13], Is.EqualTo("1.50"), $"Roll should be 1.50, got {fields[13]}");
+        Assert.That(fields[13], Is.EqualTo("15"), $"Roll should be 15 (1.5° × 10), got {fields[13]}");
         Assert.That(fields[14], Is.EqualTo("-0.30"), $"Pitch should be -0.30, got {fields[14]}");
         Assert.That(yawField, Is.EqualTo("0.20"), $"Yaw should be 0.20, got {yawField}");
     }

--- a/Tests/AgValoniaGPS.Services.Tests/NmeaParserServiceFastTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/NmeaParserServiceFastTests.cs
@@ -173,17 +173,77 @@ public class NmeaParserServiceFastTests
     [Test]
     public void ParseSpan_PAOGI_ParsesLikePANDA()
     {
-        byte[] sentence = BuildPandaBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5, 90.0, 0, 0, 0);
-        // Swap the 5 bytes of "PANDA" for "PAOGI" (same length) and recompute the checksum.
-        byte[] paogi = new byte[sentence.Length];
-        sentence.CopyTo(paogi, 0);
-        Encoding.ASCII.GetBytes("PAOGI").CopyTo(paogi, 1);
-        RecomputeChecksumInPlace(paogi);
+        byte[] sentence = BuildPaogiBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5, 90.0, 0, 0, 0);
 
-        _parser.ParseSpan(paogi);
+        _parser.ParseSpan(sentence);
 
         Assert.That(_lastGpsData, Is.Not.Null);
         Assert.That(_lastGpsData!.CurrentPosition.Latitude, Is.EqualTo(48.1173).Within(0.001));
+    }
+
+    // ── IMU heading + roll wire-format scaling (zero-copy ParseIntoState) ─
+
+    [Test]
+    public void ParseIntoState_PANDA_DividesHeadingBy10()
+    {
+        // Wire "905" represents 90.5° on the AiO PANDA encoding.
+        byte[] sentence = BuildPandaBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5,
+            heading: 90.5, roll: 0, pitch: 0, yawRate: 0);
+        var state = new VehicleState();
+
+        bool ok = NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+        Assert.That(ok, Is.True);
+        Assert.That(state.ImuValid, Is.True);
+        Assert.That(state.ImuHeading, Is.EqualTo(90.5).Within(1e-6));
+        // Primary heading is seeded from IMU at parse time (pipeline overrides at speed).
+        Assert.That(state.Heading, Is.EqualTo(90.5).Within(1e-6));
+    }
+
+    [Test]
+    public void ParseIntoState_PANDA_DividesRollBy10()
+    {
+        // Wire "57" represents 5.7° on PANDA encoding.
+        byte[] sentence = BuildPandaBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5,
+            heading: 90.0, roll: 5.7, pitch: 0, yawRate: 0);
+        var state = new VehicleState();
+
+        NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+        Assert.That(state.Roll, Is.EqualTo(5.7).Within(1e-6));
+    }
+
+    [Test]
+    public void ParseIntoState_PANDA_65535SentinelMarksImuInvalid()
+    {
+        byte[] sentence = BuildPandaBytesNoImu(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5);
+        var state = new VehicleState();
+
+        bool ok = NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+        Assert.That(ok, Is.True);
+        Assert.That(state.ImuValid, Is.False);
+        Assert.That(state.ImuHeading, Is.EqualTo(0));
+        Assert.That(state.Roll, Is.EqualTo(0));
+        Assert.That(state.Heading, Is.EqualTo(0),
+            "primary heading should fall to 0 when IMU is invalid; pipeline picks up fix-to-fix");
+    }
+
+    [Test]
+    public void ParseIntoState_PAOGI_HeadingAsFloatNoScaling_ImuStaysInvalid()
+    {
+        // PAOGI emits heading as float decimal degrees — no ×10 scaling.
+        byte[] sentence = BuildPaogiBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5,
+            heading: 90.5, roll: 1.25, pitch: 0, yawRate: 0);
+        var state = new VehicleState();
+
+        NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+        Assert.That(state.Heading, Is.EqualTo(90.5).Within(1e-6));
+        Assert.That(state.Roll, Is.EqualTo(1.25).Within(1e-6));
+        Assert.That(state.ImuValid, Is.False,
+            "PAOGI is dual-antenna ground truth — fusion isn't needed, ImuValid stays false");
+        Assert.That(state.ImuHeading, Is.EqualTo(0));
     }
 
     // ── Helpers ────────────────────────────────────────────────────────
@@ -194,9 +254,51 @@ public class NmeaParserServiceFastTests
         double diffAge, double speedKnots, double heading,
         double roll, double pitch, double yawRate)
     {
+        // PANDA wire format: heading and roll are int scaled ×10 (with 65535
+        // sentinel for "no IMU" on heading); pitch is rounded int; yawRate
+        // is float. Mirrors AiO firmware's NAVProcessor::formatPANDAMessage.
+        int headingX10 = (int)System.Math.Round(heading * 10.0);
+        int rollX10 = (int)System.Math.Round(roll * 10.0);
+        int pitchInt = (int)System.Math.Round(pitch);
         string body = string.Format(CultureInfo.InvariantCulture,
-            "PANDA,123456.00,{0:F3},{1},{2:F3},{3},{4},{5},{6:F1},{7:F1},{8:F1},{9:F1},{10:F1},{11:F1},{12:F1},{13:F1}",
-            lat, latDir, lon, lonDir, fixQuality, sats, hdop, alt, diffAge, speedKnots, heading, roll, pitch, yawRate);
+            "PANDA,123456.00,{0:F3},{1},{2:F3},{3},{4},{5},{6:F1},{7:F1},{8:F1},{9:F1},{10},{11},{12},{13:F2}",
+            lat, latDir, lon, lonDir, fixQuality, sats, hdop, alt, diffAge, speedKnots,
+            headingX10, rollX10, pitchInt, yawRate);
+        return BuildSentence(body);
+    }
+
+    /// <summary>
+    /// Builds a PANDA sentence with the "no IMU" sentinel (65535) in the
+    /// heading field. Used to test that parser detects the sentinel and
+    /// leaves <c>state.ImuValid = false</c>.
+    /// </summary>
+    private static byte[] BuildPandaBytesNoImu(
+        double lat, string latDir, double lon, string lonDir,
+        int fixQuality, int sats, double hdop, double alt,
+        double diffAge, double speedKnots)
+    {
+        string body = string.Format(CultureInfo.InvariantCulture,
+            "PANDA,123456.00,{0:F3},{1},{2:F3},{3},{4},{5},{6:F1},{7:F1},{8:F1},{9:F1},65535,0,0,0.00",
+            lat, latDir, lon, lonDir, fixQuality, sats, hdop, alt, diffAge, speedKnots);
+        return BuildSentence(body);
+    }
+
+    /// <summary>
+    /// Builds a PAOGI sentence (dual antenna). Heading and roll are float
+    /// decimal degrees, no scaling — matches AiO firmware's
+    /// NAVProcessor::formatPAOGIMessage.
+    /// </summary>
+    private static byte[] BuildPaogiBytes(
+        double lat, string latDir, double lon, string lonDir,
+        int fixQuality, int sats, double hdop, double alt,
+        double diffAge, double speedKnots, double heading,
+        double roll, double pitch, double yawRate)
+    {
+        int pitchInt = (int)System.Math.Round(pitch);
+        string body = string.Format(CultureInfo.InvariantCulture,
+            "PAOGI,123456.00,{0:F3},{1},{2:F3},{3},{4},{5},{6:F1},{7:F1},{8:F1},{9:F1},{10:F1},{11:F2},{12},{13:F2}",
+            lat, latDir, lon, lonDir, fixQuality, sats, hdop, alt, diffAge, speedKnots,
+            heading, roll, pitchInt, yawRate);
         return BuildSentence(body);
     }
 
@@ -205,18 +307,5 @@ public class NmeaParserServiceFastTests
         byte checksum = 0;
         foreach (char c in body) checksum ^= (byte)c;
         return Encoding.ASCII.GetBytes($"${body}*{checksum:X2}");
-    }
-
-    private static void RecomputeChecksumInPlace(byte[] sentence)
-    {
-        int asterisk = System.Array.IndexOf(sentence, (byte)'*');
-        if (asterisk < 0) return;
-
-        byte checksum = 0;
-        for (int i = 1; i < asterisk; i++) checksum ^= sentence[i];
-
-        string hex = checksum.ToString("X2");
-        sentence[asterisk + 1] = (byte)hex[0];
-        sentence[asterisk + 2] = (byte)hex[1];
     }
 }

--- a/Tests/AgValoniaGPS.Services.Tests/TractorPathTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/TractorPathTests.cs
@@ -185,7 +185,8 @@ public class TractorPathTests
         var sectionControl = new SectionControlService(toolPosition, coverage, appState);
 
         var headingFusion = Substitute.For<IGpsHeadingFusionService>();
-        headingFusion.FuseHeading(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>())
+        headingFusion.FuseHeading(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<bool>(),
+                                  Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>())
             .Returns(ci => ci.ArgAt<double>(0)); // Pass through GPS heading
 
         return new GpsPipelineService(

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 42
+#define VERSION_PATCH 43
 
-#define VERSION "26.4.42"
-#define VERSION_DATE "2026-04-23"
+#define VERSION "26.4.43"
+#define VERSION_DATE "2026-04-24"


### PR DESCRIPTION
## Summary
- Routes IMU heading through `GpsData.ImuHeading`/`ImuValid` instead of the never-written `SensorState.Instance.ImuHeading` — the GPS/IMU fusion slider now actually does something.
- Fixes PANDA wire-format scaling: heading and roll are `int(degrees * 10)` per AiO firmware. Parser now divides by 10 on receive and treats `65535` as the "no IMU/dual" sentinel.
- Splits PANDA vs PAOGI parsing in `NmeaParserServiceFast`: PANDA scales, PAOGI parses as float with no scaling.
- Updates `IGpsHeadingFusionService.FuseHeading` to take `(gpsHeading, imuHeading, imuValid, speed, easting, northing)` — no more singleton reads inside the fusion service.

Follows PR #294's pattern (route data through `GpsData`, not `SensorState`). Bumps version to `26.4.43`.

## Why
The fusion slider had no effect because nothing ever wrote `SensorState.Instance.ImuHeading`. PANDA heading was also 10× off because the parser didn't apply the firmware's `× 10` wire scaling, and the `65535` sentinel was treated as a real heading.

## Files
- `Shared/AgValoniaGPS.Services/NmeaParserServiceFast.cs` — branch PANDA vs PAOGI; PANDA scales by 0.1, sentinel detection.
- `Shared/AgValoniaGPS.Models/VehicleState.cs` / `GpsData.cs` — add `ImuHeading` and `ImuValid`.
- `Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs` — forward IMU fields onto `GpsData`.
- `Shared/AgValoniaGPS.Services/Gps/GpsHeadingFusionService.cs` + interface — new signature.
- `Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs` — pass `data.ImuHeading`/`ImuValid`.
- `Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualGpsReceiver.cs` — emit canonical AiO PANDA wire format.
- New parser/fusion tests covering scaling, sentinel, PAOGI float, and IMU-invalid skip.

## Test plan
- [x] `dotnet build AgValoniaGPS.sln` clean
- [x] `dotnet test` — 836/836 pass (92 Models, 194 ViewModels, 116 UI, 434 Services)
- [x] Smoke test against real hardware: heading and roll populate; lat/lon flow through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)