### PR TITLE
Remove dead brightness UI and hardcoded 10 Hz label from View Settings

### DIFF
--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -531,11 +531,6 @@ public partial class MainWindow : Window
                 MapControl.SetNorthUp(ViewModel.IsNorthUp);
             }
         }
-        else if (e.PropertyName == nameof(MainViewModel.Brightness))
-        {
-            // Brightness control depends on platform-specific implementation
-            // Currently marked as not supported in DisplaySettingsService
-        }
         else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
         {
             if (MapControl is DrawingContextMapControl dcMapControl)

--- a/Shared/AgValoniaGPS.Services/DisplaySettingsService.cs
+++ b/Shared/AgValoniaGPS.Services/DisplaySettingsService.cs
@@ -27,7 +27,6 @@ namespace AgValoniaGPS.Services;
 public class DisplaySettingsService : IDisplaySettingsService
 {
     private const double CameraPitchStep = 5.0;
-    private const int BrightnessStep = 5;
 
     // Access display config directly from the store
     private static DisplayConfig Display => ConfigurationStore.Instance.Display;
@@ -116,28 +115,6 @@ public class DisplaySettingsService : IDisplaySettingsService
     }
     public event EventHandler<bool>? ViewModeChanged;
 
-    // Brightness control - local state (platform-specific, not persisted)
-    private int _brightness = 50;
-    public int Brightness
-    {
-        get => _brightness;
-        set
-        {
-            // Clamp between 0 and 100
-            var clampedValue = Math.Max(0, Math.Min(100, value));
-            if (_brightness != clampedValue)
-            {
-                _brightness = clampedValue;
-                BrightnessChanged?.Invoke(this, clampedValue);
-            }
-        }
-    }
-    public event EventHandler<int>? BrightnessChanged;
-
-    // Brightness support depends on platform
-    // For now, we'll stub this - can implement platform-specific later
-    public bool IsBrightnessSupported => false;
-
     public void IncreaseCameraPitch()
     {
         CameraPitch += CameraPitchStep;
@@ -146,16 +123,6 @@ public class DisplaySettingsService : IDisplaySettingsService
     public void DecreaseCameraPitch()
     {
         CameraPitch -= CameraPitchStep;
-    }
-
-    public void IncreaseBrightness()
-    {
-        Brightness += BrightnessStep;
-    }
-
-    public void DecreaseBrightness()
-    {
-        Brightness -= BrightnessStep;
     }
 
     public void ToggleGrid()

--- a/Shared/AgValoniaGPS.Services/Interfaces/IDisplaySettingsService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IDisplaySettingsService.cs
@@ -38,16 +38,9 @@ namespace AgValoniaGPS.Services.Interfaces
         event EventHandler<double>? CameraPitchChanged;
         event EventHandler<bool>? ViewModeChanged;
 
-        // Brightness control
-        int Brightness { get; set; }
-        bool IsBrightnessSupported { get; }
-        event EventHandler<int>? BrightnessChanged;
-
         // Methods
         void IncreaseCameraPitch();
         void DecreaseCameraPitch();
-        void IncreaseBrightness();
-        void DecreaseBrightness();
         void ToggleGrid();
         void ToggleDayNight();
         void Toggle2D3D();

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
@@ -22,7 +22,7 @@ using CommunityToolkit.Mvvm.Input;
 namespace AgValoniaGPS.ViewModels;
 
 /// <summary>
-/// Navigation panel commands - view toggles, camera controls, brightness.
+/// Navigation panel commands - view toggles, camera controls.
 /// </summary>
 public partial class MainViewModel
 {
@@ -149,17 +149,6 @@ public partial class MainViewModel
             {
                 CameraPitch += 5.0;
             }
-        });
-
-        // Brightness controls
-        IncreaseBrightnessCommand = new RelayCommand(() =>
-        {
-            Brightness += 5;
-        });
-
-        DecreaseBrightnessCommand = new RelayCommand(() =>
-        {
-            Brightness -= 5;
         });
 
         // Display resolution: cycle Ultra → High → Medium → Low → Min → Ultra

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -27,7 +27,7 @@ namespace AgValoniaGPS.ViewModels;
 
 /// <summary>
 /// MainViewModel partial class containing View Settings and Panel Visibility.
-/// Manages UI state for panels, display settings, and camera/brightness controls.
+/// Manages UI state for panels, display settings, and camera/display controls.
 /// </summary>
 public partial class MainViewModel
 {
@@ -276,21 +276,6 @@ public partial class MainViewModel
             OnPropertyChanged();
         }
     }
