### PR TITLE
Fix #345: prevent slow-speed section flicker

### DIFF
--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -74,6 +74,31 @@ public class SectionControlService : ISectionControlService
     // Default coverage overlap threshold (used if MinCoverage is 0)
     private const double DEFAULT_COVERAGE_THRESHOLD = 0.70; // 70%
 
+    // Hysteresis gap between the OFF threshold (where a covered area is "done")
+    // and the ON threshold (where an uncovered area should be sprayed). At slow
+    // speed (~5 km/h or below) the look-ahead points sample nearly-stationary
+    // pixels, so a single boundary cell flipping causes the coverage % to bob
+    // 1-2 % around the threshold. Without a gap, that bob flips the
+    // shouldBeOn / shouldBeOff booleans every tick and produces visible
+    // flicker + missed spray. 15 percentage points is wide enough to absorb
+    // pixel-flip noise without compromising the MinCoverage intent.
+    private const double COVERAGE_HYSTERESIS_MARGIN = 0.15;
+    // Floor so the ON threshold can't go ≤ 0 when MinCoverage is set very low.
+    private const double COVERAGE_ON_THRESHOLD_FLOOR = 0.05;
+
+    // Floor on the forward distance from section center to the look-on /
+    // look-off sample points. lookAheadDistance = speed × LookAheadSetting,
+    // so at slow speed and/or LookAheadSetting=0 (the default) it goes to
+    // zero — the look-on/off check then samples cells at the section center,
+    // i.e. inside the section's own freshly-painted swath. shouldBeOff fires
+    // off the section's own coverage, IsOn flips off, paint stops; the next
+    // tick the section has crept past its own paint slightly, shouldBeOn
+    // fires, IsOn flips back on. This is the slow-speed flicker in #345.
+    // 0.3 m (3 detection cells) is enough to clear the painted swath
+    // longitudinally without changing behavior at normal speeds, where
+    // speed × time already exceeds it.
+    private const double MIN_LOOKAHEAD_FORWARD_DISTANCE_METERS = 0.3;
+
     // Minimum distance (squared) between coverage points to reduce edge jaggedness
     // At 10Hz and 10 kph (2.78 m/s), vehicle moves ~0.28m per update
     // Using 0.12m threshold ensures we add points frequently enough for accuracy
@@ -312,8 +337,13 @@ public class SectionControlService : ISectionControlService
         // flips on the first tick that shouldBe(On|Off) becomes true.
         double turnOnPhaseSec = tool.LookAheadOnSetting;
         double turnOffPhaseSec = tool.LookAheadOffSetting;
-        double lookAheadOnDist = speed * turnOnPhaseSec;
-        double lookAheadOffDist = speed * turnOffPhaseSec;
+        // Floor the FORWARD distance only (the time-based phase debounce above
+        // stays at user config). This keeps the sample point past the section's
+        // own swath at slow speed; at normal speeds speed × time exceeds the
+        // floor and the user's anticipation is preserved exactly. See the
+        // MIN_LOOKAHEAD_FORWARD_DISTANCE_METERS comment for the full reason.
+        double lookAheadOnDist = Math.Max(speed * turnOnPhaseSec, MIN_LOOKAHEAD_FORWARD_DISTANCE_METERS);
+        double lookAheadOffDist = Math.Max(speed * turnOffPhaseSec, MIN_LOOKAHEAD_FORWARD_DISTANCE_METERS);
 
         // Calculate section half-width for segment-based checks
         double halfWidth = (section.PositionRight - section.PositionLeft) / 2.0;
@@ -379,12 +409,22 @@ public class SectionControlService : ISectionControlService
             lookAheadOffDist);
         _totalCoverageMs += _sectionSw.Elapsed.TotalMilliseconds;
 
-        // Section is "covered" if coverage exceeds threshold
-        // Use MinCoverage setting from config (0-100), default to 70% if not set
-        double coverageThreshold = tool.MinCoverage > 0 ? tool.MinCoverage / 100.0 : DEFAULT_COVERAGE_THRESHOLD;
-        bool currentCovered = currentCoverage.CoveragePercent >= coverageThreshold;
-        bool lookOnCovered = lookOnCoverage.CoveragePercent >= coverageThreshold;
-        bool lookOffCovered = lookOffCoverage.CoveragePercent >= coverageThreshold;
+        // Section is "covered" if coverage exceeds the threshold.
+        // Use MinCoverage setting from config (0-100), default to 70% if not set.
+        // Apply hysteresis: a higher OFF threshold (when to consider an area
+        // "covered enough to skip") and a lower ON threshold (when to consider
+        // it "uncovered enough to spray"). The gap between them prevents the
+        // shouldBeOn / shouldBeOff booleans from oscillating when the look-ahead
+        // points sample noisy pixels near the threshold — the pathology behind
+        // the slow-speed flicker / missed spray (issue #345).
+        double coverageOffThreshold = tool.MinCoverage > 0
+            ? tool.MinCoverage / 100.0
+            : DEFAULT_COVERAGE_THRESHOLD;
+        double coverageOnThreshold = Math.Max(
+            COVERAGE_ON_THRESHOLD_FLOOR,
+            coverageOffThreshold - COVERAGE_HYSTERESIS_MARGIN);
+        bool lookOnCovered = lookOnCoverage.CoveragePercent >= coverageOnThreshold;
+        bool lookOffCovered = lookOffCoverage.CoveragePercent >= coverageOffThreshold;
 
         // Store coverage percentage for potential UI display
         section.CoveragePercent = currentCoverage.CoveragePercent;

