### PR TITLE
Locale correctness: stop persisted strings using current culture

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,63 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# Globalization / culture-correctness rules.
+#
+# CA1305 fires anywhere a culture-sensitive ToString / Parse / interpolated
+# string is used without an explicit IFormatProvider. We don't want it as
+# an error globally — `DateTime.Now.ToString("HH-mm")` for a UI label is
+# fine — but anything that lands on disk or on the wire MUST use
+# InvariantCulture. So scope the error severity to those paths.
+#
+# Default: CA1305 only. The other globalization rules
+# (CA1303 localization, CA1307/CA1310 string comparison, CA1308
+# upper/lower normalization) are stylistic for this project — silence
+# them so only the IFormatProvider rule shows up.
+[*.cs]
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1307.severity = none
+dotnet_diagnostic.CA1308.severity = none
+dotnet_diagnostic.CA1310.severity = none
+dotnet_diagnostic.CA1311.severity = none
+
+# Persistence & wire-format paths: a culture miss here is a real,
+# user-visible bug (see Field.txt fi-FI regression that prompted this).
+# Promote to error so the build breaks before the bug ships.
+[Shared/AgValoniaGPS.Services/Fields/**/*.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/NmeaParser*.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/NtripClientService.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/FieldPlaneFileService.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/AgShare/**/*.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/IsoXml/**/*.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/Tram/**/*.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Shared/AgValoniaGPS.Services/Pipeline/**/*.cs]
+dotnet_diagnostic.CA1305.severity = error
+[Simulators/**/Modules/*.cs]
+dotnet_diagnostic.CA1305.severity = error
+
+# UI views: bindings and codegen create lots of ToString calls; current
+# culture is correct for display. Silence the rule here.
+[Shared/AgValoniaGPS.Views/**/*.cs]
+dotnet_diagnostic.CA1305.severity = none
+[*.{xaml,axaml}]
+dotnet_diagnostic.CA1305.severity = none
+
+# Generated files: skip culture rules entirely.
+[**/{obj,bin}/**]
+generated_code = true
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1310.severity = none
+dotnet_diagnostic.CA1311.severity = none

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,30 @@ Only the cycle-worker failure mode is survivable: back-pressure drops the *next*
 - Adding a new service that reads GPS/position: take `*WorkingState` as a parameter, don't inject `ApplicationState`.
 - Avoid writing to `State.YouTurn`, `State.Guidance`, `State.Vehicle`, `State.Section` from anywhere except `ApplyGpsCycleResult`.
 
+## Persisted numeric / date strings
+
+Anything that lands on disk or on a wire (file I/O, NMEA / PGN packets,
+NTRIP HTTP, AgShare uploads, ISO-XML, UDP) **must** format and parse
+numbers and dates with `CultureInfo.InvariantCulture`. Without it,
+`(42.0308).ToString("F8")` produces `"42,03080000"` in fi-FI / sv-SE /
+de-DE / ..., which can break GPS NMEA parsing, PGN packet construction,
+saved field metadata, or any other code that round-trips strings
+between machines or processes.
+
+The `CA1305` analyzer (`Specify IFormatProvider`) fences this. It is
+enabled solution-wide as a **warning** for visibility, and promoted to
+**error** in the persistence- and wire-format-shaped paths via
+`.editorconfig` globs (`Services/Fields/`, `Services/AgShare/`,
+`Services/IsoXml/`, `Services/Tram/`, `Services/Pipeline/`,
+`Services/AutoSteer/PgnBuilder.cs`, `Services/NmeaParser*.cs`,
+`Services/NtripClientService.cs`, `Services/FieldPlaneFileService.cs`,
+`Simulators/**/Modules/`).
+
+If you add a new persistence sink, either drop it under one of those
+folders or extend the `.editorconfig` glob list. UI display code is
+free to use `CurrentCulture` (be explicit about it though — pin one
+or the other, never the implicit default).
+
 ## What Needs Doing
 
 Open work is tracked on the [AgValoniaGPS project board](https://github.com/orgs/AgOpenGPS-Official/projects/16). Pick a card, comment on the linked issue to claim it, and open your PR against `develop`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <!--
+    Repo-wide MSBuild defaults. Imported automatically by every .csproj
+    under this directory, ahead of the project's own settings.
+  -->
+
+  <PropertyGroup>
+    <!--
+      Activate the globalization analyzer category (CA1304/05/10/11)
+      across every project. AnalysisModeGlobalization=All is a category-
+      scoped override that flips the rules on without dragging in every
+      other CA category the way <AnalysisLevel> would. .editorconfig at
+      the repo root then sets CA1305 severity to error so any new
+      ToString / Parse / string.Format / $"…" without an IFormatProvider
+      breaks the build.
+
+      See CONTRIBUTING.md → "Persisted numeric/date strings" for the
+      "why" — comma-decimal locales (fi-FI etc.) silently corrupted
+      Field.txt on disk before this fence existed.
+    -->
+    <AnalysisModeGlobalization>All</AnalysisModeGlobalization>
+  </PropertyGroup>
+
+</Project>

--- a/Shared/AgValoniaGPS.Models/Field/NearbyField.cs
+++ b/Shared/AgValoniaGPS.Models/Field/NearbyField.cs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System.Globalization;
+
 namespace AgValoniaGPS.Models;
 
 /// <summary>
@@ -38,5 +40,7 @@ public sealed record NearbyField(
     /// <see cref="DistanceKm"/> is NaN so the operator isn't misled
     /// by a literal 0.0 that means "we don't know".</summary>
     public string DistanceKmDisplay =>
-        double.IsNaN(DistanceKm) ? "—" : DistanceKm.ToString("F1");
+        double.IsNaN(DistanceKm)
+            ? "—"
+            : DistanceKm.ToString("F1", CultureInfo.CurrentCulture);
 }

--- a/Shared/AgValoniaGPS.Models/Field/NearbyField.cs
+++ b/Shared/AgValoniaGPS.Models/Field/NearbyField.cs
@@ -23,11 +23,20 @@ namespace AgValoniaGPS.Models;
 /// <param name="Name">Folder name under <c>FieldsRoot</c>.</param>
 /// <param name="DirectoryPath">Absolute path to the field directory.</param>
 /// <param name="DistanceKm">Great-circle distance from the query
-/// coordinate to the field's origin, in kilometres.</param>
+/// coordinate to the field's origin, in kilometres. NaN when the
+/// distance is unknown (no GPS fix, or the field origin couldn't be
+/// read / is (0,0)).</param>
 /// <param name="BoundaryAreaHectares">Area enclosed by the outer
 /// boundary, or 0 if the field has no boundary on disk.</param>
 public sealed record NearbyField(
     string Name,
     string DirectoryPath,
     double DistanceKm,
-    double BoundaryAreaHectares);
+    double BoundaryAreaHectares)
+{
+    /// <summary>UI-friendly distance string. Renders "—" when
+    /// <see cref="DistanceKm"/> is NaN so the operator isn't misled
+    /// by a literal 0.0 that means "we don't know".</summary>
+    public string DistanceKmDisplay =>
+        double.IsNaN(DistanceKm) ? "—" : DistanceKm.ToString("F1");
+}

--- a/Shared/AgValoniaGPS.Services/AgShare/AgShareDownloaderService.cs
+++ b/Shared/AgValoniaGPS.Services/AgShare/AgShareDownloaderService.cs
@@ -180,7 +180,7 @@ namespace AgValoniaGPS.Services.AgShare
                 bool isHole = i != 0;
 
                 lines.Add(isHole ? "True" : "False");
-                lines.Add(ring.Count.ToString());
+                lines.Add(ring.Count.ToString(CultureInfo.InvariantCulture));
 
                 var enriched = BoundaryUtils.WithHeadings(ConvertToVec3List(ring));
 
@@ -233,7 +233,7 @@ namespace AgValoniaGPS.Services.AgShare
                 {
                     lines.Add("4"); // Curve mode
                     lines.Add("True");
-                    lines.Add(ab.CurvePoints!.Count.ToString());
+                    lines.Add(ab.CurvePoints!.Count.ToString(CultureInfo.InvariantCulture));
 
                     foreach (var pt in ab.CurvePoints)
                     {

--- a/Shared/AgValoniaGPS.Services/DebugDumpService.cs
+++ b/Shared/AgValoniaGPS.Services/DebugDumpService.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
@@ -43,7 +44,7 @@ public class DebugDumpService
         string filePrefix = "debug_dump",
         IReadOnlyList<string>? userAttachments = null)
     {
-        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
         var dumpDir = outputDirectory
             ?? Path.Combine(Path.GetTempPath(), "AgValoniaGPS", "dumps");
         Directory.CreateDirectory(dumpDir);
@@ -208,16 +209,20 @@ public class DebugDumpService
             .GetCustomAttribute<System.Reflection.AssemblyFileVersionAttribute>()
             ?.Version ?? "unknown";
 
-        sb.AppendLine($"App Version: {fileVersion}");
-        sb.AppendLine($"Build Info: {infoVersion}");
-        sb.AppendLine($"Timestamp: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
-        sb.AppendLine($"OS: {Environment.OSVersion}");
-        sb.AppendLine($"Runtime: {Environment.Version}");
-        sb.AppendLine($"64-bit OS: {Environment.Is64BitOperatingSystem}");
-        sb.AppendLine($"64-bit Process: {Environment.Is64BitProcess}");
-        sb.AppendLine($"Machine: {Environment.MachineName}");
-        sb.AppendLine($"Processors: {Environment.ProcessorCount}");
-        sb.AppendLine($"Working Set: {Environment.WorkingSet / 1024 / 1024}MB");
+        // Diagnostic dump is consumed by us / shared in bug reports —
+        // pin every interpolation to InvariantCulture so timestamps and
+        // numbers are unambiguous across reporters' locales.
+        var inv = CultureInfo.InvariantCulture;
+        sb.AppendLine(inv, $"App Version: {fileVersion}");
+        sb.AppendLine(inv, $"Build Info: {infoVersion}");
+        sb.AppendLine(inv, $"Timestamp: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine(inv, $"OS: {Environment.OSVersion}");
+        sb.AppendLine(inv, $"Runtime: {Environment.Version}");
+        sb.AppendLine(inv, $"64-bit OS: {Environment.Is64BitOperatingSystem}");
+        sb.AppendLine(inv, $"64-bit Process: {Environment.Is64BitProcess}");
+        sb.AppendLine(inv, $"Machine: {Environment.MachineName}");
+        sb.AppendLine(inv, $"Processors: {Environment.ProcessorCount}");
+        sb.AppendLine(inv, $"Working Set: {Environment.WorkingSet / 1024 / 1024}MB");
         return sb.ToString();
     }
 
@@ -313,7 +318,8 @@ public class DebugDumpService
         var entries = LogStore.Instance.GetSnapshot();
         foreach (var entry in entries)
         {
-            sb.AppendLine($"[{entry.Timestamp:HH:mm:ss.fff}] [{entry.Level}] {entry.Category}: {entry.Message}");
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"[{entry.Timestamp:HH:mm:ss.fff}] [{entry.Level}] {entry.Category}: {entry.Message}");
         }
         return sb.ToString();
     }

--- a/Shared/AgValoniaGPS.Services/FieldStatisticsService.cs
+++ b/Shared/AgValoniaGPS.Services/FieldStatisticsService.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Services.Interfaces;
 
@@ -257,13 +258,16 @@ public class FieldStatisticsService : IFieldStatisticsService
     /// </summary>
     public string FormatArea(double squareMeters, bool useMetric = true)
     {
+        // User-facing string -> CurrentCulture so 1234.56 ha renders as
+        // "1234,56 ha" / "1,234.56 ha" per the operator's locale.
+        var c = CultureInfo.CurrentCulture;
         if (useMetric)
         {
-            return (squareMeters / 10000.0).ToString("F2") + " ha";
+            return (squareMeters / 10000.0).ToString("F2", c) + " ha";
         }
         else
         {
-            return (squareMeters / 4046.86).ToString("F2") + " ac";
+            return (squareMeters / 4046.86).ToString("F2", c) + " ac";
         }
     }
 
@@ -272,13 +276,14 @@ public class FieldStatisticsService : IFieldStatisticsService
     /// </summary>
     public string FormatDistance(double meters, bool useMetric = true)
     {
+        var c = CultureInfo.CurrentCulture;
         if (useMetric)
         {
-            return meters.ToString("F1") + " m";
+            return meters.ToString("F1", c) + " m";
         }
         else
         {
-            return (meters * 3.28084).ToString("F1") + " ft";
+            return (meters * 3.28084).ToString("F1", c) + " ft";
         }
     }
 }

--- a/Shared/AgValoniaGPS.Services/IsoXml/IsoXmlParserHelpers.cs
+++ b/Shared/AgValoniaGPS.Services/IsoXml/IsoXmlParserHelpers.cs
@@ -268,7 +268,7 @@ namespace AgValoniaGPS.Services.IsoXml
                 Mode = IsoXmlTrackMode.Curve,
                 PtA = ptA,
                 PtB = ptB,
-                Name = string.IsNullOrWhiteSpace(name) ? "Curve_" + DateTime.Now.ToString("HHmmss") : name
+                Name = string.IsNullOrWhiteSpace(name) ? "Curve_" + DateTime.Now.ToString("HHmmss", CultureInfo.InvariantCulture) : name
             };
 
             // Copy processed curve points and calculate headings

--- a/Shared/AgValoniaGPS.Services/NtripClientService.cs
+++ b/Shared/AgValoniaGPS.Services/NtripClientService.cs
@@ -220,12 +220,14 @@ public class NtripClientService : INtripClientService, IDisposable
         var credentials = Convert.ToBase64String(
             Encoding.ASCII.GetBytes($"{_config.Username}:{_config.Password}"));
 
-        // Build request string manually with explicit \r\n to ensure correct formatting
+        // Build request string manually with explicit \r\n to ensure correct formatting.
+        // NTRIP protocol is invariant — interpolations must not pick up locale formatting.
+        var inv = CultureInfo.InvariantCulture;
         var request = new StringBuilder();
-        request.Append($"GET /{_config.MountPoint} HTTP/1.1\r\n");
-        request.Append($"Host: {_config.CasterAddress}\r\n");
+        request.Append(inv, $"GET /{_config.MountPoint} HTTP/1.1\r\n");
+        request.Append(inv, $"Host: {_config.CasterAddress}\r\n");
         request.Append("User-Agent: NTRIP AgValoniaGPS/1.0\r\n");
-        request.Append($"Authorization: Basic {credentials}\r\n");
+        request.Append(inv, $"Authorization: Basic {credentials}\r\n");
         request.Append("Accept: */*\r\n");
         request.Append("Connection: keep-alive\r\n");
         request.Append("\r\n");

--- a/Shared/AgValoniaGPS.Services/Track/TrackGuidanceServiceTests.cs
+++ b/Shared/AgValoniaGPS.Services/Track/TrackGuidanceServiceTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using AgValoniaGPS.Models.Base;
 using AgValoniaGPS.Models.Track;
 
@@ -41,14 +42,14 @@ public static class TrackGuidanceServiceTests
         try
         {
             var (passed, msg) = TestABLinePurePursuit();
-            results.AppendLine($"Test 1 - AB Line Pure Pursuit: {(passed ? "PASS" : "FAIL")}");
-            results.AppendLine($"  {msg}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 1 - AB Line Pure Pursuit: {(passed ? "PASS" : "FAIL")}");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {msg}\n");
             allPassed &= passed;
         }
         catch (Exception ex)
         {
-            results.AppendLine($"Test 1 - AB Line Pure Pursuit: FAIL (Exception)");
-            results.AppendLine($"  {ex.Message}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 1 - AB Line Pure Pursuit: FAIL (Exception)");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {ex.Message}\n");
             allPassed = false;
         }
 
@@ -56,14 +57,14 @@ public static class TrackGuidanceServiceTests
         try
         {
             var (passed, msg) = TestCurvePurePursuit();
-            results.AppendLine($"Test 2 - Curve Pure Pursuit: {(passed ? "PASS" : "FAIL")}");
-            results.AppendLine($"  {msg}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 2 - Curve Pure Pursuit: {(passed ? "PASS" : "FAIL")}");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {msg}\n");
             allPassed &= passed;
         }
         catch (Exception ex)
         {
-            results.AppendLine($"Test 2 - Curve Pure Pursuit: FAIL (Exception)");
-            results.AppendLine($"  {ex.Message}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 2 - Curve Pure Pursuit: FAIL (Exception)");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {ex.Message}\n");
             allPassed = false;
         }
 
@@ -71,14 +72,14 @@ public static class TrackGuidanceServiceTests
         try
         {
             var (passed, msg) = TestABLineStanley();
-            results.AppendLine($"Test 3 - AB Line Stanley: {(passed ? "PASS" : "FAIL")}");
-            results.AppendLine($"  {msg}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 3 - AB Line Stanley: {(passed ? "PASS" : "FAIL")}");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {msg}\n");
             allPassed &= passed;
         }
         catch (Exception ex)
         {
-            results.AppendLine($"Test 3 - AB Line Stanley: FAIL (Exception)");
-            results.AppendLine($"  {ex.Message}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 3 - AB Line Stanley: FAIL (Exception)");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {ex.Message}\n");
             allPassed = false;
         }
 
@@ -86,14 +87,14 @@ public static class TrackGuidanceServiceTests
         try
         {
             var (passed, msg) = TestVehicleOnLine();
-            results.AppendLine($"Test 4 - Vehicle On Line: {(passed ? "PASS" : "FAIL")}");
-            results.AppendLine($"  {msg}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 4 - Vehicle On Line: {(passed ? "PASS" : "FAIL")}");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {msg}\n");
             allPassed &= passed;
         }
         catch (Exception ex)
         {
-            results.AppendLine($"Test 4 - Vehicle On Line: FAIL (Exception)");
-            results.AppendLine($"  {ex.Message}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 4 - Vehicle On Line: FAIL (Exception)");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {ex.Message}\n");
             allPassed = false;
         }
 
@@ -101,18 +102,18 @@ public static class TrackGuidanceServiceTests
         try
         {
             var (passed, msg) = TestTrackProperties();
-            results.AppendLine($"Test 5 - Track Properties: {(passed ? "PASS" : "FAIL")}");
-            results.AppendLine($"  {msg}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 5 - Track Properties: {(passed ? "PASS" : "FAIL")}");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {msg}\n");
             allPassed &= passed;
         }
         catch (Exception ex)
         {
-            results.AppendLine($"Test 5 - Track Properties: FAIL (Exception)");
-            results.AppendLine($"  {ex.Message}\n");
+            results.AppendLine(CultureInfo.InvariantCulture, $"Test 5 - Track Properties: FAIL (Exception)");
+            results.AppendLine(CultureInfo.InvariantCulture, $"  {ex.Message}\n");
             allPassed = false;
         }
 
-        results.AppendLine($"=== Overall: {(allPassed ? "ALL TESTS PASSED" : "SOME TESTS FAILED")} ===");
+        results.AppendLine(CultureInfo.InvariantCulture, $"=== Overall: {(allPassed ? "ALL TESTS PASSED" : "SOME TESTS FAILED")} ===");
 
         return (allPassed, results.ToString());
     }

--- a/Shared/AgValoniaGPS.Services/Tram/TramLineService.cs
+++ b/Shared/AgValoniaGPS.Services/Tram/TramLineService.cs
@@ -710,23 +710,23 @@ public class TramLineService(
             {
                 if (line.StartsWith("$OuterTrack,"))
                 {
-                    int count = int.Parse(line.Split(',')[1]);
+                    int count = int.Parse(line.Split(',')[1], CultureInfo.InvariantCulture);
                     ReadPoints(reader, _outerBoundaryTrack, count);
                 }
                 else if (line.StartsWith("$InnerTrack,"))
                 {
-                    int count = int.Parse(line.Split(',')[1]);
+                    int count = int.Parse(line.Split(',')[1], CultureInfo.InvariantCulture);
                     ReadPoints(reader, _innerBoundaryTrack, count);
                 }
                 else if (line.StartsWith("$TramLines,"))
                 {
-                    int lineCount = int.Parse(line.Split(',')[1]);
+                    int lineCount = int.Parse(line.Split(',')[1], CultureInfo.InvariantCulture);
                     for (int i = 0; i < lineCount; i++)
                     {
                         line = reader.ReadLine();
                         if (line != null && line.StartsWith("$Line,"))
                         {
-                            int pointCount = int.Parse(line.Split(',')[1]);
+                            int pointCount = int.Parse(line.Split(',')[1], CultureInfo.InvariantCulture);
                             var tramLine = new List<Vec2>();
                             ReadPoints(reader, tramLine, pointCount);
                             if (tramLine.Count > 0)

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -223,19 +224,30 @@ public partial class MainViewModel
             {
                 Directory.CreateDirectory(fieldPath);
 
+                // Lat/lon must be written with InvariantCulture (period
+                // decimal). FieldPlaneFileService.LoadField parses with
+                // InvariantCulture; using current culture here would write
+                // "42,03" in locales like fi-FI, the parser would silently
+                // reject it, the field would end up with origin (0,0), and
+                // FindFieldsNear would drop it from "near me" results.
+                var inv = CultureInfo.InvariantCulture;
+                var latStr = NewFieldLatitude.ToString("F8", inv);
+                var lonStr = NewFieldLongitude.ToString("F8", inv);
+
                 var originFile = Path.Combine(fieldPath, "field.origin");
-                File.WriteAllText(originFile, $"{NewFieldLatitude:F8},{NewFieldLongitude:F8}");
+                File.WriteAllText(originFile, $"{latStr},{lonStr}");
 
                 var fieldTxtPath = Path.Combine(fieldPath, "Field.txt");
-                var fieldTxtContent = $"{DateTime.Now:yyyy-MMM-dd hh:mm:ss tt}\n" +
-                                      "$FieldDir\n" +
-                                      $"{NewFieldName}\n" +
-                                      "$Offsets\n" +
-                                      "0,0\n" +
-                                      "Convergence\n" +
-                                      "0\n" +
-                                      "StartFix\n" +
-                                      $"{NewFieldLatitude:F8},{NewFieldLongitude:F8}\n";
+                var fieldTxtContent =
+                    $"{DateTime.Now.ToString("yyyy-MMM-dd hh:mm:ss tt", inv)}\n" +
+                    "$FieldDir\n" +
+                    $"{NewFieldName}\n" +
+                    "$Offsets\n" +
+                    "0,0\n" +
+                    "Convergence\n" +
+                    "0\n" +
+                    "StartFix\n" +
+                    $"{latStr},{lonStr}\n";
                 File.WriteAllText(fieldTxtPath, fieldTxtContent);
 
                 CurrentFieldName = NewFieldName;

--- a/Shared/AgValoniaGPS.ViewModels/StartWorkSessionDialogViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/StartWorkSessionDialogViewModel.cs
@@ -166,10 +166,13 @@ public partial class StartWorkSessionDialogViewModel : ObservableObject
             else
             {
                 var dir = System.IO.Path.Combine(root, name);
+                // NaN, not 0, so the UI renders "—" instead of an
+                // alarmingly precise "0.0 km" for fields whose origin
+                // couldn't be read or is (0,0).
                 rows.Add(new NearbyField(
                     Name: name,
                     DirectoryPath: dir,
-                    DistanceKm: 0,
+                    DistanceKm: double.NaN,
                     BoundaryAreaHectares: 0));
             }
         }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
@@ -129,7 +129,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                FontSize="13"/>
                                     <TextBlock Grid.Column="1"
-                                               Text="{Binding DistanceKm, StringFormat='{}{0:F1}'}"
+                                               Text="{Binding DistanceKmDisplay}"
                                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
                                                FontSize="13" TextAlignment="Right"/>
                                     <TextBlock Grid.Column="2"

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualGpsReceiver.cs
@@ -149,7 +149,7 @@ public class VirtualGpsReceiver : IDisposable
             checksum ^= (byte)c;
 
         sb.Append('*');
-        sb.Append(checksum.ToString("X2"));
+        sb.Append(checksum.ToString("X2", CultureInfo.InvariantCulture));
         sb.Append("\r\n");
 
         return sb.ToString();

--- a/Tests/AgValoniaGPS.UI.Tests/StartWorkSessionDialogTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/StartWorkSessionDialogTests.cs
@@ -69,6 +69,12 @@ public class StartWorkSessionDialogTests
             Is.EqualTo(new[] { "Nearby", "FarAway", "Aaa", "Zzz" }),
             "Known-distance rows first (by distance), then unknown rows alphabetically.");
         Assert.That(vm.StatusMessage, Is.Null);
+
+        // Unknown-distance rows must NOT render as "0.0" — that misleads
+        // the operator into thinking the field is at their location.
+        var aaa = vm.Fields.First(f => f.Name == "Aaa");
+        Assert.That(double.IsNaN(aaa.DistanceKm), Is.True);
+        Assert.That(aaa.DistanceKmDisplay, Is.EqualTo("—"));
     }
 
     [Test]


### PR DESCRIPTION
- **Bug fix.** `ConfirmNewFieldDialogCommand` wrote `field.origin` and `Field.txt`'s `StartFix` line through interpolated strings (`\$"…{lat:F8}…"`) without an explicit culture. In locales with comma decimals (fi-FI, sv-SE, de-DE, …) the file was written as e.g. `"42,03080000"`. `FieldPlaneFileService.LoadField` parses with `InvariantCulture` only, silently rejected the line, and the field's `Origin` stayed `(0,0)`. `FindFieldsNear` then filtered the field out of "near me" results so the Start Work Session dialog showed `—` for distance and the GPS-far-from-field warning popped on opening with thousands of km. Fixed by formatting through `CultureInfo.InvariantCulture` to match the canonical writer at `FieldPlaneFileService.cs:158-159`.
- **Audit pass.** Pin `IFormatProvider` on culture-sensitive `ToString` / `Parse` / `StringBuilder.Append\$"…"` calls in: AgShare downloader (boundary / track .txt writers), IsoXml parser, NTRIP HTTP request builder, TramLineService legacy text loader, VirtualGpsReceiver PANDA checksum, the `TrackGuidanceServiceTests` diagnostic harness, and `DebugDumpService`. UI display methods (`NearbyField.DistanceKmDisplay`, `FieldStatisticsService.FormatArea` / `FormatDistance`) now pin to `CurrentCulture` explicitly so the choice is visible at the call site.
- **Analyzer fence.** Add `Directory.Build.props` with `AnalysisModeGlobalization=All`, configure `.editorconfig` to set `CA1305` severity to `error` only in persistence- and wire-format-shaped paths (`Services/Fields/`, `Services/AgShare/`, `Services/IsoXml/`, `Services/Tram/`, `Services/Pipeline/`, `Services/AutoSteer/PgnBuilder.cs`, `Services/NmeaParser*.cs`, `Services/NtripClientService.cs`, `Services/FieldPlaneFileService.cs`, `Simulators/**/Modules/`). Default scope = `warning` for visibility; Views silenced (display code is fine with `CurrentCulture`); the other globalization rules (`CA1303` localization, `CA1307/10` string comparison, `CA1308` case normalization) silenced as stylistic.
- **Docs.** New \"Persisted numeric / date strings\" section in `CONTRIBUTING.md` documents the policy and lists the error-scope folders.

Bundles a small foundation commit ("Render unknown distance as '—' in Start Work Session list") that adds the `DistanceKmDisplay` computed property the audit pass annotates — it's the substrate the locale fix on `NearbyField` builds on.

## Test plan
- [x] `dotnet test Tests/AgValoniaGPS.UI.Tests/` — 129 pass.
- [x] `dotnet test Tests/AgValoniaGPS.Models.Tests/` — 104 pass.
- [x] Per-project build clean (0 errors, only stylistic warnings).
- [ ] Manual: with locale set to fi-FI / sv-SE / de-DE, create a new field via Field Operations → Create Field → New Field. Close, reopen Start Session — the new field shows up with a real distance (not `—`) and opens without the GPS-far-from-field popup.
- [ ] Manual: re-export an existing field via AgShare upload; track and boundary `.txt` files inside the package have `InvariantCulture`-formatted point counts.