### PR TITLE
Fix coverage gap on simulator stop/restart

### DIFF
--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -210,17 +210,19 @@ public class SectionControlService : ISectionControlService
         }
         _previousHeading = toolHeading;
 
-        // Check if speed is below cutoff
+        // Check if speed is below cutoff - turn off AUTO sections but keep
+        // MANUAL ON sections active so coverage doesn't gap on stop/restart.
         if (speed < tool.SlowSpeedCutoff)
         {
             for (int i = 0; i < numSections; i++)
             {
-                UpdateSectionOff(i);
+                if (_sectionStates[i].ButtonState != SectionButtonState.On)
+                    UpdateSectionOff(i);
             }
             _yawRate = 0; // Reset when stopped
             _instantYawRate = 0;
             _vehicleYawRate = 0;
-            return;
+            // Don't return early - manual sections still need UpdateSectionOn
         }
 
         // Reset timing accumulators

--- a/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
@@ -45,9 +45,9 @@ public class SectionControlServiceTests
     #region Slow Speed
 
     [Test]
-    public void Update_SlowSpeed_AllSectionsOff()
+    public void Update_SlowSpeed_AutoSectionsOff_ManualStaysOn()
     {
-        // Set all sections to Auto and manually turn them on first
+        // Set sections: 0=Manual ON, 1=Manual ON, 2=Auto
         _service.SetAllAuto();
         _service.SetSectionState(0, SectionButtonState.On);
         _service.SetSectionState(1, SectionButtonState.On);
@@ -55,10 +55,11 @@ public class SectionControlServiceTests
         // Update at very slow speed (below 0.5 m/s cutoff)
         _service.Update(new Vec3(50, 50, 0), 0, 0, 0.1);
 
-        Assert.That(_service.SectionStates[0].IsOn, Is.False);
-        Assert.That(_service.SectionStates[1].IsOn, Is.False);
+        // Manual ON sections stay on (prevents coverage gap on stop/restart)
+        Assert.That(_service.SectionStates[0].IsOn, Is.True);
+        Assert.That(_service.SectionStates[1].IsOn, Is.True);
+        // Auto sections turn off
         Assert.That(_service.SectionStates[2].IsOn, Is.False);
-        Assert.That(_service.IsAnySectionOn, Is.False);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
SlowSpeedCutoff turned ALL sections off including manual ON (yellow), clearing coverage edge state. On restart, coverage started from a new position leaving a gap.

Fix: skip slow-speed cutoff for manual ON sections. Auto sections still turn off.

## Test plan
- [ ] `dotnet test Tests/AgValoniaGPS.Services.Tests/ --filter "SlowSpeed"`
- [ ] Simulator: drive with yellow section, stop, continue - no gap