### PR TITLE
Fix module data loss from cross-thread INPC in dead UDP handler

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -147,7 +147,6 @@ public partial class MainViewModel : ObservableObject
     private bool _isMachineDataOk;
     private bool _isImuDataOk;
     private bool _isGpsDataOk;
-    private string _debugLog = "";
 
     // Tool position (for rendering)
     private double _toolEasting;
@@ -254,7 +253,6 @@ public partial class MainViewModel : ObservableObject
 
         // Subscribe to events
         _gpsService.GpsDataUpdated += OnGpsDataUpdated;
-        _udpService.DataReceived += OnUdpDataReceived;
         _autoSteerService.StateUpdated += OnAutoSteerStateUpdated;
         (_autoSteerService as Services.AutoSteer.AutoSteerService)?.SetTramLineService(_tramLineService);
         _autoSteerService.Start(); // Enable zero-copy GPS pipeline
@@ -723,12 +721,6 @@ public partial class MainViewModel : ObservableObject
 
     // NTRIP properties are in MainViewModel.Ntrip.cs
 
-    public string DebugLog
-    {
-        get => _debugLog;
-        set => SetProperty(ref _debugLog, value);
-    }
-
     // Tool position properties (for map rendering)
     public double ToolEasting
     {
@@ -808,39 +800,6 @@ public partial class MainViewModel : ObservableObject
             // TODO: When separate Auto/Manual section buttons are implemented, handle them individually
             ToggleSectionMasterCommand?.Execute(null);
         });
-    }
-
-    private void OnUdpDataReceived(object? sender, UdpDataReceivedEventArgs e)
-    {
-        var now = DateTime.Now;
-        var packetAge = (now - e.Timestamp).TotalMilliseconds;
-
-        // Handle different message types.
-        // Phase B C3: NMEA packets (PGN == 0) are now handled by the zero-copy
-        // AutoSteerService.ProcessGpsBuffer path in UdpCommunicationService. The MVM
-        // handler only touches non-NMEA PGNs.
-        if (e.PGN != 0)
-        {
-            // Binary PGN message - log it with age to detect buffering
-            DebugLog = $"PGN: {e.PGN} (0x{e.PGN:X2}) @ {e.Timestamp:HH:mm:ss.fff} (age: {packetAge:F0}ms)";
-
-            switch (e.PGN)
-            {
-                case PgnNumbers.HELLO_FROM_AUTOSTEER:
-                    // AutoSteer module is alive
-                    break;
-
-                case PgnNumbers.HELLO_FROM_MACHINE:
-                    // Machine module is alive
-                    break;
-
-                case PgnNumbers.HELLO_FROM_IMU:
-                    // IMU module is alive
-                    break;
-
-                // TODO: Add more PGN handlers as needed
-            }
-        }
     }
 
     private void OnModuleConnectionChanged(object? sender, ModuleConnectionEventArgs e)

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 60
+#define VERSION_PATCH 61
 
-#define VERSION "26.4.60"
+#define VERSION "26.4.61"
 #define VERSION_DATE "2026-04-28"


### PR DESCRIPTION
## Summary
- `MainViewModel.OnUdpDataReceived` set `DebugLog` (an INPC property) from the UDP receive thread. The cross-thread `InvalidOperationException` aborted the `DataReceived` multicast before `AutoSteerService`'s handler ran, silently dropping every binary PGN (253/250/126/123/120).
- Symptom on real hardware: WAS steering angle stuck at 0 in AgValonia despite valid PGN 253 packets visible on Wireshark; the same AiO board reports correct angles to AgOpen. Sensor data, IMU/Machine hello bookkeeping (in subscribers downstream of the failing handler) were affected too.
- The handler had three empty `case … break;` bodies and `DebugLog` had zero readers (no XAML binding, no code-behind, no test). Deleted the handler, the subscription, the property, and the backing field rather than wrapping the assignment in `Dispatcher.UIThread.Post` — per-packet UI marshaling at 50 Hz would be a worse fix for a property no UI actually displays.
- Bumped `sys/version.h` patch to `26.4.61`.

## Test plan
- [x] Diagnostic logging confirmed root cause: `[MV] THREW PGN=… InvalidOperationException` on every binary PGN; NMEA (PGN=0) skipped the throwing line and was unaffected.
- [x] After the fix, user confirmed live AiO board now reports correct steering angle.
- [ ] CI build/test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)