### PR TITLE
Sync section UI to pipeline's 6-state color palette

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.SectionControl.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.SectionControl.cs
@@ -290,7 +290,11 @@ public partial class MainViewModel
     }
 
     /// <summary>
-    /// Get section button states (Off=0, Auto=1, On=2) for 3-state rendering.
+    /// Get per-section color codes for renderer + control bar. Returns the
+    /// pipeline's 6-state palette: 0=Off, 1=Manual On, 2=Auto On,
+    /// 3=Turning Off, 4=Turning On, 5=Auto Off. Method name is historical;
+    /// the renderer's section-bar switch and the SectionColorCodeToBackground
+    /// converter both consume these codes.
     /// </summary>
     public int[] GetSectionButtonStates()
     {
@@ -298,7 +302,7 @@ public partial class MainViewModel
         var result = new int[16];
         for (int i = 0; i < Math.Min(states.Count, 16); i++)
         {
-            result[i] = (int)states[i].ButtonState; // Off=0, Auto=1, On=2
+            result[i] = GetSectionColorCode(states[i]);
         }
         return result;
     }
@@ -438,18 +442,35 @@ public partial class MainViewModel
     }
 
     /// <summary>
-    /// Calculate color code for a section state (matches map rendering logic).
+    /// Calculate color code for a section state. Mirrors
+    /// GpsPipelineService.GetSectionColorCode so the section control bar,
+    /// the map renderer, and the cycle-driven SectionColorCodes array all
+    /// agree on the same 6-state palette:
+    ///   0 = Off (red)
+    ///   1 = Manual ON (yellow)
+    ///   2 = Auto ON (green)
+    ///   3 = Turning OFF (cyan) — IsOn but off-request pending
+    ///   4 = Turning ON (orange) — !IsOn but on-request pending
+    ///   5 = Auto OFF (gray)
     /// </summary>
     private static int GetSectionColorCode(SectionControlState state)
     {
-        // 3-state model: Off=Red, Auto=Green, On=Yellow
-        return state.ButtonState switch
-        {
-            SectionButtonState.Off => 0,  // Red - manually off
-            SectionButtonState.On => 1,   // Yellow - manually on
-            SectionButtonState.Auto => 2, // Green - automatic mode
-            _ => 0
-        };
+        if (state.ButtonState == SectionButtonState.Off)
+            return 0;
+        if (state.ButtonState == SectionButtonState.On)
+            return 1;
+
+        // Auto mode transition states
+        if (state.IsOn && state.SectionOffRequest)
+            return 3;
+        if (!state.IsOn && state.SectionOnRequest)
+            return 4;
+
+        // Auto mode steady states
+        if (state.IsOn)
+            return 2;
+
+        return 5;
     }
 
     #endregion

--- a/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
+++ b/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
@@ -332,17 +332,25 @@ public class StringToImageConverter : IValueConverter
 
 /// <summary>
 /// Converts section color code to background brush for section buttons.
