### PR TITLE
Fix slow-speed cutoff unit mismatch (km/h vs m/s)

### DIFF
--- a/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
@@ -243,6 +243,9 @@ public class ToolConfig : ObservableObject
         set => SetProperty(ref _defaultSectionWidth, value);
     }
 
+    // Cutoff is stored and edited in km/h to match the UI label and user
+    // expectation. SectionControlService converts to m/s before comparing
+    // against the GPS-reported speed.
     private double _slowSpeedCutoff = 0.5;
     public double SlowSpeedCutoff
     {

--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -212,7 +212,9 @@ public class SectionControlService : ISectionControlService
 
         // Check if speed is below cutoff - turn off AUTO sections but keep
         // MANUAL ON sections active so coverage doesn't gap on stop/restart.
-        if (speed < tool.SlowSpeedCutoff)
+        // SlowSpeedCutoff is stored in km/h (matching the UI); speed is m/s.
+        double slowSpeedCutoffMps = tool.SlowSpeedCutoff / 3.6;
+        if (speed < slowSpeedCutoffMps)
         {
             for (int i = 0; i < numSections; i++)
             {


### PR DESCRIPTION
## Summary

`SlowSpeedCutoff` is labelled and edited in km/h in the configuration UI, but `SectionControlService.Update` was comparing the raw value against `pos.Speed`, which is in m/s. Effect: the actual cutoff is 3.6x larger than the UI suggests, so the default 0.5 means 0.5 m/s (1.8 km/h), not 0.5 km/h.

User-visible symptom: auto section control appears dead at 1.7 km/h and slower with default settings.

## Fix

Convert `tool.SlowSpeedCutoff` from km/h to m/s at the comparison site. Storage stays in km/h to match the UI label and the user-entered value. Added a comment in `ToolConfig` so the convention is explicit.

## Test plan

- [ ] Run the desktop app, set tool speed to 1.7 km/h via simulator, drive into uncovered ground with a section in Auto, confirm it turns on.
- [ ] Confirm sections still turn off when stopping (Speed < 0.14 m/s with the default cutoff).
- [ ] `dotnet test Tests/AgValoniaGPS.Services.Tests/` - existing slit tests run at 5+ km/h, well above the new cutoff.