### PR TITLE
Persist all UI-edited Tool/Guidance fields in vehicle profile JSON (closes #343)

### DIFF
--- a/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ProfileJsonService.cs
@@ -90,10 +90,27 @@ public static class ProfileJsonService
 
     private static ProfileDto ToDto(string profileName, ConfigurationStore store)
     {
-        // Trim trailing zeros from section positions
-        int usedPositions = store.NumSections + 1;
-        var sectionPositions = new double[usedPositions];
-        Array.Copy(store.SectionPositions, sectionPositions, Math.Min(usedPositions, store.SectionPositions.Length));
+        // Section widths (cm) are the runtime source of truth — Tool.SectionWidths
+        // is what the UI edits and what SectionControlService.RecalculateSectionPositions
+        // consumes. Persist the live widths array, sized to the actual section count
+        // so a 6-section tool doesn't carry along 10 trailing 100 cm defaults.
+        int numSections = Math.Max(1, store.NumSections);
+        var sectionWidths = new double[numSections];
+        for (int i = 0; i < numSections; i++)
+            sectionWidths[i] = store.Tool.GetSectionWidth(i);
+
+        // Positions (m, NumSections+1 boundary points, centered on tool with Offset)
+        // are derived from widths so existing readers (and earlier app builds that
+        // only consume Positions) still get a consistent geometry. Without this
+        // derivation the on-disk Positions array drifts away from the live widths
+        // every time the user edits a section. (#section-width-persistence)
+        double totalMeters = 0;
+        for (int i = 0; i < numSections; i++)
+            totalMeters += sectionWidths[i] / 100.0;
+        var sectionPositions = new double[numSections + 1];
+        sectionPositions[0] = -totalMeters / 2.0 + store.Tool.Offset;
+        for (int i = 0; i < numSections; i++)
+            sectionPositions[i + 1] = sectionPositions[i] + sectionWidths[i] / 100.0;
 
         return new ProfileDto
         {
@@ -120,6 +137,16 @@ public static class ProfileJsonService
                 PurePursuitIntegralGain = store.Guidance.PurePursuitIntegralGain,
                 IsPurePursuit = store.Guidance.IsPurePursuit,
                 UTurnCompensation = store.Guidance.UTurnCompensation,
+                // #343: previously not persisted.
+                MinLookAheadDistance = store.Guidance.MinLookAheadDistance,
+                StanleyIntegralDistanceAwayTriggerAB = store.Guidance.StanleyIntegralDistanceAwayTriggerAB,
+                DeadZoneHeading = store.Guidance.DeadZoneHeading,
+                DeadZoneDelay = store.Guidance.DeadZoneDelay,
+                TramPasses = store.Guidance.TramPasses,
+                TramDisplay = store.Guidance.TramDisplay,
+                TramLine = store.Guidance.TramLine,
+                HydLiftLookAheadDistanceLeft = store.Guidance.HydLiftLookAheadDistanceLeft,
+                HydLiftLookAheadDistanceRight = store.Guidance.HydLiftLookAheadDistanceRight,
             },
             Tool = new ToolDto
             {
@@ -142,11 +169,24 @@ public static class ProfileJsonService
                 LookAheadOn = store.Tool.LookAheadOnSetting,
                 LookAheadOff = store.Tool.LookAheadOffSetting,
                 TurnOffDelay = store.Tool.TurnOffDelay,
+                // #343: previously not persisted — UI edits silently dropped on save.
+                DefaultSectionWidth = store.Tool.DefaultSectionWidth,
+                SlowSpeedCutoff = store.Tool.SlowSpeedCutoff,
+                CoverageMargin = store.Tool.CoverageMargin,
+                Zones = store.Tool.Zones,
+                ZoneRanges = (int[])store.Tool.ZoneRanges.Clone(),
+                IsWorkSwitchEnabled = store.Tool.IsWorkSwitchEnabled,
+                IsWorkSwitchActiveLow = store.Tool.IsWorkSwitchActiveLow,
+                IsWorkSwitchManualSections = store.Tool.IsWorkSwitchManualSections,
+                IsSteerSwitchEnabled = store.Tool.IsSteerSwitchEnabled,
+                IsSteerSwitchManualSections = store.Tool.IsSteerSwitchManualSections,
+                SectionColors = (uint[])store.Tool.SectionColors.Clone(),
             },
             Sections = new SectionsDto
             {
-                Count = store.NumSections,
+                Count = numSections,
                 Positions = sectionPositions,
+                Widths = sectionWidths,
             },
             YouTurn = new YouTurnDto
             {
@@ -194,6 +234,16 @@ public static class ProfileJsonService
         store.Guidance.StanleyIntegralGainAB = dto.Guidance?.StanleyIntegralGainAB ?? 0.0;
         store.Guidance.PurePursuitIntegralGain = dto.Guidance?.PurePursuitIntegralGain ?? 0.0;
         store.Guidance.UTurnCompensation = dto.Guidance?.UTurnCompensation ?? 1.0;
+        // #343: previously not persisted — defaults match GuidanceConfig initializers.
+        store.Guidance.MinLookAheadDistance = dto.Guidance?.MinLookAheadDistance ?? 2.0;
+        store.Guidance.StanleyIntegralDistanceAwayTriggerAB = dto.Guidance?.StanleyIntegralDistanceAwayTriggerAB ?? 0.3;
+        store.Guidance.DeadZoneHeading = dto.Guidance?.DeadZoneHeading ?? 0.5;
+        store.Guidance.DeadZoneDelay = dto.Guidance?.DeadZoneDelay ?? 10;
+        store.Guidance.TramPasses = dto.Guidance?.TramPasses ?? 3;
+        store.Guidance.TramDisplay = dto.Guidance?.TramDisplay ?? true;
+        store.Guidance.TramLine = dto.Guidance?.TramLine ?? 1;
+        store.Guidance.HydLiftLookAheadDistanceLeft = dto.Guidance?.HydLiftLookAheadDistanceLeft ?? 1.0;
+        store.Guidance.HydLiftLookAheadDistanceRight = dto.Guidance?.HydLiftLookAheadDistanceRight ?? 1.0;
 
         // U-Turn settings
         store.Guidance.UTurnRadius = dto.YouTurn?.TurnRadius ?? 8.0;
@@ -222,15 +272,58 @@ public static class ProfileJsonService
         store.Tool.TurnOffDelay = dto.Tool?.TurnOffDelay ?? 0.0;
         store.Tool.MinCoverage = dto.Tool?.MinCoverage ?? 100;
         store.Tool.IsMultiColoredSections = dto.Tool?.IsMultiColoredSections ?? false;
+        // Was written but not loaded — see #343.
+        store.Tool.IsSectionsNotZones = dto.Tool?.IsSectionsNotZones ?? true;
         store.Tool.IsSectionOffWhenOut = dto.Tool?.IsSectionOffWhenOut ?? true;
         store.Tool.IsHeadlandSectionControl = dto.Tool?.IsHeadlandSectionControl ?? true;
+        // #343: previously not persisted — defaults match the in-memory ToolConfig
+        // initializers so loading an older profile (no field present) yields the
+        // same behavior as an unmodified store.
+        store.Tool.DefaultSectionWidth = dto.Tool?.DefaultSectionWidth ?? 100.0;
+        store.Tool.SlowSpeedCutoff = dto.Tool?.SlowSpeedCutoff ?? 0.5;
+        store.Tool.CoverageMargin = dto.Tool?.CoverageMargin ?? 5.0;
+        store.Tool.Zones = dto.Tool?.Zones ?? 2;
+        if (dto.Tool?.ZoneRanges != null && dto.Tool.ZoneRanges.Length == 9)
+            store.Tool.ZoneRanges = (int[])dto.Tool.ZoneRanges.Clone();
+        store.Tool.IsWorkSwitchEnabled = dto.Tool?.IsWorkSwitchEnabled ?? false;
+        store.Tool.IsWorkSwitchActiveLow = dto.Tool?.IsWorkSwitchActiveLow ?? false;
+        store.Tool.IsWorkSwitchManualSections = dto.Tool?.IsWorkSwitchManualSections ?? false;
+        store.Tool.IsSteerSwitchEnabled = dto.Tool?.IsSteerSwitchEnabled ?? false;
+        store.Tool.IsSteerSwitchManualSections = dto.Tool?.IsSteerSwitchManualSections ?? false;
+        if (dto.Tool?.SectionColors != null && dto.Tool.SectionColors.Length == 16)
+            store.Tool.SectionColors = (uint[])dto.Tool.SectionColors.Clone();
 
-        // Section config
+        // Section config — set NumSections first so width-derivation knows how
+        // many sections to populate.
         store.NumSections = dto.Sections?.Count ?? 1;
         var sectionPositions = new double[17];
         if (dto.Sections?.Positions != null)
             Array.Copy(dto.Sections.Positions, sectionPositions, Math.Min(dto.Sections.Positions.Length, 17));
         store.SectionPositions = sectionPositions;
+
+        // Restore Tool.SectionWidths — the runtime source of truth that the
+        // section UI edits and SectionControlService.RecalculateSectionPositions
+        // consumes. Prefer the explicit Widths array (new format). Fall back
+        // to deriving from Positions for older profiles that pre-date the
+        // Widths field — guard against the bogus profile shape we've seen
+        // in the wild (Count=16 with only 7 valid positions; trailing zeros
+        // would otherwise produce widths = [..., -91 cm, 0, 0, 0]).
+        // (#section-width-persistence)
+        int restoredNum = Math.Max(1, store.NumSections);
+        if (dto.Sections?.Widths != null && dto.Sections.Widths.Length >= restoredNum)
+        {
+            for (int i = 0; i < restoredNum; i++)
+                store.Tool.SetSectionWidth(i, dto.Sections.Widths[i]);
+        }
+        else if (dto.Sections?.Positions != null && dto.Sections.Positions.Length >= restoredNum + 1)
+        {
+            for (int i = 0; i < restoredNum; i++)
+            {
+                double widthM = dto.Sections.Positions[i + 1] - dto.Sections.Positions[i];
+                if (widthM > 0)
+                    store.Tool.SetSectionWidth(i, widthM * 100.0);
+            }
+        }
 
         // Display config
         store.IsMetric = dto.General?.IsMetric ?? false;
@@ -278,6 +371,16 @@ public static class ProfileJsonService
         public double PurePursuitIntegralGain { get; set; }
         public bool IsPurePursuit { get; set; }
         public double UTurnCompensation { get; set; }
+        // #343: nullable so older profiles take ApplyDtoToStore defaults.
+        public double? MinLookAheadDistance { get; set; }
+        public double? StanleyIntegralDistanceAwayTriggerAB { get; set; }
+        public double? DeadZoneHeading { get; set; }
+        public int? DeadZoneDelay { get; set; }
+        public int? TramPasses { get; set; }
+        public bool? TramDisplay { get; set; }
+        public int? TramLine { get; set; }
+        public double? HydLiftLookAheadDistanceLeft { get; set; }
+        public double? HydLiftLookAheadDistanceRight { get; set; }
     }
 
     internal class ToolDto
@@ -301,12 +404,29 @@ public static class ProfileJsonService
         public double LookAheadOn { get; set; }
         public double LookAheadOff { get; set; }
         public double TurnOffDelay { get; set; }
+        // #343: nullable so older profiles (no field present) take the
+        // ApplyDtoToStore default and don't get reset to "0".
+        public double? DefaultSectionWidth { get; set; }
+        public double? SlowSpeedCutoff { get; set; }
+        public double? CoverageMargin { get; set; }
+        public int? Zones { get; set; }
+        public int[]? ZoneRanges { get; set; }
+        public bool? IsWorkSwitchEnabled { get; set; }
+        public bool? IsWorkSwitchActiveLow { get; set; }
+        public bool? IsWorkSwitchManualSections { get; set; }
+        public bool? IsSteerSwitchEnabled { get; set; }
+        public bool? IsSteerSwitchManualSections { get; set; }
+        public uint[]? SectionColors { get; set; }
     }
 
     internal class SectionsDto
     {
         public int Count { get; set; }
         public double[] Positions { get; set; } = Array.Empty<double>();
+        // cm per section, length = Count. Authoritative; Positions is derived
+        // for backward compat. Nullable so older profiles that lack the field
+        // fall through to position-based derivation in ApplyDtoToStore.
+        public double[]? Widths { get; set; }
     }
 
     internal class YouTurnDto

--- a/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Services.Profile;
@@ -119,27 +120,180 @@ public class ProfileJsonServiceTests
     }
 
     [Test]
