### PR TITLE
Fix Auto sections stuck on 'Turning On' at standstill (#324)

### DIFF
--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -214,7 +214,8 @@ public class SectionControlService : ISectionControlService
         // MANUAL ON sections active so coverage doesn't gap on stop/restart.
         // SlowSpeedCutoff is stored in km/h (matching the UI); speed is m/s.
         double slowSpeedCutoffMps = tool.SlowSpeedCutoff / 3.6;
-        if (speed < slowSpeedCutoffMps)
+        bool isSlowSpeedCutoff = speed < slowSpeedCutoffMps;
+        if (isSlowSpeedCutoff)
         {
             for (int i = 0; i < numSections; i++)
             {
@@ -240,9 +241,15 @@ public class SectionControlService : ISectionControlService
             _coverageThrottleTimestamp = now;
         }
 
-        // Update each section
+        // Update each section. During slow-speed cutoff, Auto sections were
+        // already cleared above; skip them here so UpdateSection's look-ahead
+        // doesn't re-arm SectionOnRequest at speed=0 (lookOnDist collapses to
+        // the section center, which evaluates as shouldBeOn inside the
+        // boundary, leaving the section pinned in TURNING_ON forever).
         for (int i = 0; i < numSections; i++)
         {
+            if (isSlowSpeedCutoff && _sectionStates[i].ButtonState == SectionButtonState.Auto)
+                continue;
             UpdateSection(i, toolPosition, toolHeading, speed);
         }
 

--- a/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
@@ -62,6 +62,46 @@ public class SectionControlServiceTests
         Assert.That(_service.SectionStates[2].IsOn, Is.False);
     }
 
+    [Test]
+    public void Update_SlowSpeed_AutoSection_InsideBoundary_DoesNotReArmOnRequest()
+    {
+        // Regression for #324: at standstill inside the boundary, Auto
+        // sections were stuck displaying "Turning ON" (orange, code 4)
+        // because the slow-speed cutoff cleared the request, then
+        // UpdateSection's look-ahead re-armed it the same frame
+        // (lookOnDist=0 at speed=0 evaluates the section center, which
+        // sits inside the boundary → shouldBeOn=true → SectionOnRequest=true).
+        // Expected: section settles to Auto OFF (code 5) — IsOn=false AND
+        // SectionOnRequest=false.
+        var outerPoly = new BoundaryPolygon();
+        outerPoly.Points.Add(new BoundaryPoint(0, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 200, 0));
+        outerPoly.Points.Add(new BoundaryPoint(0, 200, 0));
+        outerPoly.UpdateBounds();
+        _appState.Field.CurrentBoundary = new Boundary { OuterBoundary = outerPoly };
+
+        _service.SetAllAuto();
+        _service.MasterState = SectionMasterState.Auto;
+
+        // Tick a few frames at standstill so any re-arm bug compounds.
+        // Use a position well inside the boundary so all section centers are inside.
+        for (int frame = 0; frame < 5; frame++)
+        {
+            _service.Update(new Vec3(100, 100, 0), 0, 0, 0.1);
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.That(_service.SectionStates[i].IsOn, Is.False,
+                $"Section {i} IsOn should be false at standstill");
+            Assert.That(_service.SectionStates[i].SectionOnRequest, Is.False,
+                $"Section {i} SectionOnRequest should not be re-armed at standstill (would render as orange Turning ON)");
+            Assert.That(_service.SectionStates[i].SectionOnTimer, Is.EqualTo(0),
+                $"Section {i} SectionOnTimer should be 0 at standstill");
+        }
+    }
+
     #endregion
 
     #region No Boundary

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 66
+#define VERSION_PATCH 67
 
-#define VERSION "26.4.66"
-#define VERSION_DATE "2026-05-01"
+#define VERSION "26.4.67"
+#define VERSION_DATE "2026-05-02"


### PR DESCRIPTION
## Summary

- Closes #324. At standstill inside a boundary, Auto sections rendered orange (code 4 "Turning ON") indefinitely. Root cause per Xyntexx's diagnosis: the slow-speed cutoff in `SectionControlService.Update()` cleared each Auto section's request/timer state, then the per-section loop ran `UpdateSection` unconditionally — `lookOnDist=0` evaluated the section center inside the boundary, set `shouldBeOn=true`, and re-armed `SectionOnRequest` every frame. `SectionOnTimer` pinned at 1, never crossing `turnOnPhaseFrames`, so `IsOn` stayed false (valve never opened) and the color code stayed at 4.
- Fix: capture `isSlowSpeedCutoff` once and skip `UpdateSection` for Auto sections in the per-section loop. Manual ON still flows through to hold coverage on stop/restart; Manual OFF still routes through `UpdateSectionOff`.
- Bumped `sys/version.h` to `26.4.67`.

## Test plan

- [x] New regression `Update_SlowSpeed_AutoSection_InsideBoundary_DoesNotReArmOnRequest` — ticks 5 frames at standstill inside a 200×200 boundary, asserts every Auto section ends with `IsOn=false`, `SectionOnRequest=false`, `SectionOnTimer=0`. Verified it fails on the unfixed code (`SectionOnRequest=True`) and passes after the fix.
- [x] Full suite: 918 tests pass (104 models + 194 viewmodels + 123 UI + 497 services).
- [x] Manual: drive into field in Auto, stop — sections turn gray (Auto OFF) instead of staying orange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)