### PR TITLE
Bug-report dump at press; preserve drawn boundary; tractor on map dialog

### DIFF
--- a/Shared/AgValoniaGPS.Services/DebugDumpService.cs
+++ b/Shared/AgValoniaGPS.Services/DebugDumpService.cs
@@ -196,6 +196,72 @@ public class DebugDumpService
         return zipPath;
     }
 
+    /// <summary>
+    /// Append user-supplied notes and attachments to an existing dump zip,
+    /// then move it to its final location with a title-based filename.
+    /// Used by the Bug Report flow so the state-snapshot zip can be created
+    /// the moment the operator presses the Bug Report button (capturing app
+    /// state at the time the bug occurred), and only the user-visible parts
+    /// are appended after they finish typing in the dialog.
+    /// </summary>
+    /// <param name="sourceZipPath">Path to the existing dump zip (typically
+    /// from <see cref="CreateDump"/> with no notes/attachments). Deleted on
+    /// success; left in place if any step throws.</param>
+    /// <param name="outputDirectory">Final destination folder. Created if
+    /// missing.</param>
+    /// <param name="filePrefix">Final file's prefix; the timestamp suffix
+    /// is added here, not taken from the source zip's name.</param>
+    /// <param name="notes">Optional user-typed notes (becomes
+    /// <c>user_notes.txt</c> inside the zip).</param>
+    /// <param name="userAttachments">Optional list of file paths to attach
+    /// under <c>attachments/</c> inside the zip.</param>
+    /// <returns>The final zip path.</returns>
+    public static string FinalizeBugReport(
+        string sourceZipPath,
+        string outputDirectory,
+        string filePrefix,
+        string? notes,
+        IReadOnlyList<string>? userAttachments)
+    {
+        Directory.CreateDirectory(outputDirectory);
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+        var finalPath = Path.Combine(outputDirectory, $"{filePrefix}_{timestamp}.zip");
+
+        File.Copy(sourceZipPath, finalPath, overwrite: false);
+
+        using (var zipStream = File.Open(finalPath, FileMode.Open, FileAccess.ReadWrite))
+        using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Update))
+        {
+            if (!string.IsNullOrEmpty(notes))
+                AddTextEntry(archive, "user_notes.txt", notes);
+
+            if (userAttachments != null)
+            {
+                foreach (var filePath in userAttachments)
+                {
+                    try
+                    {
+                        if (File.Exists(filePath))
+                        {
+                            var fileName = Path.GetFileName(filePath);
+                            var entry = archive.CreateEntry($"attachments/{fileName}");
+                            using var entryStream = entry.Open();
+                            using var fileStream = File.OpenRead(filePath);
+                            fileStream.CopyTo(entryStream);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        AddTextEntry(archive, $"attachments/{Path.GetFileName(filePath)}_error.txt", ex.ToString());
+                    }
+                }
+            }
+        }
+
+        try { File.Delete(sourceZipPath); } catch { /* best-effort temp cleanup */ }
+        return finalPath;
+    }
+
     private static string BuildSystemInfo()
     {
         var sb = new StringBuilder();

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -199,7 +199,11 @@ public partial class MainViewModel
         // Bug Report Dialog (#249)
         ShowBugReportDialogCommand = new RelayCommand(() =>
         {
-            // Capture screenshot BEFORE dialog opens (so it shows the actual state)
+            // Capture screenshot AND the full state-snapshot zip the moment
+            // the button is pressed, so the dump reflects app state when the
+            // bug occurred — not whatever state the operator drifts into
+            // while typing the title and description. Notes + user
+            // attachments get appended to the captured zip on submit.
             _bugReportScreenshot = null;
             try { _bugReportScreenshot = ScreenshotProvider?.Invoke(); }
             catch { /* screenshot is optional */ }
@@ -207,6 +211,19 @@ public partial class MainViewModel
             BugReportTitle = string.Empty;
             BugReportDescription = string.Empty;
             BugReportAttachments.Clear();
+
+            _bugReportTempZipPath = null;
+            try
+            {
+                _bugReportTempZipPath = Services.DebugDumpService.CreateDump(
+                    _settingsService, _appState, screenshotPng: _bugReportScreenshot);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Bug report state-snapshot capture failed");
+                StatusMessage = $"Bug report capture failed: {ex.Message}";
+            }
+
             State.UI.ShowDialog(Models.State.DialogType.BugReport);
         });
 
@@ -214,6 +231,14 @@ public partial class MainViewModel
         {
             _bugReportScreenshot = null;
             BugReportAttachments.Clear();
+
+            // User cancelled — drop the captured snapshot zip.
+            if (_bugReportTempZipPath != null)
+            {
+                try { File.Delete(_bugReportTempZipPath); } catch { }
+                _bugReportTempZipPath = null;
+            }
+
             State.UI.CloseDialog();
         });
 
