### PR TITLE
Fix #348: section stays on through partial coverage to fill gaps

### DIFF
--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -74,17 +74,16 @@ public class SectionControlService : ISectionControlService
     // Default coverage overlap threshold (used if MinCoverage is 0)
     private const double DEFAULT_COVERAGE_THRESHOLD = 0.70; // 70%
 
-    // Hysteresis gap between the OFF threshold (where a covered area is "done")
-    // and the ON threshold (where an uncovered area should be sprayed). At slow
-    // speed (~5 km/h or below) the look-ahead points sample nearly-stationary
-    // pixels, so a single boundary cell flipping causes the coverage % to bob
-    // 1-2 % around the threshold. Without a gap, that bob flips the
-    // shouldBeOn / shouldBeOff booleans every tick and produces visible
-    // flicker + missed spray. 15 percentage points is wide enough to absorb
-    // pixel-flip noise without compromising the MinCoverage intent.
-    private const double COVERAGE_HYSTERESIS_MARGIN = 0.15;
-    // Floor so the ON threshold can't go ≤ 0 when MinCoverage is set very low.
-    private const double COVERAGE_ON_THRESHOLD_FLOOR = 0.05;
+    // OFF threshold: section stays on until its swath is essentially fully
+    // covered, so a pass over a partly-painted strip fills the holes instead
+    // of turning the section off as soon as it reads "mostly covered". A
+    // section-wide threshold tied to MinCoverage caused #348 (gaps don't
+    // fill on subsequent passes); decoupling the OFF decision from
+    // MinCoverage and pinning it near full coverage is the principled fix.
+    // 0.99 (with 0.01 tolerance for FP / pixel noise around 100 %) keeps the
+    // section on through any meaningful gap. MarkCellCovered is already
+    // idempotent so over-painting covered cells is a no-op.
+    private const double COVERAGE_OFF_THRESHOLD = 0.99;
 
     // Floor on the forward distance from section center to the look-on /
     // look-off sample points. lookAheadDistance = speed × LookAheadSetting,
@@ -409,20 +408,23 @@ public class SectionControlService : ISectionControlService
             lookAheadOffDist);
         _totalCoverageMs += _sectionSw.Elapsed.TotalMilliseconds;
 
-        // Section is "covered" if coverage exceeds the threshold.
-        // Use MinCoverage setting from config (0-100), default to 70% if not set.
-        // Apply hysteresis: a higher OFF threshold (when to consider an area
-        // "covered enough to skip") and a lower ON threshold (when to consider
-        // it "uncovered enough to spray"). The gap between them prevents the
-        // shouldBeOn / shouldBeOff booleans from oscillating when the look-ahead
-        // points sample noisy pixels near the threshold — the pathology behind
-        // the slow-speed flicker / missed spray (issue #345).
-        double coverageOffThreshold = tool.MinCoverage > 0
+        // The ON and OFF decisions use different thresholds — by design, not
+        // for noise hysteresis (the #345 explicit margin is gone, replaced
+        // by the natural separation below).
+        //   ON threshold = MinCoverage. User's "I want X % overlap" setting
+        //     gates turning the section on: don't bother firing if the look-
+        //     ahead area is already at or above the user's accepted overlap.
+        //   OFF threshold = COVERAGE_OFF_THRESHOLD (≈ 1.0). Section stays on
+        //     while ANY meaningful cell in its swath is uncovered, so a pass
+        //     over a partly-painted strip fills the gaps (#348). Per-cell
+        //     idempotency in MarkCellCovered handles the already-covered
+        //     cells without over-paint. The natural separation between this
+        //     and the ON threshold (≈ 30 points at default MinCoverage) is
+        //     the hysteresis that prevents slow-speed flicker (#345).
+        double coverageOnThreshold = tool.MinCoverage > 0
             ? tool.MinCoverage / 100.0
             : DEFAULT_COVERAGE_THRESHOLD;
-        double coverageOnThreshold = Math.Max(
-            COVERAGE_ON_THRESHOLD_FLOOR,
-            coverageOffThreshold - COVERAGE_HYSTERESIS_MARGIN);
+        double coverageOffThreshold = COVERAGE_OFF_THRESHOLD;
         bool lookOnCovered = lookOnCoverage.CoveragePercent >= coverageOnThreshold;
         bool lookOffCovered = lookOffCoverage.CoveragePercent >= coverageOffThreshold;
 

