### PR TITLE
Simulator heading/autosteer fixes + drive-mode toggle

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -82,6 +82,7 @@ public partial class MainViewModel
         if (result.AutoSteerDisengagedThisCycle)
         {
             IsAutoSteerEngaged = false;
+            _autoSteerService.Disengage();
             StatusMessage = result.DisengageReason ?? "AutoSteer disengaged";
         }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -885,8 +885,13 @@ public partial class MainViewModel
                 : Services.Interfaces.SoundEffect.AutoSteerOff);
             if (IsAutoSteerEngaged)
             {
+                _autoSteerService.Engage();
                 double widthMinusOverlap = ConfigStore.ActualToolWidth - Tool.Overlap;
                 _logger.LogDebug($"[NUDGE] AutoSteer ENGAGED: State.Guidance.HowManyPathsAway={State.Guidance.HowManyPathsAway}, offset={State.Guidance.HowManyPathsAway * widthMinusOverlap:F2}m");
+            }
+            else
+            {
+                _autoSteerService.Disengage();
             }
             SyncGuidanceStateToPipeline();
             StatusMessage = IsAutoSteerEngaged ? "AutoSteer ENGAGED" : "AutoSteer disengaged";

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -1523,6 +1523,7 @@ public partial class MainViewModel : ObservableObject
         if (IsAutoSteerEngaged)
         {
             IsAutoSteerEngaged = false;
+            _autoSteerService.Disengage();
             SyncGuidanceStateToPipeline();
         }
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
@@ -62,12 +62,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="From Default" VerticalAlignment="Center" FontSize="12"/>
                         </StackPanel>
                     </Button>
-                    <Button Classes="ModernButton" Command="{Binding ShowOffsetFixDialogCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/YouTurnReverse.png" Width="28" Height="28"/>
-                            <TextBlock Text="Offset Fix" VerticalAlignment="Center" FontSize="12"/>
-                        </StackPanel>
-                    </Button>
                 </UniformGrid>
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
@@ -47,5 +47,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                          Text="{loc:Localize RecordedPath}"
                          Command="{Binding ToggleRecordedPathPanelCommand}"/>
 