@@ -256,14 +281,32 @@ public partial class MainViewModel
                     ? BugReportDescription
                     : $"# {BugReportTitle}\n\n{BugReportDescription}";
 
-                var zipPath = Services.DebugDumpService.CreateDump(
-                    _settingsService,
-                    _appState,
-                    additionalNotes: notes,
-                    screenshotPng: _bugReportScreenshot,
-                    outputDirectory: bugReportsDir,
-                    filePrefix: $"bugreport_{titleSlug}",
-                    userAttachments: attachmentPaths);
+                string zipPath;
+                if (_bugReportTempZipPath != null && File.Exists(_bugReportTempZipPath))
+                {
+                    // Snapshot already exists from button-press; just append
+                    // the user's title/description/attachments and rename.
+                    zipPath = Services.DebugDumpService.FinalizeBugReport(
+                        sourceZipPath: _bugReportTempZipPath,
+                        outputDirectory: bugReportsDir,
+                        filePrefix: $"bugreport_{titleSlug}",
+                        notes: notes,
+                        userAttachments: attachmentPaths);
+                    _bugReportTempZipPath = null;
+                }
+                else
+                {
+                    // Fallback: snapshot capture failed at button-press; do
+                    // everything in one shot now.
+                    zipPath = Services.DebugDumpService.CreateDump(
+                        _settingsService,
+                        _appState,
+                        additionalNotes: notes,
+                        screenshotPng: _bugReportScreenshot,
+                        outputDirectory: bugReportsDir,
+                        filePrefix: $"bugreport_{titleSlug}",
+                        userAttachments: attachmentPaths);
+                }
 
                 _bugReportScreenshot = null;
                 BugReportAttachments.Clear();
@@ -321,6 +364,9 @@ public partial class MainViewModel
     public ICommand? RemoveBugReportAttachmentCommand { get; private set; }
 
     private byte[]? _bugReportScreenshot;
+    // Path to the dump zip captured the moment the user pressed the Bug
+    // Report button. Cleared on submit or dialog cancel.
+    private string? _bugReportTempZipPath;
 
     private string _bugReportTitle = string.Empty;
     public string BugReportTitle

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3724,6 +3724,14 @@ public partial class MainViewModel : ObservableObject
         _mapService.SetBoundary(boundary);
         CurrentBoundary = boundary;
 
+        // Keep the in-memory Field model's boundary in sync. Without this,
+        // ActiveField.Boundary remains whatever LoadField returned at open
+        // time (usually the empty placeholder for a freshly-created field),
+        // and CloseFieldAsync → FieldService.SaveField → SaveBoundary
+        // overwrites the user's drawing on disk with "$Boundary\n".
+        if (ActiveField != null)
+            ActiveField.Boundary = boundary;
+
         // Set HasBoundary based on whether we have a valid outer boundary
         HasBoundary = boundary?.OuterBoundary != null && boundary.OuterBoundary.IsValid;
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -47,6 +48,9 @@ public partial class BoundaryMapDialogPanel : UserControl
     private WritableLayer? _pointsLayer;
     private WritableLayer? _polygonLayer;
     private WritableLayer? _existingBoundaryLayer;
+    private WritableLayer? _tractorLayer;
+    private GeometryFeature? _tractorFeature;
+    private AgValoniaGPS.ViewModels.MainViewModel? _trackedVm;
     private bool _isDrawingMode;
     private bool _mapInitialized;
     private readonly List<(double Lat, double Lon)> _boundaryPoints = new();
@@ -61,14 +65,22 @@ public partial class BoundaryMapDialogPanel : UserControl
 
     private void OnPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
     {
-        if (e.Property.Name == nameof(IsVisible) && IsVisible)
+        if (e.Property.Name == nameof(IsVisible))
         {
-            if (!_mapInitialized)
+            if (IsVisible)
             {
-                SetupMap();
-                _mapInitialized = true;
+                if (!_mapInitialized)
+                {
+                    SetupMap();
+                    _mapInitialized = true;
+                }
+                UpdateExistingBoundaryLayer();
+                AttachTractorTracking();
             }
-            UpdateExistingBoundaryLayer();
+            else
+            {
+                DetachTractorTracking();
+            }
         }
     }
 
@@ -119,6 +131,21 @@ public partial class BoundaryMapDialogPanel : UserControl
         };
         map.Layers.Add(_pointsLayer);
 
+        // Tractor position marker — green dot, on top so it stays visible
+        // over the boundary the user is drawing.
+        _tractorLayer = new WritableLayer
+        {
+            Name = "Tractor",
+            Style = new SymbolStyle
+            {
+                SymbolType = SymbolType.Ellipse,
+                Fill = new Mapsui.Styles.Brush(new Mapsui.Styles.Color(46, 204, 113, 255)),  // green
+                Outline = new Mapsui.Styles.Pen(new Mapsui.Styles.Color(255, 255, 255, 255), 2),
+                SymbolScale = 0.6
+            }
+        };
+        map.Layers.Add(_tractorLayer);
+
         // Get initial position from ViewModel
         double lat = 39.8283; // Default to US center
         double lon = -98.5795;