--- a/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
@@ -1,6 +1,7 @@
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Base;
 using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.Coverage;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Services.Interfaces;
 using AgValoniaGPS.Services.Section;
@@ -170,6 +171,146 @@ public class SectionControlServiceTests
         _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
         Assert.That(_service.SectionStates[0].IsOn, Is.True,
             "Should turn on at tick 2 (completing 200 ms debounce)");
+    }
+
+    #endregion
+
+    #region Coverage hysteresis (#345)
+
+    [Test]
+    public void CoverageHysteresis_StaysInStateInsideTheGap()
+    {
+        // Repro for #345. With single-threshold logic, a section's coverage %
+        // bobbing around MinCoverage (e.g. 70 %) flips shouldBeOn /
+        // shouldBeOff every tick at slow speed and produces visible flicker.
+        // Hysteresis: 15 % gap below MinCoverage is dead-zone — the section
+        // stays in its current state.
+        var outerPoly = new BoundaryPolygon();
+        outerPoly.Points.Add(new BoundaryPoint(0, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 200, 0));
+        outerPoly.Points.Add(new BoundaryPoint(0, 200, 0));
+        outerPoly.UpdateBounds();
+        _appState.Field.CurrentBoundary = new Boundary { OuterBoundary = outerPoly };
+
+        ConfigurationStore.Instance.Tool.MinCoverage = 70; // OFF=0.70, ON=0.55
+        _service.SetAllAuto();
+        _service.MasterState = SectionMasterState.Auto;
+
+        void SetCoverage(double pct)
+        {
+            var r = new CoverageResult(pct, pct > 0, pct >= 1.0, 0);
+            _coverageMap.GetSegmentCoverageMulti(default, default, default, default, default)
+                .ReturnsForAnyArgs((r, r, r));
+        }
+
+        // Phase 1: 0 % coverage → section turns ON.
+        SetCoverage(0.0);
+        _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
+        Assert.That(_service.SectionStates[0].IsOn, Is.True,
+            "Phase 1: section should turn ON at 0 % coverage");
+
+        // Phase 2: 65 % coverage — inside the 55-70 % hysteresis gap. With
+        // single-threshold logic the section would have flapped once cov
+        // climbed above 70 % then bobbed back below; with hysteresis the
+        // section is still ON and stays that way.
+        SetCoverage(0.65);
+        for (int i = 0; i < 5; i++)
+            _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
+        Assert.That(_service.SectionStates[0].IsOn, Is.True,
+            "Phase 2: section should stay ON when coverage is in the hysteresis gap (65 %)");
+
+        // Phase 3: 70 % coverage hits the OFF threshold → section turns OFF.
+        SetCoverage(0.70);
+        _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
+        Assert.That(_service.SectionStates[0].IsOn, Is.False,
+            "Phase 3: section should turn OFF when coverage reaches 70 % (OFF threshold)");
+
+        // Phase 4: drop coverage to 60 % — back inside the gap. Without
+        // hysteresis the section would flip back ON the moment cov dropped
+        // below 70 %. With hysteresis it stays OFF.
+        SetCoverage(0.60);
+        for (int i = 0; i < 5; i++)
+            _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
+        Assert.That(_service.SectionStates[0].IsOn, Is.False,
+            "Phase 4: section should stay OFF when coverage drops back into the gap (60 %)");
+
+        // Phase 5: drop coverage below ON threshold (50 % < 55 %) → section
+        // turns ON again. This confirms the gap is not infinite — the
+        // section will resume spraying when there's a real gap to fill.
+        SetCoverage(0.50);
+        _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
+        Assert.That(_service.SectionStates[0].IsOn, Is.True,
+            "Phase 5: section should turn ON when coverage drops below ON threshold (55 %)");
+    }
+
+    [Test]
+    public void LookAheadDistance_ClampedToMinimum_AtSlowSpeedAndZeroSetting()
+    {
+        // Repro for the structural part of #345: with LookAheadOn/Off=0 and
+        // slow speed, lookAhead distance = speed × 0 = 0. The look-on/off
+        // sample point collapses onto the section center, where it samples
+        // the section's own freshly-painted swath and shouldBeOff fires off
+        // the section's own coverage every tick. The fix clamps the FORWARD
+        // distance to a minimum so the sample point clears the painted area
+        // regardless of speed or LookAheadSetting.
+        var outerPoly = new BoundaryPolygon();
+        outerPoly.Points.Add(new BoundaryPoint(0, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 200, 0));
+        outerPoly.Points.Add(new BoundaryPoint(0, 200, 0));
+        outerPoly.UpdateBounds();
+        _appState.Field.CurrentBoundary = new Boundary { OuterBoundary = outerPoly };
+
+        ConfigurationStore.Instance.Tool.LookAheadOnSetting = 0;
+        ConfigurationStore.Instance.Tool.LookAheadOffSetting = 0;
+        _service.SetAllAuto();
+        _service.MasterState = SectionMasterState.Auto;
+
+        // Slow speed (~5 km/h ≈ 1.4 m/s). With LookAheadSetting=0, the
+        // un-clamped look-ahead distance would be 0 in both directions.
+        _service.Update(new Vec3(100, 100, 0), 0, 0, 1.4);
+
+        // Both look-on and look-off distances passed to the coverage service
+        // must be ≥ the floor (~0.3 m) so the sample point clears the swath.
+        _coverageMap.Received().GetSegmentCoverageMulti(
+            Arg.Any<Vec2>(),
+            Arg.Any<double>(),
+            Arg.Any<double>(),
+            Arg.Is<double>(d => d >= 0.3),
+            Arg.Is<double>(d => d >= 0.3));
+    }
+
+    [Test]
+    public void LookAheadDistance_NotClamped_WhenSpeedTimeExceedsFloor()
+    {
+        // Inverse of the slow-speed case: at normal speed and a non-zero
+        // LookAheadSetting, the user's anticipation is preserved exactly —
+        // the floor only kicks in when speed × time would otherwise be
+        // smaller than it.
+        var outerPoly = new BoundaryPolygon();
+        outerPoly.Points.Add(new BoundaryPoint(0, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 0, 0));
+        outerPoly.Points.Add(new BoundaryPoint(200, 200, 0));
+        outerPoly.Points.Add(new BoundaryPoint(0, 200, 0));
+        outerPoly.UpdateBounds();
+        _appState.Field.CurrentBoundary = new Boundary { OuterBoundary = outerPoly };
+
+        ConfigurationStore.Instance.Tool.LookAheadOnSetting = 0.5;  // 500 ms
+        ConfigurationStore.Instance.Tool.LookAheadOffSetting = 0.4; // 400 ms
+        _service.SetAllAuto();
+        _service.MasterState = SectionMasterState.Auto;
+
+        // 4 m/s × 0.5 s = 2.0 m for ON; 4 × 0.4 = 1.6 m for OFF.
+        // Both well above the 0.3 m floor — no clamping should occur.
+        _service.Update(new Vec3(100, 100, 0), 0, 0, 4.0);
+
+        _coverageMap.Received().GetSegmentCoverageMulti(
+            Arg.Any<Vec2>(),
+            Arg.Any<double>(),
+            Arg.Any<double>(),
+            Arg.Is<double>(d => Math.Abs(d - 2.0) < 0.001),
+            Arg.Is<double>(d => Math.Abs(d - 1.6) < 0.001));
     }
 
     #endregion

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 82
+#define VERSION_PATCH 83
 
