### PR TITLE
Smart WAS: statistical wheel-angle-sensor zero calibration (#223)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -92,6 +92,9 @@ public static class ServiceCollectionExtensions
         // AutoSteer pipeline service (zero-copy GPS→PGN path)
         services.AddSingleton<IAutoSteerService, AutoSteerService>();
 
+        // Smart WAS calibration (statistical WAS zero analyzer)
+        services.AddSingleton<ISmartWasCalibrationService, SmartWasCalibrationService>();
+
         // Chart data service (collects rolling time-series for diagnostic charts)
         services.AddSingleton<IChartDataService, ChartDataService>();
 

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -92,6 +92,9 @@ public static class ServiceCollectionExtensions
         // AutoSteer pipeline service (zero-copy GPS→PGN path)
         services.AddSingleton<IAutoSteerService, AutoSteerService>();
 
+        // Smart WAS calibration (statistical WAS zero analyzer)
+        services.AddSingleton<ISmartWasCalibrationService, SmartWasCalibrationService>();
+
         // Chart data service (collects rolling time-series for diagnostic charts)
         services.AddSingleton<IChartDataService, ChartDataService>();
 

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -92,6 +92,9 @@ public static class ServiceCollectionExtensions
         // AutoSteer pipeline service (zero-copy GPS→PGN path)
         services.AddSingleton<IAutoSteerService, AutoSteerService>();
 
+        // Smart WAS calibration (statistical WAS zero analyzer)
+        services.AddSingleton<ISmartWasCalibrationService, SmartWasCalibrationService>();
+
         // Chart data service (collects rolling time-series for diagnostic charts)
         services.AddSingleton<IChartDataService, ChartDataService>();
 

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -72,6 +72,7 @@ public class UIState : ObservableObject
                 OnPropertyChanged(nameof(IsTramSettingsDialogVisible));
                 OnPropertyChanged(nameof(IsFieldBuilderDialogVisible));
                 OnPropertyChanged(nameof(IsBugReportDialogVisible));
+                OnPropertyChanged(nameof(IsSmartWasDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -114,6 +115,7 @@ public class UIState : ObservableObject
     public bool IsTramSettingsDialogVisible => ActiveDialog == DialogType.TramSettings;
     public bool IsFieldBuilderDialogVisible => ActiveDialog == DialogType.FieldBuilder;
     public bool IsBugReportDialogVisible => ActiveDialog == DialogType.BugReport;
+    public bool IsSmartWasDialogVisible => ActiveDialog == DialogType.SmartWas;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -244,7 +246,8 @@ public enum DialogType
     RecordedPath,
     TramSettings,
     FieldBuilder,
-    BugReport
+    BugReport,
+    SmartWas
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -45,6 +45,7 @@ public class AutoSteerService : IAutoSteerService
     private readonly IGpsService _gpsService;
     private readonly ApplicationState _appState;
     private ITramLineService? _tramLineService;
+    private ISmartWasCalibrationService? _smartWas;
 
     // Drift compensation applied after LocalPlane → local coordinate conversion.
     // LocalPlane itself is owned by ApplicationState.Field.LocalPlane — single shared instance
@@ -96,6 +97,16 @@ public class AutoSteerService : IAutoSteerService
     public void SetTramLineService(ITramLineService tramLineService)
     {
         _tramLineService = tramLineService;
+    }
+
+    /// <summary>
+    /// Set the Smart WAS calibration service so each PGN 253 sample is
+    /// forwarded to its analyzer. Setter-injected to avoid the constructor
+    /// cycle (Smart WAS depends on IAutoSteerService).
+    /// </summary>
+    public void SetSmartWasService(ISmartWasCalibrationService smartWas)
+    {
+        _smartWas = smartWas;
     }
 
     public void Start()
@@ -165,6 +176,8 @@ public class AutoSteerService : IAutoSteerService
         _state.ActualSteerAngle = steerData.ActualSteerAngle;
         _state.SteerSwitchActive = steerData.SteerSwitchActive;
         _state.WorkSwitchActive = steerData.WorkSwitchActive;
+
+        _smartWas?.AddSample(steerData.ActualSteerAngle);
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/SmartWasCalibrationService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/SmartWasCalibrationService.cs
@@ -1,0 +1,274 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services.AutoSteer;
+
+/// <summary>
+/// Statistical WAS zero analyzer ported from upstream CSmartWAS.cs.
+/// Accumulates steer-angle samples while autosteer is engaged and
+/// driving conditions are stable, then recommends a WAS offset
+/// based on the median of the distribution. Confidence scoring
+/// combines normal-fit, magnitude penalty, and sample-size factor.
+/// </summary>
+public sealed class SmartWasCalibrationService : ISmartWasCalibrationService
+{
+    // Buffer sizing
+    private const int MAX_SAMPLES = 2000;
+    private const int MIN_SAMPLES = 200;
+
+    // Gating thresholds — converted from upstream's km/h and mm to AgValonia's m/s and m.
+    private const double MIN_SPEED_MPS = 2.0 / 3.6;   // 2 km/h ≈ 0.5556 m/s
+    private const double MAX_DIST_OFF_M = 0.5;        // 500 mm
+    private const double MAX_ANGLE_DEG = 15.0;
+
+    // Confidence scoring weights (sum to 1.0)
+    private const double NORMAL_FIT_1SIGMA_WEIGHT = 0.3;
+    private const double NORMAL_FIT_2SIGMA_WEIGHT = 0.3;
+    private const double MAGNITUDE_WEIGHT = 0.2;
+    private const double SIZE_WEIGHT = 0.2;
+
+    private const double EXPECTED_PCT_1SIGMA = 0.68;
+    private const double EXPECTED_PCT_2SIGMA = 0.95;
+    private const double MAX_OFFSET_DEG = 10.0;
+
+    // Validity gates
+    private const double MIN_VALID_CONFIDENCE = 40.0;
+
+    private readonly IAutoSteerService _autoSteerService;
+    private readonly ApplicationState _appState;
+
+    private readonly List<double> _history = new(MAX_SAMPLES + 1);
+    private readonly object _dataLock = new();
+
+    private double _meanAngle;
+    private double _medianAngle;
+    private double _stdDeviation;
+    private double _recommendedOffset;
+    private double _confidenceLevel;
+    private bool _hasValidCalibration;
+    private bool _isCollecting;
+
+    public SmartWasCalibrationService(IAutoSteerService autoSteerService, ApplicationState appState)
+    {
+        _autoSteerService = autoSteerService;
+        _appState = appState;
+    }
+
+    public bool IsCollecting => _isCollecting;
+
+    public event EventHandler<SmartWasSnapshot>? SnapshotChanged;
+
+    public void Start()
+    {
+        lock (_dataLock)
+        {
+            _isCollecting = true;
+        }
+    }
+
+    public void Stop()
+    {
+        lock (_dataLock)
+        {
+            _isCollecting = false;
+        }
+    }
+
+    public void Reset()
+    {
+        SmartWasSnapshot snap;
+        lock (_dataLock)
+        {
+            _history.Clear();
+            _meanAngle = 0;
+            _medianAngle = 0;
+            _stdDeviation = 0;
+            _recommendedOffset = 0;
+            _confidenceLevel = 0;
+            _hasValidCalibration = false;
+            snap = BuildSnapshotLocked();
+        }
+        SnapshotChanged?.Invoke(this, snap);
+    }
+
+    public void AddSample(double steerAngleDegrees)
+    {
+        // Outside-lock fast checks. ReadonlyState reads from singletons —
+        // these can race but each is a single-field read; worst case the
+        // sample is rejected when it shouldn't have been (or vice-versa)
+        // for one frame, which is harmless in a 200-sample average.
+        if (!_isCollecting) return;
+        if (!_autoSteerService.IsEngaged) return;
+        if (_appState.Vehicle.Speed < MIN_SPEED_MPS) return;
+        if (Math.Abs(_appState.Guidance.CrossTrackError) > MAX_DIST_OFF_M) return;
+        if (Math.Abs(steerAngleDegrees) > MAX_ANGLE_DEG) return;
+
+        // WAS inversion: flip the sample sign so the recommended offset
+        // direction matches the module's expected counts polarity.
+        if (ConfigurationStore.Instance.AutoSteer.InvertWas)
+            steerAngleDegrees = -steerAngleDegrees;
+
+        SmartWasSnapshot snap;
+        lock (_dataLock)
+        {
+            _history.Add(steerAngleDegrees);
+            if (_history.Count > MAX_SAMPLES)
+                _history.RemoveAt(0);
+
+            if (_history.Count >= MIN_SAMPLES)
+                AnalyzeDataLocked();
+
+            snap = BuildSnapshotLocked();
+        }
+        SnapshotChanged?.Invoke(this, snap);
+    }
+
+    public void ApplyOffsetCorrection(double offsetDegrees)
+    {
+        SmartWasSnapshot snap;
+        lock (_dataLock)
+        {
+            if (_history.Count == 0)
+            {
+                snap = BuildSnapshotLocked();
+            }
+            else
+            {
+                for (int i = 0; i < _history.Count; i++)
+                    _history[i] += offsetDegrees;
+
+                AnalyzeDataLocked();
+                snap = BuildSnapshotLocked();
+            }
+        }
+        SnapshotChanged?.Invoke(this, snap);
+    }
+
+    public SmartWasSnapshot GetSnapshot()
+    {
+        lock (_dataLock)
+        {
+            return BuildSnapshotLocked();
+        }
+    }
+
+    private SmartWasSnapshot BuildSnapshotLocked()
+    {
+        return new SmartWasSnapshot
+        {
+            IsCollecting = _isCollecting,
+            SampleCount = _history.Count,
+            Mean = _meanAngle,
+            Median = _medianAngle,
+            StdDev = _stdDeviation,
+            RecommendedOffset = _recommendedOffset,
+            Confidence = _confidenceLevel,
+            HasValidCalibration = _hasValidCalibration,
+        };
+    }
+
+    private void AnalyzeDataLocked()
+    {
+        if (_history.Count < MIN_SAMPLES)
+        {
+            _hasValidCalibration = false;
+            return;
+        }
+
+        CalculateStatisticsLocked();
+
+        // Recommended offset is the negative of the median: if the operator's
+        // wheels-straight zero-point lies at -2.3°, applying +2.3° corrects it.
+        _recommendedOffset = -_medianAngle;
+
+        _confidenceLevel = CalculateConfidenceLocked();
+
+        _hasValidCalibration =
+            _confidenceLevel > MIN_VALID_CONFIDENCE &&
+            Math.Abs(_recommendedOffset) < MAX_OFFSET_DEG;
+    }
+
+    private void CalculateStatisticsLocked()
+    {
+        int count = _history.Count;
+
+        // Mean
+        double sum = 0;
+        for (int i = 0; i < count; i++) sum += _history[i];
+        _meanAngle = sum / count;
+
+        // Median (sort a copy; List<double>.Sort would mutate the buffer in place)
+        var sorted = new List<double>(_history);
+        sorted.Sort();
+        _medianAngle = (count % 2 == 0)
+            ? (sorted[count / 2 - 1] + sorted[count / 2]) * 0.5
+            : sorted[count / 2];
+
+        // Sample standard deviation
+        if (count > 1)
+        {
+            double sumSquares = 0;
+            for (int i = 0; i < count; i++)
+            {
+                double d = _history[i] - _meanAngle;
+                sumSquares += d * d;
+            }
+            _stdDeviation = Math.Sqrt(sumSquares / (count - 1));
+        }
+        else
+        {
+            _stdDeviation = 0;
+        }
+    }
+
+    private double CalculateConfidenceLocked()
+    {
+        int count = _history.Count;
+        if (count < MIN_SAMPLES) return 0;
+
+        int within1Std = 0;
+        int within2Std = 0;
+        for (int i = 0; i < count; i++)
+        {
+            double deviation = Math.Abs(_history[i] - _medianAngle);
+            if (deviation <= _stdDeviation) within1Std++;
+            if (deviation <= 2 * _stdDeviation) within2Std++;
+        }
+
+        double pct1 = (double)within1Std / count;
+        double pct2 = (double)within2Std / count;
+
+        double score1 = 1 - Math.Abs(pct1 - EXPECTED_PCT_1SIGMA) / EXPECTED_PCT_1SIGMA;
+        double score2 = 1 - Math.Abs(pct2 - EXPECTED_PCT_2SIGMA) / EXPECTED_PCT_2SIGMA;
+        double magnitudeScore = Math.Max(0, 1 - Math.Abs(_recommendedOffset) / MAX_OFFSET_DEG);
+        double sizeFactor = Math.Min(1.0, (double)count / (MIN_SAMPLES * 3));
+
+        double confidence =
+            (score1 * NORMAL_FIT_1SIGMA_WEIGHT +
+             score2 * NORMAL_FIT_2SIGMA_WEIGHT +
+             magnitudeScore * MAGNITUDE_WEIGHT +
+             sizeFactor * SIZE_WEIGHT) * 100.0;
+
+        return Math.Max(0, Math.Min(100, confidence));
+    }
+}

--- a/Shared/AgValoniaGPS.Services/Interfaces/ISmartWasCalibrationService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/ISmartWasCalibrationService.cs
@@ -1,0 +1,93 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// Smart WAS (Wheel Angle Sensor) automatic zero calibration.
+/// Accumulates steer-angle samples while autosteer is engaged and the
+/// vehicle is driving cleanly, then recommends a WAS offset based on
+/// statistical analysis of the distribution.
+///
+/// Ported from upstream CSmartWAS.cs. Complementary to the manual
+/// one-shot zero in WasCalibrationStepViewModel — operators may use
+/// either workflow.
+/// </summary>
+public interface ISmartWasCalibrationService
+{
+    /// <summary>Begin accumulating samples (still gated by IsEngaged + speed + XTE).</summary>
+    void Start();
+
+    /// <summary>Pause accumulation. Existing samples and analysis are preserved.</summary>
+    void Stop();
+
+    /// <summary>Clear the buffer and zero all analysis results.</summary>
+    void Reset();
+
+    /// <summary>
+    /// Add a steer-angle sample (degrees). Called from
+    /// AutoSteerService.ProcessSteerData on the UDP receive thread.
+    /// Internally gated: rejects unless IsCollecting and the vehicle
+    /// state passes speed/XTE/angle/engaged thresholds.
+    /// </summary>
+    void AddSample(double steerAngleDegrees);
+
+    /// <summary>
+    /// Shift the existing buffer by the given offset to prevent
+    /// double-correction on a follow-up Apply. Called by the
+    /// ViewModel after writing the recommended offset to the
+    /// vehicle config and pushing PGN 252.
+    /// </summary>
+    void ApplyOffsetCorrection(double offsetDegrees);
+
+    /// <summary>Atomic snapshot of the current analysis state for UI consumption.</summary>
+    SmartWasSnapshot GetSnapshot();
+
+    /// <summary>True if Start has been called and Stop hasn't.</summary>
+    bool IsCollecting { get; }
+
+    /// <summary>
+    /// Fired on the UDP receive thread after each AnalyzeData() pass.
+    /// Subscribers MUST marshal to UI thread before mutating INPC
+    /// properties (Dispatcher.UIThread.Post). See PR #320 for the
+    /// canonical reference on the cross-thread INPC hazard.
+    /// </summary>
+    event EventHandler<SmartWasSnapshot>? SnapshotChanged;
+}
+
+/// <summary>
+/// Atomic results bundle. All values reflect the buffer state at the
+/// moment GetSnapshot() (or SnapshotChanged) was produced.
+/// </summary>
+public readonly struct SmartWasSnapshot
+{
+    public bool IsCollecting { get; init; }
+    public int SampleCount { get; init; }
+    public double Mean { get; init; }
+    public double Median { get; init; }
+    public double StdDev { get; init; }
+
+    /// <summary>Recommended WAS offset in degrees (sign already negated from median).</summary>
+    public double RecommendedOffset { get; init; }
+
+    /// <summary>0..100. Above 40 with |offset| &lt; 10° qualifies as a usable calibration.</summary>
+    public double Confidence { get; init; }
+
+    /// <summary>True when Confidence &gt; 40 and |RecommendedOffset| &lt; 10.</summary>
+    public bool HasValidCalibration { get; init; }
+}

--- a/Shared/AgValoniaGPS.ViewModels/AutoSteerConfigViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/AutoSteerConfigViewModel.cs
@@ -41,6 +41,7 @@ public partial class AutoSteerConfigViewModel : ObservableObject
     private readonly IUdpCommunicationService? _udpService;
     private readonly IAutoSteerService? _autoSteerService;
     private readonly Action? _launchWizard;
+    private readonly Action? _openSmartWas;
 
     // Debounce timer for auto-sending slider changes
     private readonly System.Timers.Timer _sliderDebounceTimer;
@@ -67,12 +68,14 @@ public partial class AutoSteerConfigViewModel : ObservableObject
         IConfigurationService configService,
         IUdpCommunicationService? udpService = null,
         IAutoSteerService? autoSteerService = null,
-        Action? launchWizard = null)
+        Action? launchWizard = null,
+        Action? openSmartWas = null)
     {
         _configService = configService;
         _udpService = udpService;
         _autoSteerService = autoSteerService;
         _launchWizard = launchWizard;
+        _openSmartWas = openSmartWas;
 
         // Set up debounce timer for slider changes
         _sliderDebounceTimer = new System.Timers.Timer(SliderDebounceDelayMs);
@@ -923,6 +926,7 @@ public partial class AutoSteerConfigViewModel : ObservableObject
     public ICommand SendAndSaveCommand { get; private set; } = null!;
     public ICommand ResetToDefaultsCommand { get; private set; } = null!;
     public ICommand WizardCommand { get; private set; } = null!;
+    public ICommand OpenSmartWasCommand { get; private set; } = null!;
 
     private bool _isResetConfirmVisible;
     public bool IsResetConfirmVisible
@@ -980,6 +984,13 @@ public partial class AutoSteerConfigViewModel : ObservableObject
             // Close the config panel before launching the wizard
             IsPanelVisible = false;
             _launchWizard?.Invoke();
+        });
+
+        OpenSmartWasCommand = new RelayCommand(() =>
+        {
+            // Smart WAS dialog floats on top — keep AutoSteer config panel open
+            // so the operator can compare live readouts side-by-side.
+            _openSmartWas?.Invoke();
         });
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Configuration.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Configuration.cs
@@ -49,8 +49,29 @@ public partial class MainViewModel
         // AutoSteer Configuration Panel
         ShowAutoSteerConfigCommand = new RelayCommand(() =>
         {
-            AutoSteerConfigViewModel ??= new AutoSteerConfigViewModel(_configurationService, _udpService, _autoSteerService, ShowSteerWizard);
+            AutoSteerConfigViewModel ??= new AutoSteerConfigViewModel(
+                _configurationService,
+                _udpService,
+                _autoSteerService,
+                ShowSteerWizard,
+                () => ShowSmartWasCommand?.Execute(null));
             AutoSteerConfigViewModel.IsPanelVisible = true;
+        });
+
+        // Smart WAS calibration dialog
+        ShowSmartWasCommand = new RelayCommand(() =>
+        {
+            SmartWasViewModel ??= new SmartWasViewModel(
+                _smartWasService,
+                _configurationService,
+                _udpService,
+                _autoSteerService);
+            State.UI.ShowDialog(DialogType.SmartWas);
+        });
+
+        CloseSmartWasDialogCommand = new RelayCommand(() =>
+        {
+            State.UI.CloseDialog();
         });
 
         // Profile management

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -68,6 +68,7 @@ public partial class MainViewModel : ObservableObject
     private readonly IVehicleProfileService _vehicleProfileService;
     private readonly IConfigurationService _configurationService;
     private readonly IAutoSteerService _autoSteerService;
