### PR TITLE
Fix tool drawn as one rectangle until first section auto-on

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Services/MapService.cs
+++ b/Platforms/AgValoniaGPS.Android/Services/MapService.cs
@@ -155,6 +155,11 @@ public class MapService : IMapService
             toolX, toolY, toolHeading, toolWidth, hitchX, hitchY, toolReady);
     }
 
+    public void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections, int[] buttonStates)
+    {
+        _mapControl?.SetSectionStates(sectionOn, sectionWidths, numSections, buttonStates);
+    }
+
     public void SetReversing(bool isReversing) { if (_mapControl != null) _mapControl.IsReversing = isReversing; }
     public void SetGuidancePoints(double goalEasting, double goalNorthing, bool isActive) { _mapControl?.SetGuidancePoints(goalEasting, goalNorthing, isActive); }
 

--- a/Platforms/AgValoniaGPS.Desktop/Services/MapService.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Services/MapService.cs
@@ -105,6 +105,9 @@ public class MapService : IMapService
         GetMapControl().SetAllPositions(vehicleX, vehicleY, vehicleHeading,
             toolX, toolY, toolHeading, toolWidth, hitchX, hitchY, toolReady);
 
+    public void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections, int[] buttonStates) =>
+        GetMapControl().SetSectionStates(sectionOn, sectionWidths, numSections, buttonStates);
+
     public bool IsGridVisible
     {
         get => _mapControl?.IsGridVisible ?? false;

--- a/Platforms/AgValoniaGPS.iOS/Services/MapService.cs
+++ b/Platforms/AgValoniaGPS.iOS/Services/MapService.cs
@@ -155,6 +155,11 @@ public class MapService : IMapService
             toolX, toolY, toolHeading, toolWidth, hitchX, hitchY, toolReady);
     }
 
+    public void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections, int[] buttonStates)
+    {
+        _mapControl?.SetSectionStates(sectionOn, sectionWidths, numSections, buttonStates);
+    }
+
     public void SetReversing(bool isReversing) { if (_mapControl != null) _mapControl.IsReversing = isReversing; }
     public void SetGuidancePoints(double goalEasting, double goalNorthing, bool isActive) { _mapControl?.SetGuidancePoints(goalEasting, goalNorthing, isActive); }
 

--- a/Shared/AgValoniaGPS.Services/Interfaces/IMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IMapService.cs
@@ -66,6 +66,14 @@ public interface IMapService
         double toolX, double toolY, double toolHeading, double toolWidth,
         double hitchX, double hitchY, bool toolReady);
 
+    /// <summary>
+    /// Push section layout (count + per-section width) and current states
+    /// (on/off + button color codes) to the map renderer. Pushed every cycle
+    /// from ApplyGpsCycleResult so the renderer always has fresh layout, not
+    /// just on per-property change events.
+    /// </summary>
+    void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections, int[] buttonStates);
+
     // Grid
     bool IsGridVisible { get; set; }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -209,6 +209,20 @@ public partial class MainViewModel
         {
             UpdateSectionPropertiesFromResult(result.SectionStates, result.SectionColorCodes);
 
+            // Push section layout/state to the renderer every cycle. The
+            // platform views' per-property bridge only fires on
+            // SectionXActive/ColorCode change, which doesn't happen at app
+            // start when everything's at default — that left the tool drawn
+            // as one undivided rectangle until the first auto-on flip.
+            if (NumSections > 0)
+            {
+                _mapService.SetSectionStates(
+                    GetSectionStates(),
+                    GetSectionWidths(),
+                    NumSections,
+                    GetSectionButtonStates());
+            }
+
             // Skip-and-fill bookkeeping: any active section means the current
             // path is being worked. Was previously inside the legacy
             // UpdateCoveragePainting on the UI-thread tool-position path

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 54
+#define VERSION_PATCH 55
 
-#define VERSION "26.4.54"
+#define VERSION "26.4.55"
 #define VERSION_DATE "2026-04-27"


### PR DESCRIPTION
## Summary

At app start the tool was rendered as a single undivided rectangle. Section dividers only appeared once the tractor began moving and a section auto-flipped to On. Visible on Desktop and both tablets.

**Cause**: the platform views' `OnViewModelPropertyChanged` handler is the only path that calls `MapControl.SetSectionStates(...)`, and it only fires on `SectionXActive`/`SectionXColorCode` change. At app start every section is in default Off state (IsOn=false, ColorCode=0); the cycle's first run doesn't change those values, so PropertyChanged never fires, the renderer's `_numSections` / section widths stay at their zero defaults, and the bar falls back to one solid rectangle.

When motion crosses the speed cutoff, auto-eval flips at least one section's `IsOn`, finally firing PropertyChanged and triggering the bridge — that's why "lines appear when the tractor moves."

**Fix**: push section layout/state to the renderer from `ApplyGpsCycleResult` every cycle via `_mapService`, so the renderer always gets fresh data on the first cycle regardless of any state transition.

- `IMapService.SetSectionStates(...)` added.
- Implemented on each platform's `MapService` as a thin pass-through to `MapControl.SetSectionStates`.
- Called from `ApplyGpsCycleResult` after `UpdateSectionPropertiesFromResult` (only when `NumSections > 0`).
- Per-property bridge in platform views left in place — harmless (idempotent) and still drives manual toolbar toggles' synchronous map update.

## Test plan

- [x] Build clean on Desktop, iOS (ios-arm64), Android — 0 errors
- [x] Verified on physical iPad Pro 2nd gen and Android tablet: section dividers visible immediately at app start, no waiting for motion
- [ ] Per-section toolbar toggle still works (immediate render update)
- [ ] Master Manual / Auto / Off toggles still update correctly
- [ ] Auto headland transitions still render correctly during driving

🤖 Generated with [Claude Code](https://claude.com/claude-code)