### PR TITLE
Display: opt-in moveable ground texture toggle

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -37,6 +37,7 @@ namespace AgValoniaGPS.Models
         public bool ExtraGuidelines { get; set; } = false;
         public int ExtraGuidelinesCount { get; set; } = 10;
         public bool FieldTextureVisible { get; set; } = true;
+        public bool FieldTextureMoveable { get; set; } = false;
         public bool AutoSteerSound { get; set; } = true;
         public bool UTurnSound { get; set; } = true;
         public bool HydraulicSound { get; set; } = true;

--- a/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
@@ -227,6 +227,19 @@ public class DisplayConfig : ObservableObject
         set => SetProperty(ref _fieldTextureVisible, value);
     }
 
+    private bool _fieldTextureMoveable;
+    /// <summary>
+    /// When true, the ground texture is rendered as world-tiled bitmaps
+    /// so it visibly scrolls under the tractor as the camera pans. When
+    /// false (default), the texture is rendered as a single stretched
+    /// bitmap centered on the camera — FPS-stable but visually static.
+    /// </summary>
+    public bool FieldTextureMoveable
+    {
+        get => _fieldTextureMoveable;
+        set => SetProperty(ref _fieldTextureMoveable, value);
+    }
+
     private bool _extraGuidelines;
     public bool ExtraGuidelines
     {

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -321,6 +321,7 @@ public class ConfigurationService(
         store.Display.ExtraGuidelines = settings.ExtraGuidelines;
         store.Display.ExtraGuidelinesCount = settings.ExtraGuidelinesCount;
         store.Display.FieldTextureVisible = settings.FieldTextureVisible;
+        store.Display.FieldTextureMoveable = settings.FieldTextureMoveable;
         store.Display.AutoSteerSound = settings.AutoSteerSound;
         store.Display.UTurnSound = settings.UTurnSound;
         store.Display.HydraulicSound = settings.HydraulicSound;
@@ -386,6 +387,7 @@ public class ConfigurationService(
         settings.ExtraGuidelines = store.Display.ExtraGuidelines;
         settings.ExtraGuidelinesCount = store.Display.ExtraGuidelinesCount;
         settings.FieldTextureVisible = store.Display.FieldTextureVisible;
+        settings.FieldTextureMoveable = store.Display.FieldTextureMoveable;
         settings.AutoSteerSound = store.Display.AutoSteerSound;
         settings.UTurnSound = store.Display.UTurnSound;
         settings.HydraulicSound = store.Display.HydraulicSound;

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -912,6 +912,7 @@ public partial class ConfigurationViewModel : ObservableObject
     public event Action<bool>? FullscreenChanged;
     public ICommand ToggleElevationLogCommand { get; private set; } = null!;
     public ICommand ToggleFieldTextureCommand { get; private set; } = null!;
+    public ICommand ToggleFieldTextureMoveableCommand { get; private set; } = null!;
     public ICommand ToggleGridCommand { get; private set; } = null!;
     public ICommand ToggleExtraGuidelinesCommand { get; private set; } = null!;
     public ICommand EditExtraGuidelinesCountCommand { get; private set; } = null!;
@@ -1543,6 +1544,12 @@ public partial class ConfigurationViewModel : ObservableObject
         ToggleFieldTextureCommand = new RelayCommand(() =>
         {
             Display.FieldTextureVisible = !Display.FieldTextureVisible;
+            Config.MarkChanged();
+        });
+
+        ToggleFieldTextureMoveableCommand = new RelayCommand(() =>
+        {
+            Display.FieldTextureMoveable = !Display.FieldTextureMoveable;
             Config.MarkChanged();
         });
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -221,17 +221,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="Smoothing" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
-                        <!-- Hidden: bitmap coverage system does not populate geometry cache (#117) -->
-                        <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center"
-                                    IsVisible="False">
+                        <!-- Opt-in: tile the ground texture in world coordinates so it
+                             visibly scrolls under the tractor. Default off keeps the
+                             FPS-stable stretched-bitmap path used historically. -->
+                        <StackPanel Grid.Row="3" Grid.Column="1" Spacing="4" HorizontalAlignment="Center">
                             <Button Classes="DisplayToggle"
-                                    Background="{Binding Display.DirectionMarkersVisible, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
-                                    BorderBrush="{Binding Display.DirectionMarkersVisible, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
-                                    Command="{Binding ToggleDirectionMarkersCommand}">
-                                <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_DirectionMarker.png"
+                                    Background="{Binding Display.FieldTextureMoveable, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"
+                                    BorderBrush="{Binding Display.FieldTextureMoveable, Converter={x:Static conv:BoolToToggleBorderConverter.Instance}}"
+                                    Command="{Binding ToggleFieldTextureMoveableCommand}">
+                                <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/ConD_FloorTexture.png"
                                        Width="60" Height="60" Stretch="Uniform"/>
                             </Button>
-                            <TextBlock Text="Direction" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
+                            <TextBlock Text="Texture Moves" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
                         <!-- Hidden: bitmap coverage system does not populate geometry cache (#118) -->

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -3667,33 +3667,49 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                 return;
             }
 
-            // Opt-in moveable path: tile the texture on a fixed world-space
-            // grid so the camera pan visibly scrolls the texture under the
-            // tractor. Tile size matches PR #307's 50 m grid. The tile
-            // count is bounded so an extreme zoom-out doesn't collapse FPS
-            // — past the bound the texture stops covering the viewport, but
-            // that's acceptable on zoomed-out overview where the texture
-            // adds no information anyway.
-            const double TileSize = 50.0;
+            // Opt-in moveable path: tile the texture on a world-space grid
+            // so the camera pan visibly scrolls the texture under the
+            // tractor. Base tile is 50 m matching PR #307; tile count is
+            // bounded so extreme zoom-outs don't collapse FPS.
+            //
+            // LOD: at far zooms the bounded tile count couldn't cover the
+            // viewport with a fixed 50 m tile size (the operator reported
+            // the texture disappearing past ~300 m diagonal — 6 tiles × 50
+            // m = 300 m hard cap). Instead, scale the tile size up by
+            // powers of 2 until the bounded count covers viewSpan.
+            // Power-of-2 keeps the grid coherent across LOD steps so the
+            // pattern doesn't jitter when crossing a zoom threshold (a
+            // 100 m tile's grid lines are a subset of the 50 m grid's
+            // lines). Trade-off: the texture pattern visibly grows as you
+            // zoom out — same cost as the camera-tracking stretched mode,
+            // just more obvious because there's a pattern to compare
+            // against.
+            const double BaseTileSize = 50.0;
             const int MaxTilesPerAxis = 6; // 6*6 = 36 draw calls worst case
             double halfDiagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2;
+            double viewSpan = halfDiagonal * 2;
+
+            double tileSize = BaseTileSize;
+            while (tileSize * MaxTilesPerAxis < viewSpan)
+                tileSize *= 2.0;
+
             double minX = s.CameraX - halfDiagonal;
             double maxX = s.CameraX + halfDiagonal;
             double minY = s.CameraY - halfDiagonal;
             double maxY = s.CameraY + halfDiagonal;
-            int x0 = (int)Math.Floor(minX / TileSize);
-            int y0 = (int)Math.Floor(minY / TileSize);
-            int x1 = (int)Math.Ceiling(maxX / TileSize);
-            int y1 = (int)Math.Ceiling(maxY / TileSize);
+            int x0 = (int)Math.Floor(minX / tileSize);
+            int y0 = (int)Math.Floor(minY / tileSize);
+            int x1 = (int)Math.Ceiling(maxX / tileSize);
+            int y1 = (int)Math.Ceiling(maxY / tileSize);
             int xCount = Math.Min(x1 - x0 + 1, MaxTilesPerAxis);
             int yCount = Math.Min(y1 - y0 + 1, MaxTilesPerAxis);
             for (int iy = 0; iy < yCount; iy++)
             {
                 for (int ix = 0; ix < xCount; ix++)
                 {
-                    double tx = (x0 + ix) * TileSize;
-                    double ty = (y0 + iy) * TileSize;
-                    dc.DrawBitmap(s.GroundTexture!, new Rect(tx, ty, TileSize, TileSize));
+                    double tx = (x0 + ix) * tileSize;
+                    double ty = (y0 + iy) * tileSize;
+                    dc.DrawBitmap(s.GroundTexture!, new Rect(tx, ty, tileSize, tileSize));
                 }
             }
         }

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -278,6 +278,14 @@ internal class MapRenderState
     public bool SvennArrowVisible;
     public bool DirectionMarkersVisible;
     public bool FieldTextureVisible;
+    /// <summary>
+    /// Opt-in tiled mode: when true, the ground texture is rendered as a
+    /// grid of world-anchored tiles so it visibly scrolls under the
+    /// tractor as the camera pans. When false (default), the texture is
+    /// a single stretched bitmap centered on the camera — FPS-stable but
+    /// visually static.
+    /// </summary>
+    public bool GroundTextureMoveable;
     public bool LineSmoothEnabled;
     public bool ExtraGuidelines;
     public int ExtraGuidelinesCount;
@@ -890,6 +898,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
             SvennArrowVisible = displayCfg.SvennArrowVisible,
             DirectionMarkersVisible = displayCfg.DirectionMarkersVisible,
             FieldTextureVisible = displayCfg.FieldTextureVisible,
+            GroundTextureMoveable = displayCfg.FieldTextureMoveable,
             LineSmoothEnabled = displayCfg.LineSmoothEnabled,
             ExtraGuidelines = displayCfg.ExtraGuidelines,
             ExtraGuidelinesCount = displayCfg.ExtraGuidelinesCount,
@@ -3633,25 +3642,60 @@ public class DrawingContextMapControl : Control, ISharedMapControl
 
         private void DrawGroundTexture(ImmediateDrawingContext dc, MapRenderState s, double viewWidth, double viewHeight)
         {
-            // Always draw the texture as a single stretched bitmap covering the
-            // viewport. A tile loop produced a hard FPS discontinuity at zoom
-            // levels that crossed the tile-count threshold (e.g. 19 FPS on one
-            // side, 51 on the other). The texture pattern is intentionally
-            // non-distinct so the stretched version is visually indistinguishable
-            // from the tiled version in practice. One draw call at any zoom,
-            // constant cost.
-            //
-            // The rect is in world coordinates (the camera transform is already
-            // pushed on dc). Center on the camera so the texture tracks the
-            // viewport rather than drifting relative to fixed world features.
-            // The earlier tile-loop fallback used `-(centerY + diagonal)` here,
-            // which mirrored the Y axis incorrectly and caused the texture to
-            // appear to slide south as the tractor moved north (issue #262).
-            double centerX = s.CameraX;
-            double centerY = s.CameraY;
-            double diagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2 + 100.0;
-            var viewRect = new Rect(centerX - diagonal, centerY - diagonal, diagonal * 2, diagonal * 2);
-            dc.DrawBitmap(s.GroundTexture!, viewRect);
+            if (!s.GroundTextureMoveable)
+            {
+                // Default path: single stretched bitmap covering the viewport.
+                // A tile loop produced a hard FPS discontinuity at zoom levels
+                // that crossed the tile-count threshold (e.g. 19 FPS on one
+                // side, 51 on the other). The texture pattern is intentionally
+                // non-distinct so the stretched version is visually
+                // indistinguishable from the tiled version in practice. One
+                // draw call at any zoom, constant cost.
+                //
+                // The rect is in world coordinates (the camera transform is
+                // already pushed on dc). Center on the camera so the texture
+                // tracks the viewport rather than drifting relative to fixed
+                // world features. The earlier tile-loop fallback used
+                // `-(centerY + diagonal)` here, which mirrored the Y axis
+                // incorrectly and caused the texture to slide south as the
+                // tractor moved north (issue #262).
+                double centerX = s.CameraX;
+                double centerY = s.CameraY;
+                double diagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2 + 100.0;
+                var viewRect = new Rect(centerX - diagonal, centerY - diagonal, diagonal * 2, diagonal * 2);
+                dc.DrawBitmap(s.GroundTexture!, viewRect);
+                return;
+            }
+
+            // Opt-in moveable path: tile the texture on a fixed world-space
+            // grid so the camera pan visibly scrolls the texture under the
+            // tractor. Tile size matches PR #307's 50 m grid. The tile
+            // count is bounded so an extreme zoom-out doesn't collapse FPS
+            // — past the bound the texture stops covering the viewport, but
+            // that's acceptable on zoomed-out overview where the texture
+            // adds no information anyway.
+            const double TileSize = 50.0;
+            const int MaxTilesPerAxis = 6; // 6*6 = 36 draw calls worst case
+            double halfDiagonal = Math.Sqrt(viewWidth * viewWidth + viewHeight * viewHeight) / 2;
+            double minX = s.CameraX - halfDiagonal;
+            double maxX = s.CameraX + halfDiagonal;
+            double minY = s.CameraY - halfDiagonal;
+            double maxY = s.CameraY + halfDiagonal;
+            int x0 = (int)Math.Floor(minX / TileSize);
+            int y0 = (int)Math.Floor(minY / TileSize);
+            int x1 = (int)Math.Ceiling(maxX / TileSize);
+            int y1 = (int)Math.Ceiling(maxY / TileSize);
+            int xCount = Math.Min(x1 - x0 + 1, MaxTilesPerAxis);
+            int yCount = Math.Min(y1 - y0 + 1, MaxTilesPerAxis);
+            for (int iy = 0; iy < yCount; iy++)
+            {
+                for (int ix = 0; ix < xCount; ix++)
+                {
+                    double tx = (x0 + ix) * TileSize;
+                    double ty = (y0 + iy) * TileSize;
+                    dc.DrawBitmap(s.GroundTexture!, new Rect(tx, ty, TileSize, TileSize));
+                }
+            }
         }
 
         private void DrawBackgroundImage(ImmediateDrawingContext dc, MapRenderState s)

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -647,6 +647,7 @@ public class ConfigurationServiceMappingTests
         _settings.SimulatorSpeed = 9999;
         _settings.SimulatorSteerAngle = 9999;
         _settings.FieldTextureVisible = false; // default is true, set to non-default
+        _settings.FieldTextureMoveable = true; // default is false, set to non-default
 
         _service.LoadAppSettings();
 


### PR DESCRIPTION
Adds an opt-in 'Texture Moves' toggle in Display config that switches the ground texture from the FPS-stable stretched-bitmap-on-camera mode to a world-tiled mode that visibly scrolls under the tractor. Default OFF; existing render path unchanged for users who don't touch it.

Power-of-2 tile-size LOD keeps the tile count bounded (6 per axis, 36 max) at every zoom level — tile size doubles past 300 m viewSpan, doubles again past 600 m, etc. Coverage is always full; the texture pattern visibly enlarges at deep zoom-outs as the trade-off.

Closes the discussion that started with #307 (which was closed as superseded by this opt-in approach).

## Test plan
- [x] Toggle OFF: render path identical to current develop. Stretched bitmap centered on camera.
- [x] Toggle ON, normal zoom: pattern visibly scrolls when panning the camera.
- [x] Toggle ON, zoom out past 300 m: texture still covers full viewport, pattern doubles in size.