### PR TITLE
Profile import: read 6.8.2 split-format sibling files (#225)

### DIFF
--- a/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
+++ b/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
@@ -37,16 +37,29 @@ public class VehicleProfileService : IVehicleProfileService
     public string VehiclesDirectory { get; }
 
     public VehicleProfileService(ILogger<VehicleProfileService> logger)
+        : this(logger, DefaultVehiclesDirectory())
+    {
+    }
+
+    /// <summary>
+    /// Test seam: lets a test subclass redirect VehiclesDirectory away
+    /// from MyDocuments without touching env vars or filesystem mocks.
+    /// </summary>
+    protected VehicleProfileService(ILogger<VehicleProfileService> logger, string vehiclesDirectory)
     {
         _logger = logger;
-        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        VehiclesDirectory = Path.Combine(documentsPath, "AgValoniaGPS", "Vehicles");
+        VehiclesDirectory = vehiclesDirectory;
 
-        // Ensure directory exists
         if (!Directory.Exists(VehiclesDirectory))
         {
             Directory.CreateDirectory(VehiclesDirectory);
         }
+    }
+
+    private static string DefaultVehiclesDirectory()
+    {
+        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        return Path.Combine(documentsPath, "AgValoniaGPS", "Vehicles");
     }
 
     public List<string> GetAvailableProfiles()
@@ -75,12 +88,19 @@ public class VehicleProfileService : IVehicleProfileService
                 return true;
 
             // Fall back to legacy XML - parse and populate store directly
-            var filePath = Path.Combine(VehiclesDirectory, $"{profileName}.XML");
-            if (!File.Exists(filePath))
+            var filePath = ResolveExistingFile(profileName, ".xml");
+            if (filePath == null)
                 return false;
 
-            var doc = XDocument.Load(filePath);
-            var settings = ParseSettings(doc);
+            // Build a single dictionary by merging the primary file (legacy combined
+            // or 6.8.2 VehicleSettings) with any sibling 6.8.2 split files. The new
+            // format keeps the same <setting name="..."> keys as the old combined
+            // file — they're just spread across multiple files — so a merged
+            // dictionary feeds ApplyXmlSettingsToStore unchanged.
+            var settings = ParseSettings(XDocument.Load(filePath));
+            MergeSiblingIfPresent(profileName, ".tool.xml", settings);
+            MergeSiblingIfPresent(profileName, ".env.xml", settings);
+
             ApplyXmlSettingsToStore(settings, profileName, filePath, store);
             return true;
         }
