### PR TITLE
Default mobile coverage resolution to High on first launch

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -60,6 +60,13 @@ namespace AgValoniaGPS.Models
         public double CameraZoom { get; set; } = 100.0;
         public double CameraPitch { get; set; } = -60.0;
 
+        // Coverage display resolution multiplier (1.0 = Ultra, 1.5 = High,
+        // 2.5 = Medium, 4.0 = Low, 6.0 = Minimum). Default mirrors the
+        // platform-aware default in DisplayConfig so a missing settings file
+        // produces the same first-launch behavior as a fresh DisplayConfig.
+        public double DisplayResolutionMultiplier { get; set; } =
+            OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() ? 1.5 : 1.0;
+
         // NTRIP settings
         public string NtripCasterIp { get; set; } = string.Empty;
         public int NtripCasterPort { get; set; } = 2101;

--- a/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
@@ -309,10 +309,18 @@ public class DisplayConfig : ObservableObject
     // Coverage display resolution multiplier
     // 1.0 = Ultra, 1.5 = High, 2.5 = Medium, 4.0 = Low, 6.0 = Minimum
     // Applied to coverage bitmap cell size — detection always stays at 0.1m
-    private double _displayResolutionMultiplier = 1.0;
+    private double _displayResolutionMultiplier = GetDefaultResolutionMultiplier();
     public double DisplayResolutionMultiplier
     {
         get => _displayResolutionMultiplier;
         set => SetProperty(ref _displayResolutionMultiplier, Math.Clamp(value, 1.0, 6.0));
     }
+
+    // Default High (1.5) on mobile, Ultra (1.0) on desktop. iPad Pro 2nd gen
+    // measured ~40 FPS at High with AA on — well above the 24 FPS floor —
+    // and visual quality is close enough to Ultra that it's the right
+    // first-launch default for tablets. Users can dial up to Ultra in
+    // Display config when running on faster hardware.
+    private static double GetDefaultResolutionMultiplier() =>
+        OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() ? 1.5 : 1.0;
 }

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -158,6 +158,7 @@ public class ConfigurationService(
         store.Display.ElevationLogEnabled = settings.ElevationLogEnabled;
         store.Display.CameraZoom = settings.CameraZoom;
         store.Display.CameraPitch = settings.CameraPitch;
+        store.Display.DisplayResolutionMultiplier = settings.DisplayResolutionMultiplier;
 
         // Connection config
         store.Connections.NtripCasterHost = settings.NtripCasterIp;
@@ -219,6 +220,7 @@ public class ConfigurationService(
         settings.ElevationLogEnabled = store.Display.ElevationLogEnabled;
         settings.CameraZoom = store.Display.CameraZoom;
         settings.CameraPitch = store.Display.CameraPitch;
+        settings.DisplayResolutionMultiplier = store.Display.DisplayResolutionMultiplier;
 
         // Connection config
         settings.NtripCasterIp = store.Connections.NtripCasterHost;

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -623,6 +623,7 @@ public class ConfigurationServiceMappingTests
         _settings.ElevationLogEnabled = true;
         _settings.CameraZoom = 9999;
         _settings.CameraPitch = -50;
+        _settings.DisplayResolutionMultiplier = 4.0;
         _settings.NtripCasterIp = "MAPPED";
         _settings.NtripCasterPort = 9999;
         _settings.NtripMountPoint = "MAPPED";

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 54
+#define VERSION_PATCH 56
 
-#define VERSION "26.4.54"
+#define VERSION "26.4.56"
 #define VERSION_DATE "2026-04-27"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 56
+#define VERSION_PATCH 57
 
-#define VERSION "26.4.56"
+#define VERSION "26.4.57"
 #define VERSION_DATE "2026-04-27"


### PR DESCRIPTION
## Summary

Coverage display resolution defaults to Ultra (1.0) for all platforms. On older tablets that's overkill — measured ~40 FPS at High (1.5) with AA on on iPad Pro 2nd gen, well above the 24 FPS floor, with visual quality very close to Ultra at tablet viewing distance.

Use `OperatingSystem.IsAndroid() / IsIOS()` at field-init time to pick the default:
- Desktop: 1.0 (Ultra) — unchanged
- iOS / Android: 1.5 (High)

Users can dial up to Ultra in Display config when running on faster mobile hardware. The platform check is a runtime call, so the same shared assembly correctly picks the default on each platform.

## Test plan

- [x] Build clean on Models project
- [x] iPad Pro 2nd gen: ~40 FPS at High with AA on (measured)
- [ ] Android tablet: verify FPS at High meets the 24 FPS floor
- [ ] Confirm Display config can dial up to Ultra and dial back down

🤖 Generated with [Claude Code](https://claude.com/claude-code)