### PR TITLE
Vehicle simulator: read AutoSteer Engaged from PGN 254 Status byte

### DIFF
--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -40,7 +40,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private double _commandedAngle;
     private byte _pwmDisplay;
     private bool _steerSwitchOn = true;
-    private bool _autoSteerActive;
+    private bool _autoSteerEngaged;
     private string _statusText = "Stopped";
 
     public double Speed
@@ -115,10 +115,10 @@ public class MainWindowViewModel : INotifyPropertyChanged
         set { _steerSwitchOn = value; OnPropertyChanged(); }
     }
 
-    public bool AutoSteerActive
+    public bool AutoSteerEngaged
     {
-        get => _autoSteerActive;
-        set { _autoSteerActive = value; OnPropertyChanged(); }
+        get => _autoSteerEngaged;
+        private set { _autoSteerEngaged = value; OnPropertyChanged(); }
     }
 
     public string StatusText
@@ -202,8 +202,11 @@ public class MainWindowViewModel : INotifyPropertyChanged
     {
         if (_hub == null) return;
 
-        // When autosteer is active, WAS follows the commanded angle with response lag
-        if (_autoSteerActive)
+        // Read autosteer engaged state from PGN 254 Status byte (set by the main app).
+        AutoSteerEngaged = _hub.Steer.LastCommand?.IsEngaged ?? false;
+
+        // When autosteer is engaged by the app, WAS follows the commanded angle with response lag.
+        if (_autoSteerEngaged)
         {
             double commanded = _hub.Steer.CommandedSteerAngleDeg;
             double responseRate = 0.3; // lag factor per tick

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -76,8 +76,9 @@
                                    Minimum="0" Maximum="30" />
 
                     <CheckBox Content="Steer Switch ON" IsChecked="{Binding SteerSwitchOn}" />
-                    <CheckBox Content="AutoSteer Active" IsChecked="{Binding AutoSteerActive}"
-                              ToolTip.Tip="When enabled, WAS follows the commanded steer angle from the main app" />
+                    <CheckBox Content="AutoSteer Engaged" IsChecked="{Binding AutoSteerEngaged}"
+                              IsEnabled="False"
+                              ToolTip.Tip="Controlled by the main app via PGN 254 Status byte" />
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
## Summary

The simulator's "AutoSteer Active" checkbox was a manual toggle on the sim ViewModel; `SimulationTick` consulted its own `_autoSteerActive` field to decide whether to drive WAS toward the commanded angle. That left the sim unaware of the main app's actual autosteer state — turning on autosteer in the app did nothing until the user also flipped the sim's checkbox.

`VirtualSteerModule` already parses PGN 254 and exposes `LastCommand` with an `IsEngaged` bit (`PgnProtocol.cs:115`, byte 7 bit 2). Use it as the sole source of truth.

- Rename `_autoSteerActive` / `AutoSteerActive` to `_autoSteerEngaged` / `AutoSteerEngaged`. Setter is now private — the property is a display of the app's command, not a user toggle.
- `SimulationTick` reads `_hub.Steer.LastCommand?.IsEngaged` before the WAS-follow logic, so the sim's WAS now responds the moment the app engages autosteer.
- AXAML checkbox is now read-only (`IsEnabled="False"`); tooltip clarifies that the main app drives the state via PGN 254.

Resurrected from PR #257 (closed without merge); pieces of that PR already landed via #287 (roll), #293 (NMEA precision/encoding tests), and #321 (sim heading scaling + dedup).

## Test plan

- [ ] Launch the vehicle simulator, point the desktop app at it, engage autosteer in the app — confirm the simulator's checkbox lights up and WAS starts following the commanded angle.
- [ ] Disengage in the app — confirm the simulator's checkbox clears and WAS stops following.
- [ ] Confirm the sim's checkbox is non-interactive.