### PR TITLE
Start Work Session dialog: width on long names + far-from-field button text

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.OriginGuard.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.OriginGuard.cs
@@ -29,7 +29,7 @@ public partial class MainViewModel
             "GPS far from field",
             $"GPS reports a position {km:F1} km from the loaded field origin. " +
             "Autosteer has been disabled.\n\n" +
-            "Choose Confirm to close the field, or Cancel to keep driving without guidance.",
+            "Tap Yes to close the field, or No to keep driving without guidance.",
             () => _ = CloseFieldAsync());
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
@@ -127,7 +127,8 @@ Licensed under GNU GPL v3. See LICENSE.md.
                                 <Grid ColumnDefinitions="*,80,80">
                                     <TextBlock Grid.Column="0" Text="{Binding Name}"
                                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                               FontSize="13"/>
+                                               FontSize="13"
+                                               TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="1"
                                                Text="{Binding DistanceKmDisplay}"
                                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
@@ -147,7 +148,8 @@ Licensed under GNU GPL v3. See LICENSE.md.
                       RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                       IsVisible="{Binding SelectedField, Converter={x:Static ObjectConverters.IsNotNull}}">
                     <TextBlock Grid.Row="0" Classes="Header"
-                               Text="{Binding SelectedField.Name}"/>
+                               Text="{Binding SelectedField.Name}"
+                               TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
                     <TextBlock Grid.Row="1" Classes="SubHeader"
                                Text="{Binding SelectedField.BoundaryAreaHectares, StringFormat='Area: {0:F1} ha'}"/>
 


### PR DESCRIPTION
- **Long field names no longer widen the dialog.** The right-column header (`SelectedField.Name`) had no `TextWrapping` or `TextTrimming`, so a long name pushed the dialog out to its `MaxWidth=960`. Add `TextWrapping=Wrap` and `TextTrimming=CharacterEllipsis` on the header, and `TextTrimming=CharacterEllipsis` on the left-list `Name` column. Long names now wrap or ellipsize instead of resizing the dialog.
- **GPS-far-from-field popup text matches its buttons.** The localized confirmation dialog renders **Yes** / **No** buttons, but the message text said *"Choose Confirm to close the field, or Cancel to keep driving"*. Update the message in `MainViewModel.OriginGuard.cs` to refer to **Yes** / **No** instead.

## Test plan
- [ ] Manual: open Start Session, pick a field with a long name. Dialog stays at its normal width; the name wraps or truncates with ellipsis.
- [ ] Manual: open a field whose origin is far from the current GPS position. The far-from-field popup text says *"Tap Yes to close the field, or No to keep driving without guidance"*.