### PR TITLE
Add coverage anti-aliasing toggle to Display settings

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -209,8 +209,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="Guide Count" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
-                        <!-- Row 3: Direction Markers, Section Lines -->
-                        <!-- Line Smooth removed: Avalonia Skia renderer handles AA by default (#85) -->
+                        <!-- Row 3: Line Smooth (coverage anti-aliasing), Direction Markers, Section Lines -->
+                        <StackPanel Grid.Row="3" Grid.Column="0" Spacing="4" HorizontalAlignment="Center">
+                            <Button Classes="DisplayToggle"
+                                    Background="{Binding Display.LineSmoothEnabled, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
+                                    BorderBrush="{Binding Display.LineSmoothEnabled, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
+                                    Command="{Binding ToggleLineSmoothCommand}">
+                                <TextBlock Text="AA" FontSize="24" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Width="60" Height="60" TextAlignment="Center" Padding="0,14,0,0"/>
+                            </Button>
+                            <TextBlock Text="Smoothing" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
+                        </StackPanel>
 
                         <!-- Hidden: bitmap coverage system does not populate geometry cache (#117) -->
                         <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center"

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -270,6 +270,7 @@ internal class MapRenderState
     public bool SvennArrowVisible;
     public bool DirectionMarkersVisible;
     public bool FieldTextureVisible;
+    public bool LineSmoothEnabled;
     public bool ExtraGuidelines;
     public int ExtraGuidelinesCount;
     public bool HeadlandDistanceVisible;
@@ -859,6 +860,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             SvennArrowVisible = displayCfg.SvennArrowVisible,
             DirectionMarkersVisible = displayCfg.DirectionMarkersVisible,
             FieldTextureVisible = displayCfg.FieldTextureVisible,
+            LineSmoothEnabled = displayCfg.LineSmoothEnabled,
             ExtraGuidelines = displayCfg.ExtraGuidelines,
             ExtraGuidelinesCount = displayCfg.ExtraGuidelinesCount,
             HeadlandDistanceVisible = displayCfg.HeadlandDistanceVisible,
@@ -3170,8 +3172,10 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         private DateTime _coverageSnapshotTime = DateTime.MinValue;
         private int _coverageSnapshotInFlight;        // 0 = idle, 1 = bg task running
         private const double CoverageSnapshotIntervalMs = 200.0;
-        private static readonly SKSamplingOptions _coverageSampling =
+        private static readonly SKSamplingOptions _coverageSamplingNearest =
             new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
+        private static readonly SKSamplingOptions _coverageSamplingLinear =
+            new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None);
 
         // Immutable brushes
         private static readonly IImmutableBrush _vehicleBrushImm = new ImmutableSolidColorBrush(Color.FromRgb(0, 200, 0));
@@ -3834,7 +3838,8 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                 (float)s.BitmapMinE, (float)s.BitmapMinN,
                 (float)(s.BitmapMinE + worldWidth), (float)(s.BitmapMinN + worldHeight));
 
-            canvas.DrawImage(_coverageSnapshot, src, dst, _coverageSampling);
+            var sampling = s.LineSmoothEnabled ? _coverageSamplingLinear : _coverageSamplingNearest;
+            canvas.DrawImage(_coverageSnapshot, src, dst, sampling);
         }
 
         private void DrawBoundary(SKCanvas canvas, MapRenderState s)


### PR DESCRIPTION
## Summary
Wire LineSmoothEnabled to coverage bitmap rendering filter mode:
- ON (default): Linear filtering - smooth coverage edges
- OFF: Nearest filtering - sharp/pixelated coverage edges

"AA" toggle button added to Display config tab.

## Test plan
- [ ] Toggle AA button in Display settings, verify coverage rendering changes
- [ ] Default should be smooth (Linear)