### PR TITLE
Fix trailing-implement jitter on the map

### DIFF
--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -624,10 +624,13 @@ public sealed class GpsPipelineService : IGpsPipelineService
         youTurnPath = _youTurn.TurnPath;
 
         // ── (3) Tool position ───────────────────────────────────────────
-        _toolPositionService.Update(
-            new Vec3(driftedEasting, driftedNorthing, headingRad),
-            headingRad);
-
+        // ToolPositionService is updated by ControlLoopService at 100 Hz
+        // (MainViewModel.OnControlLoopTicked). The pipeline used to call
+        // Update here too, but that created a dual-writer race on Torriem
+        // state — pipeline fed GPS-anchored pose at 10 Hz while the control
+        // loop fed dead-reckoned pose at 100 Hz, causing the trailing-tool
+        // atan2 baseline to thrash. Single writer now; we just read the
+        // latest snapshot (lock-free, at most ~10 ms stale).
         var toolPos = _toolPositionService.ToolPosition;
         var hitchPos = _toolPositionService.HitchPosition;
         double toolHeading = _toolPositionService.ToolHeading;

--- a/Shared/AgValoniaGPS.Services/Pipeline/PositionEstimator.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/PositionEstimator.cs
@@ -37,6 +37,27 @@ public sealed class PositionEstimator : IPositionEstimator
 
     public void UpdateFromGps(PoseSnapshot snapshot)
     {
+        // Derive yaw rate from the heading delta versus the previous snapshot
+        // when none was supplied (e.g., the internal simulator has no IMU and
+        // passes YawRate=0). Without this, GetPose dead-reckons heading as
+        // constant between samples and snaps to the new value at each
+        // arrival. That snap propagates into the hitch's lateral position
+        // (which depends on heading × hitch length) and from there into the
+        // dead-reckoned tool, producing visible per-sample jitter while
+        // turning. Using the heading-delta-derived yaw rate makes heading
+        // ramp smoothly across the inter-sample interval, killing the snap.
+        var prev = Volatile.Read(ref _latest);
+        if (prev is not null && Math.Abs(snapshot.YawRateRadPerSec) < 1e-9)
+        {
+            double dt = Clock.Current.ElapsedSeconds(prev.TimestampTicks, snapshot.TimestampTicks);
+            if (dt > 1e-6)
+            {
+                double dh = snapshot.Heading - prev.Heading;
+                while (dh > Math.PI) dh -= 2 * Math.PI;
+                while (dh < -Math.PI) dh += 2 * Math.PI;
+                snapshot = snapshot with { YawRateRadPerSec = dh / dt };
+            }
+        }
         Interlocked.Exchange(ref _latest, snapshot);
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -256,12 +256,13 @@ public partial class MainViewModel
         if (result.StatusMessage != null)
             StatusMessage = result.StatusMessage;
 
-        // Map service position update (single atomic call)
-        _mapService.SetAllPositions(
-            result.Easting, result.Northing, result.Heading * Math.PI / 180.0,
-            result.ToolEasting, result.ToolNorthing, result.ToolHeadingRadians,
-            result.ToolWidth, result.HitchEasting, result.HitchNorthing,
-            result.IsToolPositionReady);
+        // Map vehicle/tool/hitch positions are pushed by OnRenderPullTick at
+        // 30 Hz (vehicle dead-reckoned to "now" from the estimator, tool/hitch
+        // from the live ToolPositionService snapshot updated at 100 Hz by the
+        // control loop). The pipeline result captures stale values at
+        // pipeline-run time; pushing them here as well caused the implement to
+        // jitter back and forth at GPS rate as the stale write fought the
+        // live render-pull write.
 
         // Live wheel angle for the front-wheel sprite (#336). Real WAS reading
         // when an autosteer module is attached, simulator slider value when

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -464,13 +464,16 @@ public partial class MainViewModel : ObservableObject
     /// and velocity, so position advances ~7 cm per 30 Hz frame at 25 km/h
     /// instead of a 28 cm jump every 100 ms.
     ///
-    /// Tool/hitch are pulled from the latest ToolPositionService snapshot
-    /// (updated at 100 Hz by the control loop) and pushed in the same
-    /// atomic SetAllPositions call as the vehicle. Otherwise the vehicle
-    /// would slide forward at 30 Hz while the tool stayed pinned to the
-    /// last 10 Hz GpsCycleResult, making the implement appear to lag and
-    /// then snap forward at every GPS sample — visible as back-and-forth
-    /// jitter relative to the tractor.
+    /// Tool/hitch are computed entirely from the current dead-reckoned
+    /// vehicle pose (for hitch) and the Torriem-stable tool heading from
+    /// the snapshot (for tool). Earlier attempts that translated the
+    /// snapshot tool by a dead-reckoned hitch delta still mixed two
+    /// estimator state bases when a GPS sample arrived between the last
+    /// control-loop tick and the render tick — the snapshot hitch used
+    /// the pre-arrival prediction while the new hitch used the post-
+    /// arrival prediction, leaking a small snap into the implement at
+    /// each sample. Computing both hitch and tool from the same single
+    /// estimator pose eliminates that.
     /// </summary>
     private void OnRenderPullTick(object? sender, EventArgs e)
     {
@@ -478,12 +481,46 @@ public partial class MainViewModel : ObservableObject
             return;
         var p = _positionEstimator.GetPose(Clock.Current.GetTimestamp());
 
-        var toolPos = _toolPositionService.ToolPosition;
-        var hitchPos = _toolPositionService.HitchPosition;
+        var tool = ConfigStore.Tool;
+        double hitchDistance = Math.Abs(tool.HitchLength);
+        if (tool.IsToolRearFixed || tool.IsToolTrailing || tool.IsToolTBT)
+            hitchDistance = -hitchDistance;
+
+        double hitchE = p.Position.Easting + Math.Sin(p.Heading) * hitchDistance;
+        double hitchN = p.Position.Northing + Math.Cos(p.Heading) * hitchDistance;
+
+        double toolE, toolN, toolHeading;
+        if (tool.IsToolFrontFixed || tool.IsToolRearFixed)
+        {
+            // Fixed tool follows the vehicle exactly — no Torriem state.
+            toolHeading = p.Heading;
+            toolE = hitchE;
+            toolN = hitchN;
+        }
+        else
+        {
+            // Trailing / TBT — use the Torriem-tracked heading from the
+            // snapshot (stable across ticks) and project the tool back from
+            // the freshly-computed hitch along that heading.
+            toolHeading = _toolPositionService.ToolHeading;
+            double pivotOffset = tool.TrailingHitchLength - tool.TrailingToolToPivotLength;
+            toolE = hitchE - Math.Sin(toolHeading) * pivotOffset;
+            toolN = hitchN - Math.Cos(toolHeading) * pivotOffset;
+        }
+
+        // Lateral offset perpendicular to tool heading (right is positive,
+        // matching ToolPositionService.ApplyLateralOffset).
+        if (Math.Abs(tool.Offset) > 0.001)
+        {
+            double perp = toolHeading + Math.PI / 2.0;
+            toolE += Math.Sin(perp) * tool.Offset;
+            toolN += Math.Cos(perp) * tool.Offset;
+        }
+
         _mapService.SetAllPositions(
             p.Position.Easting, p.Position.Northing, p.Heading,
-            toolPos.Easting, toolPos.Northing, _toolPositionService.ToolHeading,
-            ConfigStore.ActualToolWidth, hitchPos.Easting, hitchPos.Northing,
+            toolE, toolN, toolHeading,
+            ConfigStore.ActualToolWidth, hitchE, hitchN,
             _toolPositionService.IsToolPositionReady);
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -463,13 +463,28 @@ public partial class MainViewModel : ObservableObject
     /// dead-reckoned to "now" from the latest GPS snapshot using yaw rate
     /// and velocity, so position advances ~7 cm per 30 Hz frame at 25 km/h
     /// instead of a 28 cm jump every 100 ms.
+    ///
+    /// Tool/hitch are pulled from the latest ToolPositionService snapshot
+    /// (updated at 100 Hz by the control loop) and pushed in the same
+    /// atomic SetAllPositions call as the vehicle. Otherwise the vehicle
+    /// would slide forward at 30 Hz while the tool stayed pinned to the
+    /// last 10 Hz GpsCycleResult, making the implement appear to lag and
+    /// then snap forward at every GPS sample — visible as back-and-forth
+    /// jitter relative to the tractor.
     /// </summary>
     private void OnRenderPullTick(object? sender, EventArgs e)
     {
         if (_positionEstimator?.GetLatestSnapshot() is null)
             return;
         var p = _positionEstimator.GetPose(Clock.Current.GetTimestamp());
-        _mapService.SetVehiclePosition(p.Position.Easting, p.Position.Northing, p.Heading);
+
+        var toolPos = _toolPositionService.ToolPosition;
+        var hitchPos = _toolPositionService.HitchPosition;
+        _mapService.SetAllPositions(
+            p.Position.Easting, p.Position.Northing, p.Heading,
+            toolPos.Easting, toolPos.Northing, _toolPositionService.ToolHeading,
+            ConfigStore.ActualToolWidth, hitchPos.Easting, hitchPos.Northing,
+            _toolPositionService.IsToolPositionReady);
     }
 
     private void RestoreSettings()


### PR DESCRIPTION
## Summary
- Stops the trailing implement from visibly jittering / lagging the tractor in the map view, especially while turning.
- Single-writer the four pieces of state involved: ToolPositionService is now driven only by the 100 Hz control loop; map positions are written only by the 30 Hz render-pull tick; vehicle and tool are pushed atomically and computed from a single dead-reckoned vehicle pose; PositionEstimator derives yaw rate from heading deltas when no IMU is supplied.

## What was wrong
Four interacting issues:

1. **Dual writer to ``ToolPositionService``** — the GPS pipeline (~10/30 Hz) and the control loop (100 Hz) both called ``Update``, fighting Torriem's ``_lastHitchPos`` / ``_lastToolPivotPos`` state. ``Plans/UNIFIED_CONTROL_LOOP_PLAN.md:260`` called for the control loop to be the sole writer; the pipeline call was never removed.
2. **Vehicle/tool render-rate mismatch** — vehicle was pushed at 30 Hz from the dead-reckoned estimator pose (``OnRenderPullTick``), tool only at 10/30 Hz from ``ApplyGpsCycleResult``. Vehicle slid forward smoothly between samples while the implement sat pinned and snapped at each GPS tick.
3. **Mixing two estimator state bases** — even after pushing tool from the render-pull tick, translating the snapshot tool by ``newHitch - snapHitch`` mixed the pre-arrival prediction (snapshot) with the post-arrival prediction (newHitch) when a sample arrived between control-loop tick and render. Each sample leaked a small snap into the implement during turns.
4. **Heading snap at GPS arrival without IMU** — the internal simulator (and any IMU-less GPS) reports ``YawRate=0``, so ``PositionEstimator`` predicted heading as constant between samples and snapped at each one. The snap propagated through the hitch's lateral position (= heading × hitch length) and into the implement.

## What changed
- ``GpsPipelineService`` no longer calls ``ToolPositionService.Update``. The control loop is the sole 100 Hz writer to the snapshot.
- ``OnRenderPullTick`` is the sole writer of vehicle/tool/hitch to the map service. ``ApplyGpsCycleResult`` no longer pushes positions.
- ``OnRenderPullTick`` computes hitch from the dead-reckoned vehicle pose and projects the tool back along the snapshot's Torriem-tracked tool heading. Both come from a single estimator pose, so any prediction error affects them equally.
- ``PositionEstimator.UpdateFromGps`` derives yaw rate from heading delta versus the previous snapshot when none was supplied. Heading prediction now ramps smoothly across the inter-sample interval.

## Test plan
- [x] ``dotnet build Platforms/AgValoniaGPS.Desktop/AgValoniaGPS.Desktop.csproj`` clean
- [x] ``dotnet test Tests/AgValoniaGPS.Services.Tests/`` — tool-position / offset suites pass
- [x] Internal simulator, trailing tool, driving straight: implement tracks tractor smoothly
- [ ] Internal simulator, trailing tool, turning: implement should swing without back-and-forth jitter (user verifying)
- [ ] Fixed (3PT) tool: confirm no regression
- [ ] Real GPS hardware (with IMU yaw rate): confirm derived-yaw-rate path is correctly bypassed