### PR TITLE
Fix tool rendering per tool type; flip TrailingHitchLength sign convention

### DIFF
--- a/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
@@ -60,7 +60,11 @@ public class ToolConfig : ObservableObject
         set => SetProperty(ref _hitchLength, Math.Max(0, value));
     }
 
-    private double _trailingHitchLength = -2.5;
+    // Distance from hitch to trailing tool, measured behind the hitch.
+    // Convention: positive = tool is behind hitch (the only physically valid direction
+    // for a trailing implement). Sign-agnostic at runtime; legacy profiles with
+    // negative values are migrated on load.
+    private double _trailingHitchLength = 2.5;
     public double TrailingHitchLength
     {
         get => _trailingHitchLength;

--- a/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
@@ -208,7 +208,9 @@ public static class ProfileJsonService
         store.Tool.Overlap = dto.Tool?.Overlap ?? 0.0;
         store.Tool.Offset = dto.Tool?.Offset ?? 0.0;
         store.Tool.HitchLength = dto.Tool?.HitchLength ?? 1.8;
-        store.Tool.TrailingHitchLength = dto.Tool?.TrailingHitchLength ?? -2.5;
+        // Legacy profiles may have negative TrailingHitchLength from the old default;
+        // migrate to "positive = behind hitch" by taking abs.
+        store.Tool.TrailingHitchLength = Math.Abs(dto.Tool?.TrailingHitchLength ?? 2.5);
         store.Tool.TankTrailingHitchLength = dto.Tool?.TankTrailingHitchLength ?? 3.0;
         store.Tool.TrailingToolToPivotLength = dto.Tool?.TrailingToolToPivotLength ?? 0.0;
         store.Tool.IsToolTrailing = dto.Tool?.IsToolTrailing ?? false;

--- a/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
+++ b/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Globalization;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
@@ -130,7 +131,7 @@ public class VehicleProfileService : IVehicleProfileService
         store.Tool.Overlap = 0.0;
         store.Tool.Offset = 0.0;
         store.Tool.HitchLength = 1.8;
-        store.Tool.TrailingHitchLength = -2.5;
+        store.Tool.TrailingHitchLength = 2.5;
         store.Tool.TankTrailingHitchLength = 3.0;
         store.Tool.TrailingToolToPivotLength = 0.0;
         store.Tool.IsToolTrailing = false;
@@ -203,7 +204,9 @@ public class VehicleProfileService : IVehicleProfileService
         store.Tool.Overlap = GetDouble(settings, "setVehicle_toolOverlap", 0.0);
         store.Tool.Offset = GetDouble(settings, "setVehicle_toolOffset", 0.0);
         store.Tool.HitchLength = GetDouble(settings, "setVehicle_hitchLength", 1.8);
-        store.Tool.TrailingHitchLength = GetDouble(settings, "setTool_toolTrailingHitchLength", -2.5);
+        // Legacy AOG XML profiles often store TrailingHitchLength as a negative value due to
+        // a historical sign convention. Migrate to "positive = behind hitch" by taking abs.
+        store.Tool.TrailingHitchLength = Math.Abs(GetDouble(settings, "setTool_toolTrailingHitchLength", 2.5));
         store.Tool.TankTrailingHitchLength = GetDouble(settings, "setVehicle_tankTrailingHitchLength", 3.0);
         store.Tool.TrailingToolToPivotLength = GetDouble(settings, "setTool_trailingToolToPivotLength", 0.0);
         store.Tool.IsToolTrailing = GetBool(settings, "setTool_isToolTrailing", false);

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -191,6 +191,10 @@ internal class MapRenderState
     public double ToolX, ToolY, ToolHeading, ToolWidth, HitchX, HitchY;
     public bool ToolReady;
     public double HitchLength;
+    public bool IsToolTrailing;       // includes TBT — render as a single tongue line
+    public double ToolArmHalfSpread;  // half lateral spread of 3PT arms at the tractor mount
+    public double ToolArmBaseX, ToolArmBaseY; // tractor-side anchor for the 3PT arms (rear axle for rear-mounted, front of tractor for front-mounted)
+    public double ToolDrawbarBaseX, ToolDrawbarBaseY; // tractor-side anchor for the trailing drawbar (always at the rear axle)
 
     // Sections
     public bool[] SectionOn = Array.Empty<bool>();
@@ -775,6 +779,17 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             HitchY = _hitchY,
             ToolReady = _toolPositionReady,
             HitchLength = toolCfg.HitchLength,
+            IsToolTrailing = toolCfg.IsToolTrailing || toolCfg.IsToolTBT,
+            // 3PT lower-arm spread is typically narrower than the wheel track. Use 60% of
+            // half-track as a reasonable visual approximation since we don't model arm width.
+            ToolArmHalfSpread = vehicleCfg.TrackWidth * 0.5 * 0.6,
+            // Arm base = the tractor-side mount: rear axle (= vehicle pivot) for rear-mounted,
+            // or one wheelbase forward for front-mounted.
+            ToolArmBaseX = _vehicleX + (toolCfg.IsToolFrontFixed ? Math.Sin(_vehicleHeading) * vehicleCfg.Wheelbase : 0),
+            ToolArmBaseY = _vehicleY + (toolCfg.IsToolFrontFixed ? Math.Cos(_vehicleHeading) * vehicleCfg.Wheelbase : 0),
+            // Drawbar base = rear axle, always behind the vehicle pivot.
+            ToolDrawbarBaseX = _vehicleX,
+            ToolDrawbarBaseY = _vehicleY,
 
             SectionOn = (bool[])_sectionOn.Clone(),
             SectionWidths = (double[])_sectionWidths.Clone(),
@@ -4207,21 +4222,30 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             if (s.ToolWidth < 0.1) return;
             double toolDepth = 2.0;
 
-            // Hitch bar
-            double barEndX = s.HitchX + Math.Sin(s.VehicleHeading) * s.HitchLength;
-            double barEndY = s.HitchY + Math.Cos(s.VehicleHeading) * s.HitchLength;
-            var rearPen = new ImmutablePen(new ImmutableSolidColorBrush(Colors.Black), 0.3);
-            dc.DrawLine(rearPen, new Point(barEndX, barEndY), new Point(s.HitchX, s.HitchY));
-
-            // V-shape hitch
-            double hitchHalfW = s.ToolWidth / 2.0;
-            double cosH = Math.Cos(-s.ToolHeading);
-            double sinH = Math.Sin(-s.ToolHeading);
-            var leftEnd = new Point(s.ToolX + (-hitchHalfW) * cosH, s.ToolY + (-hitchHalfW) * sinH);
-            var rightEnd = new Point(s.ToolX + hitchHalfW * cosH, s.ToolY + hitchHalfW * sinH);
-            var apex = new Point(s.HitchX, s.HitchY);
-            dc.DrawLine(_hitchPenImm, apex, leftEnd);
-            dc.DrawLine(_hitchPenImm, apex, rightEnd);
+            if (s.IsToolTrailing)
+            {
+                // Trailing/TBT: single drawbar + tongue. The drawbar runs from the rear
+                // axle to the hitch ball; the tongue runs from the hitch ball to the
+                // implement center.
+                var drawbarPen = new ImmutablePen(new ImmutableSolidColorBrush(Colors.Black), 0.3);
+                dc.DrawLine(drawbarPen, new Point(s.ToolDrawbarBaseX, s.ToolDrawbarBaseY), new Point(s.HitchX, s.HitchY));
+                dc.DrawLine(_hitchPenImm, new Point(s.HitchX, s.HitchY), new Point(s.ToolX, s.ToolY));
+            }
+            else
+            {
+                // Fixed (3PT-mounted): two angled lower arms from the tractor mount out to
+                // the implement. No drawbar — the implement attaches directly. Arms diverge
+                // laterally at the mount (rear axle for rear-mounted, front of tractor for
+                // front-mounted) and converge to the implement center.
+                double cosV = Math.Cos(-s.VehicleHeading);
+                double sinV = Math.Sin(-s.VehicleHeading);
+                double armSpread = s.ToolArmHalfSpread;
+                var armBaseLeft = new Point(s.ToolArmBaseX + (-armSpread) * cosV, s.ToolArmBaseY + (-armSpread) * sinV);
+                var armBaseRight = new Point(s.ToolArmBaseX + armSpread * cosV, s.ToolArmBaseY + armSpread * sinV);
+                var implementCenter = new Point(s.ToolX, s.ToolY);
+                dc.DrawLine(_hitchPenImm, armBaseLeft, implementCenter);
+                dc.DrawLine(_hitchPenImm, armBaseRight, implementCenter);
+            }
 
             // Sections
             using (dc.PushPreTransform(Matrix.CreateTranslation(s.ToolX, s.ToolY)))
@@ -4556,21 +4580,27 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             float tx = (float)s.ToolX, ty = (float)s.ToolY;
             float toolDepth = 2.0f;
 
-            // Hitch bar (rear axle to hitch point)
-            float barEndX = (float)(s.HitchX + Math.Sin(s.VehicleHeading) * s.HitchLength);
-            float barEndY = (float)(s.HitchY + Math.Cos(s.VehicleHeading) * s.HitchLength);
-            using var rearPaint = new SKPaint { Color = SKColors.Black, Style = SKPaintStyle.Stroke, StrokeWidth = 0.3f };
-            canvas.DrawLine(barEndX, barEndY, (float)s.HitchX, (float)s.HitchY, rearPaint);
-
-            // V-shape hitch (hitch point to tool ends)
-            float hitchHalfW = (float)(s.ToolWidth / 2.0);
-            float cosH = (float)Math.Cos(-s.ToolHeading);
-            float sinH = (float)Math.Sin(-s.ToolHeading);
             using var hitchPaint = new SKPaint { Color = new SKColor(255, 255, 0), Style = SKPaintStyle.Stroke, StrokeWidth = 0.15f };
-            canvas.DrawLine((float)s.HitchX, (float)s.HitchY,
-                tx + (-hitchHalfW) * cosH, ty + (-hitchHalfW) * sinH, hitchPaint);
-            canvas.DrawLine((float)s.HitchX, (float)s.HitchY,
-                tx + hitchHalfW * cosH, ty + hitchHalfW * sinH, hitchPaint);
+
+            if (s.IsToolTrailing)
+            {
+                // Trailing/TBT: single drawbar (rear axle to hitch ball) + tongue (hitch to implement).
+                using var drawbarPaint = new SKPaint { Color = SKColors.Black, Style = SKPaintStyle.Stroke, StrokeWidth = 0.3f };
+                canvas.DrawLine((float)s.ToolDrawbarBaseX, (float)s.ToolDrawbarBaseY,
+                    (float)s.HitchX, (float)s.HitchY, drawbarPaint);
+                canvas.DrawLine((float)s.HitchX, (float)s.HitchY, tx, ty, hitchPaint);
+            }
+            else
+            {
+                // Fixed (3PT-mounted): two angled lower arms from tractor mount converging at the implement.
+                float cosV = (float)Math.Cos(-s.VehicleHeading);
+                float sinV = (float)Math.Sin(-s.VehicleHeading);
+                float baseX = (float)s.ToolArmBaseX;
+                float baseY = (float)s.ToolArmBaseY;
+                float armSpread = (float)s.ToolArmHalfSpread;
+                canvas.DrawLine(baseX + (-armSpread) * cosV, baseY + (-armSpread) * sinV, tx, ty, hitchPaint);
+                canvas.DrawLine(baseX + armSpread * cosV, baseY + armSpread * sinV, tx, ty, hitchPaint);
+            }
 
             canvas.Save();
             canvas.Translate(tx, ty);

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 43
+#define VERSION_PATCH 44
 
-#define VERSION "26.4.43"
-#define VERSION_DATE "2026-04-24"
+#define VERSION "26.4.44"
+#define VERSION_DATE "2026-04-25"


### PR DESCRIPTION
Closes #276.

## Summary
- **Bug 1 (rendering)**: Tool drawbar rendering now branches on mount type. 3PT tools (rear or front fixed) get two angled lower arms from the tractor mount to the implement; trailing/TBT tools get a single drawbar (rear axle → hitch ball) and a tongue (hitch → implement). Previously both shapes were drawn for every tool type, which made the visual cue effectively swapped from real equipment.
- **Bug 2 (TrailingHitchLength sign)**: The formula was already \"positive = behind hitch,\" but defaults were stored as `-2.5` everywhere, so fresh profiles rendered the tool in front of the tractor. Defaults flipped to `+2.5`, and legacy XML/JSON profile loaders apply `Math.Abs()` on read so existing profiles auto-migrate.

## Why
Reported in #276 as cosmetic for the rendering and correctness-affecting for the sign — a user following the UI's \"enter positive numbers\" guidance would still get the broken default. Both are fixed in one PR because they share the same code path and would otherwise need conflicting test updates.

## Files
- `Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs` — split `DrawTool` / `DrawToolSk` into trailing vs fixed branches; precompute `ToolArmBase` (vehicle pivot for rear-mounted, pivot + wheelbase for front-mounted) and `ToolDrawbarBase` (vehicle pivot) in the snapshot builder.
- `Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs` — default `TrailingHitchLength = 2.5`.
- `Shared/AgValoniaGPS.Services/VehicleProfileService.cs` — default and legacy XML loader now produce positive values.
- `Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs` — JSON profile loader takes `Math.Abs` of stored value.

## Test plan
- [x] `dotnet build AgValoniaGPS.sln` clean
- [x] `dotnet test` — 835/835 pass (3 skipped, pre-existing)
- [x] Visual smoke test on Desktop:
  - Rear Fixed: V-arms emerge from rear axle, converge at implement behind tractor. ✓
  - Front Fixed: V-arms emerge from front of tractor (one wheelbase ahead of pivot), converge at implement in front. ✓
  - Trailing: single drawbar + tongue, tool sits behind tractor. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)