### PR TITLE
Theme-aware accent panels in Tool/Implement configuration

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
@@ -107,9 +107,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Info box -->
-            <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,8,0,0">
+            <Border Background="{DynamicResource InfoPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,8,0,0">
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Note:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
+                    <TextBlock Text="Note:" Foreground="{DynamicResource AccentForegroundBrush}" FontWeight="SemiBold"/>
                     <TextBlock Text="Values are entered as positive numbers. The system automatically applies the correct sign based on tool type (negative for rear, positive for front)."
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12" TextWrapping="Wrap"/>
                 </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolOffsetSubTab.axaml
@@ -59,7 +59,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Value="{Binding Tool.Offset, Mode=TwoWay}"
                             Unit="m" FormatString="F2"
                             EditCommand="{Binding EditToolOffsetCommand}"/>
-                        <Button Content="Zero" Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                        <Button Content="Zero" Background="{DynamicResource SecondaryButtonBackgroundBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </StackPanel>
             </Grid>
@@ -79,15 +79,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Value="{Binding Tool.Overlap, Mode=TwoWay}"
                             Unit="m" FormatString="F2"
                             EditCommand="{Binding EditToolOverlapCommand}"/>
-                        <Button Content="Zero" Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                        <Button Content="Zero" Background="{DynamicResource SecondaryButtonBackgroundBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </StackPanel>
             </Grid>
 
             <!-- Info box -->
-            <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,16,0,0">
+            <Border Background="{DynamicResource InfoPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,16,0,0">
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Usage:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
+                    <TextBlock Text="Usage:" Foreground="{DynamicResource AccentForegroundBrush}" FontWeight="SemiBold"/>
                     <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Offset"/>
                         <Run Text=" - Use when tool is not centered on tractor (side-mounted sprayer)"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolPivotSubTab.axaml
@@ -45,7 +45,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <ScrollViewer>
         <StackPanel Spacing="12" Margin="16,8,16,16">
             <!-- Only relevant for Trailing/TBT -->
-            <Border Background="#DD3A3A2A" CornerRadius="6" Padding="12" Margin="0,0,0,16"
+            <Border Background="{DynamicResource WarningPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,16"
                     IsVisible="{Binding !Tool.IsToolTrailing}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <TextBlock Text="Note:" Foreground="#DAA520" FontWeight="SemiBold"/>
@@ -88,15 +88,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Unit="m" FormatString="F2"
                             EditCommand="{Binding EditToolPivotCommand}"/>
                         <Button Content="Zero" Command="{Binding ZeroToolPivotCommand}"
-                                Background="#DD4A3A3A" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                                Background="{DynamicResource SecondaryButtonBackgroundBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     </StackPanel>
                 </Grid>
             </Border>
 
             <!-- Info box -->
-            <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,16,0,0">
+            <Border Background="{DynamicResource InfoPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,16,0,0">
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Pivot Explanation:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
+                    <TextBlock Text="Pivot Explanation:" Foreground="{DynamicResource AccentForegroundBrush}" FontWeight="SemiBold"/>
                     <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Behind Pivot (positive)"/>
                         <Run Text=" - Tool working point is behind the hitch pivot (most common)"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
@@ -58,7 +58,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <ScrollViewer>
         <StackPanel Spacing="12" Margin="16,8,16,16">
             <!-- Mode Toggle -->
-            <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Border Background="{DynamicResource CardPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
                 <StackPanel>
                     <TextBlock Text="Section Mode" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                     <StackPanel Orientation="Horizontal" Spacing="16">
@@ -102,7 +102,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Individual Section Widths Grid (only shown when IsSectionsNotZones is true) -->
-            <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,8,0,0"
+            <Border Background="{DynamicResource CardPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,8,0,0"
                     IsVisible="{Binding Tool.IsSectionsNotZones}">
                 <StackPanel>
                     <TextBlock Text="Section Widths" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
@@ -236,7 +236,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Zone Configuration (only shown when IsSectionsNotZones is false) -->
-            <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,8,0,0"
+            <Border Background="{DynamicResource CardPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,8,0,0"
                     IsVisible="{Binding !Tool.IsSectionsNotZones}">
                 <StackPanel>
                     <TextBlock Text="Zone Configuration" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>
@@ -334,7 +334,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Total Width Display (calculated from sections) -->
-            <Border Background="#DD1E8449" CornerRadius="6" Padding="12" Margin="0,8,0,0">
+            <Border Background="{DynamicResource HighlightPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,8,0,0">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel VerticalAlignment="Center">
                         <TextBlock Text="Calculated Total Width" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
@@ -361,7 +361,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Section Color Preview (only shown when multi-colored is enabled) -->
-            <Border Background="#DD1A1A2E" CornerRadius="6" Padding="12" Margin="0,4,0,0"
+            <Border Background="{DynamicResource CardPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,4,0,0"
                     IsVisible="{Binding Tool.IsMultiColoredSections}">
                 <StackPanel>
                     <TextBlock Text="Section Colors" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" Margin="0,0,0,8"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSwitchesSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSwitchesSubTab.axaml
