### PR TITLE
Start Work Session: show every field, fill empty right column, promote 'New Field'

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/StartWorkSessionDialogViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/StartWorkSessionDialogViewModel.cs
@@ -145,30 +145,44 @@ public partial class StartWorkSessionDialogViewModel : ObservableObject
         var root = _settingsService.Settings.FieldsDirectory;
         var lat = _appState.Vehicle.Latitude;
         var lon = _appState.Vehicle.Longitude;
-        var maxKm = _nearbyMaxKm ?? DefaultMaxKm;
 
         Fields.Clear();
-        if (lat != 0 || lon != 0)
+
+        var allNames = _fieldService.GetAvailableFields(root);
+
+        // Always show every field on disk. When we have a fix, enrich with
+        // distance (uncapped) for sort ranking; rows whose origin is (0,0)
+        // or unreadable fall through to distance 0.0 and sort to the bottom.
+        var known = (lat != 0 || lon != 0)
+            ? _fieldService.FindFieldsNear(root, lat, lon, double.MaxValue)
+                .ToDictionary(f => f.Name, f => f, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, NearbyField>(StringComparer.OrdinalIgnoreCase);
+
+        var rows = new List<NearbyField>(allNames.Count);
+        foreach (var name in allNames)
         {
-            // Have a fix — order by distance, filter to maxKm.
-            foreach (var nf in _fieldService.FindFieldsNear(root, lat, lon, maxKm))
-                Fields.Add(nf);
-        }
-        else
-        {
-            // No fix yet — list every field with DistanceKm = 0 so the
-            // dialog still lets the operator pick one. Distance column
-            // will show 0.0 km; not useful but not lying either.
-            foreach (var name in _fieldService.GetAvailableFields(root))
+            if (known.TryGetValue(name, out var nf))
+                rows.Add(nf);
+            else
             {
                 var dir = System.IO.Path.Combine(root, name);
-                Fields.Add(new NearbyField(
+                rows.Add(new NearbyField(
                     Name: name,
                     DirectoryPath: dir,
                     DistanceKm: 0,
                     BoundaryAreaHectares: 0));
             }
         }
+        rows.Sort((a, b) =>
+        {
+            bool aKnown = known.ContainsKey(a.Name);
+            bool bKnown = known.ContainsKey(b.Name);
+            if (aKnown && bKnown) return a.DistanceKm.CompareTo(b.DistanceKm);
+            if (aKnown) return -1;
+            if (bKnown) return 1;
+            return string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+        });
+        foreach (var f in rows) Fields.Add(f);
 
         WorkTypeSuggestions.Clear();
         foreach (var s in _jobService.SuggestWorkTypes())
@@ -183,7 +197,10 @@ public partial class StartWorkSessionDialogViewModel : ObservableObject
                     string.Equals(f.Name, activeName, StringComparison.OrdinalIgnoreCase))
                 : null)
             ?? Fields.FirstOrDefault();
-        StatusMessage = null;
+
+        StatusMessage = Fields.Count == 0
+            ? "No fields found. Create one from Field Operations → Create Field."
+            : null;
     }
 
     partial void OnSelectedFieldChanged(NearbyField? value)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
@@ -219,6 +219,24 @@ Licensed under GNU GPL v3. See LICENSE.md.
                     </Grid>
                 </Grid>
 
+                <!-- Empty-state when no field is selected (or no fields exist).
+                     Keeps the right column populated so the dialog never has
+                     a wide blank area. -->
+                <Border Grid.Row="1" Grid.Column="2"
+                        IsVisible="{Binding SelectedField, Converter={x:Static ObjectConverters.IsNull}}"
+                        VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <StackPanel Spacing="8" HorizontalAlignment="Center">
+                        <TextBlock Text="No field selected"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   FontSize="14" FontWeight="SemiBold"
+                                   HorizontalAlignment="Center"/>
+                        <TextBlock Text="{Binding StatusMessage, FallbackValue='Pick a field on the left to start or resume a job.'}"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   FontSize="12" TextWrapping="Wrap" MaxWidth="320"
+                                   TextAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+
                 <!-- Status / error message -->
                 <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3"
                            Text="{Binding StatusMessage}"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
