### PR TITLE
Track import: transform between source/target field planes (#222)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -95,6 +95,9 @@ public static class ServiceCollectionExtensions
         // Smart WAS calibration (statistical WAS zero analyzer)
         services.AddSingleton<ISmartWasCalibrationService, SmartWasCalibrationService>();
 
+        // Track copying between fields (transforms via source plane → WGS84 → target plane)
+        services.AddSingleton<ITrackCopierService, TrackCopierService>();
+
         // Chart data service (collects rolling time-series for diagnostic charts)
         services.AddSingleton<IChartDataService, ChartDataService>();
 

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -95,6 +95,9 @@ public static class ServiceCollectionExtensions
         // Smart WAS calibration (statistical WAS zero analyzer)
         services.AddSingleton<ISmartWasCalibrationService, SmartWasCalibrationService>();
 
+        // Track copying between fields (transforms via source plane → WGS84 → target plane)
+        services.AddSingleton<ITrackCopierService, TrackCopierService>();
+
         // Chart data service (collects rolling time-series for diagnostic charts)
         services.AddSingleton<IChartDataService, ChartDataService>();
 

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -95,6 +95,9 @@ public static class ServiceCollectionExtensions
         // Smart WAS calibration (statistical WAS zero analyzer)
         services.AddSingleton<ISmartWasCalibrationService, SmartWasCalibrationService>();
 
+        // Track copying between fields (transforms via source plane → WGS84 → target plane)
+        services.AddSingleton<ITrackCopierService, TrackCopierService>();
+
         // Chart data service (collects rolling time-series for diagnostic charts)
         services.AddSingleton<IChartDataService, ChartDataService>();
 

--- a/Shared/AgValoniaGPS.Services/Interfaces/ITrackCopierService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/ITrackCopierService.cs
@@ -1,0 +1,56 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using AgValoniaGPS.Models;
+using TrackModel = AgValoniaGPS.Models.Track.Track;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// Copies guidance tracks between fields, transforming each point through
+/// the source field's local plane → WGS84 → target field's local plane.
+///
+/// Ported from upstream TrackCopier. AgValonia's unified Track model holds
+/// all geometry in <c>Points</c> (no separate ptA/ptB/curvePts), so the
+/// transform is simpler than upstream's per-component conversion.
+/// </summary>
+public interface ITrackCopierService
+{
+    /// <summary>
+    /// Convert tracks between two LocalPlanes. Each input track is cloned,
+    /// every point is transformed, and per-point heading is recomputed
+    /// from the converted geometry. WorkedPaths is reset and IsVisible
+    /// is forced true on the output (matches upstream behavior — copied
+    /// tracks should show up in the target field by default).
+    /// </summary>
+    List<TrackModel> ConvertTracks(
+        IReadOnlyList<TrackModel> tracks,
+        LocalPlane sourcePlane,
+        LocalPlane targetPlane);
+
+    /// <summary>
+    /// Copy <paramref name="tracks"/> from <paramref name="sourceFieldDirectory"/>
+    /// into <paramref name="targetFieldDirectory"/>. Loads the target's
+    /// existing tracks via <c>TrackFilesService</c>, appends the converted
+    /// tracks, then saves. Returns the count of tracks added.
+    /// </summary>
+    int CopyTracksToField(
+        string sourceFieldDirectory,
+        string targetFieldDirectory,
+        IReadOnlyList<TrackModel> tracks,
+        SharedFieldProperties? sharedFieldProperties = null);
+}

--- a/Shared/AgValoniaGPS.Services/TrackCopierService.cs
+++ b/Shared/AgValoniaGPS.Services/TrackCopierService.cs
@@ -1,0 +1,167 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Track;
+using TrackModel = AgValoniaGPS.Models.Track.Track;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Stateless utility for porting guidance tracks between fields.
+/// Each source point is taken to be in the source field's local plane,
+/// projected up to WGS84, then projected back down into the target
+/// plane. Per-point headings are recomputed from the converted geometry
+/// because rotating between planes can shift heading near the edges.
+/// </summary>
+public sealed class TrackCopierService : ITrackCopierService
+{
+    public List<TrackModel> ConvertTracks(
+        IReadOnlyList<TrackModel> tracks,
+        LocalPlane sourcePlane,
+        LocalPlane targetPlane)
+    {
+        if (tracks == null || tracks.Count == 0)
+            return new List<TrackModel>();
+
+        var converted = new List<TrackModel>(tracks.Count);
+        foreach (var source in tracks)
+        {
+            converted.Add(ConvertSingleTrack(source, sourcePlane, targetPlane));
+        }
+        return converted;
+    }
+
+    public int CopyTracksToField(
+        string sourceFieldDirectory,
+        string targetFieldDirectory,
+        IReadOnlyList<TrackModel> tracks,
+        SharedFieldProperties? sharedFieldProperties = null)
+    {
+        if (tracks == null || tracks.Count == 0) return 0;
+
+        var props = sharedFieldProperties ?? new SharedFieldProperties();
+
+        var sourceOrigin = LoadOrigin(sourceFieldDirectory);
+        var targetOrigin = LoadOrigin(targetFieldDirectory);
+
+        var sourcePlane = new LocalPlane(sourceOrigin, props);
+        var targetPlane = new LocalPlane(targetOrigin, props);
+
+        var convertedTracks = ConvertTracks(tracks, sourcePlane, targetPlane);
+
+        // Append-then-save so existing tracks in the target field aren't lost
+        var existing = TrackFilesService.Load(targetFieldDirectory);
+        existing.AddRange(convertedTracks);
+        TrackFilesService.Save(targetFieldDirectory, existing);
+
+        return convertedTracks.Count;
+    }
+
+    private static TrackModel ConvertSingleTrack(TrackModel source, LocalPlane sourcePlane, LocalPlane targetPlane)
+    {
+        // Step 1: project every point through source → WGS84 → target.
+        // Heading is left at zero here; we recompute below from the
+        // converted geometry so it's consistent with the new positions.
+        var convertedPoints = new List<Vec3>(source.Points.Count);
+        foreach (var p in source.Points)
+        {
+            var sourceGeo = new GeoCoord(p.Northing, p.Easting);
+            var wgs = sourcePlane.ConvertGeoCoordToWgs84(sourceGeo);
+            var targetGeo = targetPlane.ConvertWgs84ToGeoCoord(wgs);
+            convertedPoints.Add(new Vec3(targetGeo.Easting, targetGeo.Northing, 0));
+        }
+
+        // Step 2: recompute headings from the converted geometry.
+        RecomputeHeadings(convertedPoints, source.IsClosed);
+
+        return new TrackModel
+        {
+            Name = source.Name,
+            Type = source.Type,
+            IsClosed = source.IsClosed,
+            NudgeDistance = source.NudgeDistance,
+            IsVisible = true, // Copied tracks should be visible by default
+            Points = convertedPoints,
+            // Reset worked paths — they're meaningless in the new field's coordinate system
+            WorkedPaths = new HashSet<int>(),
+        };
+    }
+
+    /// <summary>
+    /// Replace each point's heading with the bearing from this point to the
+    /// next. The last point inherits the second-to-last point's heading
+    /// (matching upstream <c>TrackCopier</c>'s behavior). For 2-point AB
+    /// lines both points share the same heading, which is correct.
+    /// For closed loops (water pivot), the last point bridges back to the
+    /// first.
+    /// </summary>
+    private static void RecomputeHeadings(List<Vec3> pts, bool isClosed)
+    {
+        if (pts.Count < 2) return;
+
+        for (int i = 0; i < pts.Count - 1; i++)
+        {
+            double heading = NormalizeHeading(
+                Math.Atan2(pts[i + 1].Easting - pts[i].Easting,
+                          pts[i + 1].Northing - pts[i].Northing));
+            pts[i] = new Vec3(pts[i].Easting, pts[i].Northing, heading);
+        }
+
+        // Last point
+        double lastHeading;
+        if (isClosed)
+        {
+            lastHeading = NormalizeHeading(
+                Math.Atan2(pts[0].Easting - pts[^1].Easting,
+                          pts[0].Northing - pts[^1].Northing));
+        }
+        else
+        {
+            lastHeading = pts[^2].Heading;
+        }
+        pts[^1] = new Vec3(pts[^1].Easting, pts[^1].Northing, lastHeading);
+    }
+
+    private static double NormalizeHeading(double heading)
+    {
+        const double TwoPi = Math.PI * 2.0;
+        // Guard against the 0/2π wrap: a round-trip through WGS84 can leave
+        // an "exactly zero" Atan2 result as a tiny negative residual. Without
+        // this clamp the `while (heading < 0)` flip would produce ~2π for
+        // what should stay ~0 — visually identical but breaks tests and
+        // surprises any code that compares headings near zero.
+        if (Math.Abs(heading) < 1e-9) return 0;
+        while (heading < 0) heading += TwoPi;
+        while (heading >= TwoPi) heading -= TwoPi;
+        return heading;
+    }
+
+    /// <summary>
+    /// Read the WGS84 origin from a field directory's Field.txt.
+    /// Wraps <see cref="FieldPlaneFileService"/> so the call site doesn't
+    /// have to manage the round-trip through <see cref="Field"/>.
+    /// </summary>
+    private static Wgs84 LoadOrigin(string fieldDirectory)
+    {
+        var field = new FieldPlaneFileService().LoadField(fieldDirectory);
+        return new Wgs84(field.Origin.Latitude, field.Origin.Longitude);
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.TrackManagement.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.TrackManagement.cs
@@ -19,12 +19,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Base;
 using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Models.Track;
+using AgValoniaGPS.Services;
 using Microsoft.Extensions.Logging;
 using CommunityToolkit.Mvvm.Input;
+using TrackModel = AgValoniaGPS.Models.Track.Track;
 
 namespace AgValoniaGPS.ViewModels;
 
@@ -178,8 +181,14 @@ public partial class MainViewModel
                     return;
                 }
 
+                // Transform tracks from source field's local plane into the
+                // active field's local plane. Without this, tracks from a
+                // field with a different origin land at completely wrong
+                // physical locations.
+                var transformed = TransformImportedTracks(importedTracks, sourceDir);
+
                 int importCount = 0;
-                foreach (var track in importedTracks)
+                foreach (var track in transformed)
                 {
                     track.IsActive = false;
                     SavedTracks.Add(track);
@@ -418,6 +427,40 @@ public partial class MainViewModel
         if (_recPathRecordingPoints.Count % 20 == 0)
             StatusMessage = $"Recording path: {_recPathRecordingPoints.Count} points";
     }
+
+    /// <summary>
+/// Transform tracks from a source field's local plane into the active
+/// field's local plane. If the active field's origin can't be determined
+/// or the source has no Field.txt, falls back to returning the input
+/// unchanged so the legacy "untransformed" import path still works
+/// (better than failing entirely on partial field data).
+/// </summary>
+private List<TrackModel> TransformImportedTracks(IReadOnlyList<TrackModel> sourceTracks, string sourceDir)
+{
+    var activeField = ActiveField;
+    if (activeField == null) return sourceTracks.ToList();
+
+    Wgs84 sourceOrigin;
+    try
+    {
+        var sourceField = new FieldPlaneFileService().LoadField(sourceDir);
+        sourceOrigin = new Wgs84(sourceField.Origin.Latitude, sourceField.Origin.Longitude);
+    }
+    catch
+    {
+        // No Field.txt in the source directory or the file is malformed.
+        // Treat tracks as already in the active field's plane (legacy behavior).
+        _logger.LogWarning("[TrackImport] Could not read source field origin; importing tracks without coordinate transform");
+        return sourceTracks.ToList();
+    }
+
+    var targetOrigin = new Wgs84(activeField.Origin.Latitude, activeField.Origin.Longitude);
+    var props = new SharedFieldProperties();
+    var sourcePlane = new LocalPlane(sourceOrigin, props);
+    var targetPlane = new LocalPlane(targetOrigin, props);
+
+    return _trackCopierService.ConvertTracks(sourceTracks, sourcePlane, targetPlane);
+}
 
     #endregion
 }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -69,6 +69,7 @@ public partial class MainViewModel : ObservableObject
     private readonly IConfigurationService _configurationService;
     private readonly IAutoSteerService _autoSteerService;
     private readonly ISmartWasCalibrationService _smartWasService;
+    private readonly ITrackCopierService _trackCopierService;
     private readonly IModuleCommunicationService _moduleCommunicationService;
     private readonly IToolPositionService _toolPositionService;
     private readonly ICoverageMapService _coverageMapService;
@@ -185,6 +186,7 @@ public partial class MainViewModel : ObservableObject
         IConfigurationService configurationService,
         IAutoSteerService autoSteerService,
         ISmartWasCalibrationService smartWasService,
+        ITrackCopierService trackCopierService,
         IModuleCommunicationService moduleCommunicationService,
         IToolPositionService toolPositionService,
         ICoverageMapService coverageMapService,
@@ -241,6 +243,7 @@ public partial class MainViewModel : ObservableObject
         _configurationService = configurationService;
         _autoSteerService = autoSteerService;
         _smartWasService = smartWasService;
+        _trackCopierService = trackCopierService;
         _moduleCommunicationService = moduleCommunicationService;
         _toolPositionService = toolPositionService;
         _coverageMapService = coverageMapService;

--- a/Tests/AgValoniaGPS.Services.Tests/TrackCopierServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/TrackCopierServiceTests.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.IO;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Track;
+using AgValoniaGPS.Services;
+using TrackModel = AgValoniaGPS.Models.Track.Track;
+
+namespace AgValoniaGPS.Services.Tests;
+
+[TestFixture]
+public class TrackCopierServiceTests
+{
+    private static LocalPlane MakePlane(double lat, double lon)
+        => new LocalPlane(new Wgs84(lat, lon), new SharedFieldProperties());
+
+    [Test]
+    public void ConvertTracks_AbLine_BetweenIdenticalPlanes_PreservesGeometry()
+    {
+        // Same origin → identity transform. Position should be preserved exactly,
+        // heading recomputed from the geometry (still A→B).
+        var plane = MakePlane(40.0, -100.0);
+        var ab = TrackModel.FromABLine("AB1",
+            new Vec3(10, 20, 0),
+            new Vec3(30, 50, 0));
+
+        var sut = new TrackCopierService();
+        var converted = sut.ConvertTracks(new[] { ab }, plane, plane);
+
+        Assert.That(converted, Has.Count.EqualTo(1));
+        var c = converted[0];
+        Assert.That(c.Points[0].Easting, Is.EqualTo(10).Within(1e-6));
+        Assert.That(c.Points[0].Northing, Is.EqualTo(20).Within(1e-6));
+        Assert.That(c.Points[1].Easting, Is.EqualTo(30).Within(1e-6));
+        Assert.That(c.Points[1].Northing, Is.EqualTo(50).Within(1e-6));
+
+        // Heading is atan2(dE, dN). dE=20, dN=30 → atan2(20,30) ≈ 0.5880 rad.
+        var expectedHeading = System.Math.Atan2(20.0, 30.0);
+        Assert.That(c.Points[0].Heading, Is.EqualTo(expectedHeading).Within(1e-6));
+        Assert.That(c.Points[1].Heading, Is.EqualTo(expectedHeading).Within(1e-6),
+            "AB line: last point inherits heading from second-to-last (which is A→B itself)");
+    }
+
+    [Test]
+    public void ConvertTracks_BetweenDifferentOrigins_RoundTripsThroughWgs84()
+    {
+        // Source plane at origin A; a point at (50, 100) in source plane
+        // corresponds to a specific WGS84 location. Target plane has a
+        // different origin; the same WGS84 location lands at a different
+        // (easting, northing) in the target plane. Verify round-trip.
+        var sourcePlane = MakePlane(40.0, -100.0);
+        var targetPlane = MakePlane(40.001, -100.001);
+
+        var sourcePoint = new Vec3(50, 100, 0);
+        var ab = TrackModel.FromABLine("AB1", sourcePoint, new Vec3(150, 200, 0));
+
+        var sut = new TrackCopierService();
+        var converted = sut.ConvertTracks(new[] { ab }, sourcePlane, targetPlane);
+
+        // Convert manually for assertion
+        var sourceGeo = new GeoCoord(sourcePoint.Northing, sourcePoint.Easting);
+        var wgs = sourcePlane.ConvertGeoCoordToWgs84(sourceGeo);
+        var expectedTargetGeo = targetPlane.ConvertWgs84ToGeoCoord(wgs);
+
+        Assert.That(converted[0].Points[0].Easting, Is.EqualTo(expectedTargetGeo.Easting).Within(1e-6));
+        Assert.That(converted[0].Points[0].Northing, Is.EqualTo(expectedTargetGeo.Northing).Within(1e-6));
+    }
+
+    [Test]
+    public void ConvertTracks_Curve_RecomputesPerPointHeadings()
+    {
+        var plane = MakePlane(40.0, -100.0);
+        var curve = TrackModel.FromCurve("C1", new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(10, 0, 0),  // step east
+            new Vec3(10, 10, 0), // step north
+            new Vec3(20, 10, 0), // step east
+        });
+
+        var sut = new TrackCopierService();
+        var converted = sut.ConvertTracks(new[] { curve }, plane, plane);
+        var pts = converted[0].Points;
+
+        // pt0→pt1: dE=10, dN=0 → atan2(10,0) = π/2
+        Assert.That(pts[0].Heading, Is.EqualTo(System.Math.PI / 2).Within(1e-6));
+        // pt1→pt2: dE=0, dN=10 → atan2(0,10) = 0
+        Assert.That(pts[1].Heading, Is.EqualTo(0).Within(1e-6));
+        // pt2→pt3: dE=10, dN=0 → atan2(10,0) = π/2
+        Assert.That(pts[2].Heading, Is.EqualTo(System.Math.PI / 2).Within(1e-6));
+        // last point inherits heading from previous
+        Assert.That(pts[3].Heading, Is.EqualTo(pts[2].Heading).Within(1e-6));
+    }
+
+    [Test]
+    public void ConvertTracks_ClosedLoop_LastPointWrapsToFirst()
+    {
+        var plane = MakePlane(40.0, -100.0);
+        var loop = TrackModel.FromCurve("Loop", new List<Vec3>
+        {
+            new Vec3(0, 0, 0),
+            new Vec3(10, 0, 0),
+            new Vec3(10, 10, 0),
+        }, isClosed: true);
+
+        var sut = new TrackCopierService();
+        var converted = sut.ConvertTracks(new[] { loop }, plane, plane);
+        var pts = converted[0].Points;
+
+        // Last point's heading should be from pt[^1] back to pt[0]:
+        // dE = 0-10 = -10, dN = 0-10 = -10 → atan2(-10,-10) = -3π/4 → normalized = 5π/4
+        var expected = System.Math.Atan2(-10.0, -10.0);
+        if (expected < 0) expected += 2 * System.Math.PI;
+        Assert.That(pts[^1].Heading, Is.EqualTo(expected).Within(1e-6),
+            "Closed loop: last point's heading bridges back to first");
+    }
+
+    [Test]
+    public void ConvertTracks_PreservesMetadata_ResetsWorkedPaths()
+    {
+        var plane = MakePlane(40.0, -100.0);
+        var src = TrackModel.FromABLine("Original", new Vec3(0, 0, 0), new Vec3(10, 10, 0));
+        src.NudgeDistance = 0.42;
+        src.IsVisible = false;
+        src.MarkPathWorked(3);
+        src.MarkPathWorked(7);
+
+        var sut = new TrackCopierService();
+        var converted = sut.ConvertTracks(new[] { src }, plane, plane)[0];
+
+        Assert.That(converted.Name, Is.EqualTo("Original"));
+        Assert.That(converted.Type, Is.EqualTo(TrackType.ABLine));
+        Assert.That(converted.NudgeDistance, Is.EqualTo(0.42));
+        Assert.That(converted.IsVisible, Is.True, "Copied tracks default to visible regardless of source");
+        Assert.That(converted.WorkedPaths, Is.Empty, "WorkedPaths must reset on copy");
+    }
+
+    [Test]
+    public void ConvertTracks_EmptyInput_ReturnsEmpty()
+    {
+        var plane = MakePlane(40.0, -100.0);
+        var sut = new TrackCopierService();
+
+        Assert.That(sut.ConvertTracks(new TrackModel[0], plane, plane), Is.Empty);
+        Assert.That(sut.ConvertTracks(null!, plane, plane), Is.Empty);
+    }
+
+    [Test]
+    public void ConvertTracks_DoesNotMutateSource()
+    {
+        var plane = MakePlane(40.0, -100.0);
+        var ab = TrackModel.FromABLine("AB", new Vec3(5, 5, 0), new Vec3(15, 25, 0));
+        var originalA = ab.Points[0];
+
+        var sut = new TrackCopierService();
+        sut.ConvertTracks(new[] { ab }, plane, plane);
+
+        Assert.That(ab.Points[0].Easting, Is.EqualTo(originalA.Easting));
+        Assert.That(ab.Points[0].Northing, Is.EqualTo(originalA.Northing));
+        Assert.That(ab.Points[0].Heading, Is.EqualTo(originalA.Heading));
+    }
+
+    [Test]
+    public void CopyTracksToField_AppendsToExistingTargetTracks()
+    {
+        // Set up two field directories with Field.txt origins, plus an
+        // existing TrackLines.txt in the target. Verify the copied track
+        // is appended (not overwriting).
+        var sourceDir = Path.Combine(Path.GetTempPath(), "TrackCopySource_" + System.Guid.NewGuid().ToString("N"));
+        var targetDir = Path.Combine(Path.GetTempPath(), "TrackCopyTarget_" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sourceDir);
+        Directory.CreateDirectory(targetDir);
+
+        try
+        {
+            WriteFieldTxt(sourceDir, lat: 40.0, lon: -100.0);
+            WriteFieldTxt(targetDir, lat: 40.001, lon: -100.001);
+
+            // Pre-existing track in target
+            var existing = TrackModel.FromABLine("ExistingAB",
+                new Vec3(0, 0, 0), new Vec3(20, 0, 0));
+            TrackFilesService.Save(targetDir, new[] { existing });
+
+            // Source track to copy
+            var newTrack = TrackModel.FromABLine("FromSource",
+                new Vec3(50, 50, 0), new Vec3(150, 100, 0));
+
+            var sut = new TrackCopierService();
+            int count = sut.CopyTracksToField(sourceDir, targetDir, new[] { newTrack });
+
+            Assert.That(count, Is.EqualTo(1));
+
+            var afterTracks = TrackFilesService.Load(targetDir);
+            Assert.That(afterTracks, Has.Count.EqualTo(2));
+            Assert.That(afterTracks[0].Name, Is.EqualTo("ExistingAB"));
+            Assert.That(afterTracks[1].Name, Is.EqualTo("FromSource"));
+        }
+        finally
+        {
+            if (Directory.Exists(sourceDir)) Directory.Delete(sourceDir, recursive: true);
+            if (Directory.Exists(targetDir)) Directory.Delete(targetDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Writes a minimal Field.txt that <see cref="FieldPlaneFileService.LoadField"/> can parse.
+    /// </summary>
+    private static void WriteFieldTxt(string dir, double lat, double lon)
+    {
+        var path = Path.Combine(dir, "Field.txt");
+        // FieldPlaneFileService.LoadField expects:
+        // line 1: timestamp
+        // line 2: $FieldDir header
+        // line 3: field name
+        // line 4: $Offsets header
+        // line 5: offsets (X,Y)
+        // line 6: Convergence header
+        // line 7: convergence value
+        // line 8: $StartFix header
+        // line 9: lat,lon (origin)
+        File.WriteAllText(path,
+            "2026-01-01T00:00:00Z\n" +
+            "$FieldDir\n" +
+            "FieldNew\n" +
+            "$Offsets\n" +
+            "0,0\n" +
+            "$Convergence\n" +
+            "0\n" +
+            "$StartFix\n" +
+            $"{lat.ToString(System.Globalization.CultureInfo.InvariantCulture)},{lon.ToString(System.Globalization.CultureInfo.InvariantCulture)}\n");
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -61,6 +61,7 @@ public class MainViewModelBuilder
             configurationService: Substitute.For<IConfigurationService>(),
             autoSteerService: Substitute.For<IAutoSteerService>(),
             smartWasService: Substitute.For<ISmartWasCalibrationService>(),
+            trackCopierService: Substitute.For<ITrackCopierService>(),
             moduleCommunicationService: Substitute.For<IModuleCommunicationService>(),
             toolPositionService: Substitute.For<IToolPositionService>(),
             coverageMapService: Substitute.For<ICoverageMapService>(),

--- a/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
@@ -70,6 +70,7 @@ public class MainViewModelBuilder
             configurationService: Substitute.For<IConfigurationService>(),
             autoSteerService: AutoSteerService,
             smartWasService: Substitute.For<ISmartWasCalibrationService>(),
+            trackCopierService: Substitute.For<ITrackCopierService>(),
             moduleCommunicationService: Substitute.For<IModuleCommunicationService>(),
             toolPositionService: Substitute.For<IToolPositionService>(),
             coverageMapService: CoverageMapService,

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 63
+#define VERSION_PATCH 65
 
-#define VERSION "26.4.63"
-#define VERSION_DATE "2026-04-28"
+#define VERSION "26.4.65"
+#define VERSION_DATE "2026-04-29"


### PR DESCRIPTION
## Summary
Closes #222. Imported tracks now go through a coordinate transform when the source and target fields have different origins.

**The bug this fixes:** prior to this PR, \`ImportTracksFromFieldCommand\` loaded tracks from another field's \`TrackLines.txt\` and added them to the active field's \`SavedTracks\` **without** transforming coordinates between the two fields' local planes. Since AgValonia stores track geometry in plane-coordinates relative to each field's origin, importing a track from a field with a different origin placed it at completely wrong physical coordinates on the target map (off by the distance between origins, which can be hundreds of meters).

## Implementation choice
Rather than building a parallel "Copy Tracks" dialog (which is what upstream's \`FormCopyTracks\` is, and what #222's title literally says), the existing \`ImportTracks\` dialog already provides the user-visible feature — it just had the silent coordinate bug. Threading \`TrackCopierService.ConvertTracks\` into that existing path fixes the bug without adding a redundant dialog. Per-track selection (the one feature upstream's dialog has that AgValonia's \`ImportTracks\` doesn't) is a nice-to-have not addressed here; if it becomes desired later, it's a UI addition that calls the same service.

## What's in the PR

### New
- \`Shared/AgValoniaGPS.Services/TrackCopierService.cs\` (ported from upstream \`TrackCopier.cs\`) — stateless utility, two public methods:
  - \`ConvertTracks(tracks, sourcePlane, targetPlane)\` transforms each Vec3 point through source plane → WGS84 → target plane, recomputes per-point heading from the converted geometry, resets WorkedPaths, forces IsVisible=true.
  - \`CopyTracksToField(sourceDir, targetDir, tracks, ...)\` end-to-end disk-to-disk copy (loads source, transforms, appends to target's existing tracks, saves). Used by tests and available for future callers.
- \`ITrackCopierService\` interface, registered as singleton in all three platform DI projects.
- 8 unit tests covering identity transform, cross-origin round-trip, per-point heading recomputation for curves, closed-loop heading wrap, metadata preservation + WorkedPaths reset, empty input, source non-mutation, and end-to-end CopyTracksToField with a synthetic Field.txt fixture.

### Modified
- \`MainViewModel.TrackManagement.ImportTracksFromFieldCommand\` — reads the source field's Field.txt origin (via \`FieldPlaneFileService\`), builds source/target \`LocalPlane\`s, calls \`TrackCopierService.ConvertTracks\` before adding to SavedTracks. Falls back to the legacy untransformed behavior if the source has no readable Field.txt (logged as warning — better than failing on partial field data).
- \`MainViewModel\` ctor: new \`ITrackCopierService\` dep + assignment.
- Both \`MainViewModelBuilder\`s in test projects: NSubstitute mock injection.

## Subtle correctness note
\`NormalizeHeading\` clamps sub-epsilon residuals to zero before the \`while (heading < 0)\` flip. Without this, a round-trip through WGS84 can leave a mathematically-zero heading as a tiny negative double, which the unguarded \`while\` would normalize to \`~2π\` — visually identical but breaks tests and any code that compares headings near zero. (Test \`ConvertTracks_Curve_RecomputesPerPointHeadings\` caught this.)

## Test plan
- [x] 8 new \`TrackCopierServiceTests\` pass
- [x] Full Services suite green: 487 / 487
- [x] Full UI suite green: 123 / 123
- [ ] Manual smoke: import tracks from a field with a different origin into the active field; verify tracks land at the correct physical position on the map
- [ ] iOS smoke on physical iPad (\`-r ios-arm64\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)