-
-    public int Brightness
-    {
-        get => _displaySettings.Brightness;
-        set
-        {
-            _displaySettings.Brightness = value;
-            OnPropertyChanged();
-            OnPropertyChanged(nameof(BrightnessDisplay));
-        }
-    }
-
-    public string BrightnessDisplay => _displaySettings.IsBrightnessSupported
-        ? $"{_displaySettings.Brightness}%"
-        : "??";
 
     public string DisplayResolutionLabel => ConfigStore.Display.DisplayResolutionMultiplier switch
     {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3221,8 +3221,6 @@ public partial class MainViewModel : ObservableObject
     public ICommand? ToggleCameraModeCommand { get; private set; }
     public ICommand? IncreaseCameraPitchCommand { get; private set; }
     public ICommand? DecreaseCameraPitchCommand { get; private set; }
-    public ICommand? IncreaseBrightnessCommand { get; private set; }
-    public ICommand? DecreaseBrightnessCommand { get; private set; }
     public ICommand? CycleDisplayResolutionCommand { get; private set; }
 
     // iOS Sheet Toggle Commands

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/DisplayConfigTab.axaml
@@ -107,7 +107,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="Headland Dist" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11" HorizontalAlignment="Center"/>
                         </StackPanel>
 
-                        <!-- Row 1: Brightness, Svenn Arrow, Start Fullscreen, Elevation Log -->
+                        <!-- Row 1: Auto Day/Night, Svenn Arrow, Start Fullscreen, Elevation Log -->
                         <StackPanel Grid.Row="1" Grid.Column="0" Spacing="4" HorizontalAlignment="Center">
                             <Button Classes="DisplayToggle"
                                     Background="{Binding Display.AutoDayNight, Converter={x:Static conv:BoolToToggleBackgroundConverter.Instance}}"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
@@ -83,29 +83,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Content="{loc:Localize Grid}" Margin="2" ClickMode="Press"
                             Command="{Binding ToggleGridCommand}"
                             ToolTip.Tip="Toggle grid"/>
-                    <Button Grid.Row="1" Grid.Column="0" Classes="VSButton"
+                    <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Classes="VSButton"
                             Content="{loc:Localize DayNight}" Margin="2" ClickMode="Press"
                             Command="{Binding ToggleDayNightCommand}"
                             ToolTip.Tip="Day/Night mode"/>
-                    <TextBlock Grid.Row="1" Grid.Column="1"
-                               Text="10 Hz" Margin="2" Padding="8"
-                               HorizontalAlignment="Center" VerticalAlignment="Center"
-                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                               FontWeight="Bold" FontSize="12"/>
-                </Grid>
-
-                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
-
-                <!-- Brightness -->
-                <Grid ColumnDefinitions="*,*">
-                    <Button Grid.Column="0" Classes="VSButton"
-                            Content="{Binding BrightnessDisplay, StringFormat='Dim -{0}'}" Margin="2" ClickMode="Press"
-                            Command="{Binding DecreaseBrightnessCommand}"
-                            ToolTip.Tip="Decrease brightness"/>
-                    <Button Grid.Column="1" Classes="VSButton"
-                            Content="Bright +" Margin="2" ClickMode="Press"
-                            Command="{Binding IncreaseBrightnessCommand}"
-                            ToolTip.Tip="Increase brightness"/>
                 </Grid>
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>


### PR DESCRIPTION
The Dim/Bright buttons in the floating View Settings panel were wired to commands but \`IDisplaySettingsService.IsBrightnessSupported\` was always false and no consumer existed. The '10 Hz' TextBlock next to them was a hardcoded literal, not a binding.

Removes both, plus everything that becomes orphaned:
- Brightness button block + separator in \`ViewSettingsPanel.axaml\`. Day/Night button spans both columns.
- '10 Hz' TextBlock.
- \`IncreaseBrightnessCommand\` / \`DecreaseBrightnessCommand\` in \`MainViewModel.Commands.Navigation.cs\`.
- \`Brightness\` and \`BrightnessDisplay\` properties in \`MainViewModel.ViewSettings.cs\`.
- ICommand declarations in \`MainViewModel.cs\`.
- No-op \`Brightness\` PropertyChanged branch in Desktop's \`MainWindow.axaml.cs\`.
- All brightness API on \`DisplaySettingsService\` (property, event, support flag, increment methods) and \`IDisplaySettingsService\`.
- Stale comment fix on \`DisplayConfigTab.axaml\` for the Auto Day/Night row.

Verified: \`grep -rn "Brightness\\b|BrightnessChanged|IsBrightnessSupported"\` returns zero matches across \`Shared/\`, \`Platforms/\`, \`Tests/\`.

Net −96 / +4 lines across 8 files.

## Test plan
- [x] Build clean (0 errors).
- [x] Open View Settings panel: shows Camera Controls / 2D-3D / North + Grid / Day-Night spanning / Quality. No Dim/Bright. No '10 Hz'.
- [x] Existing service tests still pass.