+    private readonly ISmartWasCalibrationService _smartWasService;
     private readonly IModuleCommunicationService _moduleCommunicationService;
     private readonly IToolPositionService _toolPositionService;
     private readonly ICoverageMapService _coverageMapService;
@@ -183,6 +184,7 @@ public partial class MainViewModel : ObservableObject
         IVehicleProfileService vehicleProfileService,
         IConfigurationService configurationService,
         IAutoSteerService autoSteerService,
+        ISmartWasCalibrationService smartWasService,
         IModuleCommunicationService moduleCommunicationService,
         IToolPositionService toolPositionService,
         ICoverageMapService coverageMapService,
@@ -238,6 +240,7 @@ public partial class MainViewModel : ObservableObject
         _vehicleProfileService = vehicleProfileService;
         _configurationService = configurationService;
         _autoSteerService = autoSteerService;
+        _smartWasService = smartWasService;
         _moduleCommunicationService = moduleCommunicationService;
         _toolPositionService = toolPositionService;
         _coverageMapService = coverageMapService;
@@ -255,6 +258,7 @@ public partial class MainViewModel : ObservableObject
         _gpsService.GpsDataUpdated += OnGpsDataUpdated;
         _autoSteerService.StateUpdated += OnAutoSteerStateUpdated;
         (_autoSteerService as Services.AutoSteer.AutoSteerService)?.SetTramLineService(_tramLineService);
