### PR TITLE
Fix #354: U-turn arc aligns with NextTrack regardless of activation order

### DIFF
--- a/Shared/AgValoniaGPS.Services/AgValoniaGPS.Services.csproj
+++ b/Shared/AgValoniaGPS.Services/AgValoniaGPS.Services.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\AgValoniaGPS.Models\AgValoniaGPS.Models.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="AgValoniaGPS.Services.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -371,7 +371,7 @@ public partial class YouTurnCreationService
         return new Vec2(ptA.Easting + t * abE, ptA.Northing + t * abN);
     }
 
-    private static Vec2? FindTrackHeadlandIntersectionAhead(
+    internal static Vec2? FindTrackHeadlandIntersectionAhead(
         Models.Track.Track track,
         Vec3 vehiclePos,
         IReadOnlyList<Vec3> headlandLine,
@@ -414,18 +414,32 @@ public partial class YouTurnCreationService
             return null;
         }
 
-        // AB line: extend the line in the travel direction and find the closest crossing.
+        // AB line: intersect the AB line itself (extended past both endpoints)
+        // with the headland; pick the intersection closest to the vehicle.
+        //
+        // The intersection MUST be a point on the AB line — anything else
+        // produces a perpendicular-offset reference point, which cascades into
+        // FindABTurnPoint and the U-turn arc landing off the cyan NextTrack
+        // line by the same offset (issue #354). The previous implementation
+        // intersected a *vehicle-anchored* line with the headland, which only
+        // landed on AB when the vehicle happened to be on AB exactly — and
+        // produced the order-dependent misalignment when the vehicle was
+        // perpendicular-offset (e.g. activation before the auto-pass-detect
+        // had time to update HowManyPathsAway from a stale 0).
         var ptA = track.Points[0];
         var ptB = track.Points[1];
-        var (startPoint, endPoint) = headingSameWay ? (ptA, ptB) : (ptB, ptA);
 
-        double dx = endPoint.Easting - startPoint.Easting;
-        double dy = endPoint.Northing - startPoint.Northing;
+        double dx = ptB.Easting - ptA.Easting;
+        double dy = ptB.Northing - ptA.Northing;
         double len = Math.Sqrt(dx * dx + dy * dy);
         if (len < 0.001) return null;
 
-        double extendedE = endPoint.Easting + (dx / len) * 1000;
-        double extendedN = endPoint.Northing + (dy / len) * 1000;
+        double dirE = dx / len;
+        double dirN = dy / len;
+        double extendedStartE = ptA.Easting - dirE * 1000;
+        double extendedStartN = ptA.Northing - dirN * 1000;
+        double extendedEndE = ptB.Easting + dirE * 1000;
+        double extendedEndN = ptB.Northing + dirN * 1000;
 
         Vec2? closestIntersection = null;
         double closestDist = double.MaxValue;
@@ -436,7 +450,7 @@ public partial class YouTurnCreationService
             var h2 = headlandLine[(j + 1) % headlandLine.Count];
 
             var intersection = GeometryMath.TryGetSegmentIntersection(
-                vehiclePos.Easting, vehiclePos.Northing, extendedE, extendedN,
+                extendedStartE, extendedStartN, extendedEndE, extendedEndN,
                 h1.Easting, h1.Northing, h2.Easting, h2.Northing);
 
             if (intersection.HasValue)

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurnHeadlandIntersectionTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurnHeadlandIntersectionTests.cs
@@ -1,0 +1,111 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Services.YouTurn;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Repro for issue #354. The U-turn arc lands on cyan NextTrack only if the
+/// arc start is on the current pass. The arc start comes from
+/// FindABTurnPoint, which extends a ray from ABReferencePoint, which comes
+/// from FindTrackHeadlandIntersectionAhead. So the latter must always
+/// return a point on the AB line — independent of the vehicle's
+/// perpendicular distance from it.
+///
+/// Before the fix: the AB-line branch built a vehicle-anchored line and
+/// intersected it with the headland, so a vehicle perpendicular-offset from
+/// AB produced an intersection perpendicular-offset from AB by the same
+/// amount, cascading into the U-turn arc landing perpendicular-offset from
+/// NextTrack. This was sequence-dependent — the perpendicular offset is
+/// non-zero when activation happens before the auto-pass-detect catches up.
+/// </summary>
+[TestFixture]
+public class YouTurnHeadlandIntersectionTests
+{
+    [Test]
+    public void Returns_PointOnAbLine_WhenVehicleOnAbLine()
+    {
+        // Sanity check baseline.
+        var track = MakeAbLine(0, -100, 0, 100); // vertical AB at E=0
+        var headland = MakeRectangularHeadland(southN: 50, northN: 100);
+        var vehicle = new Vec3(0, 0, 0);
+
+        var result = YouTurnCreationService.FindTrackHeadlandIntersectionAhead(
+            track, vehicle, headland, headingSameWay: true);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value.Easting, Is.EqualTo(0).Within(0.001));
+        Assert.That(result.Value.Northing, Is.EqualTo(50).Within(0.001));
+    }
+
+    [Test]
+    public void Returns_PointOnAbLine_WhenVehiclePerpendicularOffsetFromAbLine()
+    {
+        // Issue #354 repro: vehicle 10 m perpendicular-offset from the AB line.
+        // Pre-fix this returned (10, 50) — the intersection of the
+        // vehicle-anchored ray with the headland. Post-fix returns (0, 50)
+        // — the intersection of the AB line with the headland.
+        var track = MakeAbLine(0, -100, 0, 100);
+        var headland = MakeRectangularHeadland(southN: 50, northN: 100);
+        var vehicle = new Vec3(10, 0, 0); // 10 m east of AB
+
+        var result = YouTurnCreationService.FindTrackHeadlandIntersectionAhead(
+            track, vehicle, headland, headingSameWay: true);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value.Easting, Is.EqualTo(0).Within(0.001),
+            "Intersection must be on the AB line, not on a vehicle-anchored ray");
+        Assert.That(result.Value.Northing, Is.EqualTo(50).Within(0.001));
+    }
+
+    [Test]
+    public void Returns_PointOnAbLine_WhenAbLineIsNotPerpendicularToHeadland()
+    {
+        // Diagonal AB + horizontal headland; vehicle off-line.
+        // AB from (-50,-100) to (50,100) crosses N=0 at E=0.
+        var track = MakeAbLine(-50, -100, 50, 100);
+        var headland = MakeRectangularHeadland(southN: 0, northN: 50);
+        var vehicle = new Vec3(20, -50, 0);
+
+        var result = YouTurnCreationService.FindTrackHeadlandIntersectionAhead(
+            track, vehicle, headland, headingSameWay: true);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value.Easting, Is.EqualTo(0).Within(0.001),
+            "Intersection must be on the AB line, not biased by vehicle E=20");
+        Assert.That(result.Value.Northing, Is.EqualTo(0).Within(0.001));
+    }
+
+    [Test]
+    public void HeadingOpposite_StillReturnsPointOnAbLine()
+    {
+        // headingSameWay=false (vehicle going B→A). Same property must hold.
+        var track = MakeAbLine(0, -100, 0, 100);
+        // Headland behind the vehicle (south). South edge is the close one.
+        var headland = MakeRectangularHeadland(southN: -100, northN: -50);
+        var vehicle = new Vec3(10, 0, 0);
+
+        var result = YouTurnCreationService.FindTrackHeadlandIntersectionAhead(
+            track, vehicle, headland, headingSameWay: false);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value.Easting, Is.EqualTo(0).Within(0.001));
+        Assert.That(result.Value.Northing, Is.EqualTo(-50).Within(0.001));
+    }
+
+    private static AgValoniaGPS.Models.Track.Track MakeAbLine(double aE, double aN, double bE, double bN) =>
+        AgValoniaGPS.Models.Track.Track.FromABLine("test", new Vec3(aE, aN, 0), new Vec3(bE, bN, 0));
+
+    private static List<Vec3> MakeRectangularHeadland(double southN, double northN) => new()
+    {
+        new Vec3(-200, southN, 0),
+        new Vec3(200, southN, 0),
+        new Vec3(200, northN, 0),
+        new Vec3(-200, northN, 0),
+    };
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 85
+#define VERSION_PATCH 86
 
