### PR TITLE
Fix two map-render glitches: section toggles + tool oscillation

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -294,36 +294,15 @@ public partial class MainView : UserControl
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // Update vehicle position when Easting, Northing, or Heading changes
+        // Vehicle/tool/hitch positions are pushed atomically via
+        // _mapService.SetAllPositions(...) at the end of ApplyGpsCycleResult,
+        // so we must NOT also push them per-property here. Doing both caused
+        // visible tool/hitch oscillation: SetVehiclePosition moves the camera
+        // and triggers a render with stale tool state, then SetAllPositions
+        // snaps the tool forward — once per GPS tick.
         if (_mapControl != null && _viewModel != null)
         {
-            if (e.PropertyName == nameof(MainViewModel.Easting) ||
-                e.PropertyName == nameof(MainViewModel.Northing) ||
-                e.PropertyName == nameof(MainViewModel.Heading))
-            {
-                // Convert heading from degrees to radians (ViewModel stores degrees, map expects radians)
-                double headingRadians = _viewModel.Heading * Math.PI / 180.0;
-                _mapControl.SetVehiclePosition(_viewModel.Easting, _viewModel.Northing, headingRadians);
-            }
-            else if (e.PropertyName == nameof(MainViewModel.ToolEasting) ||
-                     e.PropertyName == nameof(MainViewModel.ToolNorthing))
-            {
-                // Tool position updated - update map control
-                _mapControl.SetToolPosition(
-                    _viewModel.ToolEasting,
-                    _viewModel.ToolNorthing,
-                    _viewModel.ToolHeadingRadians,
-                    _viewModel.ToolWidth,
-                    _viewModel.HitchEasting,
-                    _viewModel.HitchNorthing);
-                // Also update section states for rendering
-                _mapControl.SetSectionStates(
-                    _viewModel.GetSectionStates(),
-                    _viewModel.GetSectionWidths(),
-                    _viewModel.NumSections,
-                    _viewModel.GetSectionButtonStates());
-            }
-            else if (e.PropertyName?.StartsWith("Section") == true &&
+            if (e.PropertyName?.StartsWith("Section") == true &&
                      (e.PropertyName.EndsWith("Active") || e.PropertyName.EndsWith("ColorCode")))
             {
                 // Section state or color code changed - update map control

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -472,42 +472,13 @@ public partial class MainWindow : Window
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(MainViewModel.Easting) ||
-            e.PropertyName == nameof(MainViewModel.Northing) ||
-            e.PropertyName == nameof(MainViewModel.Heading))
-        {
-            if (ViewModel != null && MapControl != null)
-            {
-                // Convert heading from degrees to radians
-                double headingRadians = ViewModel.Heading * Math.PI / 180.0;
-                MapControl.SetVehiclePosition(ViewModel.Easting, ViewModel.Northing, headingRadians);
-                // NOTE: Boundary point recording is now handled by MainViewModel
-            }
-        }
-        else if (e.PropertyName == nameof(MainViewModel.ToolEasting) ||
-                 e.PropertyName == nameof(MainViewModel.ToolNorthing) ||
-                 e.PropertyName == nameof(MainViewModel.ToolWidth))
-        {
-            // Tool position updated - update map control
-            if (ViewModel != null && MapControl != null)
-            {
-                MapControl.SetToolPosition(
-                    ViewModel.ToolEasting,
-                    ViewModel.ToolNorthing,
-                    ViewModel.ToolHeadingRadians,
-                    ViewModel.ToolWidth,
-                    ViewModel.HitchEasting,
-                    ViewModel.HitchNorthing,
-                    ViewModel.IsToolPositionReady);
-                // Also update section states for rendering
-                MapControl.SetSectionStates(
-                    ViewModel.GetSectionStates(),
-                    ViewModel.GetSectionWidths(),
-                    ViewModel.NumSections,
-                    ViewModel.GetSectionButtonStates());
-            }
-        }
-        else if (e.PropertyName?.StartsWith("Section") == true &&
+        // Vehicle/tool/hitch positions are pushed atomically via
+        // _mapService.SetAllPositions(...) at the end of ApplyGpsCycleResult,
+        // so we must NOT also push them per-property here. Doing both caused
+        // visible tool/hitch oscillation: SetVehiclePosition moves the camera
+        // and triggers a render with stale tool state, then SetAllPositions
+        // snaps the tool forward — once per GPS tick.
+        if (e.PropertyName?.StartsWith("Section") == true &&
                  (e.PropertyName.EndsWith("Active") || e.PropertyName.EndsWith("ColorCode")))
         {
             // Section state or color code changed - update map control

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -297,36 +297,15 @@ public partial class MainView : UserControl
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // Update vehicle position when Easting, Northing, or Heading changes
+        // Vehicle/tool/hitch positions are pushed atomically via
+        // _mapService.SetAllPositions(...) at the end of ApplyGpsCycleResult,
+        // so we must NOT also push them per-property here. Doing both caused
+        // visible tool/hitch oscillation: SetVehiclePosition moves the camera
+        // and triggers a render with stale tool state, then SetAllPositions
+        // snaps the tool forward — once per GPS tick.
         if (_mapControl != null && _viewModel != null)
         {
-            if (e.PropertyName == nameof(MainViewModel.Easting) ||
-                e.PropertyName == nameof(MainViewModel.Northing) ||
-                e.PropertyName == nameof(MainViewModel.Heading))
-            {
-                // Convert heading from degrees to radians (ViewModel stores degrees, map expects radians)
-                double headingRadians = _viewModel.Heading * Math.PI / 180.0;
-                _mapControl.SetVehiclePosition(_viewModel.Easting, _viewModel.Northing, headingRadians);
-            }
-            else if (e.PropertyName == nameof(MainViewModel.ToolEasting) ||
-                     e.PropertyName == nameof(MainViewModel.ToolNorthing))
-            {
-                // Tool position updated - update map control
-                _mapControl.SetToolPosition(
-                    _viewModel.ToolEasting,
-                    _viewModel.ToolNorthing,
-                    _viewModel.ToolHeadingRadians,
-                    _viewModel.ToolWidth,
-                    _viewModel.HitchEasting,
-                    _viewModel.HitchNorthing);
-                // Also update section states for rendering
-                _mapControl.SetSectionStates(
-                    _viewModel.GetSectionStates(),
-                    _viewModel.GetSectionWidths(),
-                    _viewModel.NumSections,
-                    _viewModel.GetSectionButtonStates());
-            }
-            else if (e.PropertyName?.StartsWith("Section") == true &&
+            if (e.PropertyName?.StartsWith("Section") == true &&
                      (e.PropertyName.EndsWith("Active") || e.PropertyName.EndsWith("ColorCode")))
             {
                 // Section state or color code changed - update map control

--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -890,6 +890,14 @@ public class SectionControlService : ISectionControlService
         for (int i = 0; i < 16; i++)
         {
             _sectionStates[i].ButtonState = state;
+
+            // Mirror SetSectionState: sync IsOn for manual states so the UI
+            // reflects the change immediately. Auto is left for Update() to
+            // determine based on coverage/boundaries.
+            if (state == SectionButtonState.On)
+                _sectionStates[i].IsOn = true;
+            else if (state == SectionButtonState.Off)
+                _sectionStates[i].IsOn = false;
         }
 
         SectionStateChanged?.Invoke(this, new SectionStateChangedEventArgs

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -793,10 +793,7 @@ public partial class MainViewModel
                 IsSectionMasterOn = false;
 
             var newState = IsManualSectionMode ? SectionButtonState.On : SectionButtonState.Off;
-            for (int i = 0; i < _sectionControlService.NumSections; i++)
-            {
-                _sectionControlService.SetSectionState(i, newState);
-            }
+            _sectionControlService.SetAllSections(newState);
 
             StatusMessage = IsManualSectionMode ? "All sections ON" : "All sections OFF";
         });
@@ -808,10 +805,7 @@ public partial class MainViewModel
                 IsManualSectionMode = false;
 
             var newState = IsSectionMasterOn ? SectionButtonState.Auto : SectionButtonState.Off;
-            for (int i = 0; i < _sectionControlService.NumSections; i++)
-            {
-                _sectionControlService.SetSectionState(i, newState);
-            }
+            _sectionControlService.SetAllSections(newState);
 
             StatusMessage = IsSectionMasterOn ? "All sections AUTO" : "All sections OFF";
         });

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 44
+#define VERSION_PATCH 45
 
-#define VERSION "26.4.44"
-#define VERSION_DATE "2026-04-25"
+#define VERSION "26.4.45"
+#define VERSION_DATE "2026-04-27"


### PR DESCRIPTION
Two unrelated UI-thread bugs that both manifested as visible glitches in the map render loop. Bundled into one PR because each is small and they were caught/fixed during the same session.

## 1. Tool/hitch oscillation while driving (commit `f95596b`)

The tool and hitch bars vibrated forward/backward each GPS tick — the tractor sprite was unaffected because it's anchored to screen-center via the camera.

`MainViewModel.ApplyResults.ApplyGpsCycleResult` is the single writer of `Easting`/`Northing`/`Heading` and `ToolEasting`/`ToolNorthing`/etc. on `MainViewModel`, and it already pushes all positions atomically via `_mapService.SetAllPositions(...)` at the end of each cycle. The platform views (Desktop/iOS/Android) were **also** subscribing to `PropertyChanged` on those properties and calling `SetVehiclePosition` / `SetToolPosition` individually as each setter fired:

1. `Easting=` → `SetVehiclePosition`: camera moves to new vehicle pos and `SendStateToHandler` fires a render — but tool is still at OLD position.
2. `Northing=`, `Heading=` → two more `SetVehiclePosition` calls, each re-rendering with stale tool state.
3. Tool setters fire — `SetToolPosition` updates internal tool state but does **not** call `SendStateToHandler`.
4. `SetAllPositions(...)` finally pushes the atomic snapshot, snapping the tool forward.

Net: each tick the tool/hitch lagged backward (camera moved, tool didn't), then snapped forward — the "frame-sync-like" oscillation.

**Fix:** delete the position-push branches from all three platform `PropertyChanged` handlers. Section-state branches preserved — those still do real bridging work (`ApplyGpsCycleResult` writes per-section VM properties without pushing to the map control directly).

## 2. Render-loop pause on right-panel section toggles (commit `5e65f77`, originally PR #303)

The right-panel "All Sections Manual" and "All Sections Master" buttons paused the map render loop visibly when toggled. The per-section toolbar buttons did not — that was the giveaway.

The right-panel commands called `_sectionControlService.SetSectionState(i, ...)` in a loop over all 16 sections. Each call fires `SectionStateChanged` synchronously on the UI thread, and the handler:

- Plays a section sound (NetCoreAudio `Process.Start` per call on macOS/Linux)
- Raises 32 `PropertyChanged` notifications that re-evaluate section-button bindings

16x of that synchronously stalled the dispatcher.

**Fix:** route both toggles through the existing `SetAllSections(state)` batch helper, which fires a single event with `SectionIndex = -1` (the handler already suppresses the per-section sound on negative indices). Also fixed a latent bug in `SetAllSections` where it updated `ButtonState` but not `IsOn` for manual On/Off — that was why the original commands looped instead of using the batch helper.

## Test plan

- [x] `dotnet build` — clean (0 errors)
- [x] `dotnet test` SectionControl filter — 12/12 pass
- [x] Manually verified: toggling all-manual / all-auto from the right panel no longer pauses rendering
- [x] Manually verified: tool and hitch bars stay glued to the tractor while driving (no oscillation)
- [ ] Per-section toolbar buttons still behave as before
- [ ] Section colors still update correctly when toggling all (Auto = green via `Update()` after first tick; On = yellow immediately; Off = red immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)