@@ -38,6 +38,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Create Field -->
                 <UniformGrid Columns="2">
+                    <Button Classes="ModernButton" Command="{Binding ShowNewFieldDialogCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png" Width="28" Height="28"/>
+                            <TextBlock Text="New Field" VerticalAlignment="Center" FontSize="12"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="ModernButton" Command="{Binding ShowFromExistingFieldDialogCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileExisting.png" Width="28" Height="28"/>
+                            <TextBlock Text="From Existing" VerticalAlignment="Center" FontSize="12"/>
+                        </StackPanel>
+                    </Button>
                     <Button Classes="ModernButton" Command="{Binding ShowIsoXmlImportDialogCommand}">
                         <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ISOXML.png" Width="28" Height="28"/>
@@ -48,18 +60,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/GoogleEarth.png" Width="28" Height="28"/>
                             <TextBlock Text="From KML" VerticalAlignment="Center" FontSize="12"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Classes="ModernButton" Command="{Binding ShowFromExistingFieldDialogCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileExisting.png" Width="28" Height="28"/>
-                            <TextBlock Text="From Existing" VerticalAlignment="Center" FontSize="12"/>
-                        </StackPanel>
-                    </Button>
-                    <Button Classes="ModernButton" Command="{Binding ShowNewFieldDialogCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
-                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/FileNew.png" Width="28" Height="28"/>
-                            <TextBlock Text="From Default" VerticalAlignment="Center" FontSize="12"/>
                         </StackPanel>
                     </Button>
                 </UniformGrid>

--- a/Tests/AgValoniaGPS.UI.Tests/StartWorkSessionDialogTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/StartWorkSessionDialogTests.cs
@@ -1,0 +1,108 @@
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Job;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels;
+using NSubstitute;
+
+namespace AgValoniaGPS.UI.Tests;
+
+/// <summary>
+/// Regression fence for #XXX: the Start Work Session dialog used to call
+/// IFieldService.FindFieldsNear with a 100 km cap when a GPS fix was
+/// available, silently dropping every field whose origin was &gt; 100 km
+/// away or had not yet been georeferenced (origin == (0,0)). The
+/// canonical row source is now IFieldService.GetAvailableFields, with
+/// FindFieldsNear used only to enrich entries with distance for sorting.
+/// </summary>
+[TestFixture]
+public class StartWorkSessionDialogTests
+{
+    private const string FieldsRoot = "/tmp/fields";
+
+    private static StartWorkSessionDialogViewModel BuildVm(
+        IFieldService fieldService,
+        ApplicationState? appState = null)
+    {
+        var settings = Substitute.For<ISettingsService>();
+        settings.Settings.Returns(new AppSettings { FieldsDirectory = FieldsRoot });
+
+        var jobs = Substitute.For<IJobService>();
+        jobs.SuggestWorkTypes().Returns(Array.Empty<string>());
+        jobs.ListJobs(Arg.Any<string>()).Returns(Array.Empty<JobSummary>());
+
+        return new StartWorkSessionDialogViewModel(
+            fieldService: fieldService,
+            jobService: jobs,
+            settingsService: settings,
+            appState: appState ?? new ApplicationState(),
+            close: () => { },
+            openField: (_, _) => { },
+            openFieldStartingNewJob: (_, _, _, _, _) => { },
+            openFieldResumingJob: (_, _, _) => { },
+            confirm: (_, _) => { });
+    }
+
+    [Test]
+    public void Refresh_WithFix_PopulatesAllAvailableFields_NearOnesFirst()
+    {
+        var fields = Substitute.For<IFieldService>();
+        fields.GetAvailableFields(FieldsRoot)
+            .Returns(new List<string> { "Aaa", "FarAway", "Nearby", "Zzz" });
+        fields.FindFieldsNear(FieldsRoot, Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>())
+            .Returns(new List<NearbyField>
+            {
+                new("Nearby",  $"{FieldsRoot}/Nearby",  DistanceKm: 0.5,    BoundaryAreaHectares: 12),
+                new("FarAway", $"{FieldsRoot}/FarAway", DistanceKm: 5000.0, BoundaryAreaHectares: 7)
+            });
+
+        var appState = new ApplicationState();
+        appState.Vehicle.Latitude = 42.0;
+        appState.Vehicle.Longitude = -93.0;
+
+        var vm = BuildVm(fields, appState);
+        vm.Refresh();
+
+        // All four fields show up.
+        Assert.That(vm.Fields.Select(f => f.Name).ToArray(),
+            Is.EqualTo(new[] { "Nearby", "FarAway", "Aaa", "Zzz" }),
+            "Known-distance rows first (by distance), then unknown rows alphabetically.");
+        Assert.That(vm.StatusMessage, Is.Null);
+    }
+
+    [Test]
+    public void Refresh_WithFix_EmptyFindFieldsNear_StillShowsAllAvailableFields()
+    {
+        var fields = Substitute.For<IFieldService>();
+        fields.GetAvailableFields(FieldsRoot)
+            .Returns(new List<string> { "FieldA", "FieldB" });
+        fields.FindFieldsNear(FieldsRoot, Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>())
+            .Returns(Array.Empty<NearbyField>());
+
+        var appState = new ApplicationState();
+        appState.Vehicle.Latitude = 42.0;
+        appState.Vehicle.Longitude = -93.0;
+
+        var vm = BuildVm(fields, appState);
+        vm.Refresh();
+
+        Assert.That(vm.Fields.Select(f => f.Name).ToArray(),
+            Is.EqualTo(new[] { "FieldA", "FieldB" }),
+            "Refresh must not silently hide fields just because none have a usable origin.");
+        Assert.That(vm.StatusMessage, Is.Null);
+    }
+
+    [Test]
+    public void Refresh_NoFieldsOnDisk_LeavesListEmpty_AndSetsStatusMessage()
+    {
+        var fields = Substitute.For<IFieldService>();
+        fields.GetAvailableFields(FieldsRoot).Returns(new List<string>());
+
+        var vm = BuildVm(fields);
+        vm.Refresh();
+
+        Assert.That(vm.Fields, Is.Empty);
+        Assert.That(vm.StatusMessage, Does.Contain("No fields found"));
+    }
+}


