### PR TITLE
Fix #347: lock sections off and hide UI when no field is open

### DIFF
--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -868,7 +868,13 @@ public class SectionControlService : ISectionControlService
     {
         var boundary = _state.Field.CurrentBoundary;
         if (boundary == null || !boundary.IsValid)
-            return BoundaryResult.FullyInside; // No boundary = always in
+            // No field open → treat every section as fully outside.
+            // shouldBeOn requires lookOnInBoundary, so this gates Auto sections off.
+            // The strict isInBoundary check (>= 95 %) also fails, so the early
+            // UpdateSectionOff in UpdateAutoSection fires and forces IsOn=false.
+            // Issue #347: spraying outside a defined field is never the
+            // intended operation; the firmware on AiO already enforces this.
+            return BoundaryResult.FullyOutside;
 
         return boundary.GetSegmentBoundaryStatus(sectionCenter, heading, halfWidth);
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
@@ -90,8 +90,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Button>
 
             <!-- 2. Manual Mode Toggle - All sections Manual On/Off -->
+            <!-- Hidden when no field open (#347): sections can't paint with no boundary anyway. -->
             <Button Classes="RightPanelButton" ToolTip.Tip="All Sections Manual On/Off"
-                    Command="{Binding ToggleManualModeCommand}">
+                    Command="{Binding ToggleManualModeCommand}"
+                    IsVisible="{Binding HasBoundary}">
                 <Panel>
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ManualOn.png" Stretch="Uniform"
                            IsVisible="{Binding IsManualSectionMode}"/>
@@ -101,8 +103,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Button>
 
             <!-- 3. Section Master Toggle - All sections Auto/Off -->
+            <!-- Hidden when no field open (#347). -->
             <Button Classes="RightPanelButton" ToolTip.Tip="All Sections Auto/Off"
-                    Command="{Binding ToggleSectionMasterCommand}">
+                    Command="{Binding ToggleSectionMasterCommand}"
+                    IsVisible="{Binding HasBoundary}">
                 <Panel>
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SectionMasterOn.png" Stretch="Uniform"
                            IsVisible="{Binding IsSectionMasterOn}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
@@ -68,9 +68,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <!-- Floating panel with section indicators -->
+    <!-- Floating panel with section indicators.
+         Hidden when no field open (#347): sections can't paint with no boundary. -->
     <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="12"
-            BoxShadow="0 4 16 2 #40000000">
+            BoxShadow="0 4 16 2 #40000000"
+            IsVisible="{Binding HasBoundary}">
         <StackPanel Orientation="Horizontal" Spacing="8">
             <!-- Section buttons - 2 rows of up to 8 each -->
             <StackPanel Orientation="Vertical" Spacing="4">

--- a/Tests/AgValoniaGPS.Services.Tests/AutoSteerUTurnNUnitTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoSteerUTurnNUnitTests.cs
@@ -419,6 +419,9 @@ public class AutoSteerUTurnNUnitTests
         outerPoly.UpdateBounds();
         var boundary = new Boundary { OuterBoundary = outerPoly };
         _pipeline.SetBoundary(boundary);
+        // Section control reads CurrentBoundary off the shared ApplicationState;
+        // pipeline.SetBoundary only updates the pipeline's private copy. (#347)
+        _appState.Field.CurrentBoundary = boundary;
 
         // Create headland line for YouTurn detection
         var headlandLine = new List<Vec3>
@@ -645,6 +648,8 @@ public class AutoSteerUTurnNUnitTests
         outerPoly.UpdateBounds();
         var boundary = new Boundary { OuterBoundary = outerPoly };
         _pipeline.SetBoundary(boundary);
+        // Section control reads CurrentBoundary off the shared ApplicationState (#347).
+        _appState.Field.CurrentBoundary = boundary;
 
         var headlandLine = new List<Vec3>
         {

--- a/Tests/AgValoniaGPS.Services.Tests/LookAheadSlitTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/LookAheadSlitTests.cs
@@ -236,7 +236,13 @@ public class LookAheadSlitTests
         outerPoly.Points.Add(new BoundaryPoint { Easting = FIELD_SIZE, Northing = FIELD_SIZE });
         outerPoly.Points.Add(new BoundaryPoint { Easting = 0, Northing = FIELD_SIZE });
         outerPoly.UpdateBounds();
-        _pipeline.SetBoundary(new Boundary { OuterBoundary = outerPoly });
+        var boundary = new Boundary { OuterBoundary = outerPoly };
+        _pipeline.SetBoundary(boundary);
+        // Section control reads CurrentBoundary directly off the shared
+        // ApplicationState; pipeline.SetBoundary only updates the pipeline's
+        // private copy. Without this, sections see no boundary and stay OFF
+        // (issue #347 fix).
+        _appState.Field.CurrentBoundary = boundary;
     }
 
     /// <summary>

--- a/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
@@ -318,21 +318,22 @@ public class SectionControlServiceTests
     #region No Boundary
 
     [Test]
-    public void Update_NoBoundary_AutoSectionsTurnOnAnywhere()
+    public void Update_NoBoundary_AutoSectionsStayOff()
     {
-        // No boundary set on _appState.Field. GetSegmentBoundaryStatus returns
-        // FullyInside in that case, so Auto sections aren't blocked by the
-        // boundary check. Combined with no coverage and no headland, shouldBeOn
-        // is true and the section flips on after one TURNING_ON phase tick
-        // (LookAheadOnSetting defaults to 0 → 1-tick floor in the section
-        // state machine). This documents current behavior; if we want a
-        // defensive "no boundary, no spray" mode that's a separate change.
+        // Issue #347: no field open (boundary null) must mean "no spray".
+        // GetSegmentBoundaryStatus returns FullyOutside in that case, so the
+        // strict isInBoundary check fails for every section and the early
+        // UpdateSectionOff path forces IsOn=false. Spraying outside a defined
+        // field is never the intended operation — matches firmware behavior.
         _service.SetAllAuto();
         _service.MasterState = SectionMasterState.Auto;
 
-        _service.Update(new Vec3(50, 50, 0), 0, 0, 5.0);
+        // Run several ticks to outlast any TURNING_ON debounce; with no
+        // boundary, IsAnySectionOn must remain false.
+        for (int i = 0; i < 5; i++)
+            _service.Update(new Vec3(50, 50, 0), 0, 0, 5.0);
 
-        Assert.That(_service.IsAnySectionOn, Is.True);
+        Assert.That(_service.IsAnySectionOn, Is.False);
     }
 
     #endregion

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 83
+#define VERSION_PATCH 84
 
-#define VERSION "26.4.83"
+#define VERSION "26.4.84"
 #define VERSION_DATE "2026-05-04"


### PR DESCRIPTION
## Summary

Fixes #347. When the app was running with no field/boundary loaded, `GetSegmentBoundaryStatus` returned `FullyInside` as a fallback — Auto sections then satisfied `shouldBeOn` and turned on after their TURNING_ON debounce, and Manual ON also accepted the toggle. Spraying outside a defined field is never the intended operation; the firmware on AiO already enforces this.

## Changes

**Service** — `SectionControlService.GetSegmentBoundaryStatus` now returns `FullyOutside` when `CurrentBoundary` is null/invalid. `shouldBeOn` requires `lookOnInBoundary`, which now fails; the strict `isInBoundary` check in `UpdateAutoSection` also fails and the early `UpdateSectionOff` path forces `IsOn=false`.

**UI** (shared, all platforms) — Bind `IsVisible` to `HasBoundary` on:
- Right-bar Manual Mode Toggle button
- Right-bar Section Master Toggle button
- `SectionControlPanel` (section bar)

**Tests**
- `Update_NoBoundary_AutoSectionsTurnOnAnywhere` → `Update_NoBoundary_AutoSectionsStayOff`, assertion flipped.
- `LookAheadSlitTests.SetUpField` and the two `AutoSteerUTurnNUnitTests` boundary setups now also assign `_appState.Field.CurrentBoundary`. `pipeline.SetBoundary` only updates the pipeline's private copy; the old `FullyInside` fallback was hiding that omission.

## Test plan

- [x] 539 service tests pass (was 539 before, 1 renamed + flipped)
- [x] 104 model tests pass
- [x] 123 UI tests pass
- [x] Desktop build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)