-/// Color codes: 0=Red (Off), 1=Yellow (Manual On), 2=Green (Auto On), 3=Gray (Auto Off)
+/// Mirrors the renderer's 6-state palette in DrawingContextMapControl:
+///   0 = Off (red)
+///   1 = Manual ON (yellow)
+///   2 = Auto ON (green)
+///   3 = Turning OFF (cyan)
+///   4 = Turning ON (orange)
+///   5 = Auto OFF (gray)
 /// </summary>
 public class SectionColorCodeToBackgroundConverter : IValueConverter
 {
     public static readonly SectionColorCodeToBackgroundConverter Instance = new();
 
     // Match the exact colors used in DrawingContextMapControl
-    private static readonly IBrush RedBrush = new SolidColorBrush(Color.FromRgb(242, 51, 51));     // #F23333 - Off
-    private static readonly IBrush YellowBrush = new SolidColorBrush(Color.FromRgb(247, 247, 0)); // #F7F700 - Manual On
-    private static readonly IBrush GreenBrush = new SolidColorBrush(Color.FromRgb(0, 242, 0));    // #00F200 - Auto On
-    private static readonly IBrush GrayBrush = new SolidColorBrush(Color.FromRgb(100, 100, 100)); // #646464 - Auto Off
+    private static readonly IBrush RedBrush         = new SolidColorBrush(Color.FromRgb(242,  51,  51)); // #F23333 - Off
+    private static readonly IBrush YellowBrush      = new SolidColorBrush(Color.FromRgb(247, 247,   0)); // #F7F700 - Manual On
+    private static readonly IBrush GreenBrush       = new SolidColorBrush(Color.FromRgb(  0, 242,   0)); // #00F200 - Auto On
+    private static readonly IBrush CyanBrush        = new SolidColorBrush(Color.FromRgb(  0, 222, 222)); // #00DEDE - Turning Off
+    private static readonly IBrush OrangeBrush      = new SolidColorBrush(Color.FromRgb(255, 165,   0)); // #FFA500 - Turning On
+    private static readonly IBrush GrayBrush        = new SolidColorBrush(Color.FromRgb(150, 150, 150)); // #969696 - Auto Off
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
@@ -350,10 +358,12 @@ public class SectionColorCodeToBackgroundConverter : IValueConverter
         {
             return colorCode switch
             {
-                0 => RedBrush,    // Off
-                1 => YellowBrush, // Manual On
-                2 => GreenBrush,  // Auto On
-                3 => GrayBrush,   // Auto Off
+                0 => RedBrush,
+                1 => YellowBrush,
+                2 => GreenBrush,
+                3 => CyanBrush,
+                4 => OrangeBrush,
+                5 => GrayBrush,
                 _ => GrayBrush
             };
         }

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 57
+#define VERSION_PATCH 58
 
-#define VERSION "26.4.57"
-#define VERSION_DATE "2026-04-27"
+#define VERSION "26.4.58"
+#define VERSION_DATE "2026-04-28"


### PR DESCRIPTION
## Summary

Xyntexx's commit `65cc9fc` (Look-ahead slit tests + section control timing fix) expanded section color codes from 3-state to a 6-state palette and updated the cycle's `GetSectionColorCode` and the map renderer's tool-bar switch — but three UI consumers were left on the old mapping, producing visible bugs:

1. **Section control bar flicker (rapid green↔red)** — `MainViewModel.SectionControl.GetSectionColorCode` used a 3-state Off/Manual-On/Auto switch. `Section1ColorCode` etc. alternated between *that* code (via `OnSectionStateChanged` event running per cycle) and the pipeline's 6-state code (via `UpdateSectionPropertiesFromResult`) — flickering once per cycle.
2. **Tool drawn yellow instead of green** — `GetSectionButtonStates()` returned the raw `SectionButtonState` enum cast to int (`Off=0, Auto=1, On=2`). The map renderer's tool-bar switch expects `0=Off, 1=Manual On, 2=Auto On`, so an Auto section was sent as 1 and rendered as the Manual-On yellow brush.
3. **`SectionColorCodeToBackgroundConverter` missing colors** — handled codes 0-3 only and mapped 3 to gray. Pipeline now emits 3=Turning Off (cyan), 4=Turning On (orange), 5=Auto Off (gray); the converter only knew the first three.

## Fix

Bring all three into agreement with `GpsPipelineService.GetSectionColorCode` (Xyntexx's authoritative 6-state):

| Code | Meaning | Brush |
|---|---|---|
| 0 | Off | Red |
| 1 | Manual ON | Yellow |
| 2 | Auto ON | Green |
| 3 | Turning OFF (IsOn + off-request) | Cyan |
| 4 | Turning ON (!IsOn + on-request) | Orange |
| 5 | Auto OFF | Gray |

- `MainViewModel.SectionControl.GetSectionColorCode` rewritten to mirror pipeline.
- `GetSectionButtonStates()` calls it instead of casting the enum.
- `SectionColorCodeToBackgroundConverter` has explicit brushes for all six.

## Test plan

- [x] All 461 service tests passing
- [x] Build clean on Desktop
- [ ] Section control bar shows steady green when sections are Auto-on, no flicker
- [ ] Tool bar renders green (not yellow) for Auto-on sections
- [ ] Cyan/orange transition colors visible briefly when sections enter/exit headland in Auto mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)