--- a/Tests/AgValoniaGPS.Services.Tests/LookAheadSlitTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/LookAheadSlitTests.cs
@@ -842,17 +842,23 @@ public class LookAheadSlitTests
     [Test]
     public void DriveOverPartialSlit_OuterSectionsStayOn()
     {
-        // 3 sections x 2m = 6m tool. Slit only covers center 2m.
-        // Center section should turn off, outer sections should stay on.
+        // 3 sections x 2m = 6m tool. Slit covers the center 4m so the centre
+        // section's swath is unambiguously fully covered while the outer
+        // sections see ≈50 % coverage. Center turns off (>= the OFF threshold
+        // ≈ full coverage); outer sections stay on. Was 2m wide before #348
+        // but with the OFF threshold now at ~99 % rather than MinCoverage,
+        // a slit equal to one section width leaves a few edge cells
+        // unmatched and the section correctly stays on to fill them.
         SetUpPipeline(numSections: 3, totalToolWidth: 6.0);
         SetUpField();
 
         double toolCenter = FIELD_SIZE / 2;
         double slitNorthing = FIELD_SIZE / 2;
 
-        // Paint a narrow slit that only covers the center section (E=99..101)
+        // Paint a slit that fully covers the centre section's 2m swath
+        // (E=99..101) plus 1m on either side (E=98..102, 4m total).
         _coverage.MarkRectangleCovered(
-            toolCenter - 1, toolCenter + 1,  // 2m wide, centered
+            toolCenter - 2, toolCenter + 2,  // 4m wide, centered
             slitNorthing - 3, slitNorthing + 3,  // 6m tall
             zone: 0);
 

--- a/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SectionControlServiceTests.cs
@@ -175,16 +175,18 @@ public class SectionControlServiceTests
 
     #endregion
 
-    #region Coverage hysteresis (#345)
+    #region Coverage thresholds (#345 hysteresis + #348 gap-fill)
 
     [Test]
-    public void CoverageHysteresis_StaysInStateInsideTheGap()
+    public void Coverage_StaysOnUntilFullyCovered_TurnsOnBelowMinCoverage()
     {
-        // Repro for #345. With single-threshold logic, a section's coverage %
-        // bobbing around MinCoverage (e.g. 70 %) flips shouldBeOn /
-        // shouldBeOff every tick at slow speed and produces visible flicker.
-        // Hysteresis: 15 % gap below MinCoverage is dead-zone — the section
-        // stays in its current state.
+        // Combined repro for #345 (slow-speed flicker — needs hysteresis gap
+        // between ON and OFF thresholds) and #348 (sections turn off too
+        // early over partly-painted strips, leaving gaps unfilled).
+        //
+        // Design: ON threshold = MinCoverage (user's overlap preference);
+        // OFF threshold = 0.99 (only when essentially fully covered).
+        // The ~30 percentage-point gap between them is the hysteresis.
         var outerPoly = new BoundaryPolygon();
         outerPoly.Points.Add(new BoundaryPoint(0, 0, 0));
         outerPoly.Points.Add(new BoundaryPoint(200, 0, 0));
@@ -193,7 +195,7 @@ public class SectionControlServiceTests
         outerPoly.UpdateBounds();
         _appState.Field.CurrentBoundary = new Boundary { OuterBoundary = outerPoly };
 
-        ConfigurationStore.Instance.Tool.MinCoverage = 70; // OFF=0.70, ON=0.55
+        ConfigurationStore.Instance.Tool.MinCoverage = 70; // ON=0.70, OFF=0.99
         _service.SetAllAuto();
         _service.MasterState = SectionMasterState.Auto;
 
@@ -204,44 +206,54 @@ public class SectionControlServiceTests
                 .ReturnsForAnyArgs((r, r, r));
         }
 
-        // Phase 1: 0 % coverage → section turns ON.
+        // Phase 1: 0 % coverage → section turns ON (well below MinCoverage).
         SetCoverage(0.0);
         _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
         Assert.That(_service.SectionStates[0].IsOn, Is.True,
             "Phase 1: section should turn ON at 0 % coverage");
 
-        // Phase 2: 65 % coverage — inside the 55-70 % hysteresis gap. With
-        // single-threshold logic the section would have flapped once cov
-        // climbed above 70 % then bobbed back below; with hysteresis the
-        // section is still ON and stays that way.
+        // Phase 2: 65 % coverage — below the ON threshold. Section is already
+        // ON, stays ON. (Exercises the slow-speed-flicker scenario from #345
+        // where coverage % bobs around MinCoverage; the natural ON↔OFF gap
+        // means neither boolean flips.)
         SetCoverage(0.65);
         for (int i = 0; i < 5; i++)
             _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
         Assert.That(_service.SectionStates[0].IsOn, Is.True,
-            "Phase 2: section should stay ON when coverage is in the hysteresis gap (65 %)");
+            "Phase 2: section should stay ON below ON threshold (65 %)");
 