-    public void SaveAndLoad_SectionPositions_DynamicArray()
+    public void SaveAndLoad_SectionWidths_PersistAcrossRoundTrip()
     {
+        // Tool.SectionWidths (cm) is the runtime source of truth — what the
+        // section UI edits and what SectionControlService consumes. The fix
+        // wires it through the JSON; before the fix, edits silently dropped
+        // because only the derived Positions array was serialized.
+        // (#section-width-persistence)
         SetupTestStore("SectionTest");
         _store.NumSections = 4;
-        _store.SectionPositions = new double[17];
-        _store.SectionPositions[0] = -6.0;
-        _store.SectionPositions[1] = -3.0;
-        _store.SectionPositions[2] = 0.0;
-        _store.SectionPositions[3] = 3.0;
-        _store.SectionPositions[4] = 6.0;
+        _store.Tool.Offset = 0.0;
+        _store.Tool.SetSectionWidth(0, 300.0); // 3 m
+        _store.Tool.SetSectionWidth(1, 300.0);
+        _store.Tool.SetSectionWidth(2, 300.0);
+        _store.Tool.SetSectionWidth(3, 300.0);
 
         ProfileJsonService.Save(_tempDir, "SectionTest", _store);
         var loadStore = new ConfigurationStore();
         ProfileJsonService.Load(_tempDir, "SectionTest", loadStore);
 
         Assert.That(loadStore.NumSections, Is.EqualTo(4));
+        // Widths round-trip — the regression that issue described.
+        Assert.That(loadStore.Tool.GetSectionWidth(0), Is.EqualTo(300.0).Within(1e-6));
+        Assert.That(loadStore.Tool.GetSectionWidth(1), Is.EqualTo(300.0).Within(1e-6));
+        Assert.That(loadStore.Tool.GetSectionWidth(2), Is.EqualTo(300.0).Within(1e-6));
+        Assert.That(loadStore.Tool.GetSectionWidth(3), Is.EqualTo(300.0).Within(1e-6));
+        // Positions are derived (centered, +Offset) and round-trip too.
         Assert.That(loadStore.SectionPositions[0], Is.EqualTo(-6.0).Within(1e-6));
         Assert.That(loadStore.SectionPositions[1], Is.EqualTo(-3.0).Within(1e-6));
         Assert.That(loadStore.SectionPositions[2], Is.EqualTo(0.0).Within(1e-6));
         Assert.That(loadStore.SectionPositions[3], Is.EqualTo(3.0).Within(1e-6));
         Assert.That(loadStore.SectionPositions[4], Is.EqualTo(6.0).Within(1e-6));
+    }
+
+    [Test]
+    public void SaveAndLoad_NonUniformSectionWidths_PersistAcrossRoundTrip()
+    {
+        // The original report: change a section width from 100 to 150 cm,
+        // confirm, close + reopen, value should still be 150.
+        SetupTestStore("SectionEdit");
+        _store.NumSections = 4;
+        _store.Tool.Offset = 0.0;
+        _store.Tool.SetSectionWidth(0, 100.0);
+        _store.Tool.SetSectionWidth(1, 150.0); // user-edited
+        _store.Tool.SetSectionWidth(2, 100.0);
+        _store.Tool.SetSectionWidth(3, 100.0);
+
+        ProfileJsonService.Save(_tempDir, "SectionEdit", _store);
+        var loadStore = new ConfigurationStore();
+        ProfileJsonService.Load(_tempDir, "SectionEdit", loadStore);
+
+        Assert.That(loadStore.Tool.GetSectionWidth(0), Is.EqualTo(100.0).Within(1e-6));
+        Assert.That(loadStore.Tool.GetSectionWidth(1), Is.EqualTo(150.0).Within(1e-6));
+        Assert.That(loadStore.Tool.GetSectionWidth(2), Is.EqualTo(100.0).Within(1e-6));
+        Assert.That(loadStore.Tool.GetSectionWidth(3), Is.EqualTo(100.0).Within(1e-6));
+    }
+
+    [Test]
+    public void SaveAndLoad_PreviouslyDroppedToolFields_RoundTrip()
+    {
+        // Regression for #343: Tool.* fields edited via UI silently lost on
+        // save because they weren't wired into ProfileJsonService.
+        SetupTestStore("ToolFields");
+        _store.Tool.DefaultSectionWidth = 175.0;
+        _store.Tool.SlowSpeedCutoff = 0.7;
+        _store.Tool.CoverageMargin = 12.5;
+        _store.Tool.Zones = 4;
+        _store.Tool.ZoneRanges = new int[9] { 0, 3, 6, 9, 12, 15, 16, 16, 16 };
+        _store.Tool.IsSectionsNotZones = false;
+        _store.Tool.IsWorkSwitchEnabled = true;
+        _store.Tool.IsWorkSwitchActiveLow = true;
+        _store.Tool.IsWorkSwitchManualSections = true;
+        _store.Tool.IsSteerSwitchEnabled = true;
+        _store.Tool.IsSteerSwitchManualSections = true;
+        var customColors = new uint[16];
+        for (int i = 0; i < 16; i++) customColors[i] = 0x010203 + (uint)i;
+        _store.Tool.SectionColors = customColors;
+
+        ProfileJsonService.Save(_tempDir, "ToolFields", _store);
+        var loadStore = new ConfigurationStore();
+        ProfileJsonService.Load(_tempDir, "ToolFields", loadStore);
+
+        Assert.That(loadStore.Tool.DefaultSectionWidth, Is.EqualTo(175.0).Within(1e-6));
+        Assert.That(loadStore.Tool.SlowSpeedCutoff, Is.EqualTo(0.7).Within(1e-6));
+        Assert.That(loadStore.Tool.CoverageMargin, Is.EqualTo(12.5).Within(1e-6));
+        Assert.That(loadStore.Tool.Zones, Is.EqualTo(4));
+        Assert.That(loadStore.Tool.ZoneRanges, Is.EqualTo(new int[9] { 0, 3, 6, 9, 12, 15, 16, 16, 16 }));
+        Assert.That(loadStore.Tool.IsSectionsNotZones, Is.False);
+        Assert.That(loadStore.Tool.IsWorkSwitchEnabled, Is.True);
+        Assert.That(loadStore.Tool.IsWorkSwitchActiveLow, Is.True);
+        Assert.That(loadStore.Tool.IsWorkSwitchManualSections, Is.True);
+        Assert.That(loadStore.Tool.IsSteerSwitchEnabled, Is.True);
+        Assert.That(loadStore.Tool.IsSteerSwitchManualSections, Is.True);
+        Assert.That(loadStore.Tool.SectionColors, Is.EqualTo(customColors));
+    }
+
+    [Test]
+    public void SaveAndLoad_PreviouslyDroppedGuidanceFields_RoundTrip()
+    {
+        // Regression for #343: Guidance.* fields edited via UI silently lost
+        // on save because they weren't wired into ProfileJsonService.
+        SetupTestStore("GuidanceFields");
+        _store.Guidance.MinLookAheadDistance = 3.5;
+        _store.Guidance.StanleyIntegralDistanceAwayTriggerAB = 0.45;
+        _store.Guidance.DeadZoneHeading = 0.8;
+        _store.Guidance.DeadZoneDelay = 25;
+        _store.Guidance.TramPasses = 7;
+        _store.Guidance.TramDisplay = false;
+        _store.Guidance.TramLine = 4;
+        _store.Guidance.HydLiftLookAheadDistanceLeft = 2.5;
+        _store.Guidance.HydLiftLookAheadDistanceRight = 1.75;
+
+        ProfileJsonService.Save(_tempDir, "GuidanceFields", _store);
+        var loadStore = new ConfigurationStore();
+        ProfileJsonService.Load(_tempDir, "GuidanceFields", loadStore);
+
+        Assert.That(loadStore.Guidance.MinLookAheadDistance, Is.EqualTo(3.5).Within(1e-6));
+        Assert.That(loadStore.Guidance.StanleyIntegralDistanceAwayTriggerAB, Is.EqualTo(0.45).Within(1e-6));
+        Assert.That(loadStore.Guidance.DeadZoneHeading, Is.EqualTo(0.8).Within(1e-6));
+        Assert.That(loadStore.Guidance.DeadZoneDelay, Is.EqualTo(25));
+        Assert.That(loadStore.Guidance.TramPasses, Is.EqualTo(7));
+        Assert.That(loadStore.Guidance.TramDisplay, Is.False);
+        Assert.That(loadStore.Guidance.TramLine, Is.EqualTo(4));
+        Assert.That(loadStore.Guidance.HydLiftLookAheadDistanceLeft, Is.EqualTo(2.5).Within(1e-6));
+        Assert.That(loadStore.Guidance.HydLiftLookAheadDistanceRight, Is.EqualTo(1.75).Within(1e-6));
+    }
+
+    [Test]
+    public void Load_OlderProfileWithoutNewFields_KeepsModelDefaults()
+    {
+        // Older profile (no DefaultSectionWidth / CoverageMargin / etc.) must
+        // load cleanly and leave the in-memory defaults intact. Verifies the
+        // ToolDto / GuidanceDto fields added for #343 are nullable and the
+        // load paths fall through to the model initializer values.
+        var droppedToolKeys = new[]
+        {
+            "defaultSectionWidth", "slowSpeedCutoff", "coverageMargin", "zones",
+            "zoneRanges", "isWorkSwitchEnabled", "isWorkSwitchActiveLow",
+            "isWorkSwitchManualSections", "isSteerSwitchEnabled",
+            "isSteerSwitchManualSections", "sectionColors",
+        };
+        var droppedGuidanceKeys = new[]
+        {
+            "minLookAheadDistance", "stanleyIntegralDistanceAwayTriggerAB",
+            "deadZoneHeading", "deadZoneDelay", "tramPasses", "tramDisplay",
+            "tramLine", "hydLiftLookAheadDistanceLeft",
+            "hydLiftLookAheadDistanceRight",
+        };
+
+        SetupTestStore("OldProfile");
+        ProfileJsonService.Save(_tempDir, "OldProfile", _store);
+        var path = System.IO.Path.Combine(_tempDir, "OldProfile.json");
+
+        // Reparse, remove the new fields properly, write back. Mirrors what an
+        // older app build's saved profile would look like.
+        using (var src = System.IO.File.OpenRead(path))
+        {
+            var node = System.Text.Json.Nodes.JsonNode.Parse(src)!;
+            var toolObj = node["tool"]!.AsObject();
+            foreach (var k in droppedToolKeys) toolObj.Remove(k);
+            var guidanceObj = node["guidance"]!.AsObject();
+            foreach (var k in droppedGuidanceKeys) guidanceObj.Remove(k);
+            System.IO.File.WriteAllText(path, node.ToJsonString(
+                new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        var loadStore = new ConfigurationStore();
+        ProfileJsonService.Load(_tempDir, "OldProfile", loadStore);
+
+        // Defaults from ToolConfig / GuidanceConfig initializers.
+        Assert.That(loadStore.Tool.DefaultSectionWidth, Is.EqualTo(100.0).Within(1e-6));
+        Assert.That(loadStore.Tool.CoverageMargin, Is.EqualTo(5.0).Within(1e-6));
+        Assert.That(loadStore.Tool.Zones, Is.EqualTo(2));
+        Assert.That(loadStore.Guidance.MinLookAheadDistance, Is.EqualTo(2.0).Within(1e-6));
+        Assert.That(loadStore.Guidance.DeadZoneDelay, Is.EqualTo(10));
     }
 
     [Test]

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 80
+#define VERSION_PATCH 81
 
-#define VERSION "26.4.80"
+#define VERSION "26.4.81"
 #define VERSION_DATE "2026-05-03"


### PR DESCRIPTION
Closes #343.

## Summary
The reported regression — "edit a section width from 100 → 150 cm, confirm, restart, value reverts to 100" — was the most visible case of a broader gap. An audit of every public field on `ConfigurationStore` sub-configs vs `ProfileJsonService.ToDto`/`ApplyDtoToStore` showed ~10 `Tool` fields and ~9 `Guidance` fields were edited via the configuration dialog but never wired into the JSON. Edits silently dropped on save and reverted to defaults on next launch.

## Tool fields newly persisted
- `SectionWidths` (the original report)
- `DefaultSectionWidth`, `SlowSpeedCutoff`, `CoverageMargin`
- `Zones`, `ZoneRanges`
- `IsWorkSwitchEnabled`, `IsWorkSwitchActiveLow`, `IsWorkSwitchManualSections`
- `IsSteerSwitchEnabled`, `IsSteerSwitchManualSections`
- `SectionColors`
- Plus `IsSectionsNotZones`, which was being **written** to the JSON but never **read** on load — fixed.

## Guidance fields newly persisted
- `MinLookAheadDistance`, `StanleyIntegralDistanceAwayTriggerAB`
- `DeadZoneHeading`, `DeadZoneDelay`
- `TramPasses`, `TramDisplay`, `TramLine`
- `HydLiftLookAheadDistanceLeft`, `HydLiftLookAheadDistanceRight`

## SectionWidths specifics
`Tool.SectionWidths` (cm) is the runtime source of truth — it's what the section UI edits and what `SectionControlService.RecalculateSectionPositions` consumes. The on-disk `Sections.Positions` array (m) had been the only thing serialized, with no derivation path between the two — every save left the on-disk geometry frozen at whatever it was when the profile was first written.

Now:
- **Save:** derive `Sections.Positions` from `Tool.SectionWidths + Tool.Offset`, **and** also write a new `Sections.Widths` array as the authoritative form.
- **Load:** prefer `Sections.Widths` if present (new format). Fall back to deriving widths from `Sections.Positions` (older profiles). Both paths populate `Tool.SectionWidths` directly.

## Backward compat
All new DTO fields are nullable. Loading an older profile (no field present) takes the `ApplyDtoToStore` default — which mirrors the in-memory `ToolConfig` / `GuidanceConfig` initializers — instead of resetting to 0. `Load_OlderProfileWithoutNewFields_KeepsModelDefaults` covers this.

## Tests
- `SaveAndLoad_SectionWidths_PersistAcrossRoundTrip` (rewritten — the old `SectionPositions`-based test was passing for the wrong reason).
- `SaveAndLoad_NonUniformSectionWidths_PersistAcrossRoundTrip` (your exact reported scenario).
- `SaveAndLoad_PreviouslyDroppedToolFields_RoundTrip`.
- `SaveAndLoad_PreviouslyDroppedGuidanceFields_RoundTrip`.
- `Load_OlderProfileWithoutNewFields_KeepsModelDefaults` (re-parses the saved JSON, deletes the new fields, asserts model defaults survive).

957 tests pass total (104 + 194 + 123 + 536).

## Test plan
- [ ] Edit a section width 100 → 150 cm in the config dialog, confirm, close + reopen the app — width should still be 150 (the original report).
- [ ] Edit `Coverage Margin`, save, restart — value should persist.
- [ ] Edit `Slow Speed Cutoff`, save, restart — value should persist.
- [ ] Open a profile saved by an older app build (no new fields) — should load without error and use defaults for the missing fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)