-#define VERSION "26.4.82"
+#define VERSION "26.4.83"
 #define VERSION_DATE "2026-05-04"


### PR DESCRIPTION
## Summary

Fixes #345. Two pathologies at slow ground speed (≲ 6 km/h) with default `LookAheadOnSetting = LookAheadOffSetting = 0`:

1. **Sample point collapses onto section center.** `lookAhead*Dist = speed × LookAheadSetting` goes to zero, so the look-on/look-off check samples cells *at* the section — inside its own freshly-painted swath. `shouldBeOff` fires off the section's own paint, IsOn=false, section drifts forward less than a cell, `shouldBeOn` fires, IsOn=true. Repeats every tick. Dominant cause; hysteresis alone did not fix it (verified on hardware).
2. **Threshold flap.** Coverage % at the sample point bobs ±1-2 % from per-cell flips; without a hysteresis gap that bob flips the booleans across MinCoverage.

## Changes

- Floor the forward look-ahead distance at 0.3 m (≈ 3 detection cells): `Math.Max(speed × LookAheadSetting, 0.3)`. Only kicks in when speed × time < 0.3 m; preserves user anticipation timing at normal speeds.
- 15-point hysteresis band around MinCoverage. OFF threshold = MinCoverage, ON threshold = MinCoverage − 0.15 (floored at 0.05). Inside the band, neither shouldBeOn nor shouldBeOff fires — section stays in current state.
- Removed unused `currentCovered` while in the same area.

## Test plan

- [x] Unit test: hysteresis dead-zone keeps section in current state for cov in 55-70 % gap, flips at the edges
- [x] Unit test: at slow speed + LookAheadSetting=0, look-on/off distances passed to coverage service are ≥ 0.3 m
- [x] Unit test: at normal speed + non-zero LookAheadSetting, look-on/off distances are unchanged
- [x] All 539 existing service tests pass
- [ ] User verifies on hardware that section flicker is gone at 5 km/h

🤖 Generated with [Claude Code](https://claude.com/claude-code)