@@ -124,9 +124,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Border>
 
             <!-- Info box -->
-            <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,8,0,0">
+            <Border Background="{DynamicResource InfoPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,8,0,0">
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Switch Usage:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
+                    <TextBlock Text="Switch Usage:" Foreground="{DynamicResource AccentForegroundBrush}" FontWeight="SemiBold"/>
                     <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Work Switch"/>
                         <Run Text=" - Typically connected to implement hydraulic raise/lower sensor"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTimingSubTab.axaml
@@ -82,9 +82,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Grid>
 
             <!-- Info box -->
-            <Border Background="#DD2A4A3A" CornerRadius="6" Padding="12" Margin="0,16,0,0">
+            <Border Background="{DynamicResource InfoPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,16,0,0">
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Timing Tips:" Foreground="#4A9A7E" FontWeight="SemiBold"/>
+                    <TextBlock Text="Timing Tips:" Foreground="{DynamicResource AccentForegroundBrush}" FontWeight="SemiBold"/>
                     <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12" TextWrapping="Wrap">
                         <Run Text="Look Ahead On"/>
                         <Run Text=" - Increase for slow-responding equipment (spray valves)"/>

--- a/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
@@ -49,6 +49,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <SolidColorBrush x:Key="SystemControlForegroundBaseMediumHighBrush" Color="#333333"/>
             <SolidColorBrush x:Key="SystemControlForegroundBaseMediumBrush" Color="#555555"/>
             <SolidColorBrush x:Key="SystemControlForegroundBaseLowBrush" Color="#888888"/>
+
+            <!-- Semantic accent panels used in configuration dialogs -->
+            <SolidColorBrush x:Key="InfoPanelBackgroundBrush" Color="#E8F5EE"/>
+            <SolidColorBrush x:Key="CardPanelBackgroundBrush" Color="#EEF1F7"/>
+            <SolidColorBrush x:Key="HighlightPanelBackgroundBrush" Color="#C8E8D6"/>
+            <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="#F5F1DC"/>
+            <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="#E8DCD8"/>
+            <SolidColorBrush x:Key="AccentForegroundBrush" Color="#1E8449"/>
         </ResourceDictionary>
         <!-- Dark: use dark blue-gray instead of pure black -->
         <ResourceDictionary x:Key="Dark">
@@ -59,6 +67,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <SolidColorBrush x:Key="SystemControlBackgroundBaseLowBrush" Color="#3A3A4E"/>
             <SolidColorBrush x:Key="SystemControlBackgroundBaseMediumLowBrush" Color="#45455A"/>
             <SolidColorBrush x:Key="SystemControlBackgroundBaseMediumBrush" Color="#505068"/>
+
+            <!-- Semantic accent panels used in configuration dialogs -->
+            <SolidColorBrush x:Key="InfoPanelBackgroundBrush" Color="#DD2A4A3A"/>
+            <SolidColorBrush x:Key="CardPanelBackgroundBrush" Color="#DD1A1A2E"/>
+            <SolidColorBrush x:Key="HighlightPanelBackgroundBrush" Color="#DD1E8449"/>
+            <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="#DD3A3A2A"/>
+            <SolidColorBrush x:Key="SecondaryButtonBackgroundBrush" Color="#DD4A3A3A"/>
+            <SolidColorBrush x:Key="AccentForegroundBrush" Color="#4A9A7E"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 


### PR DESCRIPTION
## Summary

The Tool sub-tabs (Hitch, Offset, Pivot, Sections, Switches, Timing) hardcoded dark hex backgrounds (`#DD2A4A3A`, `#DD1A1A2E`, `#DD1E8449`, `#DD3A3A2A`, `#DD4A3A3A`) and a hardcoded green accent foreground (`#4A9A7E`) for their info boxes, card panels, highlight panels, and secondary buttons. These looked correct in dark mode but rendered as dark blocks against a light background in light mode.

Add five semantic theme-aware brushes to `SharedResources.axaml` plus an `AccentForegroundBrush`, with light and dark variants. Replace all six hardcoded colors in the Tool sub-tabs with `DynamicResource` references. Dark variants keep the existing values verbatim, so the dark theme is unchanged.

## Test plan

- [ ] Light mode: open Configuration → Tool, navigate through Hitch / Offset / Pivot / Sections / Switches / Timing sub-tabs. Confirm info/note boxes, card panels, highlight panels, and Zero buttons all render with light tinted backgrounds.
- [ ] Dark mode: same navigation; confirm panels look identical to before this PR (no visible regression).
- [ ] Confirm the green "Note:" / "Tip:" / "Usage:" labels remain readable on the new light backgrounds.