### PR TITLE
Detect GPS far from local origin: re-anchor temp plane / warn on loaded field

### DIFF
--- a/Shared/AgValoniaGPS.Models/State/GpsCycleResult.cs
+++ b/Shared/AgValoniaGPS.Models/State/GpsCycleResult.cs
@@ -69,6 +69,35 @@ public record GpsCycleResult
     /// </summary>
     public LocalPlane? FirstFixLocalPlane { get; init; }
 
+    /// <summary>
+    /// Non-null on the single cycle where the cycle worker re-anchors the
+    /// temporary local plane because the live GPS source has moved beyond
+    /// the configured threshold from the existing origin (no field loaded).
+    /// The UI thread overwrites <c>State.Field.LocalPlane</c> and surfaces
+    /// a status toast describing how far the source jumped.
+    /// </summary>
+    public LocalPlane? ReplacementLocalPlane { get; init; }
+
+    /// <summary>
+    /// Distance in kilometres between the previous origin and the live GPS
+    /// position on the cycle that triggered <see cref="ReplacementLocalPlane"/>.
+    /// </summary>
+    public double ReplacementDistanceKm { get; init; }
+
+    /// <summary>
+    /// Non-null on the single cycle where the cycle worker first detects
+    /// that the live GPS position is far from the loaded field origin.
+    /// The UI thread disables autosteer and prompts the operator.
+    /// </summary>
+    public FarFromFieldWarning? FarFromFieldWarning { get; init; }
+
     // Status
     public string? StatusMessage { get; init; }
 }
+
+/// <summary>
+/// Payload for the "GPS far from field" warning: how far the live position
+/// is from the loaded field's local-plane origin, plus the offending lat/lon.
+/// </summary>
+public sealed record FarFromFieldWarning(
+    double DistanceMeters, double Latitude, double Longitude);

--- a/Shared/AgValoniaGPS.Services/Interfaces/IGpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IGpsPipelineService.cs
@@ -72,6 +72,14 @@ public interface IGpsPipelineService
     /// </summary>
     void SetYouTurnConfig(int uTurnSkipRows, bool isSkipWorkedMode, double headlandCalculatedWidth, double headlandDistance);
 
+    /// <summary>
+    /// Tell the pipeline whether a real field is currently loaded. Used by the
+    /// cycle worker to choose between silently re-anchoring the temporary
+    /// origin (no field) and emitting a far-from-field warning (field loaded)
+    /// when the live GPS position drifts beyond the configured threshold.
+    /// </summary>
+    void SetHasActiveField(bool hasActiveField);
+
     // ── Read-back state the ViewModel needs for commands ─────────────────
 
     /// <summary>Whether autosteer is currently engaged.</summary>

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -35,6 +35,17 @@ public sealed class GpsPipelineService : IGpsPipelineService
     // Matches AgOpen's setAS_guidanceLookAheadTime default. See #261.
     private const double GuidanceLookAheadSeconds = 2.0;
 
+    // Re-anchor the temporary first-fix LocalPlane when the live GPS jumps
+    // farther than this from the existing origin (no field loaded). The
+    // flat-earth approximation gets noisy at very large local-plane offsets
+    // and the camera/render math goes weird, so silently re-anchor.
+    private const double TempOriginReinitDistanceM = 50_000.0;
+
+    // Surface a "GPS far from field" warning when the live GPS reports a
+    // position farther than this from the loaded field's origin. Autosteer
+    // is dropped immediately as a safety measure on the UI thread.
+    private const double FieldOriginWarnDistanceM = 10_000.0;
+
     // ── Dependencies ────────────────────────────────────────────────────
     private readonly IGpsService _gpsService;
     private readonly IToolPositionService _toolPositionService;
@@ -94,6 +105,12 @@ public sealed class GpsPipelineService : IGpsPipelineService
     private Boundary? _boundary;
     private double _driftE;
     private double _driftN;