@@ -88,6 +108,54 @@ public class VehicleProfileService : IVehicleProfileService
         {
             _logger.LogError(ex, "Error loading vehicle profile '{ProfileName}'", profileName);
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Case-insensitively resolve a {profileName}{suffix} file in the Vehicles
+    /// directory. Returns the actual on-disk path or null if not found.
+    /// Needed because the existing convention is .XML (uppercase) for the
+    /// primary file but the 6.8.2 sibling files use .xml (lowercase).
+    /// </summary>
+    private string? ResolveExistingFile(string profileName, string suffix)
+    {
+        // Check exact match first (cheapest case on case-sensitive filesystems)
+        var primary = Path.Combine(VehiclesDirectory, profileName + suffix);
+        if (File.Exists(primary)) return primary;
+
+        var upper = Path.Combine(VehiclesDirectory, profileName + suffix.ToUpperInvariant());
+        if (File.Exists(upper)) return upper;
+
+        // Fallback: enumerate the directory once and match case-insensitively
+        if (!Directory.Exists(VehiclesDirectory)) return null;
+        var target = profileName + suffix;
+        foreach (var path in Directory.EnumerateFiles(VehiclesDirectory))
+        {
+            if (string.Equals(Path.GetFileName(path), target, StringComparison.OrdinalIgnoreCase))
+                return path;
+        }
+        return null;
+    }
+
+    private void MergeSiblingIfPresent(string profileName, string suffix, Dictionary<string, string> dict)
+    {
+        var path = ResolveExistingFile(profileName, suffix);
+        if (path == null) return;
+
+        try
+        {
+            var siblingDoc = XDocument.Load(path);
+            foreach (var kv in ParseSettings(siblingDoc))
+            {
+                // Sibling values take precedence on key collision; with the 6.8.2
+                // split there shouldn't be any, but if there is the more-specific
+                // file (tool/env) wins.
+                dict[kv.Key] = kv.Value;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not parse sibling settings file '{Path}'", path);
         }
     }
 

--- a/Tests/AgValoniaGPS.Services.Tests/VehicleProfileSplitFormatImportTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/VehicleProfileSplitFormatImportTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.IO;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Verifies that VehicleProfileService can import the 6.8.2 split XML
+/// profile format (separate VehicleSettings / ToolSettings / Environment
+/// files) in addition to the legacy combined format. Both formats use the
+/// same `&lt;setting name="..."&gt;` keys; the split is structural only,
+/// so the service merges sibling files into one dictionary before applying.
+/// </summary>
+[TestFixture]
+public class VehicleProfileSplitFormatImportTests
+{
+    private string _tempDir = null!;
+    private VehicleProfileService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // VehicleProfileService.VehiclesDirectory is constructed from
+        // MyDocuments/AgValoniaGPS/Vehicles in production; for tests we
+        // redirect MyDocuments via the env var that .NET respects on macOS/Linux,
+        // OR construct the service and write into its directory.
+        _tempDir = Path.Combine(Path.GetTempPath(), "VehicleProfileSplitTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        _service = new TestableVehicleProfileService(_tempDir, NullLogger<VehicleProfileService>.Instance);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static string SettingFile(params (string Name, string Value)[] settings)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        sb.AppendLine("<configuration><userSettings><AgOpenGPS.Properties.Settings>");
+        foreach (var (name, value) in settings)
+        {
+            sb.Append($"<setting name=\"{name}\"><value>{value}</value></setting>");
+        }
+        sb.AppendLine("</AgOpenGPS.Properties.Settings></userSettings></configuration>");
+        return sb.ToString();
+    }
+
+    [Test]
+    public void Load_LegacyCombinedXml_ParsesSingleFile()
+    {
+        // Drop a single combined file — every key in one place, mirroring
+        // the pre-6.8.2 layout. No siblings.
+        File.WriteAllText(Path.Combine(_tempDir, "TestProfile.XML"),
+            SettingFile(
+                ("setVehicle_wheelbase", "3.14"),
+                ("setVehicle_toolWidth", "12.0")));
+
+        var store = new ConfigurationStore();
+        var ok = _service.Load("TestProfile", store);
+
+        Assert.That(ok, Is.True);
+        Assert.That(store.Vehicle.Wheelbase, Is.EqualTo(3.14));
+        Assert.That(store.Tool.Width, Is.EqualTo(12.0));
+    }
+
+    [Test]
+    public void Load_SplitFormat_PrimaryAndToolSibling_MergesBoth()
+    {
+        // 6.8.2-style split: primary holds vehicle keys, sibling .tool.xml
+        // holds tool keys. Both should land in the merged dictionary.
+        File.WriteAllText(Path.Combine(_tempDir, "Split.XML"),
+            SettingFile(("setVehicle_wheelbase", "2.78")));
+
+        File.WriteAllText(Path.Combine(_tempDir, "Split.tool.xml"),
+            SettingFile(("setVehicle_toolWidth", "9.5")));
+
+        var store = new ConfigurationStore();
+        var ok = _service.Load("Split", store);
+
+        Assert.That(ok, Is.True);
+        Assert.That(store.Vehicle.Wheelbase, Is.EqualTo(2.78));
+        Assert.That(store.Tool.Width, Is.EqualTo(9.5),
+            "Tool keys from .tool.xml sibling must merge into the import dictionary");
+    }
+
+    [Test]
+    public void Load_SplitFormat_AllThreeSiblings_AllMerged()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "Triple.XML"),
+            SettingFile(("setVehicle_wheelbase", "1.5")));
+
+        File.WriteAllText(Path.Combine(_tempDir, "Triple.tool.xml"),
+            SettingFile(("setVehicle_toolWidth", "4.2")));
+
+        // env file currently doesn't have any keys ApplyXmlSettingsToStore
+        // reads, but should be loaded without throwing — used to verify
+        // the merge path itself doesn't reject env-only siblings.
+        File.WriteAllText(Path.Combine(_tempDir, "Triple.env.xml"),
+            SettingFile(("setMenu_isMetric", "True")));
+
+        var store = new ConfigurationStore();
+        var ok = _service.Load("Triple", store);
+
+        Assert.That(ok, Is.True);
+        Assert.That(store.Vehicle.Wheelbase, Is.EqualTo(1.5));
+        Assert.That(store.Tool.Width, Is.EqualTo(4.2));
+        Assert.That(store.IsMetric, Is.True,
+            "env-file keys should also reach ApplyXmlSettingsToStore");
+    }
+
+    [Test]
+    public void Load_SplitFormat_VehicleOnly_PartialImport()
+    {
+        // User dropped only the vehicle file from a 6.8.2 export. Tool keys
+        // are absent → ApplyXmlSettingsToStore uses defaults for those.
+        // Documents the partial-import behavior so users can be told that
+        // copying the .tool.xml sibling fills in the rest.
+        File.WriteAllText(Path.Combine(_tempDir, "VehOnly.XML"),
+            SettingFile(("setVehicle_wheelbase", "2.0")));
+
+        var store = new ConfigurationStore();
+        var ok = _service.Load("VehOnly", store);
+
+        Assert.That(ok, Is.True);
+        Assert.That(store.Vehicle.Wheelbase, Is.EqualTo(2.0));
+        // Default tool width when no sibling provides setVehicle_toolWidth
+        Assert.That(store.Tool.Width, Is.EqualTo(6.0));
+    }
+
+    [Test]
+    public void Load_SiblingKeyCollision_SiblingWins()
+    {
+        // If both files define the same key, the sibling overwrites the
+        // primary. This is conservative — split-format files shouldn't
+        // share keys, but if a hand-edited file does, the more-specific
+        // tool/env file should win.
+        File.WriteAllText(Path.Combine(_tempDir, "Coll.XML"),
+            SettingFile(("setVehicle_toolWidth", "1.0")));
+
+        File.WriteAllText(Path.Combine(_tempDir, "Coll.tool.xml"),
+            SettingFile(("setVehicle_toolWidth", "7.0")));
+
+        var store = new ConfigurationStore();
+        _service.Load("Coll", store);
+
+        Assert.That(store.Tool.Width, Is.EqualTo(7.0));
+    }
+
+    [Test]
+    public void Load_SiblingFilenameCaseInsensitive()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "Mixed.XML"),
+            SettingFile(("setVehicle_wheelbase", "3.0")));
+
+        // Sibling written with a different case to verify resolver is case-insensitive
+        File.WriteAllText(Path.Combine(_tempDir, "Mixed.TOOL.XML"),
+            SettingFile(("setVehicle_toolWidth", "5.5")));
+
+        var store = new ConfigurationStore();
+        _service.Load("Mixed", store);
+
+        Assert.That(store.Tool.Width, Is.EqualTo(5.5),
+            "Sibling resolver must match {profile}.tool.xml regardless of filename case");
+    }
+
+    [Test]
+    public void Load_NoFile_ReturnsFalse()
+    {
+        var store = new ConfigurationStore();
+        var ok = _service.Load("DoesNotExist", store);
+
+        Assert.That(ok, Is.False);
+    }
+
+    /// <summary>
+    /// Subclass that injects the test directory via the protected test-seam ctor.
+    /// </summary>
+    private sealed class TestableVehicleProfileService : VehicleProfileService
+    {
+        public TestableVehicleProfileService(string vehiclesDirectory, Microsoft.Extensions.Logging.ILogger<VehicleProfileService> logger)
+            : base(logger, vehiclesDirectory)
+        {
+        }
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 63
+#define VERSION_PATCH 64
 
-#define VERSION "26.4.63"
-#define VERSION_DATE "2026-04-28"
+#define VERSION "26.4.64"
+#define VERSION_DATE "2026-04-29"


### PR DESCRIPTION
## Summary
Closes #225. Adds 6.8.2 split-format support to AgValonia's legacy XML profile import path.

Upstream 6.8.2 splits the previously-combined vehicle/tool/environment XML profile across three separate files (`VehicleProfiles/`, `ToolProfiles/`, `Environment/`). The \`<setting name="...">\` keys are unchanged — only the structural layout differs — so the existing \`ApplyXmlSettingsToStore\` handler works as-is once siblings are merged into one dictionary.

## Convention
AgValonia keeps a single \`Vehicles/\` directory rather than mirroring upstream's three parallel directories. Split-format companions use the same base name with descriptive suffixes:

| File | Source | Purpose |
|---|---|---|
| \`Vehicles/{name}.XML\` | already supported | primary — legacy combined OR 6.8.2 VehicleSettings |
| \`Vehicles/{name}.tool.xml\` | new | 6.8.2 ToolSettings split |
| \`Vehicles/{name}.env.xml\` | new | 6.8.2 environment Settings split |

\`Load()\` reads the primary file, then merges any sibling \`<setting>\` elements before applying. Tradeoff vs mirroring upstream's directory layout: a flat-with-suffix layout keeps everything in one folder, simpler for users to manage manually.

## Behavior
- **Legacy combined** (single \`{name}.XML\`): unchanged. No siblings, no merge.
- **Split with all three**: merge produces one dictionary that hits every \`ApplyXmlSettingsToStore\` branch.
- **Split with vehicle-only**: vehicle keys imported, tool/env defaults apply. Partial-import is intentional and recoverable — copy the missing companion next to the primary.
- **Sibling key collision** (shouldn't happen in practice): sibling wins.
- **Filename case**: case-insensitive resolution. Files written as \`{name}.XML\` + \`{name}.tool.xml\` (mixed case) or \`{name}.TOOL.XML\` all resolve.

## Tests
- [x] 7 unit tests in \`VehicleProfileSplitFormatImportTests.cs\` cover all scenarios above
- [x] Full Services test suite green: 486 / 486
- [ ] CI

## Implementation notes
- \`VehicleProfileService\` gained a \`protected\` test-seam ctor that takes an explicit \`vehiclesDirectory\` so unit tests don't depend on \`MyDocuments\`. Production ctor is unchanged.
- \`ResolveExistingFile\` does a case-insensitive lookup once per access (cheap; \`Vehicles/\` typically has tens of files at most).

🤖 Generated with [Claude Code](https://claude.com/claude-code)