### PR TITLE
Cap NTRIP header buffer at 8 KiB to prevent memory-exhaustion DoS (#286)

### DIFF
--- a/Shared/AgValoniaGPS.Services/NtripClientService.cs
+++ b/Shared/AgValoniaGPS.Services/NtripClientService.cs
@@ -52,6 +52,12 @@ public class NtripClientService : INtripClientService, IDisposable
     private readonly Queue<byte> _rtcmQueue = new Queue<byte>();
     private readonly object _queueLock = new object();
     private const int RTCM_PACKET_SIZE = 256; // Match AgIO default
+
+    // Cap header accumulation to prevent memory-exhaustion DoS from a
+    // malicious caster — or a MITM on the path — streaming bytes without
+    // the \r\n\r\n terminator. Real caster headers are well under 1 KB;
+    // 8 KiB is generous. See issue #286 / threat model finding F2.
+    private const int MaxHeaderBytes = 8 * 1024;
     private readonly IGpsService _gpsService;
     private readonly ILogger<NtripClientService> _logger;
 
@@ -222,6 +228,18 @@ public class NtripClientService : INtripClientService, IDisposable
                     // First response is HTTP header - check for success
                     if (!headerReceived)
                     {
+                        // Bail if the header has grown past the cap without a
+                        // terminator. Without this an unbounded caster could
+                        // OOM the tablet by streaming bytes forever.
+                        if (_headerBuffer.Count + bytesReceived > MaxHeaderBytes)
+                        {
+                            _logger.LogWarning(
+                                "NTRIP header exceeded {Max} bytes without \\r\\n\\r\\n terminator; disconnecting",
+                                MaxHeaderBytes);
+                            await DisconnectAsync();
+                            return;
+                        }
+
                         // Accumulate header bytes
                         for (int i = 0; i < bytesReceived; i++)
                         {

--- a/Tests/AgValoniaGPS.Services.Tests/NtripHeaderBufferCapTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/NtripHeaderBufferCapTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Regression test for issue #286: a malicious caster — or MITM — that
+/// streams bytes without the \r\n\r\n header terminator must not be able
+/// to grow the client's header buffer until the tablet OOMs. The fix caps
+/// the buffer at 8 KiB and disconnects cleanly.
+/// </summary>
+[TestFixture]
+public class NtripHeaderBufferCapTests
+{
+    [Test]
+    public async Task ReceiveLoop_HeaderExceedsCap_DisconnectsCleanly()
+    {
+        // Spin up a loopback TCP server that accepts the NTRIP request
+        // and then streams 9 KiB of garbage with no header terminator.
+        // The pre-fix code would have grown _headerBuffer indefinitely.
+        // The post-fix code caps at 8 KiB and disconnects.
+        var listener = new TcpListener(IPAddress.Loopback, port: 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var serverDone = new TaskCompletionSource<bool>();
+        var clientDisconnected = new ManualResetEventSlim(initialState: false);
+
+        // Server side: accept, drain the request, blast 9 KiB of garbage,
+        // then keep the socket open so we can observe the *client* closing.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+
+                // Drain the client's NTRIP request (it's <1KB)
+                var requestBuffer = new byte[2048];
+                _ = await stream.ReadAsync(requestBuffer, 0, requestBuffer.Length);
+
+                // Stream 9 KiB of 'X' — no \r\n\r\n terminator anywhere.
+                var garbage = Encoding.ASCII.GetBytes(new string('X', 9 * 1024));
+                await stream.WriteAsync(garbage, 0, garbage.Length);
+                await stream.FlushAsync();
+
+                // Keep the socket open *long enough* that any disconnect we
+                // observe must come from the client deciding to close
+                // (not from the server timing out and closing on its own).
+                // The buffer-cap fix should disconnect within milliseconds of
+                // receiving the 9 KiB; without the fix the client would keep
+                // buffering and only disconnect when the server eventually
+                // closes — which we never do here.
+                serverDone.SetResult(true);
+                await Task.Delay(TimeSpan.FromSeconds(30));
+            }
+            catch
+            {
+                // Client closed first — expected outcome
+                serverDone.TrySetResult(true);
+            }
+        });
+
+        var service = new NtripClientService(
+            NSubstitute.Substitute.For<IGpsService>(),
+            NullLogger<NtripClientService>.Instance);
+        service.ConnectionStatusChanged += (_, args) =>
+        {
+            if (!args.IsConnected) clientDisconnected.Set();
+        };
+
+        var config = new NtripConfiguration
+        {
+            CasterAddress = "127.0.0.1",
+            CasterPort = port,
+            MountPoint = "TEST",
+            Username = "u",
+            Password = "p",
+            SubnetAddress = "127.0.0",
+            UdpForwardPort = 0,        // 0 disables the forward target; harmless for this test
+            GgaIntervalSeconds = 0,    // skip the GGA timer
+        };
+
+        try
+        {
+            await service.ConnectAsync(config);
+        }
+        catch
+        {
+            // ConnectAsync may throw if the GGA/UDP plumbing trips; the
+            // receive-loop fix is what we're testing, so as long as we
+            // don't get stuck we're fine.
+        }
+
+        // The fix disconnects within ms of the 9 KiB arriving. Use a tight
+        // 2s window: well below the server's 30s hold so any disconnect
+        // observed must be the client's own decision to close.
+        bool disconnectedInTime = clientDisconnected.Wait(TimeSpan.FromSeconds(2));
+
+        Assert.That(disconnectedInTime, Is.True,
+            "NtripClientService must close the connection when the header buffer exceeds the cap");
+        Assert.That(service.IsConnected, Is.False);
+
+        listener.Stop();
+        service.Dispose();
+    }
+
+    [Test]
+    public async Task ReceiveLoop_NormalSizedHeader_DoesNotTripTheCap()
+    {
+        // Sanity check: a well-formed 200 OK response well under the cap
+        // must NOT trip the disconnect. Otherwise the cap would break
+        // legitimate connections.
+        var listener = new TcpListener(IPAddress.Loopback, port: 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var connected = new ManualResetEventSlim(initialState: false);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+
+                var requestBuffer = new byte[2048];
+                _ = await stream.ReadAsync(requestBuffer, 0, requestBuffer.Length);
+
+                // Send a valid 200 OK header well under the 8 KiB cap
+                var response = Encoding.ASCII.GetBytes(
+                    "ICY 200 OK\r\nServer: Test\r\n\r\n");
+                await stream.WriteAsync(response, 0, response.Length);
+                await stream.FlushAsync();
+
+                // Hold the socket so the test can observe IsConnected=true
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            }
+            catch { /* test will assert below */ }
+        });
+
+        var service = new NtripClientService(
+            NSubstitute.Substitute.For<IGpsService>(),
+            NullLogger<NtripClientService>.Instance);
+        service.ConnectionStatusChanged += (_, args) =>
+        {
+            if (args.IsConnected) connected.Set();
+        };
+
+        var config = new NtripConfiguration
+        {
+            CasterAddress = "127.0.0.1",
+            CasterPort = port,
+            MountPoint = "TEST",
+            Username = "u",
+            Password = "p",
+            SubnetAddress = "127.0.0",
+            UdpForwardPort = 0,
+            GgaIntervalSeconds = 0,
+        };
+
+        try { await service.ConnectAsync(config); } catch { /* see above */ }
+
+        bool gotConnected = connected.Wait(TimeSpan.FromSeconds(3));
+
+        Assert.That(gotConnected, Is.True,
+            "A normal-sized header (well under 8 KiB) must not trip the cap or break connection");
+
+        listener.Stop();
+        service.Dispose();
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 64
+#define VERSION_PATCH 65
 
-#define VERSION "26.4.64"
+#define VERSION "26.4.65"
 #define VERSION_DATE "2026-04-29"


### PR DESCRIPTION
## Summary
Closes #286 (which had been closed prematurely — the unbounded buffer pattern was still present in code as of this PR's parent commit).

**Threat model finding F2.** \`NtripClientService.ReceiveLoop\` accumulates caster response bytes into \`_headerBuffer\` until it sees \`\\r\\n\\r\\n\`. With no size cap, a malicious caster — or a MITM on the path between the tablet and the caster — can stream bytes indefinitely without the terminator and grow the buffer until the tablet OOMs. A few hundred MB of garbage is enough; achievable in seconds at LAN speeds.

## Fix
Five-line change in the receive loop:

\`\`\`csharp
// Cap header accumulation to prevent memory-exhaustion DoS from a
// malicious caster — or a MITM on the path — streaming bytes without
// the \r\n\r\n terminator. Real caster headers are well under 1 KB;
// 8 KiB is generous. See issue #286 / threat model finding F2.
private const int MaxHeaderBytes = 8 * 1024;
\`\`\`

The receive loop bails before adding new bytes if the buffer would exceed the cap, logging a warning and calling \`DisconnectAsync\` (same pattern as the existing "authorization failed" branch).

No protocol impact, no effect on legitimate connections.

## Tests
Two new regression tests in \`NtripHeaderBufferCapTests.cs\`:

- \`ReceiveLoop_HeaderExceedsCap_DisconnectsCleanly\` — loopback TCP server streams 9 KiB of \`X\` with no terminator and holds the socket open for 30 seconds. Asserts the client disconnects within 2 seconds, **before** the server's hold-open expires. Verified the test **fails on the unpatched code** (the only reason a stash-based parent passes is server-side socket close, which is gated behind the 30s hold) and **passes with the fix**.
- \`ReceiveLoop_NormalSizedHeader_DoesNotTripTheCap\` — sanity check; a normal \`ICY 200 OK\` response well under 8 KiB must still complete the connection cleanly.

## Test plan
- [x] New tests pass
- [x] Verified test correctly fails on unpatched code (\`git stash\` of the service file before running)
- [ ] CI green
- [ ] iOS smoke on physical iPad — not strictly needed; this is a service-layer fix with no UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)