+        (_autoSteerService as Services.AutoSteer.AutoSteerService)?.SetSmartWasService(_smartWasService);
         _autoSteerService.Start(); // Enable zero-copy GPS pipeline
 
         // Start the background GPS processing pipeline
@@ -2389,9 +2393,19 @@ public partial class MainViewModel : ObservableObject
         set => SetProperty(ref _autoSteerConfigViewModel, value);
     }
 
+    // Smart WAS calibration dialog
+    private SmartWasViewModel? _smartWasViewModel;
+    public SmartWasViewModel? SmartWasViewModel
+    {
+        get => _smartWasViewModel;
+        set => SetProperty(ref _smartWasViewModel, value);
+    }
+
     public ICommand? ShowConfigurationDialogCommand { get; private set; }
     public ICommand? CancelConfigurationDialogCommand { get; private set; }
     public ICommand? ShowAutoSteerConfigCommand { get; private set; }
+    public ICommand? ShowSmartWasCommand { get; private set; }
+    public ICommand? CloseSmartWasDialogCommand { get; private set; }
     public ICommand? ShowLoadProfileDialogCommand { get; private set; }
     public ICommand? ShowNewProfileDialogCommand { get; private set; }
     public ICommand? LoadSelectedProfileCommand { get; private set; }

--- a/Shared/AgValoniaGPS.ViewModels/SmartWasViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/SmartWasViewModel.cs
@@ -1,0 +1,238 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Globalization;
+using System.Windows.Input;
+
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+
+using Avalonia.Threading;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// View-model for the Smart WAS calibration dialog. Subscribes to
+/// the calibration service's SnapshotChanged event (which fires on
+/// the UDP receive thread) and marshals each update onto the UI
+/// thread before mutating INPC properties.
+/// </summary>
+public partial class SmartWasViewModel : ObservableObject
+{
+    private const int MIN_SAMPLES_FOR_VALID = 200;
+
+    private readonly ISmartWasCalibrationService _smartWas;
+    private readonly IConfigurationService _configService;
+    private readonly IUdpCommunicationService _udpService;
+    private readonly IAutoSteerService _autoSteerService;
+
+    public SmartWasViewModel(
+        ISmartWasCalibrationService smartWas,
+        IConfigurationService configService,
+        IUdpCommunicationService udpService,
+        IAutoSteerService autoSteerService)
+    {
+        _smartWas = smartWas;
+        _configService = configService;
+        _udpService = udpService;
+        _autoSteerService = autoSteerService;
+
+        StartCommand = new RelayCommand(() => _smartWas.Start());
+        StopCommand = new RelayCommand(() => _smartWas.Stop());
+        ResetCommand = new RelayCommand(() => _smartWas.Reset());
+        ApplyCommand = new RelayCommand(Apply, () => _hasValidCalibration);
+
+        _smartWas.SnapshotChanged += OnSnapshotChanged;
+
+        // Pull initial state in case samples have already accumulated.
+        OnSnapshotChanged(this, _smartWas.GetSnapshot());
+    }
+
+    public ICommand StartCommand { get; }
+    public ICommand StopCommand { get; }
+    public ICommand ResetCommand { get; }
+    public ICommand ApplyCommand { get; }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Display properties (set on the UI thread from OnSnapshotChanged)
+    // ────────────────────────────────────────────────────────────────────
+
+    private bool _isCollecting;
+    public bool IsCollecting
+    {
+        get => _isCollecting;
+        private set => SetProperty(ref _isCollecting, value);
+    }
+
+    private int _sampleCount;
+    public int SampleCount
+    {
+        get => _sampleCount;
+        private set
+        {
+            if (SetProperty(ref _sampleCount, value))
+            {
+                OnPropertyChanged(nameof(SampleCountText));
+                OnPropertyChanged(nameof(StatusMessage));
+            }
+        }
+    }
+
+    public string SampleCountText =>
+        string.Format(CultureInfo.InvariantCulture, "{0} / {1} min", _sampleCount, MIN_SAMPLES_FOR_VALID);
+
+    private double _mean;
+    public double Mean
+    {
+        get => _mean;
+        private set => SetProperty(ref _mean, value);
+    }
+
+    private double _median;
+    public double Median
+    {
+        get => _median;
+        private set => SetProperty(ref _median, value);
+    }
+
+    private double _stdDev;
+    public double StdDev
+    {
+        get => _stdDev;
+        private set => SetProperty(ref _stdDev, value);
+    }
+
+    private double _recommendedOffsetDegrees;
+    public double RecommendedOffsetDegrees
+    {
+        get => _recommendedOffsetDegrees;
+        private set
+        {
+            if (SetProperty(ref _recommendedOffsetDegrees, value))
+                OnPropertyChanged(nameof(RecommendedOffsetCounts));
+        }
+    }
+
+    public int RecommendedOffsetCounts
+    {
+        get
+        {
+            var cpd = _configService.Store.AutoSteer.CountsPerDegree;
+            return cpd > 0
+                ? (int)Math.Round(_recommendedOffsetDegrees * cpd)
+                : 0;
+        }
+    }
+
+    private double _confidence;
+    public double Confidence
+    {
+        get => _confidence;
+        private set => SetProperty(ref _confidence, value);
+    }
+
+    private bool _hasValidCalibration;
+    public bool HasValidCalibration
+    {
+        get => _hasValidCalibration;
+        private set
+        {
+            if (SetProperty(ref _hasValidCalibration, value))
+                ((RelayCommand)ApplyCommand).NotifyCanExecuteChanged();
+        }
+    }
+
+    public string StatusMessage
+    {
+        get
+        {
+            if (!_isCollecting)
+                return _sampleCount > 0
+                    ? string.Format(CultureInfo.InvariantCulture, "Stopped — {0} samples", _sampleCount)
+                    : "Stopped";
+
+            if (!_autoSteerService.IsEngaged)
+                return "Waiting for autosteer engage...";
+
+            if (_sampleCount < MIN_SAMPLES_FOR_VALID)
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Collecting — need {0} samples, have {1}",
+                    MIN_SAMPLES_FOR_VALID, _sampleCount);
+
+            return "Collecting";
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Snapshot subscription — marshalled to UI thread (PR #320 hazard)
+    // ────────────────────────────────────────────────────────────────────
+
+    private void OnSnapshotChanged(object? sender, SmartWasSnapshot snap)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            ApplySnapshot(snap);
+        else
+            Dispatcher.UIThread.Post(() => ApplySnapshot(snap));
+    }
+
+    private void ApplySnapshot(SmartWasSnapshot snap)
+    {
+        IsCollecting = snap.IsCollecting;
+        SampleCount = snap.SampleCount;
+        Mean = snap.Mean;
+        Median = snap.Median;
+        StdDev = snap.StdDev;
+        RecommendedOffsetDegrees = snap.RecommendedOffset;
+        Confidence = snap.Confidence;
+        HasValidCalibration = snap.HasValidCalibration;
+        OnPropertyChanged(nameof(StatusMessage));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Apply: push offset into config + module + persist + shift buffer
+    // ────────────────────────────────────────────────────────────────────
+
+    private void Apply()
+    {
+        var snap = _smartWas.GetSnapshot();
+        if (!snap.HasValidCalibration) return;
+
+        var autoSteer = _configService.Store.AutoSteer;
+        var cpd = autoSteer.CountsPerDegree;
+        if (cpd <= 0) return;
+
+        int offsetCounts = (int)Math.Round(snap.RecommendedOffset * cpd);
+        autoSteer.WasOffset += offsetCounts;
+        _configService.Store.MarkChanged();
+
+        // Shift the buffer so the next analysis recommends ~0°
+        _smartWas.ApplyOffsetCorrection(snap.RecommendedOffset);
+
+        // Push PGN 252 with the new WasOffset
+        var pgn = AgValoniaGPS.Services.AutoSteer.PgnBuilder.BuildSteerSettingsPgn(autoSteer);
+        _udpService.SendToModules(pgn);
+
+        // Persist current vehicle profile
+        var profileName = _configService.Store.ActiveProfileName;
+        if (!string.IsNullOrEmpty(profileName))
+            _configService.SaveProfile(profileName);
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -66,6 +66,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:BugReportDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>
+        <dialogs:SmartWasDialogPanel/>
 
         <!-- Wizards -->
         <wizards:WizardDialogPanel DataContext="{Binding SteerWizardViewModel}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
@@ -1081,13 +1081,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                             <!-- Bottom Action Buttons -->
                             <Grid Grid.Row="1" ColumnDefinitions="*,*,*,Auto" Margin="0,8,0,0">
-                                <!-- Wizard -->
+                                <!-- Smart WAS calibration -->
                                 <Button Grid.Column="0" Margin="2" Padding="4"
-                                        Background="#DD9B59B6" IsEnabled="False" Opacity="0.5">
+                                        Background="#DD2196F3" Command="{Binding OpenSmartWasCommand}">
                                     <StackPanel HorizontalAlignment="Center">
-                                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png"
+                                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Chart.png"
                                                Width="32" Height="32" Stretch="Uniform" HorizontalAlignment="Center"/>
-                                        <TextBlock Text="{loc:Localize Wizard}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                                        <TextBlock Text="Smart WAS" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <!-- Reset -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SmartWasDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SmartWasDialogPanel.axaml
@@ -1,0 +1,115 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.SmartWasDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsSmartWasDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsSmartWasDialogVisible}">
+
+    <!-- Semi-transparent backdrop -->
+    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
+
+        <!-- Inner panel: switch DataContext to the SmartWasViewModel -->
+        <Border DataContext="{Binding SmartWasViewModel}"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="12" Padding="20"
+                MinWidth="380" MaxWidth="420"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                BoxShadow="0 4 16 #40000000"
+                PointerPressed="InnerPanel_PointerPressed">
+
+            <StackPanel Spacing="14">
+
+                <TextBlock Text="Smart WAS Calibration" FontSize="20" FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+
+                <!-- Status row -->
+                <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                    <TextBlock Text="Status:" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding StatusMessage}"/>
+                </StackPanel>
+
+                <!-- Statistics group -->
+                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        CornerRadius="6" Padding="12">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="Statistics" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="3">
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="Samples"/>
+                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding SampleCountText}"
+                                       FontFamily="Consolas,Menlo,monospace"/>
+
+                            <TextBlock Grid.Column="0" Grid.Row="1" Text="Mean"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1"
+                                       Text="{Binding Mean, StringFormat='{}{0:+0.00;-0.00;0.00}°'}"
+                                       FontFamily="Consolas,Menlo,monospace"/>
+
+                            <TextBlock Grid.Column="0" Grid.Row="2" Text="Median"/>
+                            <TextBlock Grid.Column="1" Grid.Row="2"
+                                       Text="{Binding Median, StringFormat='{}{0:+0.00;-0.00;0.00}°'}"
+                                       FontFamily="Consolas,Menlo,monospace"/>
+
+                            <TextBlock Grid.Column="0" Grid.Row="3" Text="Std Dev"/>
+                            <TextBlock Grid.Column="1" Grid.Row="3"
+                                       Text="{Binding StdDev, StringFormat='{}{0:0.00}°'}"
+                                       FontFamily="Consolas,Menlo,monospace"/>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <!-- Recommendation group -->
+                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        CornerRadius="6" Padding="12">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="Recommendation" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" RowSpacing="3">
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="Offset"/>
+                            <StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal" Spacing="6">
+                                <TextBlock Text="{Binding RecommendedOffsetDegrees, StringFormat='{}{0:+0.00;-0.00;0.00}°'}"
+                                           FontFamily="Consolas,Menlo,monospace"/>
+                                <TextBlock Text="{Binding RecommendedOffsetCounts, StringFormat='({0:+0;-0;0} counts)'}"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                           FontFamily="Consolas,Menlo,monospace"/>
+                            </StackPanel>
+
+                            <TextBlock Grid.Column="0" Grid.Row="1" Text="Confidence"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1"
+                                       Text="{Binding Confidence, StringFormat='{}{0:0}%'}"
+                                       FontFamily="Consolas,Menlo,monospace"/>
+                        </Grid>
+                        <ProgressBar Value="{Binding Confidence}" Minimum="0" Maximum="100" Height="8"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Instructions -->
+                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        CornerRadius="6" Padding="10">
+                    <TextBlock TextWrapping="Wrap" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                               Text="Drive at &gt;2 km/h with autosteer engaged. Keep the cross-track error within ±0.5 m. Click Apply once confidence reaches 40%+."/>
+                </Border>
+
+                <!-- Action row -->
+                <Grid ColumnDefinitions="*,*,*,*,*" ColumnSpacing="8">
+                    <Button Grid.Column="0" Content="Reset" HorizontalAlignment="Stretch" MinHeight="36"
+                            Command="{Binding ResetCommand}"/>
+                    <Button Grid.Column="1" Content="Start" HorizontalAlignment="Stretch" MinHeight="36"
+                            Command="{Binding StartCommand}"
+                            IsEnabled="{Binding !IsCollecting}"/>
+                    <Button Grid.Column="2" Content="Stop" HorizontalAlignment="Stretch" MinHeight="36"
+                            Command="{Binding StopCommand}"
+                            IsEnabled="{Binding IsCollecting}"/>
+                    <Button Grid.Column="3" Content="Apply" HorizontalAlignment="Stretch" MinHeight="36"
+                            Background="#DD2196F3"
+                            Command="{Binding ApplyCommand}"/>
+                    <!-- Close binds to MainViewModel via the outer DataContext -->
+                    <Button Grid.Column="4" Content="Close" HorizontalAlignment="Stretch" MinHeight="36"
+                            Click="OnCloseClick"/>
+                </Grid>
+
+            </StackPanel>
+        </Border>
+    </Border>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SmartWasDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SmartWasDialogPanel.axaml.cs
@@ -1,0 +1,39 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class SmartWasDialogPanel : UserControl
+{
+    public SmartWasDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Only close if the click was on the backdrop itself (not bubbling from inner panel).
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+            vm.CloseSmartWasDialogCommand?.Execute(null);
+    }
+
+    private void InnerPanel_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Swallow inner clicks so they don't bubble to the backdrop and close the dialog.
+        e.Handled = true;
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
+    {
+        // The UserControl's DataContext is MainViewModel (inherited from
+        // DialogOverlayHost). Only the inner Border switches to SmartWasViewModel.
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+            vm.CloseSmartWasDialogCommand?.Execute(null);
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/SmartWasCalibrationServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SmartWasCalibrationServiceTests.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Linq;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+[NonParallelizable] // Mutates ConfigurationStore.Instance and ApplicationState
+public class SmartWasCalibrationServiceTests
+{
+    private IAutoSteerService _autoSteer = null!;
+    private ApplicationState _appState = null!;
+    private SmartWasCalibrationService _service = null!;
+
+    private const int MIN_SAMPLES = 200;
+    private const double IN_BOUND_SPEED_MPS = 1.0;     // > 0.5556
+    private const double IN_BOUND_XTE_M = 0.1;         // < 0.5
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+
+        _autoSteer = Substitute.For<IAutoSteerService>();
+        _autoSteer.IsEngaged.Returns(true);
+
+        _appState = new ApplicationState();
+        _appState.Vehicle.Speed = IN_BOUND_SPEED_MPS;
+        _appState.Guidance.CrossTrackError = IN_BOUND_XTE_M;
+
+        _service = new SmartWasCalibrationService(_autoSteer, _appState);
+        _service.Start();
+    }
+
+    private void FeedSamples(int count, Func<int, double> sampleFn)
+    {
+        for (int i = 0; i < count; i++)
+            _service.AddSample(sampleFn(i));
+    }
+
+    private static double[] DeterministicNormal(int n, double mean, double stdDev, int seed)
+    {
+        var rng = new Random(seed);
+        var samples = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            // Box-Muller
+            double u1 = 1.0 - rng.NextDouble();
+            double u2 = 1.0 - rng.NextDouble();
+            double z = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+            samples[i] = mean + stdDev * z;
+        }
+        return samples;
+    }
+
+    // 1. Mean/median/stddev correctness
+    [Test]
+    public void Statistics_NormalDistribution_MatchExpectedWithinTolerance()
+    {
+        var samples = DeterministicNormal(1000, mean: -0.5, stdDev: 0.2, seed: 42);
+        FeedSamples(samples.Length, i => samples[i]);
+
+        var snap = _service.GetSnapshot();
+        Assert.That(snap.Mean, Is.EqualTo(-0.5).Within(0.05));
+        Assert.That(snap.Median, Is.EqualTo(-0.5).Within(0.05));
+        Assert.That(snap.StdDev, Is.EqualTo(0.2).Within(0.05));
+        Assert.That(snap.RecommendedOffset, Is.EqualTo(0.5).Within(0.05));
+    }
+
+    // 2. Confidence high for clean normal distribution
+    [Test]
+    public void Confidence_NormalDistribution_ScoresHigh()
+    {
+        var samples = DeterministicNormal(600, mean: -0.5, stdDev: 0.15, seed: 7);
+        FeedSamples(samples.Length, i => samples[i]);
+
+        var snap = _service.GetSnapshot();
+        Assert.That(snap.Confidence, Is.GreaterThan(85),
+            "A clean N(μ,σ) sample should score very high on the normal-fit terms");
+        Assert.That(snap.HasValidCalibration, Is.True);
+    }
+
+    // 3. Confidence drops to invalid when |offset| ≥ 10°
+    [Test]
+    public void Confidence_LargeOffsetExceedsLimit_HasValidCalibrationFalse()
+    {
+        // Force a large median by feeding samples around -10.5 (still under |angle|<15° gate)
+        var samples = DeterministicNormal(500, mean: -10.5, stdDev: 0.1, seed: 13);
+        FeedSamples(samples.Length, i => samples[i]);
+
+        var snap = _service.GetSnapshot();
+        Assert.That(Math.Abs(snap.RecommendedOffset), Is.GreaterThanOrEqualTo(10.0));
+        Assert.That(snap.HasValidCalibration, Is.False,
+            "When |recommendedOffset| ≥ 10°, calibration must be marked invalid even if confidence math passes");
+    }
+
+    // 4. Min sample gate
+    [Test]
+    public void HasValidCalibration_BelowMinSamples_StaysFalse()
+    {
+        FeedSamples(MIN_SAMPLES - 1, _ => 0.1);
+
+        var snap = _service.GetSnapshot();
+        Assert.That(snap.SampleCount, Is.EqualTo(MIN_SAMPLES - 1));
+        Assert.That(snap.HasValidCalibration, Is.False);
+    }
+
+    [Test]
+    public void HasValidCalibration_AtMinSamples_TriggersAnalysis()
+    {
+        FeedSamples(MIN_SAMPLES, _ => 0.0);
+
+        var snap = _service.GetSnapshot();
+        Assert.That(snap.SampleCount, Is.EqualTo(MIN_SAMPLES));
+        // With all-zero samples, mean/median/std=0 → magnitudeScore=1, sizeFactor=200/600≈0.33
+        // Normal-fit: deviation==0 for all → within1Std=count, pct1=1.0; expected1=0.68 → score1<0
+        // The math may or may not cross 40 — we just assert that analysis ran
+        Assert.That(snap.Mean, Is.EqualTo(0).Within(1e-9));
+    }
+
+    // 5. MAX_SAMPLES rolling buffer
+    [Test]
+    public void Buffer_ExceedsMax_RollsOff()
+    {
+        FeedSamples(2500, i => i * 0.001);
+
+        var snap = _service.GetSnapshot();
+        Assert.That(snap.SampleCount, Is.EqualTo(2000), "Buffer should roll off at MAX_SAMPLES");
+    }
+
+    // 6. Gating: speed
+    [Test]
+    public void Gating_SpeedBelowCutoff_RejectsSamples()
+    {
+        _appState.Vehicle.Speed = 0.5; // < 0.5556 m/s (2 km/h)
+        FeedSamples(MIN_SAMPLES + 50, _ => 0.1);
+        Assert.That(_service.GetSnapshot().SampleCount, Is.EqualTo(0));
+
+        _appState.Vehicle.Speed = 0.6; // > cutoff
+        FeedSamples(50, _ => 0.1);
+        Assert.That(_service.GetSnapshot().SampleCount, Is.EqualTo(50));
+    }
+
+    // 7. Gating: XTE
+    [Test]
+    public void Gating_XteAboveCutoff_RejectsSamples()
+    {
+        _appState.Guidance.CrossTrackError = 0.51; // > 0.5 m
+        FeedSamples(MIN_SAMPLES + 50, _ => 0.1);
+        Assert.That(_service.GetSnapshot().SampleCount, Is.EqualTo(0));
+
+        _appState.Guidance.CrossTrackError = -0.49; // negative side, within bound
+        FeedSamples(50, _ => 0.1);
+        Assert.That(_service.GetSnapshot().SampleCount, Is.EqualTo(50));
+    }
+
+    // 8. Gating: |angle| > 15° rejected
+    [Test]
+    public void Gating_AngleAboveLimit_RejectsSamples()
+    {
+        FeedSamples(50, _ => 16.0);
+        FeedSamples(50, _ => -16.0);
+        FeedSamples(100, _ => 14.9);
+
+        Assert.That(_service.GetSnapshot().SampleCount, Is.EqualTo(100),
+            "Only samples within ±15° should be accumulated");
+    }
+
+    // 9. Gating: not engaged
+    [Test]
+    public void Gating_NotEngaged_RejectsSamples()
+    {
+        _autoSteer.IsEngaged.Returns(false);
+        FeedSamples(MIN_SAMPLES + 50, _ => 0.1);
+
+        Assert.That(_service.GetSnapshot().SampleCount, Is.EqualTo(0));
+    }
+
+    // 10. InvertWas flips sample sign
+    [Test]
+    public void InvertWas_FlipsSampleSign()
+    {
+        ConfigurationStore.Instance.AutoSteer.InvertWas = true;
+        FeedSamples(MIN_SAMPLES, _ => 1.0);
+
+        var snap = _service.GetSnapshot();
+        Assert.That(snap.Mean, Is.EqualTo(-1.0).Within(1e-9),
+            "With InvertWas=true, +1° input should land in the buffer as -1°");
+    }
+
+    // 11. ApplyOffsetCorrection shifts buffer
+    [Test]
+    public void ApplyOffsetCorrection_ShiftsBufferAndRecomputes()
+    {
+        FeedSamples(MIN_SAMPLES, _ => -0.4);
+        var beforeApply = _service.GetSnapshot();
+        Assert.That(beforeApply.Median, Is.EqualTo(-0.4).Within(1e-9));
+        Assert.That(beforeApply.RecommendedOffset, Is.EqualTo(0.4).Within(1e-9));
+
+        _service.ApplyOffsetCorrection(0.4);
+
+        var afterApply = _service.GetSnapshot();
+        Assert.That(afterApply.Median, Is.EqualTo(0.0).Within(1e-9));
+        Assert.That(afterApply.RecommendedOffset, Is.EqualTo(0.0).Within(1e-9));
+    }
+
+    // 12. Reset clears buffer + analysis
+    [Test]
+    public void Reset_ClearsEverything()
+    {
+        FeedSamples(MIN_SAMPLES, _ => -0.5);
+        _service.Reset();
+
+        var snap = _service.GetSnapshot();
+        Assert.That(snap.SampleCount, Is.EqualTo(0));
+        Assert.That(snap.Mean, Is.EqualTo(0));
+        Assert.That(snap.Median, Is.EqualTo(0));
+        Assert.That(snap.RecommendedOffset, Is.EqualTo(0));
+        Assert.That(snap.Confidence, Is.EqualTo(0));
+        Assert.That(snap.HasValidCalibration, Is.False);
+    }
+
+    // 13. Stop halts accumulation but keeps analysis
+    [Test]
+    public void Stop_PreservesAnalysisButRejectsNewSamples()
+    {
+        FeedSamples(MIN_SAMPLES, _ => -0.3);
+        var afterCollect = _service.GetSnapshot();
+
+        _service.Stop();
+        FeedSamples(50, _ => 0.0);
+        var afterStop = _service.GetSnapshot();
+
+        Assert.That(afterStop.SampleCount, Is.EqualTo(afterCollect.SampleCount),
+            "Sample count must not grow after Stop");
+        Assert.That(afterStop.Median, Is.EqualTo(afterCollect.Median).Within(1e-9));
+        Assert.That(_service.IsCollecting, Is.False);
+    }
+
+    // SnapshotChanged is wired correctly
+    [Test]
+    public void SnapshotChanged_FiresOnSampleAdd()
+    {
+        int eventCount = 0;
+        _service.SnapshotChanged += (_, _) => eventCount++;
+
+        FeedSamples(5, _ => 0.1);
+        Assert.That(eventCount, Is.EqualTo(5));
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -60,6 +60,7 @@ public class MainViewModelBuilder
             vehicleProfileService: VehicleProfileService,
             configurationService: Substitute.For<IConfigurationService>(),
             autoSteerService: Substitute.For<IAutoSteerService>(),
+            smartWasService: Substitute.For<ISmartWasCalibrationService>(),
             moduleCommunicationService: Substitute.For<IModuleCommunicationService>(),
             toolPositionService: Substitute.For<IToolPositionService>(),
             coverageMapService: Substitute.For<ICoverageMapService>(),

--- a/Tests/AgValoniaGPS.UI.Tests/SmartWasViewModelTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/SmartWasViewModelTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Threading.Tasks;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using NSubstitute;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// VM-level tests for the Smart WAS calibration dialog. Most tests are pure
+/// CPU; the off-thread SnapshotChanged test uses [AvaloniaTest] so it has a
+/// real Dispatcher to marshal to.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // Touches ConfigurationStore.Instance in PGN builders
+public class SmartWasViewModelTests
+{
+    private ISmartWasCalibrationService _smartWas = null!;
+    private IConfigurationService _configService = null!;
+    private IUdpCommunicationService _udpService = null!;
+    private IAutoSteerService _autoSteer = null!;
+    private ConfigurationStore _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // PgnBuilder.BuildSteerSettingsPgn reads ConfigurationStore.Instance internally
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+
+        _smartWas = Substitute.For<ISmartWasCalibrationService>();
+        _udpService = Substitute.For<IUdpCommunicationService>();
+        _autoSteer = Substitute.For<IAutoSteerService>();
+
+        _configService = Substitute.For<IConfigurationService>();
+        _store = new ConfigurationStore();
+        _store.AutoSteer.CountsPerDegree = 100;
+        _store.AutoSteer.WasOffset = 10;
+        _store.ActiveProfileName = "TestProfile";
+        _configService.Store.Returns(_store);
+    }
+
+    private SmartWasViewModel BuildVm()
+    {
+        // Ensure GetSnapshot() returns something coherent for the constructor's initial pull
+        _smartWas.GetSnapshot().Returns(new SmartWasSnapshot
+        {
+            HasValidCalibration = false,
+            SampleCount = 0,
+        });
+        return new SmartWasViewModel(_smartWas, _configService, _udpService, _autoSteer);
+    }
+
+    private void SetSnapshot(SmartWasSnapshot snap)
+    {
+        _smartWas.GetSnapshot().Returns(snap);
+        _smartWas.SnapshotChanged += Raise.Event<EventHandler<SmartWasSnapshot>>(_smartWas, snap);
+    }
+
+    // 1. Apply writes additively to WasOffset
+    [Test]
+    public void Apply_AddsRoundedOffsetCountsToExistingWasOffset()
+    {
+        var vm = BuildVm();
+        SetSnapshot(new SmartWasSnapshot
+        {
+            HasValidCalibration = true,
+            RecommendedOffset = 0.5, // degrees
+        });
+
+        vm.ApplyCommand.Execute(null);
+
+        // 0.5° × 100 cpd = 50 counts; existing WasOffset 10 → 60
+        Assert.That(_store.AutoSteer.WasOffset, Is.EqualTo(60));
+    }
+
+    // 2. Apply calls ApplyOffsetCorrection on the service
+    [Test]
+    public void Apply_CallsApplyOffsetCorrectionWithRecommendedOffset()
+    {
+        var vm = BuildVm();
+        SetSnapshot(new SmartWasSnapshot
+        {
+            HasValidCalibration = true,
+            RecommendedOffset = -0.3,
+        });
+
+        vm.ApplyCommand.Execute(null);
+
+        _smartWas.Received(1).ApplyOffsetCorrection(-0.3);
+    }
+
+    // 3. Apply sends PGN 252 (Steer Settings) over UDP
+    [Test]
+    public void Apply_SendsSteerSettingsPgn()
+    {
+        var vm = BuildVm();
+        SetSnapshot(new SmartWasSnapshot
+        {
+            HasValidCalibration = true,
+            RecommendedOffset = 0.4,
+        });
+
+        vm.ApplyCommand.Execute(null);
+
+        _udpService.Received(1).SendToModules(
+            Arg.Is<byte[]>(pgn =>
+                pgn.Length >= 4 &&
+                pgn[0] == 0x80 &&
+                pgn[1] == 0x81 &&
+                pgn[3] == 0xFC));  // 252 = STEER_SETTINGS
+    }
+
+    // 4. Apply disabled while HasValidCalibration is false
+    [Test]
+    public void Apply_DisabledWhenInvalid()
+    {
+        var vm = BuildVm();
+        SetSnapshot(new SmartWasSnapshot
+        {
+            HasValidCalibration = false,
+        });
+
+        Assert.That(vm.ApplyCommand.CanExecute(null), Is.False);
+    }
+
+    [Test]
+    public void Apply_EnabledWhenValid()
+    {
+        var vm = BuildVm();
+        SetSnapshot(new SmartWasSnapshot
+        {
+            HasValidCalibration = true,
+            RecommendedOffset = 0.2,
+        });
+
+        Assert.That(vm.ApplyCommand.CanExecute(null), Is.True);
+    }
+
+    // 5. Off-thread SnapshotChanged reaches UI properties (PR #320 regression)
+    [AvaloniaTest]
+    public async Task SnapshotChanged_FromBackgroundThread_UpdatesUiPropertiesAfterDispatcherTick()
+    {
+        var vm = BuildVm();
+
+        // Fire SnapshotChanged from a background thread (simulating UDP receive thread)
+        await Task.Run(() =>
+        {
+            _smartWas.SnapshotChanged += Raise.Event<EventHandler<SmartWasSnapshot>>(_smartWas,
+                new SmartWasSnapshot
+                {
+                    SampleCount = 612,
+                    Mean = -0.42,
+                    Median = -0.38,
+                    StdDev = 0.21,
+                    RecommendedOffset = 0.38,
+                    Confidence = 76,
+                    HasValidCalibration = true,
+                });
+        });
+
+        // Drain the dispatcher so the posted ApplySnapshot runs
+        await Dispatcher.UIThread.InvokeAsync(() => { });
+
+        Assert.That(vm.SampleCount, Is.EqualTo(612));
+        Assert.That(vm.Median, Is.EqualTo(-0.38));
+        Assert.That(vm.Confidence, Is.EqualTo(76));
+        Assert.That(vm.HasValidCalibration, Is.True);
+    }
+
+    // 6. CloseSmartWasDialogCommand on MainViewModel restores ActiveDialog=None
+    [AvaloniaTest]
+    public void CloseSmartWasDialogCommand_RestoresActiveDialogToNone()
+    {
+        var builder = new MainViewModelBuilder();
+        var mvm = builder.Build();
+
+        // Open and then close
+        mvm.ShowSmartWasCommand?.Execute(null);
+        Assert.That(mvm.State.UI.ActiveDialog, Is.EqualTo(AgValoniaGPS.Models.State.DialogType.SmartWas));
+
+        mvm.CloseSmartWasDialogCommand?.Execute(null);
+        Assert.That(mvm.State.UI.ActiveDialog, Is.EqualTo(AgValoniaGPS.Models.State.DialogType.None));
+    }
+}

--- a/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
@@ -69,6 +69,7 @@ public class MainViewModelBuilder
             vehicleProfileService: VehicleProfileService,
             configurationService: Substitute.For<IConfigurationService>(),
             autoSteerService: AutoSteerService,
+            smartWasService: Substitute.For<ISmartWasCalibrationService>(),
             moduleCommunicationService: Substitute.For<IModuleCommunicationService>(),
             toolPositionService: Substitute.For<IToolPositionService>(),
             coverageMapService: CoverageMapService,

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 62
+#define VERSION_PATCH 63
 
-#define VERSION "26.4.62"
+#define VERSION "26.4.63"
 #define VERSION_DATE "2026-04-28"


### PR DESCRIPTION
## Summary
Port of upstream \`CSmartWAS.cs\` as a complementary calibration workflow alongside the existing manual one-shot zero in the steer wizard. Closes #223.

The service accumulates up to 2000 steer-angle samples while autosteer is engaged and the vehicle is driving cleanly (≥ 2 km/h, |XTE| < 0.5 m, |angle| < 15°), computes mean/median/std-dev, and recommends a WAS offset = \`-median\` with a confidence score combining normal-distribution fit + magnitude penalty + sample-size factor. Operator clicks **Apply** once confidence > 40 % and |offset| < 10° to commit; offset is added to the existing \`WasOffset\` (additive, like the manual zero), buffer is shifted to prevent double-correction, PGN 252 goes out, profile persists.

## Key implementation choices

- **Sample input**: direct call from \`AutoSteerService.ProcessSteerData\` (~50 Hz) via setter-injected reference (mirrors \`SetTramLineService\` pattern, avoids the constructor cycle). One extra null-checked method call on the hot path.
- **Threading**: \`SnapshotChanged\` fires on the UDP receive thread; \`SmartWasViewModel\` marshals every event through \`Dispatcher.UIThread.Post\` before mutating INPC properties — same discipline PR #320 codified.
- **UI surface**: repurposed the previously-disabled "Wizard" button cell on \`AutoSteerConfigPanel\` as the "Smart WAS" launcher. Dialog floats on top of the AutoSteer config panel so the operator keeps both readouts visible.
- **Unit conversions** (the main risk the plan flagged): upstream uses km/h + mm; AgValonia uses m/s + m. Constants converted to \`MIN_SPEED_MPS = 2.0/3.6\` and \`MAX_DIST_OFF_M = 0.5\`. Verified by gating tests.

## Test plan
- [x] 15 service unit tests pass (math, gating per-axis, InvertWas, ApplyOffsetCorrection, Reset, Start/Stop, SnapshotChanged)
- [x] 7 ViewModel headless UI tests pass (Apply additive write, ApplyOffsetCorrection invocation, PGN 252 send, Apply enable/disable on \`HasValidCalibration\`, **off-thread→UI marshalling regression**, \`CloseSmartWasDialogCommand\`)
- [x] Full \`Tests/\` suite green: 706 / 706 (104 Models + 479 Services + 123 UI)
- [ ] Manual smoke on Desktop with simulator-driven samples
- [ ] iOS smoke on **physical iPad** (build with \`-r ios-arm64\`)

## Plan reference
\`Plans/SMART_WAS_IMPLEMENTATION_PLAN.md\` (PR #326) — every step in §9 was followed in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)