### PR TITLE
Fix 90° heading flip on first non-zero-speed tick

### DIFF
--- a/Shared/AgValoniaGPS.Services/Gps/AntennaToPivotTransform.cs
+++ b/Shared/AgValoniaGPS.Services/Gps/AntennaToPivotTransform.cs
@@ -1,0 +1,64 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using AgValoniaGPS.Models.Configuration;
+
+namespace AgValoniaGPS.Services.Gps;
+
+/// <summary>
+/// Antenna-to-pivot transform with optional roll correction. Single source
+/// of truth — the GPS pipeline calls this once per cycle on local-plane
+/// (E, N), and tests call it directly with synthetic positions.
+///
+/// Sign conventions:
+///   AntennaPivot:  Positive = antenna is AHEAD of pivot (typical roof mount).
+///   AntennaOffset: Negative = antenna is LEFT of centerline, Positive = RIGHT.
+///   Roll: positive = vehicle tilts right.
+/// </summary>
+public static class AntennaToPivotTransform
+{
+    /// <summary>
+    /// Apply the fore/aft, lateral, and roll-correction shifts in place
+    /// to <paramref name="easting"/> / <paramref name="northing"/>.
+    /// </summary>
+    public static void Apply(
+        ref double easting,
+        ref double northing,
+        double headingRadians,
+        VehicleConfig vehicle,
+        double imuRollDegrees)
+    {
+        // Fore/aft offset (AntennaPivot): antenna is AHEAD of pivot, so to
+        // recover pivot we move BACKWARD from antenna position.
+        if (Math.Abs(vehicle.AntennaPivot) > 0.001)
+        {
+            easting -= Math.Sin(headingRadians) * vehicle.AntennaPivot;
+            northing -= Math.Cos(headingRadians) * vehicle.AntennaPivot;
+        }
+
+        // Lateral offset (AntennaOffset): antenna RIGHT of centerline, so
+        // to recover centerline we move LEFT (perpendicular RIGHT vector,
+        // negated).
+        if (Math.Abs(vehicle.AntennaOffset) > 0.001)
+        {
+            double perpHeading = headingRadians + Math.PI / 2.0;
+            easting -= Math.Sin(perpHeading) * vehicle.AntennaOffset;
+            northing -= Math.Cos(perpHeading) * vehicle.AntennaOffset;
+        }
+
+        // Roll correction: high-mounted antenna shifts laterally when the
+        // vehicle tilts. Project antenna height through roll perpendicular
+        // to heading. Matches legacy AgOpenGPS formula.
+        if (Math.Abs(imuRollDegrees) > 0.01 && Math.Abs(vehicle.AntennaHeight) > 0.01)
+        {
+            double rollRadians = imuRollDegrees * Math.PI / 180.0;
+            double rollCorrectionDistance = Math.Sin(rollRadians) * -vehicle.AntennaHeight;
+
+            easting += Math.Cos(-headingRadians) * rollCorrectionDistance;
+            northing += Math.Sin(-headingRadians) * rollCorrectionDistance;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Services/GpsService.cs
+++ b/Shared/AgValoniaGPS.Services/GpsService.cs
@@ -59,93 +59,21 @@ public class GpsService : IGpsService
     }
 
     /// <summary>
-    /// Update GPS data directly (called by NMEA parser)
-    /// Applies antenna-to-pivot transformation before storing
+    /// Update GPS data directly (called by NMEA parser).
+    /// Stores the raw antenna position. Antenna-to-pivot transform is
+    /// applied by GpsPipelineService.ProcessCycle (step 1b) so it lives
+    /// in one place and runs consistently — the previous transform here
+    /// was skipped on (0,0) ticks (sim sitting at field origin) but ran
+    /// once N became non-zero, producing a discontinuous antenna offset
+    /// that the heading fusion read as a 90° east jump on the very first
+    /// non-zero-speed tick. (See diag in /tmp/flip.log.)
     /// </summary>
     public void UpdateGpsData(GpsData newData)
     {
-        // Apply antenna-to-pivot transformation
-        TransformAntennaToPivot(newData);
-
         CurrentData = newData;
         _lastGpsDataReceived = Clock.Current.Now;
         IsConnected = newData.IsValid;
         GpsDataUpdated?.Invoke(this, CurrentData);
-    }
-
-    /// <summary>
-    /// Transform GPS antenna position to tractor center (pivot point).
-    ///
-    /// The GPS reports the antenna's true world coordinates. We calculate the tractor
-    /// center position so that guidance steers the tractor/implement over the correct
-    /// real-world coordinates.
-    ///
-    /// Example: Antenna is 1m LEFT of tractor center, heading North, antenna at x=-1.
-    ///   - AntennaOffset = -1.0 (negative = LEFT of center)
-    ///   - Tractor center = antenna_x - perpRight * (-1) = -1 + 1 = 0
-    ///   - Result: Tractor center calculated at x=0 (prime meridian) ✓
-    ///
-    /// Sign conventions:
-    ///   AntennaPivot: Positive = antenna is AHEAD of pivot (typical roof mount)
-    ///   AntennaOffset: Negative = antenna is LEFT of center, Positive = RIGHT
-    /// </summary>
-    private void TransformAntennaToPivot(GpsData gpsData)
-    {
-        // Skip when Easting/Northing are still 0 (not yet converted to local
-        // coordinates). The pipeline applies these corrections after local plane
-        // conversion in ProcessCycle step (1b). Applying them here to zeros
-        // corrupts the pipeline's auto-conversion check.
-        if (Math.Abs(gpsData.CurrentPosition.Easting) < 0.001
-            && Math.Abs(gpsData.CurrentPosition.Northing) < 0.001)
-            return;
-
-        var vehicle = ConfigurationStore.Instance.Vehicle;
-
-        // Convert heading to radians
-        double headingRadians = gpsData.CurrentPosition.Heading * Math.PI / 180.0;
-
-        // Start with antenna position
-        double pivotEasting = gpsData.CurrentPosition.Easting;
-        double pivotNorthing = gpsData.CurrentPosition.Northing;
-
-        // Apply fore/aft offset (AntennaPivot):
-        // Positive value = antenna is ahead of pivot (typical roof mount)
-        // To find pivot: move BACKWARD from antenna position
-        if (Math.Abs(vehicle.AntennaPivot) > 0.001)
-        {
-            pivotEasting -= Math.Sin(headingRadians) * vehicle.AntennaPivot;
-            pivotNorthing -= Math.Cos(headingRadians) * vehicle.AntennaPivot;
-        }
-
-        // Apply lateral offset (AntennaOffset):
-        // Positive value = antenna is RIGHT of centerline
-        // To find centerline: move LEFT from antenna position
-        if (Math.Abs(vehicle.AntennaOffset) > 0.001)
-        {
-            double perpHeading = headingRadians + Math.PI / 2.0; // Points right
-            pivotEasting -= Math.Sin(perpHeading) * vehicle.AntennaOffset;
-            pivotNorthing -= Math.Cos(perpHeading) * vehicle.AntennaOffset;
-        }
-
-        // Apply roll correction: when the vehicle tilts, the high-mounted antenna
-        // shifts laterally. Correct by projecting the antenna height through the
-        // roll angle perpendicular to heading. Matches legacy AgOpenGPS formula.
-        double imuRoll = SensorState.Instance.ImuRoll;
-        if (Math.Abs(imuRoll) > 0.01 && Math.Abs(vehicle.AntennaHeight) > 0.01)
-        {
-            double rollRadians = imuRoll * Math.PI / 180.0;
-            double rollCorrectionDistance = Math.Sin(rollRadians) * -vehicle.AntennaHeight;
-
-            pivotEasting += Math.Cos(-headingRadians) * rollCorrectionDistance;
-            pivotNorthing += Math.Sin(-headingRadians) * rollCorrectionDistance;
-        }
-
-        // Create new Position with transformed coordinates (Position is a record with init-only props)
-        gpsData.CurrentPosition = gpsData.CurrentPosition with
-        {
-            Easting = pivotEasting,
-            Northing = pivotNorthing
-        };
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -460,39 +460,15 @@ public sealed class GpsPipelineService : IGpsPipelineService
         pos = pos with { Heading = fusedHeading };
 
         // ── (1b) Antenna-to-pivot transform in local coordinates ────────
-        // GpsService.TransformAntennaToPivot cannot apply these because it
-        // runs before local plane conversion (E/N still 0). Apply here
-        // where E/N are valid local coordinates.
-        {
-            var vehicle = ConfigurationStore.Instance.Vehicle;
-            double hdgRad = pos.Heading * Math.PI / 180.0;
-
-            // Fore/aft offset (AntennaPivot)
-            if (Math.Abs(vehicle.AntennaPivot) > 0.001)
-            {
-                posEasting -= Math.Sin(hdgRad) * vehicle.AntennaPivot;
-                posNorthing -= Math.Cos(hdgRad) * vehicle.AntennaPivot;
-            }
-
-            // Lateral offset (AntennaOffset)
-            if (Math.Abs(vehicle.AntennaOffset) > 0.001)
-            {
-                double perpHeading = hdgRad + Math.PI / 2.0;
-                posEasting -= Math.Sin(perpHeading) * vehicle.AntennaOffset;
-                posNorthing -= Math.Cos(perpHeading) * vehicle.AntennaOffset;
-            }
-
-            // Roll correction (read from GpsData, not SensorState — Phase B
-            // removed NmeaParserService which was the only SensorState writer)
-            double imuRoll = data.ImuRoll;
-            if (Math.Abs(imuRoll) > 0.01 && Math.Abs(vehicle.AntennaHeight) > 0.01)
-            {
-                double rollRad = imuRoll * Math.PI / 180.0;
-                double rollDist = Math.Sin(rollRad) * -vehicle.AntennaHeight;
-                posEasting += Math.Cos(-hdgRad) * rollDist;
-                posNorthing += Math.Sin(-hdgRad) * rollDist;
-            }
-        }
+        // Single source of truth for the antenna-to-pivot transform. Runs
+        // here on local-plane (E, N) so the math is consistent regardless
+        // of how the GPS data arrived (real NMEA, simulator, replay).
+        AntennaToPivotTransform.Apply(
+            ref posEasting,
+            ref posNorthing,
+            pos.Heading * Math.PI / 180.0,
+            ConfigurationStore.Instance.Vehicle,
+            data.ImuRoll);
 
         // ── (2) Apply drift compensation ────────────────────────────────
         double driftedEasting = posEasting + driftE;
@@ -589,6 +565,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
         double toolHeading = _toolPositionService.ToolHeading;
         bool isToolReady = _toolPositionService.IsToolPositionReady;
         double toolWidth = config.ActualToolWidth;
+
 
         // Map positions are now sent via GpsCycleResult → ViewModel → MapRenderState.
         // The pipeline does NOT call _mapService directly.

--- a/Tests/AgValoniaGPS.Services.Tests/RollCorrectionTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/RollCorrectionTests.cs
@@ -1,138 +1,108 @@
 // AgValoniaGPS
 // Copyright (C) 2024-2025 AgValoniaGPS Contributors
 //
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Licensed under GNU GPL v3. See LICENSE.md.
 
 using System;
-using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Configuration;
-using AgValoniaGPS.Services;
-using AgValoniaGPS.Services.Interfaces;
-using NSubstitute;
+using AgValoniaGPS.Services.Gps;
 
 namespace AgValoniaGPS.Services.Tests;
 
+/// <summary>
+/// Tests for the antenna-to-pivot + roll correction transform. The
+/// transform was previously embedded inside <c>GpsService.UpdateGpsData</c>
+/// (with a (0,0)-skip guard that broke heading on the first non-zero
+/// movement frame); now it lives in <see cref="AntennaToPivotTransform"/>
+/// and is exercised here directly.
+/// </summary>
 [TestFixture]
 public class RollCorrectionTests
 {
-    private IGpsService _gpsService = null!;
+    private VehicleConfig _vehicle = null!;
 
     [SetUp]
     public void Setup()
     {
-        // Reset sensor state for each test
-        SensorState.Instance.ImuRoll = 0;
-        SensorState.Instance.ImuPitch = 0;
-
-        // Reset vehicle config
-        var config = ConfigurationStore.Instance;
-        config.Vehicle.AntennaHeight = 3.0;
-        config.Vehicle.AntennaPivot = 0;
-        config.Vehicle.AntennaOffset = 0;
+        _vehicle = new VehicleConfig
+        {
+            AntennaHeight = 3.0,
+            AntennaPivot = 0,
+            AntennaOffset = 0,
+        };
     }
 
     [Test]
     public void NoRoll_PositionUnchanged()
     {
-        var gpsService = new GpsService();
-        SensorState.Instance.ImuRoll = 0;
+        double e = 100, n = 200;
+        AntennaToPivotTransform.Apply(ref e, ref n, headingRadians: 0, _vehicle, imuRollDegrees: 0);
 
-        var gpsData = MakeGpsData(easting: 100, northing: 200, heading: 0);
-        gpsService.UpdateGpsData(gpsData);
-
-        Assert.That(gpsData.CurrentPosition.Easting, Is.EqualTo(100.0).Within(0.001));
-        Assert.That(gpsData.CurrentPosition.Northing, Is.EqualTo(200.0).Within(0.001));
+        Assert.That(e, Is.EqualTo(100.0).Within(0.001));
+        Assert.That(n, Is.EqualTo(200.0).Within(0.001));
     }
 
     [Test]
     public void RollRight_HeadingNorth_ShiftsPositionWest()
     {
-        // When vehicle rolls right (positive roll), antenna moves right.
-        // Correction should shift position LEFT (west when heading north).
-        var gpsService = new GpsService();
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 3.0;
-        SensorState.Instance.ImuRoll = 10.0; // 10 degrees right
+        // Vehicle rolls right (positive roll) → antenna moves right.
+        // Correction shifts position LEFT (west when heading north).
+        double e = 100, n = 200;
+        AntennaToPivotTransform.Apply(ref e, ref n, headingRadians: 0, _vehicle, imuRollDegrees: 10);
 
-        var gpsData = MakeGpsData(easting: 100, northing: 200, heading: 0);
-        gpsService.UpdateGpsData(gpsData);
-
-        // sin(10 deg) * 3.0m = 0.521m correction
-        // Heading north, perpendicular is east. Roll right = antenna goes east,
-        // so correction moves west (decreases easting).
         double expectedOffset = Math.Sin(10.0 * Math.PI / 180.0) * 3.0;
-        Assert.That(gpsData.CurrentPosition.Easting, Is.LessThan(100.0),
+        Assert.That(e, Is.LessThan(100.0),
             "Roll right heading north should decrease easting (shift west)");
-        Assert.That(Math.Abs(gpsData.CurrentPosition.Easting - 100.0),
-            Is.EqualTo(expectedOffset).Within(0.05),
+        Assert.That(Math.Abs(e - 100.0), Is.EqualTo(expectedOffset).Within(0.05),
             "Correction magnitude should match sin(roll) * height");
-        Assert.That(gpsData.CurrentPosition.Northing, Is.EqualTo(200.0).Within(0.05),
+        Assert.That(n, Is.EqualTo(200.0).Within(0.05),
             "Northing should be mostly unchanged for north heading");
     }
 
     [Test]
     public void RollLeft_HeadingNorth_ShiftsPositionEast()
     {
-        var gpsService = new GpsService();
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 3.0;
-        SensorState.Instance.ImuRoll = -10.0; // 10 degrees left
+        double e = 100, n = 200;
+        AntennaToPivotTransform.Apply(ref e, ref n, headingRadians: 0, _vehicle, imuRollDegrees: -10);
 
-        var gpsData = MakeGpsData(easting: 100, northing: 200, heading: 0);
-        gpsService.UpdateGpsData(gpsData);
-
-        Assert.That(gpsData.CurrentPosition.Easting, Is.GreaterThan(100.0),
+        Assert.That(e, Is.GreaterThan(100.0),
             "Roll left heading north should increase easting (shift east)");
     }
 
     [Test]
     public void RollRight_HeadingEast_ShiftsPositionNorth()
     {
-        // Heading east (90 deg), roll right = antenna goes south,
-        // correction should shift north.
-        var gpsService = new GpsService();
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 3.0;
-        SensorState.Instance.ImuRoll = 10.0;
+        // Heading east → roll right pushes antenna south, correction goes north.
+        double e = 100, n = 200;
+        AntennaToPivotTransform.Apply(ref e, ref n, headingRadians: Math.PI / 2.0, _vehicle, imuRollDegrees: 10);
 
-        var gpsData = MakeGpsData(easting: 100, northing: 200, heading: 90);
-        gpsService.UpdateGpsData(gpsData);
-
-        Assert.That(gpsData.CurrentPosition.Northing, Is.GreaterThan(200.0),
+        Assert.That(n, Is.GreaterThan(200.0),
             "Roll right heading east should increase northing (shift north)");
     }
 
     [Test]
     public void ZeroAntennaHeight_NoCorrectionApplied()
     {
-        var gpsService = new GpsService();
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 0;
-        SensorState.Instance.ImuRoll = 15.0;
+        _vehicle.AntennaHeight = 0;
+        double e = 100, n = 200;
+        AntennaToPivotTransform.Apply(ref e, ref n, headingRadians: 0, _vehicle, imuRollDegrees: 15);
 
-        var gpsData = MakeGpsData(easting: 100, northing: 200, heading: 0);
-        gpsService.UpdateGpsData(gpsData);
-
-        Assert.That(gpsData.CurrentPosition.Easting, Is.EqualTo(100.0).Within(0.001),
+        Assert.That(e, Is.EqualTo(100.0).Within(0.001),
             "No correction when antenna height is zero");
     }
 
     [Test]
     public void LargeAntennaHeight_LargerCorrection()
     {
-        var gpsService = new GpsService();
-        SensorState.Instance.ImuRoll = 5.0;
+        _vehicle.AntennaHeight = 3.0;
+        double e1 = 100, n1 = 200;
+        AntennaToPivotTransform.Apply(ref e1, ref n1, headingRadians: 0, _vehicle, imuRollDegrees: 5);
+        double offset3m = Math.Abs(e1 - 100.0);
 
-        // 3m antenna
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 3.0;
-        var gpsData1 = MakeGpsData(easting: 100, northing: 200, heading: 0);
-        gpsService.UpdateGpsData(gpsData1);
-        double offset3m = Math.Abs(gpsData1.CurrentPosition.Easting - 100.0);
-
-        // 6m antenna
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 6.0;
-        var gpsData2 = MakeGpsData(easting: 100, northing: 200, heading: 0);
-        gpsService.UpdateGpsData(gpsData2);
-        double offset6m = Math.Abs(gpsData2.CurrentPosition.Easting - 100.0);
+        _vehicle.AntennaHeight = 6.0;
+        double e2 = 100, n2 = 200;
+        AntennaToPivotTransform.Apply(ref e2, ref n2, headingRadians: 0, _vehicle, imuRollDegrees: 5);
+        double offset6m = Math.Abs(e2 - 100.0);
 
         Assert.That(offset6m, Is.EqualTo(offset3m * 2).Within(0.01),
             "Double antenna height should double correction");
@@ -141,19 +111,12 @@ public class RollCorrectionTests
     [Test]
     public void CorrectionMagnitude_MatchesFormula()
     {
-        // Verify exact formula: correction = sin(roll) * -height
-        // Applied perpendicular to heading
-        var gpsService = new GpsService();
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 4.0;
-        SensorState.Instance.ImuRoll = 15.0;
-
-        var gpsData = MakeGpsData(easting: 500, northing: 500, heading: 0);
-        gpsService.UpdateGpsData(gpsData);
+        _vehicle.AntennaHeight = 4.0;
+        double e = 500, n = 500;
+        AntennaToPivotTransform.Apply(ref e, ref n, headingRadians: 0, _vehicle, imuRollDegrees: 15);
 
         double expected = Math.Sin(15.0 * Math.PI / 180.0) * 4.0; // ~1.035m
-        double actualShift = Math.Sqrt(
-            Math.Pow(gpsData.CurrentPosition.Easting - 500, 2) +
-            Math.Pow(gpsData.CurrentPosition.Northing - 500, 2));
+        double actualShift = Math.Sqrt(Math.Pow(e - 500, 2) + Math.Pow(n - 500, 2));
 
         Assert.That(actualShift, Is.EqualTo(expected).Within(0.05),
             $"Total shift should be sin(15)*4 = {expected:F3}m, got {actualShift:F3}m");
@@ -162,39 +125,14 @@ public class RollCorrectionTests
     [Test]
     public void RollCorrectionCombinedWithAntennaPivot()
     {
-        // Both antenna offset and roll correction should apply
-        var gpsService = new GpsService();
-        ConfigurationStore.Instance.Vehicle.AntennaPivot = 2.0; // 2m ahead
-        ConfigurationStore.Instance.Vehicle.AntennaHeight = 3.0;
-        SensorState.Instance.ImuRoll = 10.0;
+        _vehicle.AntennaPivot = 2.0;   // 2m ahead
+        _vehicle.AntennaHeight = 3.0;
+        double e = 100, n = 200;
+        AntennaToPivotTransform.Apply(ref e, ref n, headingRadians: 0, _vehicle, imuRollDegrees: 10);
 
-        var gpsData = MakeGpsData(easting: 100, northing: 200, heading: 0);
-        gpsService.UpdateGpsData(gpsData);
-
-        // Pivot moves 2m south (behind when heading north)
-        // Roll correction moves ~0.52m west
-        Assert.That(gpsData.CurrentPosition.Northing, Is.LessThan(200.0),
-            "Pivot should move position south");
-        Assert.That(gpsData.CurrentPosition.Easting, Is.LessThan(100.0),
-            "Roll should move position west");
-    }
-
-    private static GpsData MakeGpsData(double easting, double northing, double heading)
-    {
-        return new GpsData
-        {
-            CurrentPosition = new Position
-            {
-                Easting = easting,
-                Northing = northing,
-                Heading = heading,
-                Latitude = 43.7,
-                Longitude = -74.0,
-                Speed = 5.0
-            },
-            FixQuality = 4,
-            SatellitesInUse = 12,
-            Hdop = 0.8
-        };
+        // Pivot offset moves position south (behind when heading north).
+        // Roll correction moves position west.
+        Assert.That(n, Is.LessThan(200.0), "Pivot should move position south");
+        Assert.That(e, Is.LessThan(100.0), "Roll should move position west");
     }
 }

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 86
+#define VERSION_PATCH 87
 
-#define VERSION "26.4.86"
+#define VERSION "26.4.87"
 #define VERSION_DATE "2026-05-04"


### PR DESCRIPTION
## Summary

- `GpsService.UpdateGpsData` was running the antenna-to-pivot transform on raw `GpsData` *before* LocalPlane conversion, guarded by an `(E, N) ≈ (0, 0)` skip. On the first sim tick after the speed slider moved off zero, the guard released and the transform shifted Easting by the full antenna offset, which the heading fusion then read as a ~90° east jump for one frame.
- The pipeline already applied the same transform in the right place (after LocalPlane), so `GpsService`'s copy was both wrong-location and a duplicate.
- Extracted the math into `AntennaToPivotTransform.Apply` (single source of truth). Pipeline calls it; tests call it directly.

## Test plan

- [x] `dotnet test Tests/AgValoniaGPS.Services.Tests` — 543 pass
- [x] `dotnet test Tests/AgValoniaGPS.UI.Tests` — 123 pass
- [x] `dotnet test Tests/AgValoniaGPS.Models.Tests` — 104 pass
- [x] Local Desktop run with field + auto-section + auto-uturn + auto-steer: tractor no longer rotates 90° clockwise on the first speed tick; no spurious headland coverage smear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)