-        // Phase 3: 70 % coverage hits the OFF threshold → section turns OFF.
-        SetCoverage(0.70);
+        // Phase 3: 85 % coverage — past MinCoverage but well short of full.
+        // This is the #348 case: under the old logic the section would have
+        // turned OFF here, leaving the remaining 15 % of cells unsprayed.
+        // With the new OFF threshold it stays ON to fill the remaining gaps.
+        SetCoverage(0.85);
+        for (int i = 0; i < 5; i++)
+            _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
+        Assert.That(_service.SectionStates[0].IsOn, Is.True,
+            "Phase 3: section should stay ON over partly-painted area (85 %) to fill gaps (#348)");
+
+        // Phase 4: 99 % coverage hits the OFF threshold → section turns OFF.
+        SetCoverage(0.99);
         _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
         Assert.That(_service.SectionStates[0].IsOn, Is.False,
-            "Phase 3: section should turn OFF when coverage reaches 70 % (OFF threshold)");
+            "Phase 4: section should turn OFF when coverage reaches 99 % (full)");
 
-        // Phase 4: drop coverage to 60 % — back inside the gap. Without
-        // hysteresis the section would flip back ON the moment cov dropped
-        // below 70 %. With hysteresis it stays OFF.
-        SetCoverage(0.60);
+        // Phase 5: 75 % coverage — above MinCoverage, in the hysteresis
+        // dead-zone. Section just turned OFF; stays OFF. Without the gap the
+        // section would flap back on the moment coverage dropped below 99 %.
+        SetCoverage(0.75);
         for (int i = 0; i < 5; i++)
             _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
         Assert.That(_service.SectionStates[0].IsOn, Is.False,
-            "Phase 4: section should stay OFF when coverage drops back into the gap (60 %)");
+            "Phase 5: section should stay OFF in the hysteresis gap (75 %)");
 
-        // Phase 5: drop coverage below ON threshold (50 % < 55 %) → section
-        // turns ON again. This confirms the gap is not infinite — the
-        // section will resume spraying when there's a real gap to fill.
-        SetCoverage(0.50);
+        // Phase 6: 60 % coverage — below MinCoverage (the ON threshold). The
+        // section turns back on: there's enough uncovered area to be worth
+        // spraying.
+        SetCoverage(0.60);
         _service.Update(new Vec3(100, 100, 0), 0, 0, 5.0);
         Assert.That(_service.SectionStates[0].IsOn, Is.True,
-            "Phase 5: section should turn ON when coverage drops below ON threshold (55 %)");
+            "Phase 6: section should turn ON below MinCoverage (60 %)");
     }
 
     [Test]

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 84
+#define VERSION_PATCH 85
 
-#define VERSION "26.4.84"
+#define VERSION "26.4.85"
 #define VERSION_DATE "2026-05-04"


### PR DESCRIPTION
## Summary

Fixes #348. A previous coverage pass with unsprayed gaps (operator skipped, partial section during a turn, hardware glitch) used to stay unsprayed forever — on the next pass over the strip, the section turned OFF as soon as `MinCoverage %` of its swath read as covered, leaving the holes unpainted.

The principled fix from the issue: section stays on whenever any cell in its swath is uncovered. Per-cell idempotency in `MarkCellCovered` already exists (early-return when the bit is already set), so this just needs a decision-side change.

## Changes

Decouple the OFF threshold from `MinCoverage`:

- **`coverageOnThreshold = MinCoverage / 100`** — preserves the user's "I want X % overlap" semantic for the *turn-ON* decision. If the look-ahead area is already at or above the user's accepted overlap, don't bother firing.
- **`coverageOffThreshold = COVERAGE_OFF_THRESHOLD = 0.99`** (new constant) — section stays on while ANY meaningful cell in its swath is uncovered.

The natural ~30 percentage-point gap between ON and OFF replaces the explicit `COVERAGE_HYSTERESIS_MARGIN` from #345 — both that constant and the symmetric-margin computation are gone. The slow-speed flicker behavior #345 fixed is preserved by the wider natural separation.

## Test plan

- [x] Combined hysteresis + gap-fill test: walks coverage 0 → 65 → 85 → 99 → 75 → 60 % and asserts state at each phase. The 85 % phase is the #348 assertion (stays ON over partly-painted area).
- [x] `DriveOverPartialSlit_OuterSectionsStayOn` slit widened from 2 m to 4 m so centre section's swath is unambiguously fully covered under the new ≥ 99 % threshold. (A 2 m slit aligned with a 2 m section swath leaves a few edge cells unmatched at sample alignment; the section correctly stays on to fill them — that's exactly the new intended behavior.)
- [x] All 539 service tests pass
- [x] All 104 model tests pass
- [x] All 123 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)