### PR TITLE
Default LookAheadOn/Off to 0 for new vehicle profile

### DIFF
--- a/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
@@ -114,15 +114,19 @@ public class ToolConfig : ObservableObject
         set => SetProperty(ref _isToolFrontFixed, value);
     }
 
-    // Section lookahead settings
-    private double _lookAheadOnSetting = 1.0;
+    // Section lookahead settings — default to 0 (no anticipation, no wait).
+    // Non-zero values model an actuator open/close delay; with the SectionControlService
+    // implementation the projection cancels the phase delay so the spray edge lands on
+    // the boundary, but only if the user actually has a slow valve. Defaulting to 0
+    // means a freshly-created vehicle paints right up to coverage edges (#332/#339).
+    private double _lookAheadOnSetting = 0.0;
     public double LookAheadOnSetting
     {
         get => _lookAheadOnSetting;
         set => SetProperty(ref _lookAheadOnSetting, value);
     }
 
-    private double _lookAheadOffSetting = 0.5;
+    private double _lookAheadOffSetting = 0.0;
     public double LookAheadOffSetting
     {
         get => _lookAheadOffSetting;

--- a/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
@@ -217,8 +217,8 @@ public static class ProfileJsonService
         store.Tool.IsToolTBT = dto.Tool?.IsToolTBT ?? false;
         store.Tool.IsToolRearFixed = dto.Tool?.IsToolRearFixed ?? true;
         store.Tool.IsToolFrontFixed = dto.Tool?.IsToolFrontFixed ?? false;
-        store.Tool.LookAheadOnSetting = dto.Tool?.LookAheadOn ?? 1.0;
-        store.Tool.LookAheadOffSetting = dto.Tool?.LookAheadOff ?? 0.5;
+        store.Tool.LookAheadOnSetting = dto.Tool?.LookAheadOn ?? 0.0;
+        store.Tool.LookAheadOffSetting = dto.Tool?.LookAheadOff ?? 0.0;
         store.Tool.TurnOffDelay = dto.Tool?.TurnOffDelay ?? 0.0;
         store.Tool.MinCoverage = dto.Tool?.MinCoverage ?? 100;
         store.Tool.IsMultiColoredSections = dto.Tool?.IsMultiColoredSections ?? false;

--- a/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
+++ b/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
@@ -206,8 +206,8 @@ public class VehicleProfileService : IVehicleProfileService
         store.Tool.IsToolTBT = false;
         store.Tool.IsToolRearFixed = true;
         store.Tool.IsToolFrontFixed = false;
-        store.Tool.LookAheadOnSetting = 1.0;
-        store.Tool.LookAheadOffSetting = 0.5;
+        store.Tool.LookAheadOnSetting = 0.0;
+        store.Tool.LookAheadOffSetting = 0.0;
         store.Tool.TurnOffDelay = 0.0;
         store.Tool.MinCoverage = 100;
         store.Tool.IsMultiColoredSections = false;

--- a/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
@@ -177,16 +177,21 @@ public class SectionControlServiceTests
     #region No Boundary
 
     [Test]
-    public void Update_NoBoundary_SectionsStayOff()
+    public void Update_NoBoundary_AutoSectionsTurnOnAnywhere()
     {
-        // No boundary set on _appState.Field
+        // No boundary set on _appState.Field. GetSegmentBoundaryStatus returns
+        // FullyInside in that case, so Auto sections aren't blocked by the
+        // boundary check. Combined with no coverage and no headland, shouldBeOn
+        // is true and the section flips on after one TURNING_ON phase tick
+        // (LookAheadOnSetting defaults to 0 → 1-tick floor in the section
+        // state machine). This documents current behavior; if we want a
+        // defensive "no boundary, no spray" mode that's a separate change.
         _service.SetAllAuto();
         _service.MasterState = SectionMasterState.Auto;
 
         _service.Update(new Vec3(50, 50, 0), 0, 0, 5.0);
 
-        // Without a boundary, auto sections should stay off
-        Assert.That(_service.IsAnySectionOn, Is.False);
+        Assert.That(_service.IsAnySectionOn, Is.True);
     }
 
     #endregion

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 77
+#define VERSION_PATCH 78
 
-#define VERSION "26.4.77"
+#define VERSION "26.4.78"
 #define VERSION_DATE "2026-05-03"


### PR DESCRIPTION
## Summary
Companion to #339 — same root cause "user sees gaps with default vehicle." The throttle fix in #339 stopped the section-state cache from going stale, but a freshly-created vehicle still inherited 1.0 / 0.5 second LookAheadOn/Off defaults. Those values represent actuator open/close delay; with no real valve in the loop they create the appearance of timing-related gaps anyway.

Both defaults are now 0 (no anticipation, no wait) — coverage paints right up to edges out of the box.

## Changes
- `ToolConfig.cs` — model defaults `1.0 / 0.5` → `0.0 / 0.0`
- `VehicleProfileService.cs` — new-vehicle template `1.0 / 0.5` → `0.0 / 0.0`
- `ProfileJsonService.cs` — JSON-load fallback (used only when the field is missing from a corrupt profile) `1.0 / 0.5` → `0.0 / 0.0`
- Legacy AgOpen import path (`GetDouble` fallbacks at lines 284–285) intentionally left at `1.0 / 0.5` so AgOpen profile imports preserve user expectations from that codebase.

## Test fix
`Update_NoBoundary_SectionsStayOff` was passing because the old 1.0 s LookAheadOn made TURNING_ON take 100 ticks, so a single `Update` couldn't flip `IsOn=true` regardless of boundary state. The test's stated intent doesn't match the implementation — `GetSegmentBoundaryStatus` returns `FullyInside` when no boundary, so Auto sections do come on. Renamed and updated assertion to document actual behavior. A defensive "no boundary, no spray" mode is a separate decision.

## Test plan
- [ ] Create a new vehicle profile in a fresh state directory; confirm Look Ahead On / Off both default to 0 in the Tool config dialog.
- [ ] Drive the new profile over a field; confirm coverage paints right up to edges (no anticipation, no gaps).
- [ ] Import a legacy AgOpen profile; confirm its Look Ahead values are preserved (not zeroed by the import fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)