### PR TITLE
Fix render-loop pause on right-panel section toggles

### DIFF
--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -890,6 +890,14 @@ public class SectionControlService : ISectionControlService
         for (int i = 0; i < 16; i++)
         {
             _sectionStates[i].ButtonState = state;
+
+            // Mirror SetSectionState: sync IsOn for manual states so the UI
+            // reflects the change immediately. Auto is left for Update() to
+            // determine based on coverage/boundaries.
+            if (state == SectionButtonState.On)
+                _sectionStates[i].IsOn = true;
+            else if (state == SectionButtonState.Off)
+                _sectionStates[i].IsOn = false;
         }
 
         SectionStateChanged?.Invoke(this, new SectionStateChangedEventArgs

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -793,10 +793,7 @@ public partial class MainViewModel
                 IsSectionMasterOn = false;
 
             var newState = IsManualSectionMode ? SectionButtonState.On : SectionButtonState.Off;
-            for (int i = 0; i < _sectionControlService.NumSections; i++)
-            {
-                _sectionControlService.SetSectionState(i, newState);
-            }
+            _sectionControlService.SetAllSections(newState);
 
             StatusMessage = IsManualSectionMode ? "All sections ON" : "All sections OFF";
         });
@@ -808,10 +805,7 @@ public partial class MainViewModel
                 IsManualSectionMode = false;
 
             var newState = IsSectionMasterOn ? SectionButtonState.Auto : SectionButtonState.Off;
-            for (int i = 0; i < _sectionControlService.NumSections; i++)
-            {
-                _sectionControlService.SetSectionState(i, newState);
-            }
+            _sectionControlService.SetAllSections(newState);
 
             StatusMessage = IsSectionMasterOn ? "All sections AUTO" : "All sections OFF";
         });

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 44
+#define VERSION_PATCH 45
 
-#define VERSION "26.4.44"
-#define VERSION_DATE "2026-04-25"
+#define VERSION "26.4.45"
+#define VERSION_DATE "2026-04-27"


### PR DESCRIPTION
## Summary

- Right-panel "All Sections Manual" and "All Sections Master" buttons now call the existing `SetAllSections` batch helper instead of looping `SetSectionState` 16 times. The looped path fired `SectionStateChanged` 16x synchronously on the UI thread, which spawned 16 NetCoreAudio `Process.Start` calls and raised 512 `PropertyChanged` notifications — enough to visibly pause the map render loop.
- Fixed a latent bug in `SectionControlService.SetAllSections`: it updated `ButtonState` but not `IsOn` for manual On/Off, which is why the right-panel commands originally looped (so the UI would reflect the change). `SetAllSections` now mirrors `SetSectionState`'s IsOn sync; Auto is still left for `Update()` to determine.
- The per-section toolbar button (`ToggleSectionCommand`) was unaffected — it only fires the event once, which matches the user's observation that the toolbar doesn't pause the render loop.

## Test plan

- [x] `dotnet build` — clean (0 errors)
- [x] `dotnet test` SectionControl filter — 12/12 pass
- [ ] Manually toggle "All Sections Manual" and "All Sections Master" on the right panel — render loop should not pause
- [ ] Per-section buttons on the toolbar still behave as before
- [ ] Section colors update correctly when toggling all (Auto = green via `Update()` after first tick; On = yellow immediately; Off = red immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)