### PR TITLE
Vehicle simulator: PANDA heading scaling + stop duplicate GPS packets

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -209,8 +209,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="Guide Count" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
-                        <!-- Row 3: Direction Markers, Section Lines -->
-                        <!-- Line Smooth removed: Avalonia Skia renderer handles AA by default (#85) -->
+                        <!-- Row 3: Line Smooth (coverage anti-aliasing), Direction Markers, Section Lines -->
+                        <StackPanel Grid.Row="3" Grid.Column="0" Spacing="4" HorizontalAlignment="Center">
+                            <Button Classes="DisplayToggle"
+                                    Background="{Binding Display.LineSmoothEnabled, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
+                                    BorderBrush="{Binding Display.LineSmoothEnabled, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
+                                    Command="{Binding ToggleLineSmoothCommand}">
+                                <TextBlock Text="AA" FontSize="24" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Width="60" Height="60" TextAlignment="Center" Padding="0,14,0,0"/>
+                            </Button>
+                            <TextBlock Text="Smoothing" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
+                        </StackPanel>
 
                         <!-- Hidden: bitmap coverage system does not populate geometry cache (#117) -->
                         <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center"

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -270,6 +270,7 @@ internal class MapRenderState
     public bool SvennArrowVisible;
     public bool DirectionMarkersVisible;
     public bool FieldTextureVisible;
+    public bool LineSmoothEnabled;
     public bool ExtraGuidelines;
     public int ExtraGuidelinesCount;
     public bool HeadlandDistanceVisible;
@@ -859,6 +860,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             SvennArrowVisible = displayCfg.SvennArrowVisible,
             DirectionMarkersVisible = displayCfg.DirectionMarkersVisible,
             FieldTextureVisible = displayCfg.FieldTextureVisible,
+            LineSmoothEnabled = displayCfg.LineSmoothEnabled,
             ExtraGuidelines = displayCfg.ExtraGuidelines,
             ExtraGuidelinesCount = displayCfg.ExtraGuidelinesCount,
             HeadlandDistanceVisible = displayCfg.HeadlandDistanceVisible,
@@ -3170,8 +3172,10 @@ public class DrawingContextMapControl : Control, ISharedMapControl
         private DateTime _coverageSnapshotTime = DateTime.MinValue;
         private int _coverageSnapshotInFlight;        // 0 = idle, 1 = bg task running
         private const double CoverageSnapshotIntervalMs = 200.0;
-        private static readonly SKSamplingOptions _coverageSampling =
+        private static readonly SKSamplingOptions _coverageSamplingNearest =
             new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
+        private static readonly SKSamplingOptions _coverageSamplingLinear =
+            new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None);
 
         // Immutable brushes
         private static readonly IImmutableBrush _vehicleBrushImm = new ImmutableSolidColorBrush(Color.FromRgb(0, 200, 0));
@@ -3834,7 +3838,8 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                 (float)s.BitmapMinE, (float)s.BitmapMinN,
                 (float)(s.BitmapMinE + worldWidth), (float)(s.BitmapMinN + worldHeight));
 
-            canvas.DrawImage(_coverageSnapshot, src, dst, _coverageSampling);
+            var sampling = s.LineSmoothEnabled ? _coverageSamplingLinear : _coverageSamplingNearest;
+            canvas.DrawImage(_coverageSnapshot, src, dst, sampling);
         }
 
         private void DrawBoundary(SKCanvas canvas, MapRenderState s)

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
@@ -134,8 +134,13 @@ public class VirtualGpsReceiver : IDisposable
         sb.Append(Altitude.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(DifferentialAge.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(SpeedKnots.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(HeadingDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(RollDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
+        // PANDA encodes IMU heading and roll as int(degrees * 10) on the wire
+        // (per AiO firmware); the parser scales them back by 0.1 on receive.
+        // Sentinel 65535 means "no IMU" — never emit it from the simulator.
+        int headingScaled = (int)Math.Round(HeadingDegrees * 10.0);
+        int rollScaled = (int)Math.Round(RollDegrees * 10.0);
+        sb.Append(headingScaled.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
+        sb.Append(rollScaled.ToString(CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(PitchDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(YawRateDegPerSec.ToString("F2", CultureInfo.InvariantCulture));
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualModuleHub.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualModuleHub.cs
@@ -46,7 +46,9 @@ public class VirtualModuleHub : IDisposable
     {
         Steer.Start();
         Machine.Start();
-        Gps.Start();
+        // Don't start Gps's auto-send loop here — the host drives SendOnce
+        // from its physics tick. Running both produces duplicate packets at
+        // a drifting phase, which the receiver sees as a stuttering position.
     }
 
     public void Stop()


### PR DESCRIPTION
Two fixes for the standalone vehicle simulator's GPS path. Both surfaced when reviewing why heading/position behaved poorly when feeding the desktop app from the simulator.

## 1. PANDA heading/roll scaling (commit c916ea5)

Commit e3623cd corrected the NMEA parser to read PANDA's IMU heading (field 12) and roll (field 13) as `int(degrees * 10)` — the wire format AiO firmware emits. The integration-tests copy of `VirtualGpsReceiver` was updated in lockstep, but the standalone `Simulators/AgValoniaGPS.VehicleSimulator/` copy still wrote them as float `F2` decimals.

Effect: simulator heading `90.00` was parsed as int `90`, then scaled by `0.1` to `9` degrees — the rendered heading was 10x off and only inconsistently recovered by fix-to-fix once the vehicle moved fast enough.

Mirror the integration-tests build: emit `headingX10` and `rollX10` as plain integers. Pitch and yaw rate stay as `F2` floats (parser reads those as floats in both PANDA and PAOGI).

## 2. Stop sending duplicate GPS packets (commit 96f0e4e)

`VirtualModuleHub.Start` kicked off `VirtualGpsReceiver.SendLoop`, which emits a PANDA every 100ms on the thread pool. The host UI's `SimulationTick` already runs at 10 Hz (`DispatcherTimer`) and explicitly calls `Gps.SendOnce` after each physics step.

Both paths read the same `Heading`/`Latitude`/`Longitude` fields, but only the tick advances them. So the receiver sees ~20 packets/sec where every pair carries identical position data; the rendered tractor steps once per pair and sits still on the duplicate — visible as jumpy/stuttering motion.

Drop `Gps.Start()` from the hub. The host's tick is the sole packet emitter; `SendOnce` remains available for tests that drive emission explicitly.

## Test plan

- [ ] Launch `AgValoniaGPS.VehicleSimulator`, point the desktop app at it, drive in a circle. Confirm rendered heading matches commanded heading at all speeds.
- [ ] Confirm tractor motion is smooth at low/high speed (no stuttering).
- [ ] Confirm IMU roll value tracks the simulator's `RollDegrees`.