+    private bool _hasActiveField;
+
+    // One-shot latch so the field-far warning fires once per loaded field.
+    // SetHasActiveField clears it on the false->true transition (new field
+    // opened) so the next field gets a fresh chance to warn.
+    private bool _farFromFieldWarned;
 
     // ── Pipeline-owned guidance state (only touched on background thread) ─
     private Models.Track.TrackGuidanceState? _trackGuidanceState;
@@ -253,6 +270,19 @@ public sealed class GpsPipelineService : IGpsPipelineService
         lock (_stateLock) { _driftE = driftE; _driftN = driftN; }
     }
 
+    public void SetHasActiveField(bool hasActiveField)
+    {
+        lock (_stateLock)
+        {
+            // Reset the one-shot warning latch on the false->true transition so
+            // re-opening (or opening a different) field gets a fresh shot at
+            // the warning.
+            if (hasActiveField && !_hasActiveField)
+                _farFromFieldWarned = false;
+            _hasActiveField = hasActiveField;
+        }
+    }
+
     // ══════════════════════════════════════════════════════════════════════
     // Read-back properties
     // ══════════════════════════════════════════════════════════════════════
@@ -384,6 +414,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
         List<Vec3>? headlandLine;
         Boundary? boundary;
         double driftE, driftN;
+        bool hasActiveField;
 
         lock (_stateLock)
         {
@@ -404,6 +435,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
             boundary = _boundary;
             driftE = _driftE;
             driftN = _driftN;
+            hasActiveField = _hasActiveField;
         }
 
         // YouTurn working state is cycle-owned — no cross-thread writers.
@@ -449,6 +481,42 @@ public sealed class GpsPipelineService : IGpsPipelineService
                 new Wgs84(pos.Latitude, pos.Longitude));
             posEasting = geoCoord.Easting;
             posNorthing = geoCoord.Northing;
+        }
+
+        // Origin guard: if the live GPS source has drifted very far from the
+        // current LocalPlane origin, either silently re-anchor (no field) or
+        // surface a warning (field loaded). Skip when only the cycle-local
+        // cache exists — that means we just bootstrapped the plane this tick.
+        LocalPlane? replacementLocalPlane = null;
+        double replacementDistanceKm = 0.0;
+        FarFromFieldWarning? farFromFieldWarning = null;
+        if (committedLocalPlane != null && data.FixQuality > 0)
+        {
+            var converted = committedLocalPlane.ConvertWgs84ToGeoCoord(
+                new Wgs84(pos.Latitude, pos.Longitude));
+            double distFromOrigin = Math.Sqrt(
+                converted.Easting * converted.Easting +
+                converted.Northing * converted.Northing);
+
+            if (!hasActiveField && distFromOrigin > TempOriginReinitDistanceM)
+            {
+                var newPlane = new LocalPlane(
+                    new Wgs84(pos.Latitude, pos.Longitude),
+                    new SharedFieldProperties());
+                _cycleLocalPlane = newPlane;
+                replacementLocalPlane = newPlane;
+                replacementDistanceKm = distFromOrigin / 1000.0;
+                posEasting = 0;
+                posNorthing = 0;
+            }
+            else if (hasActiveField
+                     && distFromOrigin > FieldOriginWarnDistanceM
+                     && !_farFromFieldWarned)
+            {
+                farFromFieldWarning = new FarFromFieldWarning(
+                    distFromOrigin, pos.Latitude, pos.Longitude);
+                _farFromFieldWarned = true;
+            }
         }
 
         // Stage 3 (Phase B C2): Heading fusion. Replaces the raw NMEA heading
@@ -824,6 +892,13 @@ public sealed class GpsPipelineService : IGpsPipelineService
             // Phase E: first-fix LocalPlane auto-create — non-null only on
             // the single cycle where the cycle bootstrapped the plane.
             FirstFixLocalPlane = firstFixLocalPlane,
+
+            // Origin guard: replacement plane (silent re-anchor when no field
+            // is loaded and the GPS source jumped > TempOriginReinitDistanceM)
+            // or a far-from-field warning (field loaded, > FieldOriginWarnDistanceM).
+            ReplacementLocalPlane = replacementLocalPlane,
+            ReplacementDistanceKm = replacementDistanceKm,
+            FarFromFieldWarning = farFromFieldWarning,
 
             // Status
             StatusMessage = statusMessage ?? youTurnTickEffects?.StatusMessage ?? fixRejectionReason

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -205,6 +205,24 @@ public partial class MainViewModel
             State.Field.LocalPlane = result.FirstFixLocalPlane;
         }
 