-#define VERSION "26.4.85"
+#define VERSION "26.4.86"
 #define VERSION_DATE "2026-05-04"


### PR DESCRIPTION
## Summary

Fixes #354. The U-turn arc was rendering perpendicular-offset from the cyan next-track line when the AB guidance line was activated before the simulator had a chance to drive auto-pass-detect to its proper `HowManyPathsAway` value. Visible as ~0.75 m offset between the cyan line and where the U-turn arc actually lands.

## Root cause

In `FindTrackHeadlandIntersectionAhead`, the AB-line branch (Points.Count == 2) built a **vehicle-anchored** line (vehicle pos → 1000 m past the AB endpoint) and intersected it with the headland. When the vehicle is perpendicular-offset from AB, the vehicle-anchored line is offset too — and the returned "current track reference point" lands off the AB line by the same offset. The bad point cascades through `FindABTurnPoint` (extends a ray from there in AB direction → boundary intersection off-line) and into the auto-turn arc (`goal = start + perpendicular × turnOffset` → lands off cyan).

The curve branch (Points.Count > 2) doesn't have this bug: it walks track points and intersects each segment with the headland directly.

## Order-dependence

Confirmed via diagnostic logs in both sequences (full data captured during investigation):

- **BAD** (open field → activate AB → start sim): vehicle hasn't ticked yet, auto-pass-detect hasn't run, `HowManyPathsAway = 0`, vehicle perpendicular-offset 14 m from AB line. Bug fires; arc lands 0.75 m off cyan.
- **GOOD** (start sim → open field → activate AB): vehicle has been ticking, auto-pass-detect has set `HowManyPathsAway = -2` (nearest pass to vehicle's actual location), vehicle on the offset pass to within 0.03 m. Bug doesn't fire; arc lands on cyan within 0.03 m.

## Fix

Intersect the AB line itself (extended 1000 m past both endpoints) with the headland; pick the intersection closest to the vehicle. The result is always a point on the AB segment, independent of vehicle position. Curve branch unchanged.

## Test plan

- [x] 4 new unit tests in `YouTurnHeadlandIntersectionTests.cs`: vehicle on line; vehicle perpendicular-offset (the #354 repro); diagonal AB with off-line vehicle; headingSameWay=false.
- [x] All 543 service tests green (was 539 + 4 new).
- [x] All 104 model tests + 123 UI tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)