### PR TITLE
ISOXML: accept LSG type 2 (interior) for inner boundaries

### DIFF
--- a/Shared/AgValoniaGPS.Services/IsoXml/IsoXmlParserHelpers.cs
+++ b/Shared/AgValoniaGPS.Services/IsoXml/IsoXmlParserHelpers.cs
@@ -88,7 +88,10 @@ namespace AgValoniaGPS.Services.IsoXml
                 }
                 else if (type == "3" || type == "4" || type == "6")
                 {
-                    if (node.SelectSingleNode("LSG[@A='1']") is XmlNode lsg)
+                    // Inner boundaries can use LSG type 1 (exterior) or 2 (interior)
+                    XmlNode? lsg = node.SelectSingleNode("LSG[@A='1']")
+                                ?? node.SelectSingleNode("LSG[@A='2']");
+                    if (lsg is not null)
                     {
                         boundaries.Add(ParseBoundaryFromLSG(lsg, localPlane));
                     }

--- a/Tests/AgValoniaGPS.Services.Tests/IsoXmlParserHelpersTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/IsoXmlParserHelpersTests.cs
@@ -1,0 +1,70 @@
+using System.Xml;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Services.IsoXml;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class IsoXmlParserHelpersTests
+{
+    private const string SamplePointsThree =
+        "<PNT C='0.0' D='0.0'/><PNT C='0.001' D='0.0'/><PNT C='0.001' D='0.001'/>";
+
+    private const string SamplePointsFour =
+        "<PNT C='0.0' D='0.0'/><PNT C='0.002' D='0.0'/><PNT C='0.002' D='0.002'/><PNT C='0.0' D='0.002'/>";
+
+    private static LocalPlane MakePlane()
+        => new LocalPlane(new Wgs84(0.0, 0.0), new SharedFieldProperties());
+
+    private static XmlNodeList MakeFieldParts(string innerXml)
+    {
+        var doc = new XmlDocument();
+        doc.LoadXml($"<PFD>{innerXml}</PFD>");
+        return doc.DocumentElement!.ChildNodes;
+    }
+
+    [Test]
+    public void ParseBoundaries_InnerHole_LsgA1_Parses()
+    {
+        var xml = $@"
+            <PLN A='1'><LSG A='1'>{SamplePointsThree}</LSG></PLN>
+            <PLN A='3'><LSG A='1'>{SamplePointsThree}</LSG></PLN>";
+
+        var boundaries = IsoXmlParserHelpers.ParseBoundaries(MakeFieldParts(xml), MakePlane());
+
+        Assert.That(boundaries, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void ParseBoundaries_InnerHole_LsgA2_NowParses()
+    {
+        var xml = $@"
+            <PLN A='1'><LSG A='1'>{SamplePointsThree}</LSG></PLN>
+            <PLN A='3'><LSG A='2'>{SamplePointsThree}</LSG></PLN>";
+
+        var boundaries = IsoXmlParserHelpers.ParseBoundaries(MakeFieldParts(xml), MakePlane());
+
+        Assert.That(boundaries, Has.Count.EqualTo(2),
+            "Inner boundary using LSG type 2 (interior) should be parsed");
+    }
+
+    [Test]
+    public void ParseBoundaries_InnerHole_BothLsgA1AndA2_PrefersA1()
+    {
+        // PLN A='3' carries both LSG types. The `??` fallback picks A='1' first.
+        // Distinguish by point count: A='1' has 3 points, A='2' has 4.
+        var xml = $@"
+            <PLN A='1'><LSG A='1'>{SamplePointsThree}</LSG></PLN>
+            <PLN A='3'>
+                <LSG A='1'>{SamplePointsThree}</LSG>
+                <LSG A='2'>{SamplePointsFour}</LSG>
+            </PLN>";
+
+        var boundaries = IsoXmlParserHelpers.ParseBoundaries(MakeFieldParts(xml), MakePlane());
+
+        Assert.That(boundaries, Has.Count.EqualTo(2));
+        Assert.That(boundaries[1].FenceLine, Has.Count.EqualTo(3),
+            "Inner boundary should reflect the A='1' shape (3 points), not A='2' (4 points)");
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 61
+#define VERSION_PATCH 62
 
-#define VERSION "26.4.61"
+#define VERSION "26.4.62"
 #define VERSION_DATE "2026-04-28"


### PR DESCRIPTION
## Summary
- Match upstream parser behavior for inner boundaries (PLN type 3/4/6): try \`LSG[@A='1']\` first, fall back to \`LSG[@A='2']\`. Without this, ISOXML files that mark interior holes with the LSG type-2 marker silently lost their inner-boundary geometry on import.
- Three new unit tests in \`IsoXmlParserHelpersTests.cs\`: A=1-only (regression), A=2-only (the new path), A=1+A=2 together (verifies the \`??\` precedence picks A=1 when both exist).
- Bumped \`sys/version.h\` patch to \`26.4.62\`.

## Scope context
This is the platform-agnostic slice of issue #227. The remaining CISOBUS module integration (port \`CISOBUS.cs\` + \`FormISOBUS.cs\` + cross-thread-safe service) is deferred — \`AOG-TaskController\` only ships Windows binaries today (verified against its build/release CI), so the wider port doesn't pay off until its CI matrix adds Mac/Linux. Will open a follow-up issue for that, blocked on upstream platform availability.

## Test plan
- [x] \`dotnet test --filter IsoXmlParserHelpersTests\` — 3/3 pass
- [ ] CI green
- [ ] Spot-check existing IsoXml import workflow still works on a real file (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)