### PR DESCRIPTION
- **Empty fields list bug.** `StartWorkSessionDialogViewModel.Refresh()` called `FindFieldsNear(root, lat, lon, 100 km)` whenever the vehicle had any GPS fix, silently dropping fields whose origin was `(0,0)`, unreadable, or more than 100 km away. Switch the canonical row source to `IFieldService.GetAvailableFields` so every field under `FieldsDirectory` shows up regardless of geo state; when a fix exists, enrich rows with distance via `FindFieldsNear(... double.MaxValue)` for sort ranking. Rows without a known distance fall to the bottom with `0.0 km` (matching the no-fix UX). Empty directory now surfaces a status message: "No fields found. Create one from Field Operations → Create Field."
- **Dialog right column never blank.** When `SelectedField` was null the right detail Grid hid itself, leaving a wide empty area. Add a sibling empty-state Border in the same grid cell that shows a centred "No field selected" hint and the dialog's `StatusMessage`.
- **'From Default' → 'New Field' and promoted to first position.** The button that creates a brand-new blank field at the current GPS position was both ambiguously labelled and last in the Create Field row. Rename to "New Field" and move first. No command/icon changes.

## Test plan
- [x] `dotnet test Tests/AgValoniaGPS.UI.Tests/` — 129 pass (3 new in `StartWorkSessionDialogTests`).
- [ ] Manual: launch with simulator at default Iowa coords; with at least one field on disk whose origin is far away (or `(0,0)`), open Field Operations → Start Session — field appears, auto-selected, right side shows Jobs / New Job form.
- [ ] Manual: stop simulator (no fix), repeat — same fields appear.
- [ ] Manual: empty Fields directory — list is empty, right side shows hint and status message.
- [ ] Manual: Field Operations → Create Field — "New Field" is the first button.