+        // Origin guard: live GPS jumped beyond the temp-origin threshold while
+        // no field was loaded. Overwrite the existing observable plane (the
+        // cycle has already swapped its own cache) and surface a status toast.
+        if (result.ReplacementLocalPlane != null)
+        {
+            State.Field.LocalPlane = result.ReplacementLocalPlane;
+            StatusMessage =
+                $"GPS source moved {result.ReplacementDistanceKm:F0} km " +
+                $"from local origin; origin re-anchored.";
+        }
+
+        // Origin guard: live GPS far from the loaded field. Drop autosteer
+        // and prompt the operator for a close/keep-driving decision.
+        if (result.FarFromFieldWarning is { } w)
+        {
+            HandleFarFromFieldWarning(w);
+        }
+
         // Section states
         if (result.SectionStates != null)
         {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.OriginGuard.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.OriginGuard.cs
@@ -1,0 +1,35 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using AgValoniaGPS.Models.State;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// MainViewModel partial: handles the cycle worker's far-from-field warning.
+/// The cycle detects when the live GPS position is well past any sane offset
+/// from the loaded field's local-plane origin; this UI-thread handler drops
+/// autosteer immediately and prompts the operator to close the field or keep
+/// driving without guidance.
+/// </summary>
+public partial class MainViewModel
+{
+    private void HandleFarFromFieldWarning(FarFromFieldWarning warning)
+    {
+        if (IsAutoSteerEngaged)
+        {
+            IsAutoSteerEngaged = false;
+            SyncGuidanceStateToPipeline();
+        }
+
+        double km = warning.DistanceMeters / 1000.0;
+        ShowConfirmationDialog(
+            "GPS far from field",
+            $"GPS reports a position {km:F1} km from the loaded field origin. " +
+            "Autosteer has been disabled.\n\n" +
+            "Choose Confirm to close the field, or Cancel to keep driving without guidance.",
+            () => _ = CloseFieldAsync());
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -1197,6 +1197,7 @@ public partial class MainViewModel : ObservableObject
             CurrentFieldName = fieldName;
             IsFieldOpen = true;
             FieldsRootDirectory = Path.GetDirectoryName(fieldPath) ?? string.Empty;
+            _gpsPipelineService.SetHasActiveField(true);
 
             // Load field origin from Field.txt
             try
@@ -1529,6 +1530,7 @@ public partial class MainViewModel : ObservableObject
 
         CurrentFieldName = string.Empty;
         IsFieldOpen = false;
+        _gpsPipelineService.SetHasActiveField(false);
 
         // Clear boundary
         SetCurrentBoundary(null);

--- a/Tests/AgValoniaGPS.Services.Tests/Pipeline/OriginGuardCycleTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/Pipeline/OriginGuardCycleTests.cs
@@ -1,0 +1,212 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Collections.Generic;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Coverage;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Pipeline;
+using AgValoniaGPS.Services.Section;
+using AgValoniaGPS.Services.Tool;
+using AgValoniaGPS.Services.Track;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests.Pipeline;
+
+/// <summary>
+/// Origin-guard contract: GpsPipelineService must detect when the live
+/// GPS source has wandered far from the LocalPlane origin and either
+/// silently re-anchor the temporary plane (no field) or surface a one-shot
+/// far-from-field warning (field loaded). The hard cases are
+/// off-thread — manual repro requires swapping GPS sources mid-session —
+/// so the cycle behavior is locked here.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore is a singleton.
+public class OriginGuardCycleTests
+{
+    private GpsService _gpsService = null!;
+    private GpsPipelineService _pipeline = null!;
+    private ApplicationState _appState = null!;
+    private List<GpsCycleResult> _results = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var config = ConfigurationStore.Instance;
+        config.Vehicle.AntennaPivot = 0;
+        config.Vehicle.AntennaOffset = 0;
+        config.Vehicle.AntennaHeight = 0;
+        config.Tool.Width = 6;
+        config.NumSections = 1;
+        config.Tool.SetSectionWidth(0, 600);
+
+        _appState = new ApplicationState();
+        _appState.Field.LocalPlane = new LocalPlane(
+            new Wgs84(43.7128, -74.006), new SharedFieldProperties());
+
+        _gpsService = new GpsService();
+        _gpsService.Start();
+
+        var toolPosition = new ToolPositionService();
+        var coverage = new CoverageMapService();
+        var sectionControl = new SectionControlService(toolPosition, coverage, _appState);
+        var autoSteer = new AutoSteerService(new TrackGuidanceService(),
+            Substitute.For<IUdpCommunicationService>(), _gpsService, _appState);
+
+        var headingFusion = Substitute.For<IGpsHeadingFusionService>();
+        headingFusion.FuseHeading(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<bool>(),
+                Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>())
+            .Returns(ci => ci.ArgAt<double>(0));
+
+        _pipeline = new GpsPipelineService(
+            _gpsService, toolPosition, new TrackGuidanceService(),
+            sectionControl, coverage, autoSteer,
+            new YouTurnGuidanceService(),
+            new YouTurnStateMachine(
+                new YouTurnCreationService(NullLogger<YouTurnCreationService>.Instance,
+                    Substitute.For<AgValoniaGPS.Services.Geometry.IPolygonOffsetService>()),
+                new YouTurnPathingService(NullLogger<YouTurnPathingService>.Instance),
+                NullLogger<YouTurnStateMachine>.Instance),
+            Substitute.For<IAudioService>(),
+            new PipelineIntents(),
+            headingFusion,
+            NullLogger<GpsPipelineService>.Instance, _appState,
+            new PositionEstimator());
+
+        _pipeline.SynchronousMode = true;
+        _pipeline.Start();
+
+        _results = new List<GpsCycleResult>();
+        _pipeline.CycleCompleted += r => _results.Add(r);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _pipeline.Stop();
+        _gpsService.Stop();
+    }
+
+    private GpsCycleResult Last => _results[^1];
+
+    private static GpsData At(double lat, double lon) => new()
+    {
+        CurrentPosition = new Position { Latitude = lat, Longitude = lon },
+        FixQuality = 4,
+        IsValid = true,
+    };
+
+    [Test]
+    public void TempOrigin_WithinThreshold_DoesNotReanchor()
+    {
+        // No active field by default; GPS ~1 km from the origin.
+        _gpsService.UpdateGpsData(At(43.72, -74.01));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Last.ReplacementLocalPlane, Is.Null);
+            Assert.That(Last.ReplacementDistanceKm, Is.EqualTo(0.0));
+            Assert.That(Last.FarFromFieldWarning, Is.Null);
+        });
+    }
+
+    [Test]
+    public void TempOrigin_BeyondThreshold_EmitsReplacementPlane()
+    {
+        // Stockholm: ~6300 km from the upstate-NY origin. No active field
+        // → silent re-anchor channel must fire.
+        _gpsService.UpdateGpsData(At(59.3293, 18.0686));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Last.ReplacementLocalPlane, Is.Not.Null,
+                "GPS jumped >50 km from temp origin with no field loaded → must re-anchor");
+            Assert.That(Last.ReplacementDistanceKm, Is.GreaterThan(50.0),
+                "Reported distance must reflect the offset that triggered re-anchor");
+            Assert.That(Last.FarFromFieldWarning, Is.Null,
+                "Far-from-field warning is the field-loaded channel only");
+        });
+    }
+
+    [Test]
+    public void TempOrigin_AfterReanchor_DoesNotReanchorAgainNearby()
+    {
+        // First cycle: trigger re-anchor.
+        _gpsService.UpdateGpsData(At(59.3293, 18.0686));
+        var newPlane = Last.ReplacementLocalPlane;
+        Assert.That(newPlane, Is.Not.Null, "precondition: first cycle re-anchors");
+
+        // Mirror what ApplyGpsCycleResult does on the UI thread so the next
+        // cycle reads the new origin from ApplicationState.
+        _appState.Field.LocalPlane = newPlane;
+
+        // Second cycle: stay near the new origin → no further replacement.
+        _gpsService.UpdateGpsData(At(59.330, 18.069));
+
+        Assert.That(Last.ReplacementLocalPlane, Is.Null,
+            "After re-anchor + commit, nearby positions must not retrigger");
+    }
+
+    [Test]
+    public void FieldLoaded_WithinThreshold_NoWarning()
+    {
+        _pipeline.SetHasActiveField(true);
+        _gpsService.UpdateGpsData(At(43.72, -74.01)); // ~1 km from field origin
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Last.FarFromFieldWarning, Is.Null);
+            Assert.That(Last.ReplacementLocalPlane, Is.Null,
+                "Field loaded → silent re-anchor must never fire");
+        });
+    }
+
+    [Test]
+    public void FieldLoaded_BeyondThreshold_EmitsWarningOnce()
+    {
+        _pipeline.SetHasActiveField(true);
+
+        // ~14 km north of the field origin.
+        _gpsService.UpdateGpsData(At(43.85, -74.006));
+        Assert.That(Last.FarFromFieldWarning, Is.Not.Null,
+            "First far-from-field cycle must emit a warning");
+        Assert.That(Last.FarFromFieldWarning!.DistanceMeters, Is.GreaterThan(10_000));
+        Assert.That(Last.ReplacementLocalPlane, Is.Null,
+            "Field loaded → no silent re-anchor");
+
+        // Second far cycle: latch holds, no repeated warning.
+        _gpsService.UpdateGpsData(At(43.86, -74.006));
+        Assert.That(Last.FarFromFieldWarning, Is.Null,
+            "One-shot latch must suppress repeats so the dialog is not nag-spammed");
+    }
+
+    [Test]
+    public void FieldReopen_ResetsWarningLatch()
+    {
+        _pipeline.SetHasActiveField(true);
+
+        _gpsService.UpdateGpsData(At(43.85, -74.006));
+        Assert.That(Last.FarFromFieldWarning, Is.Not.Null, "precondition: first warning fires");
+
+        _gpsService.UpdateGpsData(At(43.86, -74.006));
+        Assert.That(Last.FarFromFieldWarning, Is.Null, "precondition: latch holds");
+
+        // Close + reopen mirrors MainViewModel.ClearFieldState + OpenFieldAsync.
+        _pipeline.SetHasActiveField(false);
+        _pipeline.SetHasActiveField(true);
+
+        _gpsService.UpdateGpsData(At(43.87, -74.006));
+        Assert.That(Last.FarFromFieldWarning, Is.Not.Null,
+            "Reopening a field must clear the one-shot latch so the next jump warns again");
+    }
+}


### PR DESCRIPTION
Detects when live GPS drifts far from the active LocalPlane origin and reacts:

- **Temp origin (no field, > 50 km):** silently re-anchors the LocalPlane to the new position; status toast.
- **Loaded field (> 10 km):** drops autosteer, shows a "GPS far from field" dialog with Close / Keep Driving.

Triggered by switching from the built-in NY simulator to an external GPS source elsewhere in the world — without this, the tractor ends up millions of meters from local origin and the camera/render math goes weird.

Detection runs on the cycle worker; UI commit + dialog/autosteer-drop on the UI thread. A latch ensures the field-loaded warning fires once per loaded field (resets on close + reopen).

## Test plan
- [ ] Built-in sim → external GPS at 50+ km away: status toast appears, tractor stays centered, no dialog
- [ ] Loaded field + GPS jump > 10 km: autosteer drops, dialog shows; Confirm closes field, Cancel keeps driving
- [ ] Drive normally inside a field (no jump): no warning, no toast
- [ ] Close + reopen same field, jump again: latch resets, warning fires again

6 new NUnit tests in `OriginGuardCycleTests` lock the cycle-side behavior (sub-threshold, beyond-threshold, post-reanchor, field warning + latch, latch reset on reopen).