### PR TITLE
Fix #337: project U-turn goal past path end so dot stops freezing

### DIFF
--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnGuidanceService.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnGuidanceService.cs
@@ -285,8 +285,23 @@ namespace AgValoniaGPS.Services.YouTurn
 
                 if (i == ptCount - 1) // goalPointDistance is longer than remaining u-turn
                 {
-                    output.IsTurnComplete = true;
-                    return;
+                    // Lookahead extends past the last point of the U-turn path.
+                    // Project the remainder along the endpoint heading so the
+                    // goal point keeps advancing onto the next pass direction.
+                    // Do NOT set IsTurnComplete here — that would zero the goal
+                    // upstream and gate off SetGuidancePoints, freezing the
+                    // goal-point dot at the U-turn end while the tractor is
+                    // still approaching it. Turn completion is owned by
+                    // YouTurnStateMachine.Tick's closest-approach check, which
+                    // uses the actual tractor position. Without this projection
+                    // the steering controller chases a stationary target during
+                    // the headland traverse, producing visible wobble entering
+                    // the next pass. (#337)
+                    double remaining = goalPointDistance - distSoFar;
+                    var endPt = input.TurnPath[i];
+                    goalPoint.Easting = endPt.Easting + Math.Sin(endPt.Heading) * remaining;
+                    goalPoint.Northing = endPt.Northing + Math.Cos(endPt.Heading) * remaining;
+                    break;
                 }
 
                 if (input.UTurnStyle == 1 && input.IsReverse)

--- a/Tests/AgValoniaGPS.Services.Tests/GuidancePipelineIntegrationTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/GuidancePipelineIntegrationTests.cs
@@ -195,9 +195,16 @@ public class GuidancePipelineIntegrationTests
             path.Add(new Vec3(10, 15 - i, Math.PI));
 
         bool turnComplete = false;
+        // Drive the pivot all the way to the last point (was capped at path.Count - 2,
+        // which only worked because YouTurnGuidanceService used to set IsTurnComplete
+        // any time the goal-point lookahead extended past the end of the path. That
+        // signal froze the goal point during the last few meters of the turn (#337);
+        // the lookahead-past-end branch now keeps publishing a forward-projected goal,
+        // so completion correctly requires the pivot itself to reach the end — matching
+        // YouTurnStateMachine's closest-approach detection in production.
         for (int i = 0; i < 100 && !turnComplete; i++)
         {
-            int idx = Math.Min(i, path.Count - 2);
+            int idx = Math.Min(i, path.Count - 1);
             var pos = path[idx];
 
             var output = guidanceService.CalculateGuidance(new AgValoniaGPS.Models.YouTurn.YouTurnGuidanceInput

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 78
+#define VERSION_PATCH 79
 
-#define VERSION "26.4.78"
+#define VERSION "26.4.79"
 #define VERSION_DATE "2026-05-03"


### PR DESCRIPTION
## Summary
`YouTurnGuidanceService.CalculatePurePursuitGuidance` short-circuited with `IsTurnComplete=true` whenever the goal-point lookahead extended past the last point of the U-turn path — and returned **without filling in `goalPoint`**. The pipeline then zeroed it (`return (0,0,0,0,true)`), and `ApplyGpsCycleResult`'s `HasGuidance` gate suppressed `SetGuidancePoints`. The goal dot froze at its last value while the tractor was still approaching the arc end.

Turn completion is already owned by `YouTurnStateMachine.Tick`'s closest-approach detection, which uses the actual tractor position. So the goal-side completion signal here was both redundant and harmful: the steering controller chased a stationary target through the headland traverse, producing visible wobble entering the next pass on all three platforms (Mac/iPad/Android, per #337's repro).

## Fix
When the lookahead extends past `path[^1]`, project the remaining lookahead along the endpoint heading and continue normal guidance. Goal point flows smoothly off the arc onto the next-pass direction; turn completion fires from the state machine at the right moment based on tractor position.

## Test fix
`UTurn_CreateAndFollow_CompletesSuccessfully` capped the simulated pivot at `path.Count - 2` and was "passing" because the (removed) lookahead-past-end signal short-circuited it. Updated to drive the pivot all the way to `path[^1]` — matches production behavior where completion requires the tractor itself to reach the end of the path.

## Verification
- Live U-turn drive on Desktop: goal dot transitions smoothly from arc to next-pass direction; no wobble entering next pass.
- 953 tests pass (104 models + 194 VMs + 123 UI + 532 services).

## Test plan
- [ ] Drive a U-turn on macOS Desktop; confirm red goal dot smoothly advances past the arc end without freezing.
- [ ] Same on iPad and Android (issue was reproducible on all three platforms).
- [ ] Confirm coverage entering the next pass has no S-curve / wobble correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)