+    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/YouTurnReverse.png"
+                         Text="{loc:Localize OffsetFix}"
+                         Command="{Binding ShowOffsetFixDialogCommand}"/>
+
   </controls:FloatingPanel>
 </UserControl>

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
@@ -134,8 +134,11 @@ public class VirtualGpsReceiver : IDisposable
         sb.Append(Altitude.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(DifferentialAge.ToString("F1", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(SpeedKnots.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(HeadingDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
-        sb.Append(RollDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
+        // Fields 12-13: heading and roll as (int)(deg * 10), per Teensy firmware.
+        sb.Append(((int)Math.Round(HeadingDegrees * 10.0)).ToString(CultureInfo.InvariantCulture));
+        sb.Append(',');
+        sb.Append(((int)Math.Round(RollDegrees * 10.0)).ToString(CultureInfo.InvariantCulture));
+        sb.Append(',');
         sb.Append(PitchDegrees.ToString("F2", CultureInfo.InvariantCulture)); sb.Append(',');
         sb.Append(YawRateDegPerSec.ToString("F2", CultureInfo.InvariantCulture));
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -16,6 +16,12 @@ using AgValoniaGPS.VehicleSimulator.Modules;
 
 namespace AgValoniaGPS.VehicleSimulator.ViewModels;
 
+public enum DriveMode
+{
+    Bicycle,
+    Raw
+}
+
 public class MainWindowViewModel : INotifyPropertyChanged
 {
     private VirtualModuleHub? _hub;
@@ -40,7 +46,8 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private double _commandedAngle;
     private byte _pwmDisplay;
     private bool _steerSwitchOn = true;
-    private bool _autoSteerActive;
+    private bool _autoSteerEngaged;
+    private DriveMode _driveMode = DriveMode.Bicycle;
     private string _statusText = "Stopped";
 
     public double Speed
@@ -115,10 +122,20 @@ public class MainWindowViewModel : INotifyPropertyChanged
         set { _steerSwitchOn = value; OnPropertyChanged(); }
     }
 
-    public bool AutoSteerActive
+    /// <summary>
+    /// Read-only indicator: autosteer engaged signal received from the host
+    /// (PGN 254 IsEngaged bit).
+    /// </summary>
+    public bool AutoSteerEngaged
     {
-        get => _autoSteerActive;
-        set { _autoSteerActive = value; OnPropertyChanged(); }
+        get => _autoSteerEngaged;
+        private set { _autoSteerEngaged = value; OnPropertyChanged(); }
+    }
+
+    public DriveMode DriveMode
+    {
+        get => _driveMode;
+        set { _driveMode = value; OnPropertyChanged(); }
     }
 
     public string StatusText
@@ -202,25 +219,44 @@ public class MainWindowViewModel : INotifyPropertyChanged
     {
         if (_hub == null) return;
 
-        // When autosteer is active, WAS follows the commanded angle with response lag
-        if (_autoSteerActive)
+        // Mirror host's autosteer engagement to the read-only indicator. When
+        // engaged, the simulated WAS follows the commanded angle with lag.
+        bool engaged = _hub.Steer.LastCommand?.IsEngaged ?? false;
+        AutoSteerEngaged = engaged;
+        if (engaged)
         {
             double commanded = _hub.Steer.CommandedSteerAngleDeg;
-            double responseRate = 0.3; // lag factor per tick
+            double responseRate = 0.3;
             WasAngle += (commanded - WasAngle) * responseRate;
         }
 
-        // Feed current values into the physics model
-        _vehicle.SpeedKmh = Speed;
-        _vehicle.SteerAngleDeg = WasAngle;
+        const double dt = 0.1; // 10 Hz tick
+        if (DriveMode == DriveMode.Bicycle)
+        {
+            _vehicle.SpeedKmh = Speed;
+            _vehicle.SteerAngleDeg = WasAngle;
+            _vehicle.Step(dt);
 
-        // Step the bicycle model (10 Hz = 0.1s per tick)
-        _vehicle.Step(0.1);
+            Heading = _vehicle.HeadingDeg;
+            Latitude = _vehicle.Latitude;
+            Longitude = _vehicle.Longitude;
+        }
+        else
+        {
+            // Raw mode: slider Heading is source of truth; just integrate position.
+            double speedMs = Speed / 3.6;
+            double headingRad = Heading * Math.PI / 180.0;
+            double dNorth = speedMs * Math.Cos(headingRad) * dt;
+            double dEast = speedMs * Math.Sin(headingRad) * dt;
+            Latitude += dNorth / 111320.0;
+            Longitude += dEast / (111320.0 * Math.Cos(Latitude * Math.PI / 180.0));
 
-        // Read back physics results
-        Heading = _vehicle.HeadingDeg;
-        Latitude = _vehicle.Latitude;
-        Longitude = _vehicle.Longitude;
+            // Keep the bicycle model's pose in sync so a switch back to Bicycle
+            // mode resumes from the user's current pose rather than snapping back.
+            _vehicle.Latitude = Latitude;
+            _vehicle.Longitude = Longitude;
+            _vehicle.HeadingDeg = Heading;
+        }
 
         // Push updated values to GPS module
         _hub.Gps.Latitude = Latitude;

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -45,7 +45,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private bool _isRunning;
     private double _commandedAngle;
     private byte _pwmDisplay;
-    private bool _steerSwitchOn = true;
+    private bool _steerSwitchOn;
     private bool _autoSteerEngaged;
     private DriveMode _driveMode = DriveMode.Bicycle;
     private string _statusText = "Stopped";

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -28,6 +28,12 @@
                 <StackPanel Spacing="8">
                     <TextBlock Text="Vehicle" FontWeight="SemiBold" FontSize="14" />
 
+                    <TextBlock Text="Drive Mode" />
+                    <ComboBox SelectedItem="{Binding DriveMode}" HorizontalAlignment="Stretch">
+                        <vm:DriveMode>Bicycle</vm:DriveMode>
+                        <vm:DriveMode>Raw</vm:DriveMode>
+                    </ComboBox>
+
                     <TextBlock Text="{Binding Speed, StringFormat='Speed: {0:F1} km/h'}" />
                     <Slider Minimum="0" Maximum="30" Value="{Binding Speed}"
                             TickFrequency="1" IsSnapToTickEnabled="False" />
@@ -76,8 +82,18 @@
                                    Minimum="0" Maximum="30" />
 
                     <CheckBox Content="Steer Switch ON" IsChecked="{Binding SteerSwitchOn}" />
-                    <CheckBox Content="AutoSteer Active" IsChecked="{Binding AutoSteerActive}"
-                              ToolTip.Tip="When enabled, WAS follows the commanded steer angle from the main app" />
+
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <Panel Width="14" Height="14">
+                            <Border CornerRadius="7" BorderBrush="Black" BorderThickness="1"
+                                    Background="LimeGreen"
+                                    IsVisible="{Binding AutoSteerEngaged}" />
+                            <Border CornerRadius="7" BorderBrush="Black" BorderThickness="1"
+                                    Background="DimGray"
+                                    IsVisible="{Binding !AutoSteerEngaged}" />
+                        </Panel>
+                        <TextBlock Text="AutoSteer Engaged (from host)" VerticalAlignment="Center" />
+                    </StackPanel>
                 </StackPanel>
             </Border>
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -5,7 +5,7 @@
         x:DataType="vm:MainWindowViewModel"
         Title="AgValoniaGPS Vehicle Simulator"
         Width="750" Height="480"
-        MinWidth="650" MinHeight="400">
+        MinWidth="400" MinHeight="200">
 
     <Design.DataContext>
         <vm:MainWindowViewModel />
@@ -18,8 +18,11 @@
                    FontSize="20" FontWeight="Bold"
                    Margin="0,0,0,12" />
 
-        <!-- Main content: three columns -->
-        <Grid Grid.Row="1" ColumnDefinitions="*,*,*" Margin="0,0,0,12">
+        <!-- Main content: three columns, scrollable when window is too small -->
+        <ScrollViewer Grid.Row="1" Margin="0,0,0,12"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto">
+        <Grid ColumnDefinitions="*,*,*">
 
             <!-- Column 1: Vehicle -->
             <Border Grid.Column="0" Margin="0,0,6,0" Padding="12"
@@ -122,6 +125,7 @@
                 </StackPanel>
             </Border>
         </Grid>
+        </ScrollViewer>
 
         <!-- Bottom bar -->
         <Grid Grid.Row="2" ColumnDefinitions="Auto,*">

--- a/Tests/AgValoniaGPS.Services.Tests/PgnBuilderEngageBitTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/PgnBuilderEngageBitTests.cs
@@ -1,0 +1,51 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services.AutoSteer;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Fences PGN 254 status byte bit 2 (AutoSteerEngaged) so the wire-level
+/// engage signal can never silently regress again. The companion VM-level
+/// wiring tests (UI.Tests) ensure VehicleState.IsAutoSteerEngaged actually
+/// gets set when the user toggles autosteer; this test ensures that, once
+/// set, the bit ends up on the outbound packet.
+/// </summary>
+[TestFixture]
+public class PgnBuilderEngageBitTests
+{
+    private const int STATUS_BYTE_INDEX = 7;
+    private const byte ENGAGED_BIT = 0x04;
+
+    [Test]
+    public void BuildAutoSteerPgn_WhenEngaged_SetsStatusBit2()
+    {
+        var state = new VehicleState
+        {
+            IsAutoSteerEngaged = true,
+            GpsValid = true,
+            SteerSwitchActive = true
+        };
+
+        var packet = PgnBuilder.BuildAutoSteerPgn(ref state);
+
+        Assert.That(packet[STATUS_BYTE_INDEX] & ENGAGED_BIT, Is.EqualTo(ENGAGED_BIT),
+            "Status bit 2 (engaged) must be set when state.IsAutoSteerEngaged is true.");
+    }
+
+    [Test]
+    public void BuildAutoSteerPgn_WhenNotEngaged_ClearsStatusBit2()
+    {
+        var state = new VehicleState
+        {
+            IsAutoSteerEngaged = false,
+            GpsValid = true,
+            SteerSwitchActive = true
+        };
+
+        var packet = PgnBuilder.BuildAutoSteerPgn(ref state);
+
+        Assert.That(packet[STATUS_BYTE_INDEX] & ENGAGED_BIT, Is.EqualTo(0),
+            "Status bit 2 (engaged) must be clear when state.IsAutoSteerEngaged is false.");
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/AutoSteerWiringTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/AutoSteerWiringTests.cs
@@ -1,0 +1,71 @@
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Regression fence for the autosteer engage/disengage wire-up between
+/// MainViewModel and IAutoSteerService. The bug previously was: the VM
+/// flipped its own IsAutoSteerEngaged property and notified the pipeline,
+/// but never called Engage()/Disengage() on AutoSteerService — which is
+/// what flips the state PgnBuilder reads when assembling PGN 254. As a
+/// result the engaged status bit on the wire stayed 0 and external steer
+/// modules never saw engagement. The in-app simulator wasn't affected
+/// because it bypasses the wire and reads VM/pipeline state directly.
+/// </summary>
+[TestFixture]
+public class AutoSteerWiringTests
+{
+    [Test]
+    public void ToggleAutoSteerCommand_WhenEngaged_CallsDisengageOnService()
+    {
+        var builder = new MainViewModelBuilder();
+        var vm = builder.Build();
+
+        // Disengage path has no preconditions ("the user must be able to
+        // stop the tractor even after the track/field has been cleared").
+        vm.IsAutoSteerEngaged = true;
+        builder.AutoSteerService.ClearReceivedCalls();
+
+        vm.ToggleAutoSteerCommand!.Execute(null);
+
+        Assert.That(vm.IsAutoSteerEngaged, Is.False);
+        builder.AutoSteerService.Received(1).Disengage();
+        builder.AutoSteerService.DidNotReceive().Engage();
+    }
+
+    [Test]
+    public void ApplyGpsCycleResult_WithAutoSteerDisengagedThisCycle_CallsDisengageOnService()
+    {
+        var builder = new MainViewModelBuilder();
+        var vm = builder.Build();
+
+        vm.IsAutoSteerEngaged = true;
+        builder.AutoSteerService.ClearReceivedCalls();
+
+        vm.ApplyGpsCycleResult(new GpsCycleResult
+        {
+            AutoSteerDisengagedThisCycle = true,
+            DisengageReason = "test boundary kickout"
+        });
+
+        Assert.That(vm.IsAutoSteerEngaged, Is.False);
+        builder.AutoSteerService.Received(1).Disengage();
+    }
+
+    [Test]
+    public async Task CloseFieldAsync_WhileEngaged_CallsDisengageOnService()
+    {
+        var builder = new MainViewModelBuilder();
+        var vm = builder.Build();
+
+        vm.IsAutoSteerEngaged = true;
+        builder.AutoSteerService.ClearReceivedCalls();
+
+        await vm.CloseFieldAsync();
+
+        Assert.That(vm.IsAutoSteerEngaged, Is.False);
+        builder.AutoSteerService.Received(1).Disengage();
+    }
+}

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -18,6 +18,7 @@ public class MainViewModelBuilder
     public ISettingsService SettingsService { get; } = Substitute.For<ISettingsService>();
     public IVehicleProfileService VehicleProfileService { get; } = Substitute.For<IVehicleProfileService>();
     public INtripProfileService NtripProfileService { get; } = Substitute.For<INtripProfileService>();
+    public IAutoSteerService AutoSteerService { get; } = Substitute.For<IAutoSteerService>();
     public AgValoniaGPS.Services.Pipeline.PipelineIntents Intents { get; } = new();
 
     public MainViewModelBuilder()
@@ -59,7 +60,7 @@ public class MainViewModelBuilder
             turnAreaService: Substitute.For<AgValoniaGPS.Services.Interfaces.ITurnAreaService>(),
             vehicleProfileService: VehicleProfileService,
             configurationService: Substitute.For<IConfigurationService>(),
-            autoSteerService: Substitute.For<IAutoSteerService>(),
+            autoSteerService: AutoSteerService,
             smartWasService: Substitute.For<ISmartWasCalibrationService>(),
             trackCopierService: Substitute.For<ITrackCopierService>(),
             moduleCommunicationService: Substitute.For<IModuleCommunicationService>(),


### PR DESCRIPTION
- Fix PANDA heading and roll wire format in the simulator (`int * 10`, matching Teensy firmware) so the heading slider rotates the vehicle 1:1 in the host.
- Add Drive Mode toggle (Bicycle / Raw) to the simulator. Raw mode makes the heading slider the source of truth and bypasses the bicycle physics override.
- Replace the misleading "AutoSteer Active" checkbox with a read-only LED indicator wired to PGN 254 `IsEngaged`. The simulator's WAS-follow-commanded-angle simulation now runs while the host reports engaged.
- Wire the host's AutoSteer engage toggle to `AutoSteerService.Engage()`/`Disengage()`. The toggle was only flipping a VM property and the pipeline state; `AutoSteerService._state.IsAutoSteerEngaged` (which `PgnBuilder` reads to set status bit 2 in PGN 254) was never updated, so external steer modules never saw engagement. The in-app simulator wasn't affected because it reads VM/pipeline state directly.
- Make the simulator window resizable below content size (vertical `ScrollViewer`, lower `MinWidth`/`MinHeight`).
- Move Offset Fix from Field Operations to Field Tools menu.
- Default the simulator steer switch to off.

## Test plan
- [ ] Build solution; existing test suites pass (`dotnet test Tests/`).
- [ ] Launch simulator + Desktop. With Drive Mode = Raw, Speed = 0, drag heading slider — vehicle in AgValoniaGPS rotates 1:1.
- [ ] Engage autosteer on the host with simulator's Steer Switch ON; simulator's "AutoSteer Engaged" indicator turns green and WAS chases the commanded angle.
- [ ] Disengaging on the host (or host-side boundary kickout) clears the indicator; WAS stops chasing.
- [ ] Offset Fix opens from Field Tools menu (not from Field Operations).