@@ -154,6 +181,73 @@ public partial class BoundaryMapDialogPanel : UserControl
 
         // Handle pointer movement for coordinate display
         MapControl.PointerMoved += OnPointerMoved;
+    }
+
+    /// <summary>
+    /// Subscribe to the VM's GPS PropertyChanged so the tractor marker
+    /// follows live position while the dialog is open. Idempotent.
+    /// </summary>
+    private void AttachTractorTracking()
+    {
+        if (DataContext is not AgValoniaGPS.ViewModels.MainViewModel vm) return;
+        if (ReferenceEquals(_trackedVm, vm)) return;
+
+        DetachTractorTracking();
+        _trackedVm = vm;
+        _trackedVm.PropertyChanged += OnVmPropertyChanged;
+        UpdateTractorMarker(); // initial render
+    }
+
+    private void DetachTractorTracking()
+    {
+        if (_trackedVm != null)
+        {
+            _trackedVm.PropertyChanged -= OnVmPropertyChanged;
+            _trackedVm = null;
+        }
+    }
+
+    private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(AgValoniaGPS.ViewModels.MainViewModel.Latitude)
+                           or nameof(AgValoniaGPS.ViewModels.MainViewModel.Longitude))
+        {
+            // Hop to UI thread; PropertyChanged from the GPS pipeline can
+            // arrive on a worker thread depending on dispatcher state.
+            if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+                UpdateTractorMarker();
+            else
+                Avalonia.Threading.Dispatcher.UIThread.Post(UpdateTractorMarker);
+        }
+    }
+
+    private void UpdateTractorMarker()
+    {
+        if (_tractorLayer == null || _trackedVm == null || MapControl?.Map == null)
+            return;
+
+        double lat = _trackedVm.Latitude;
+        double lon = _trackedVm.Longitude;
+        if (lat == 0 && lon == 0)
+        {
+            // No fix — hide the marker rather than render at (0,0).
+            _tractorLayer.Clear();
+            _tractorFeature = null;
+            _tractorLayer.DataHasChanged();
+            return;
+        }
+
+        var merc = SphericalMercator.FromLonLat(lon, lat);
+        if (_tractorFeature == null)
+        {
+            _tractorFeature = new GeometryFeature(new NtsPoint(merc.x, merc.y));
+            _tractorLayer.Add(_tractorFeature);
+        }
+        else
+        {
+            _tractorFeature.Geometry = new NtsPoint(merc.x, merc.y);
+        }
+        _tractorLayer.DataHasChanged();
     }
 
     /// <summary>


### PR DESCRIPTION
- **Bug-report dump captures app state at button press, not at submit.** Previously the dialog opened, the user typed a title and description, and only on submit did `DebugDumpService.CreateDump` run — so logs / runtime snapshot / settings reflected post-typing state, not the moment the bug happened. Move the snapshot zip's creation into `ShowBugReportDialogCommand` alongside the screenshot capture, then `FinalizeBugReport` appends the title-derived notes and user attachments to the pre-built zip on submit. Cancel paths delete the captured zip.
- **Drawn boundary survives field close.** When the user drew a boundary via the BoundaryMap map tool, `ConfirmBoundaryMapDialogCommand` wrote it to `Boundary.txt` and updated the VM's `CurrentBoundary`, but `ActiveField.Boundary` kept pointing at the empty placeholder loaded at field-open time. On close, `FieldService.SaveField` saw that empty Boundary, called `SaveBoundary`, and overwrote the user's polygon with `"\$Boundary\n"` — losing the work. Sync `ActiveField.Boundary` inside `SetCurrentBoundary` so the close-save uses the up-to-date boundary.
- **Tractor visible on the boundary-map drawing dialog.** Add a green-dot WritableLayer to `BoundaryMapDialogPanel`'s Mapsui map and subscribe to `MainViewModel.Latitude` / `Longitude` changes while the dialog is visible. Marker hides at exact `(0, 0)` (no fix) instead of rendering in the gulf of guinea.

## Test plan
- [x] `dotnet test Tests/AgValoniaGPS.UI.Tests/` — 129 pass.
- [x] Per-project build clean (0 errors).
- [ ] Manual: open a field, draw a boundary on the map tool, save. Close the field (or close the app). Reopen — boundary is still there.
- [ ] Manual: open the boundary-map dialog while the simulator is running. Green dot appears at the simulator's current position and follows it as the simulator moves.
- [ ] Manual: open the bug-report dialog; while it's open, drive in the simulator for a few seconds; submit the report. The `logs.txt` and `gps_data_log.csv` inside the resulting zip reflect state from BEFORE the user typed the description, not after.