### PR TITLE
Port AddStartEndPoints / ReducePointsByAngle / ChaikinsSmooth from CTrackMethods

### DIFF
--- a/Shared/AgValoniaGPS.Models/Guidance/CurveProcessing.cs
+++ b/Shared/AgValoniaGPS.Models/Guidance/CurveProcessing.cs
@@ -425,5 +425,217 @@ namespace AgValoniaGPS.Models.Guidance
             // Leave some margin (80% of min radius) to avoid artifacts
             return (int)(minRadius * 0.8 / passWidth);
         }
+
+        // ──────────────────────────────────────────────────────────────────
+        // Track extension and reduction (ported from AgOpenGPS 6.8.2
+        // CTrackMethods, issue #229)
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Extends a track by adding straight-line points before the start
+        /// and after the end, projected along the existing endpoint headings.
+        /// Useful for AB lines that need to extend past their recorded
+        /// endpoints to reach field boundaries.
+        ///
+        /// The first point's heading drives the prepend direction (going
+        /// backwards), the last point's heading drives the append direction
+        /// (going forwards).
+        /// </summary>
+        /// <param name="points">Input track (must have at least one point with valid heading on the endpoints).</param>
+        /// <param name="ptsToAdd">Number of points to add at each end. Default 10.</param>
+        /// <param name="distBetweenPoints">Spacing in meters. Default 50.</param>
+        /// <returns>Extended track: ptsToAdd-1 prepended points + original + ptsToAdd-1 appended points.</returns>
+        public static List<Vec3> AddStartEndPoints(IReadOnlyList<Vec3> points, int ptsToAdd = 10, double distBetweenPoints = 50)
+        {
+            if (points == null || points.Count == 0)
+                return new List<Vec3>();
+
+            var result = new List<Vec3>(points.Count + 2 * Math.Max(0, ptsToAdd - 1));
+            AppendPrependPoints(result, points, ptsToAdd, distBetweenPoints, prepend: true, append: true);
+            return result;
+        }
+
+        /// <summary>
+        /// Extends a track only at the start. See <see cref="AddStartEndPoints"/>.
+        /// </summary>
+        public static List<Vec3> AddStartPoints(IReadOnlyList<Vec3> points, int ptsToAdd = 10, double distBetweenPoints = 50)
+        {
+            if (points == null || points.Count == 0)
+                return new List<Vec3>();
+
+            var result = new List<Vec3>(points.Count + Math.Max(0, ptsToAdd));
+            AppendPrependPoints(result, points, ptsToAdd, distBetweenPoints, prepend: true, append: false);
+            return result;
+        }
+
+        /// <summary>
+        /// Extends a track only at the end. See <see cref="AddStartEndPoints"/>.
+        /// </summary>
+        public static List<Vec3> AddEndPoints(IReadOnlyList<Vec3> points, int ptsToAdd = 10, double distBetweenPoints = 50)
+        {
+            if (points == null || points.Count == 0)
+                return new List<Vec3>();
+
+            var result = new List<Vec3>(points.Count + Math.Max(0, ptsToAdd));
+            AppendPrependPoints(result, points, ptsToAdd, distBetweenPoints, prepend: false, append: true);
+            return result;
+        }
+
+        // Shared helper. The 6.8.2 originals used different loop bounds for
+        // the two-sided vs one-sided variants (i < ptsToAdd vs i <= ptsToAdd).
+        // We preserve that distinction: AddStartEndPoints adds ptsToAdd-1
+        // points at each end (matching 6.8.2's `for (int i = 1; i < ptsToAdd; i++)`),
+        // while AddStartPoints / AddEndPoints add ptsToAdd points (matching
+        // `for (int i = 1; i <= ptsToAdd; i++)`).
+        private static void AppendPrependPoints(
+            List<Vec3> output,
+            IReadOnlyList<Vec3> points,
+            int ptsToAdd,
+            double distBetweenPoints,
+            bool prepend,
+            bool append)
+        {
+            // For two-sided extension, the original 6.8.2 code uses i < ptsToAdd
+            // (so adds ptsToAdd-1 points). Single-sided uses i <= ptsToAdd
+            // (adds ptsToAdd). Pick the bound to match.
+            int upperExclusive = (prepend && append) ? ptsToAdd : ptsToAdd + 1;
+
+            if (prepend)
+            {
+                var start = points[0];
+                double sin = Math.Sin(start.Heading);
+                double cos = Math.Cos(start.Heading);
+                for (int i = upperExclusive - 1; i >= 1; i--)
+                {
+                    output.Add(new Vec3(
+                        start.Easting - sin * i * distBetweenPoints,
+                        start.Northing - cos * i * distBetweenPoints,
+                        start.Heading));
+                }
+            }
+
+            output.AddRange(points);
+
+            if (append)
+            {
+                var end = points[points.Count - 1];
+                double sin = Math.Sin(end.Heading);
+                double cos = Math.Cos(end.Heading);
+                for (int i = 1; i < upperExclusive; i++)
+                {
+                    output.Add(new Vec3(
+                        end.Easting + sin * i * distBetweenPoints,
+                        end.Northing + cos * i * distBetweenPoints,
+                        end.Heading));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reduces a track's point count by skipping points that don't
+        /// contribute meaningful curvature change. Useful for compressing
+        /// recorded curve tracks (storage + render perf) without losing
+        /// shape. The first and last two points are always preserved.
+        ///
+        /// A point is kept when EITHER the accumulated heading delta since
+        /// the last kept point exceeds <paramref name="angleDelta"/> radians,
+        /// OR the squared distance from the last kept point exceeds
+        /// (spread² × 0.95).
+        /// </summary>
+        /// <param name="points">Input track. Each point must have a valid Heading.</param>
+        /// <param name="angleDelta">Max heading change in radians before a point is forced. Default 0.005 (~0.29°).</param>
+        /// <param name="spread">Max distance in meters before a point is forced. Default 2.</param>
+        public static List<Vec3> ReducePointsByAngle(IReadOnlyList<Vec3> points, double angleDelta = 0.005, double spread = 2)
+        {
+            if (points == null || points.Count < 6)
+                return points == null ? new List<Vec3>() : new List<Vec3>(points);
+
+            int count = points.Count;
+            int last = count - 1;
+
+            var result = new List<Vec3>(count);
+            double accumulatedDelta = 0;
+            double accumulatedDistSq = 0;
+            double maxDistSq = spread * spread * 0.95;
+            Vec3 lastKeptPos = points[0];
+
+            for (int i = 0; i < count; i++)
+            {
+                // Always keep the first two and last two points
+                if (i < 2 || i > last - 2)
+                {
+                    result.Add(points[i]);
+                    continue;
+                }
+
+                double headingDelta = points[i - 1].Heading - points[i].Heading;
+                if (headingDelta > Math.PI) headingDelta -= GeometryMath.twoPI;
+                else if (headingDelta < -Math.PI) headingDelta += GeometryMath.twoPI;
+
+                accumulatedDelta += headingDelta;
+                accumulatedDistSq += GeometryMath.DistanceSquared(lastKeptPos, points[i]);
+                lastKeptPos = points[i];
+
+                if (Math.Abs(accumulatedDelta) > angleDelta || accumulatedDistSq >= maxDistSq)
+                {
+                    result.Add(points[i]);
+                    accumulatedDelta = 0;
+                    accumulatedDistSq = 0;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Smooths a track using Chaikin's corner-cutting algorithm. Each
+        /// iteration replaces every interior segment endpoint pair with two
+        /// new points at 25% and 75% along the segment, rounding sharp
+        /// corners. Use small iteration counts (1–3) — each iteration
+        /// roughly doubles the point count.
+        ///
+        /// Alternative to <see cref="SmoothWithCatmullRom"/>: Chaikin produces
+        /// a tighter, more "rounded" curve and is cheaper but less faithful
+        /// to the original control points.
+        /// </summary>
+        /// <param name="points">Input polyline.</param>
+        /// <param name="iterations">Number of corner-cutting passes (1–3 typical).</param>
+        /// <param name="preserveEndPoints">If true, the first and last points are kept exactly (open curve). If false, all points are rounded (closed loop).</param>
+        public static List<Vec3> ChaikinsSmooth(IReadOnlyList<Vec3> points, int iterations, bool preserveEndPoints = true)
+        {
+            if (points == null || points.Count < 2 || iterations <= 0)
+                return points == null ? new List<Vec3>() : new List<Vec3>(points);
+
+            var current = new List<Vec3>(points);
+            for (int iter = 0; iter < iterations; iter++)
+            {
+                var next = new List<Vec3>(current.Count * 2);
+
+                if (preserveEndPoints && current.Count > 0)
+                    next.Add(current[0]);
+
+                for (int i = 0; i < current.Count - 1; i++)
+                {
+                    var p0 = current[i];
+                    var p1 = current[i + 1];
+
+                    next.Add(new Vec3(
+                        0.75 * p0.Easting + 0.25 * p1.Easting,
+                        0.75 * p0.Northing + 0.25 * p1.Northing,
+                        0));
+                    next.Add(new Vec3(
+                        0.25 * p0.Easting + 0.75 * p1.Easting,
+                        0.25 * p0.Northing + 0.75 * p1.Northing,
+                        0));
+                }
+
+                if (preserveEndPoints && current.Count > 1)
+                    next.Add(current[current.Count - 1]);
+
+                current = next;
+            }
+
+            return current;
+        }
     }
 }

--- a/Tests/AgValoniaGPS.Models.Tests/CurveProcessingTests.cs
+++ b/Tests/AgValoniaGPS.Models.Tests/CurveProcessingTests.cs
@@ -1,0 +1,248 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Guidance;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Models.Tests;
+
+/// <summary>
+/// Tests for the track-extension and reduction methods ported from
+/// AgOpenGPS 6.8.2 CTrackMethods (issue #229).
+/// </summary>
+[TestFixture]
+public class CurveProcessingTests
+{
+    // ──────────────────────────────────────────────────────────────────
+    // AddStartEndPoints / AddStartPoints / AddEndPoints
+    // ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void AddStartEndPoints_EmptyInput_ReturnsEmpty()
+    {
+        var result = CurveProcessing.AddStartEndPoints(new List<Vec3>(), 5, 10);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void AddStartEndPoints_NorthwardLine_PrependsAndAppendsAlongHeading()
+    {
+        // Heading 0 = north → +Northing direction
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(0, 100, 0),
+        };
+
+        // ptsToAdd=3 with two-sided semantics adds (3-1)=2 at each end
+        var result = CurveProcessing.AddStartEndPoints(input, 3, 10);
+
+        Assert.That(result.Count, Is.EqualTo(input.Count + 2 + 2));
+
+        // Two prepended points are 10m and 20m before the start (negative Northing)
+        Assert.That(result[0].Northing, Is.EqualTo(-20).Within(1e-6));
+        Assert.That(result[1].Northing, Is.EqualTo(-10).Within(1e-6));
+
+        // Originals preserved in order
+        Assert.That(result[2].Northing, Is.EqualTo(0).Within(1e-6));
+        Assert.That(result[3].Northing, Is.EqualTo(100).Within(1e-6));
+
+        // Two appended points are 10m and 20m past the end
+        Assert.That(result[4].Northing, Is.EqualTo(110).Within(1e-6));
+        Assert.That(result[5].Northing, Is.EqualTo(120).Within(1e-6));
+    }
+
+    [Test]
+    public void AddStartPoints_OnlyPrepends_ptsToAddCount()
+    {
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(0, 100, 0),
+        };
+
+        // Single-sided semantics: ptsToAdd=3 adds 3 points
+        var result = CurveProcessing.AddStartPoints(input, 3, 10);
+
+        Assert.That(result.Count, Is.EqualTo(input.Count + 3));
+        Assert.That(result[0].Northing, Is.EqualTo(-30).Within(1e-6));
+        Assert.That(result[1].Northing, Is.EqualTo(-20).Within(1e-6));
+        Assert.That(result[2].Northing, Is.EqualTo(-10).Within(1e-6));
+        Assert.That(result[3].Northing, Is.EqualTo(0).Within(1e-6));
+        Assert.That(result[4].Northing, Is.EqualTo(100).Within(1e-6));
+    }
+
+    [Test]
+    public void AddEndPoints_OnlyAppends_ptsToAddCount()
+    {
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(0, 100, 0),
+        };
+
+        var result = CurveProcessing.AddEndPoints(input, 3, 10);
+
+        Assert.That(result.Count, Is.EqualTo(input.Count + 3));
+        Assert.That(result[0].Northing, Is.EqualTo(0).Within(1e-6));
+        Assert.That(result[1].Northing, Is.EqualTo(100).Within(1e-6));
+        Assert.That(result[2].Northing, Is.EqualTo(110).Within(1e-6));
+        Assert.That(result[3].Northing, Is.EqualTo(120).Within(1e-6));
+        Assert.That(result[4].Northing, Is.EqualTo(130).Within(1e-6));
+    }
+
+    [Test]
+    public void AddStartEndPoints_EastwardLine_ProjectsAlongEasting()
+    {
+        // Heading π/2 = east → +Easting direction
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, Math.PI / 2),
+            new Vec3(100, 0, Math.PI / 2),
+        };
+
+        var result = CurveProcessing.AddStartEndPoints(input, 3, 10);
+
+        // Prepend goes -Easting, append goes +Easting
+        Assert.That(result[0].Easting, Is.EqualTo(-20).Within(1e-6));
+        Assert.That(result[1].Easting, Is.EqualTo(-10).Within(1e-6));
+        Assert.That(result[4].Easting, Is.EqualTo(110).Within(1e-6));
+        Assert.That(result[5].Easting, Is.EqualTo(120).Within(1e-6));
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // ReducePointsByAngle
+    // ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ReducePointsByAngle_FewerThanSixPoints_ReturnsCopy()
+    {
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(0, 1, 0),
+        };
+        var result = CurveProcessing.ReducePointsByAngle(input);
+        Assert.That(result.Count, Is.EqualTo(input.Count));
+    }
+
+    [Test]
+    public void ReducePointsByAngle_StraightLine_KeepsBoundaryPoints()
+    {
+        // 10 collinear points heading north. Endpoints (first 2, last 2)
+        // are always preserved; interior points may be dropped because
+        // straight-line headings produce zero accumulated delta and
+        // close-spaced points won't reach the spread threshold.
+        var input = new List<Vec3>();
+        for (int i = 0; i < 10; i++)
+            input.Add(new Vec3(0, i * 0.1, 0)); // 10cm spacing → well under spread²*0.95 (~3.8 m²)
+
+        var result = CurveProcessing.ReducePointsByAngle(input);
+
+        // Always-keep boundary slots (4 of them) are guaranteed
+        Assert.That(result.Count, Is.GreaterThanOrEqualTo(4));
+        // First two preserved
+        Assert.That(result[0].Northing, Is.EqualTo(0).Within(1e-6));
+        Assert.That(result[1].Northing, Is.EqualTo(0.1).Within(1e-6));
+        // Last two preserved
+        Assert.That(result[result.Count - 2].Northing, Is.EqualTo(0.8).Within(1e-6));
+        Assert.That(result[result.Count - 1].Northing, Is.EqualTo(0.9).Within(1e-6));
+    }
+
+    [Test]
+    public void ReducePointsByAngle_CurvyTrack_ReducesPointCount()
+    {
+        // A track that wiggles enough to trigger the spread/distance threshold
+        // but not so much that every point is forced kept.
+        var input = new List<Vec3>();
+        for (int i = 0; i < 100; i++)
+        {
+            double n = i * 0.05; // 5cm spacing — most points fail spread threshold
+            input.Add(new Vec3(0, n, 0));
+        }
+        var result = CurveProcessing.ReducePointsByAngle(input, angleDelta: 0.005, spread: 2);
+
+        // Should reduce well below 100, but always keep at least the 4 boundary
+        Assert.That(result.Count, Is.LessThan(input.Count));
+        Assert.That(result.Count, Is.GreaterThanOrEqualTo(4));
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // ChaikinsSmooth
+    // ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ChaikinsSmooth_SinglePoint_ReturnsCopy()
+    {
+        var input = new List<Vec3> { new Vec3(0, 0, 0) };
+        var result = CurveProcessing.ChaikinsSmooth(input, 2);
+        Assert.That(result.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ChaikinsSmooth_ZeroIterations_ReturnsCopy()
+    {
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(10, 0, 0),
+            new Vec3(20, 5, 0),
+        };
+        var result = CurveProcessing.ChaikinsSmooth(input, 0);
+        Assert.That(result.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void ChaikinsSmooth_PreserveEndpointsTrue_FirstAndLastUnchanged()
+    {
+        // Sharp corner at (10, 0)
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(10, 0, 0),
+            new Vec3(10, 10, 0),
+        };
+        var result = CurveProcessing.ChaikinsSmooth(input, 2, preserveEndPoints: true);
+
+        // Endpoints are byte-identical
+        Assert.That(result[0].Easting, Is.EqualTo(0).Within(1e-6));
+        Assert.That(result[0].Northing, Is.EqualTo(0).Within(1e-6));
+        Assert.That(result[result.Count - 1].Easting, Is.EqualTo(10).Within(1e-6));
+        Assert.That(result[result.Count - 1].Northing, Is.EqualTo(10).Within(1e-6));
+
+        // Interior point at (10,0) gets rounded — no point should be exactly at the corner now
+        bool foundCorner = false;
+        for (int i = 1; i < result.Count - 1; i++)
+        {
+            if (Math.Abs(result[i].Easting - 10) < 1e-6 && Math.Abs(result[i].Northing) < 1e-6)
+            {
+                foundCorner = true;
+                break;
+            }
+        }
+        Assert.That(foundCorner, Is.False, "Sharp corner should have been smoothed away");
+    }
+
+    [Test]
+    public void ChaikinsSmooth_DoublesSegmentCountPerIteration()
+    {
+        // Open polyline of 4 points, 1 iteration with preserveEndPoints=true.
+        // Original has 3 segments. After one iteration with endpoint preservation:
+        //   start + 2 cuts per segment + end = 1 + 2*3 + 1 = 8 points.
+        var input = new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(10, 0, 0),
+            new Vec3(10, 10, 0),
+            new Vec3(20, 10, 0),
+        };
+        var result = CurveProcessing.ChaikinsSmooth(input, 1, preserveEndPoints: true);
+
+        Assert.That(result.Count, Is.EqualTo(8));
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 58
+#define VERSION_PATCH 59
 
-#define VERSION "26.4.58"
+#define VERSION "26.4.59"
 #define VERSION_DATE "2026-04-28"


### PR DESCRIPTION
Closes #229. Closes #224.

## Background

Two issues evaluated AgOpenGPS 6.8.2 features against AgValonia's existing implementations:

- **#224 (Dubins path planning)** — `DubinsPath.cs`, `DubinsPathSelector.cs`, `DubinsPathConstraints.cs`. Diff against AgOpenGPS 6.8.2 source (`/Users/chris/Code/AgOpenGPS/SourceCode/AgOpenGPS.Core/Models/Guidance/`) shows the existing AgValonia versions are **functional copies** — only license header and namespace differ. **OBE; no port needed.**

- **#229 (Track processing methods)** — `CTrackMethods.cs` (620 lines, 17 methods) vs AgValonia's `CurveProcessing.cs` (429 lines, 12 methods). Catmull-Rom smoothing, equidistant points, and heading calculation are already ported. Five method families weren't.

## What's ported (this PR)

The three method families with the strongest practical use cases:

| New method | Purpose |
|---|---|
| `AddStartEndPoints` / `AddStartPoints` / `AddEndPoints` | Extend a track beyond recorded endpoints, projecting along endpoint headings. AB lines need this to reach field boundaries past their recorded extent. |
| `ReducePointsByAngle` | Curvature-based point decimation. Skips points that don't contribute meaningful heading change. Compresses recorded curve tracks (storage + render perf) without losing shape. Always preserves endpoint integrity (first/last two points). |
| `ChaikinsSmooth` | Corner-cutting smoothing alternative to `SmoothWithCatmullRom`. Produces tighter, more rounded curves at lower cost. Less faithful to control points — useful for noisy recordings where Catmull-Rom over-fits. |

The two-sided `AddStartEndPoints` preserves 6.8.2's specific loop-bound quirk (adds `ptsToAdd-1` at each end), while the single-sided variants add `ptsToAdd` exactly, matching the originals.

## Methods deliberately not ported

| 6.8.2 method | Reason |
|---|---|
| `FixReferenceTrack` | Loop-curve preprocessing utility. AgValonia doesn't currently have a closed-curve track use case. |
| `GenerateEquidistantPoints` with `isLoop` | AgValonia's `InterpolatePoints` covers the open-curve case. Loop support reachable later if closed-boundary smoothing comes up. |
| `SmoothSegments` | Segment-by-segment smoothing alternative. Catmull-Rom and Chaikin's already cover smoothing well. |
| `CalculateAverageHeadings` / `CalculateSingleHeadings` | `CalculateHeadings` already covers the per-point heading calc. |

## Test coverage

12 new tests in `Tests/AgValoniaGPS.Models.Tests/CurveProcessingTests.cs` verify each algorithm against the 6.8.2 expected behavior. Total: **104 Models tests + 461 Services tests = 565 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)