### PR TITLE
App Settings dialog + move IsMetric off vehicle profile

### DIFF
--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -38,6 +38,23 @@ namespace AgValoniaGPS.Models
         public int ExtraGuidelinesCount { get; set; } = 10;
         public bool FieldTextureVisible { get; set; } = true;
         public bool FieldTextureMoveable { get; set; } = false;
+
+        /// <summary>
+        /// Device-/user-scoped metric vs imperial preference. The source of
+        /// truth lives here (in AppSettings); vehicle profiles must not
+        /// dictate units. Default false (imperial) matches the legacy
+        /// per-vehicle default before the migration.
+        /// </summary>
+        public bool IsMetric { get; set; } = false;
+
+        /// <summary>
+        /// One-shot migration latch: if false, the next vehicle-profile
+        /// load that carries a legacy <c>General.IsMetric</c> field will
+        /// copy that value into <see cref="IsMetric"/> and set this flag
+        /// to true. Subsequent loads ignore the profile field — units are
+        /// then a device preference, not vehicle-scoped.
+        /// </summary>
+        public bool HasMigratedIsMetric { get; set; } = false;
         public bool AutoSteerSound { get; set; } = true;
         public bool UTurnSound { get; set; } = true;
         public bool HydraulicSound { get; set; } = true;

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -76,6 +76,7 @@ public class UIState : ObservableObject
                 OnPropertyChanged(nameof(IsBugReportDialogVisible));
                 OnPropertyChanged(nameof(IsSmartWasDialogVisible));
                 OnPropertyChanged(nameof(IsLoadVehicleToolDialogVisible));
+                OnPropertyChanged(nameof(IsAppSettingsDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -122,6 +123,7 @@ public class UIState : ObservableObject
     public bool IsBugReportDialogVisible => ActiveDialog == DialogType.BugReport;
     public bool IsSmartWasDialogVisible => ActiveDialog == DialogType.SmartWas;
     public bool IsLoadVehicleToolDialogVisible => ActiveDialog == DialogType.LoadVehicleTool;
+    public bool IsAppSettingsDialogVisible => ActiveDialog == DialogType.AppSettings;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -257,6 +259,7 @@ public enum DialogType
     LoadVehicleTool,
     StartWorkSession,
     ResumeJob,
+    AppSettings,
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -76,6 +76,13 @@ public class ConfigurationService(
         toolProfileService.Load(toolName, Store);
 
         LoadAutoSteerConfig(vehicleName);
+
+        // IsMetric source-of-truth lives in AppSettings. A legacy profile
+        // may have written into Store.IsMetric above; either it's a fresh
+        // value (migrate to AppSettings) or AppSettings is authoritative
+        // and the profile's value is overridden.
+        ReconcileIsMetricAfterProfileLoad();
+
         Store.HasUnsavedChanges = false;
 
         // Persist the active pair so the next startup restores the same
@@ -297,6 +304,37 @@ public class ConfigurationService(
         settingsService.Save();
     }
 
+    /// <summary>
+    /// Reconcile the device-scoped <see cref="AppSettings.IsMetric"/> with
+    /// whatever value a vehicle profile just wrote into the store. Called
+    /// after a profile load so the source-of-truth move from
+    /// vehicle-profile to AppSettings holds:
+    ///
+    ///  - If migration has not yet happened, the profile's value seeds
+    ///    AppSettings (one-shot legacy fallback) and the migration latch
+    ///    flips so subsequent profile loads can't drag the unit
+    ///    preference around.
+    ///  - If migration has already happened, AppSettings is authoritative
+    ///    and re-asserted onto the store, overriding whatever the profile
+    ///    file carried.
+    ///
+    /// Either way, on return the store and AppSettings agree.
+    /// </summary>
+    public void ReconcileIsMetricAfterProfileLoad()
+    {
+        var settings = settingsService.Settings;
+        if (!settings.HasMigratedIsMetric)
+        {
+            settings.IsMetric = Store.IsMetric;
+            settings.HasMigratedIsMetric = true;
+            settingsService.Save();
+        }
+        else
+        {
+            Store.IsMetric = settings.IsMetric;
+        }
+    }
+
     #endregion
 
     #region AppSettings <-> Store Mapping
@@ -322,6 +360,7 @@ public class ConfigurationService(
         store.Display.ExtraGuidelinesCount = settings.ExtraGuidelinesCount;
         store.Display.FieldTextureVisible = settings.FieldTextureVisible;
         store.Display.FieldTextureMoveable = settings.FieldTextureMoveable;
+        store.IsMetric = settings.IsMetric;
         store.Display.AutoSteerSound = settings.AutoSteerSound;
         store.Display.UTurnSound = settings.UTurnSound;
         store.Display.HydraulicSound = settings.HydraulicSound;
@@ -388,6 +427,7 @@ public class ConfigurationService(
         settings.ExtraGuidelinesCount = store.Display.ExtraGuidelinesCount;
         settings.FieldTextureVisible = store.Display.FieldTextureVisible;
         settings.FieldTextureMoveable = store.Display.FieldTextureMoveable;
+        settings.IsMetric = store.IsMetric;
         settings.AutoSteerSound = store.Display.AutoSteerSound;
         settings.UTurnSound = store.Display.UTurnSound;
         settings.HydraulicSound = store.Display.HydraulicSound;

--- a/Shared/AgValoniaGPS.Services/Interfaces/IConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IConfigurationService.cs
@@ -123,6 +123,14 @@ public interface IConfigurationService
     /// </summary>
     void SaveAppSettings();
 
+    /// <summary>
+    /// Reconcile <see cref="AppSettings.IsMetric"/> with the value a
+    /// vehicle profile just wrote into the store. One-shot migration on
+    /// first call; thereafter AppSettings is authoritative and the
+    /// profile's value is overridden.
+    /// </summary>
+    void ReconcileIsMetricAfterProfileLoad();
+
     #endregion
 
     #region Events

--- a/Shared/AgValoniaGPS.Services/Profile/ProfileJsonServiceV1.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ProfileJsonServiceV1.cs
@@ -203,7 +203,11 @@ public static class ProfileJsonServiceV1
             },
             General = new GeneralDto
             {
-                IsMetric = store.IsMetric,
+                // IsMetric intentionally omitted: device-/user-scoped, lives
+                // in AppSettings now. Kept as a nullable field on the DTO so
+                // pre-migration profiles still parse, but new writes don't
+                // emit it (JsonIgnoreCondition.WhenWritingNull elides it).
+                IsMetric = null,
                 IsSimulatorOn = store.Simulator.Enabled,
                 SimLatitude = store.Simulator.Latitude,
                 SimLongitude = store.Simulator.Longitude,
@@ -330,8 +334,13 @@ public static class ProfileJsonServiceV1
             }
         }
 
-        // Display config
-        store.IsMetric = dto.General?.IsMetric ?? false;
+        // Display config — IsMetric used to live here; it now lives in
+        // AppSettings. Apply only if the legacy field is present in the
+        // file; ReconcileIsMetricAfterProfileLoad post-load decides
+        // whether the value sticks (one-shot migration) or AppSettings
+        // overrides it (post-migration).
+        if (dto.General?.IsMetric is bool legacyIsMetric)
+            store.IsMetric = legacyIsMetric;
 
         // Profile metadata
         store.ActiveVehicleProfileName = profileName;
@@ -447,7 +456,14 @@ public static class ProfileJsonServiceV1
 
     internal class GeneralDto
     {
-        public bool IsMetric { get; set; }
+        /// <summary>
+        /// Nullable so the writer can elide it for new profiles and the
+        /// reader can detect "field absent" vs "field present with value
+        /// false". On load, a non-null value seeds AppSettings via the
+        /// one-shot migration in
+        /// <see cref="IConfigurationService.ReconcileIsMetricAfterProfileLoad"/>.
+        /// </summary>
+        public bool? IsMetric { get; set; }
         public bool IsSimulatorOn { get; set; }
         public double SimLatitude { get; set; }
         public double SimLongitude { get; set; }

--- a/Shared/AgValoniaGPS.Services/Profile/VehicleProfileJsonService.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/VehicleProfileJsonService.cs
@@ -108,7 +108,10 @@ public static class VehicleProfileJsonService
         },
         General = new GeneralDto
         {
-            IsMetric = store.IsMetric,
+            // IsMetric intentionally omitted: device-/user-scoped, lives
+            // in AppSettings now. Kept as a nullable field on the DTO so
+            // pre-migration profiles still parse; new writes elide it.
+            IsMetric = null,
             IsSimulatorOn = store.Simulator.Enabled,
             SimLatitude = store.Simulator.Latitude,
             SimLongitude = store.Simulator.Longitude,
@@ -158,8 +161,13 @@ public static class VehicleProfileJsonService
         store.Guidance.UTurnStyle = dto.YouTurn?.Style ?? 0;
         store.Guidance.UTurnSmoothing = dto.YouTurn?.Smoothing ?? 14;
 
-        // General
-        store.IsMetric = dto.General?.IsMetric ?? false;
+        // General — IsMetric used to live here; it now lives in AppSettings.
+        // Apply only if the legacy field is present in the file;
+        // ReconcileIsMetricAfterProfileLoad post-load decides whether the
+        // value sticks (one-shot migration) or AppSettings overrides it
+        // (post-migration).
+        if (dto.General?.IsMetric is bool legacyIsMetric)
+            store.IsMetric = legacyIsMetric;
 
         // Profile metadata
         store.ActiveVehicleProfileName = profileName;
@@ -223,7 +231,14 @@ public static class VehicleProfileJsonService
 
     internal class GeneralDto
     {
-        public bool IsMetric { get; set; }
+        /// <summary>
+        /// Nullable so writers can elide it for new profiles and readers
+        /// can detect "field absent" vs "field present with value false".
+        /// On load, a non-null value seeds AppSettings via the one-shot
+        /// migration in
+        /// <see cref="IConfigurationService.ReconcileIsMetricAfterProfileLoad"/>.
+        /// </summary>
+        public bool? IsMetric { get; set; }
         public bool IsSimulatorOn { get; set; }
         public double SimLatitude { get; set; }
         public double SimLongitude { get; set; }

--- a/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
+++ b/Shared/AgValoniaGPS.Services/VehicleProfileService.cs
@@ -261,7 +261,8 @@ public class VehicleProfileService : IVehicleProfileService
         sectionPositions[1] = 3.0;   // Right edge
         store.SectionPositions = sectionPositions;
 
-        store.IsMetric = false;
+        // IsMetric used to be reset here; it now lives in AppSettings and
+        // is unaffected by creating a new default vehicle profile.
 
         store.ActiveVehicleProfileName = profileName;
         store.ActiveVehicleProfilePath = Path.Combine(VehiclesDirectory, $"{profileName}.json");
@@ -340,8 +341,14 @@ public class VehicleProfileService : IVehicleProfileService
         }
         store.SectionPositions = sectionPositions;
 
-        // Display config
-        store.IsMetric = GetBool(settings, "setMenu_isMetric", false);
+        // Display config — IsMetric used to live in the vehicle XML.
+        // It now lives in AppSettings; apply the legacy XML value to the
+        // store so the post-load ReconcileIsMetricAfterProfileLoad can
+        // perform the one-shot migration (the same path the JSON profile
+        // services use). Once migration has completed, AppSettings
+        // overrides the XML value on subsequent loads.
+        if (settings.ContainsKey("setMenu_isMetric"))
+            store.IsMetric = GetBool(settings, "setMenu_isMetric", false);
 
         // Profile metadata
         store.ActiveVehicleProfileName = profileName;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -47,6 +47,16 @@ public partial class MainViewModel
             State.UI.CloseDialog();
         });
 
+        ShowAppSettingsDialogCommand = new RelayCommand(() =>
+        {
+            State.UI.ShowDialog(Models.State.DialogType.AppSettings);
+        });
+
+        CloseAppSettingsDialogCommand = new RelayCommand(() =>
+        {
+            State.UI.CloseDialog();
+        });
+
         ShowAboutDialogCommand = new RelayCommand(() =>
         {
             State.UI.ShowDialog(Models.State.DialogType.About);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -49,6 +49,14 @@ public partial class MainViewModel
 
         ShowAppSettingsDialogCommand = new RelayCommand(() =>
         {
+            // Tabs inside the App Settings dialog (DisplayConfigTab,
+            // AdditionalOptionsConfigTab) bind to ConfigurationViewModel.
+            // Mirror ShowConfigurationDialogCommand's lazy-init so the
+            // tabs work even if the user never opened Configuration first.
+            if (ConfigurationViewModel == null)
+            {
+                ConfigurationViewModel = new ConfigurationViewModel(_configurationService);
+            }
             State.UI.ShowDialog(Models.State.DialogType.AppSettings);
         });
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2126,6 +2126,8 @@ public partial class MainViewModel : ObservableObject
     // Settings Commands
     public ICommand? ShowAppDirectoriesDialogCommand { get; private set; }
     public ICommand? CloseAppDirectoriesDialogCommand { get; private set; }
+    public ICommand? ShowAppSettingsDialogCommand { get; private set; }
+    public ICommand? CloseAppSettingsDialogCommand { get; private set; }
     public ICommand? ShowAboutDialogCommand { get; private set; }
     public ICommand? CloseAboutDialogCommand { get; private set; }
     public ICommand? ResetAllSettingsCommand { get; private set; }

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -65,6 +65,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:FieldBuilderDialogPanel/>
         <dialogs:BugReportDialogPanel/>
         <dialogs:ConfigurationDialog DataContext="{Binding ConfigurationViewModel}"/>
+        <dialogs:AppSettingsDialogPanel/>
         <dialogs:AutoSteerConfigPanel DataContext="{Binding AutoSteerConfigViewModel}"/>
         <dialogs:SmartWasDialogPanel/>
         <dialogs:LoadVehicleToolDialogPanel/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
@@ -1,0 +1,124 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2026 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:config="clr-namespace:AgValoniaGPS.Views.Controls.Dialogs.Configuration;assembly=AgValoniaGPS.Views"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="720"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.AppSettingsDialogPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsAppSettingsDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsAppSettingsDialogVisible}">
+
+    <UserControl.Styles>
+        <!-- Reuse the existing left-icon-strip TabControl look used by
+             ConfigurationDialog so the two dialogs feel consistent. -->
+        <Style Selector="TabControl.AppSettingsTabs">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+        <Style Selector="TabControl.AppSettingsTabs > TabItem">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+            <Setter Property="Padding" Value="12"/>
+            <Setter Property="Margin" Value="0,2"/>
+            <Setter Property="MinWidth" Value="64"/>
+            <Setter Property="MinHeight" Value="64"/>
+        </Style>
+        <Style Selector="TabControl.AppSettingsTabs > TabItem:selected">
+            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+        </Style>
+        <Style Selector="TabControl.AppSettingsTabs > TabItem:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+        </Style>
+    </UserControl.Styles>
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <ImageBrush x:Key="IconDisplay" Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Con_Display.png"/>
+                    <ImageBrush x:Key="IconFeatures" Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Con_FeatureMenu.png"/>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <ImageBrush x:Key="IconDisplay" Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Dark/Con_Display.png"/>
+                    <ImageBrush x:Key="IconFeatures" Source="avares://AgValoniaGPS.Views/Assets/Icons/Config/Dark/Con_FeatureMenu.png"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <!-- Full screen modal overlay -->
+    <Grid>
+        <!-- Semi-transparent backdrop, tap-to-close. -->
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <!-- Dialog container, fixed size to prevent resize on tab switch. -->
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="8"
+                Width="900"
+                Height="720"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                BorderThickness="1"
+                BoxShadow="0 8 32 #80000000">
+            <Grid RowDefinitions="Auto,*,Auto"
+                  DataContext="{Binding ConfigurationViewModel}"
+                  x:DataType="vm:ConfigurationViewModel">
+                <!-- Header -->
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,8">
+                    <TextBlock Text="App Settings" FontSize="18" FontWeight="Bold"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                </Border>
+
+                <!-- Tabs: Display + Additional Options. ConfigurationViewModel
+                     is the DataContext both child tabs already bind to in
+                     ConfigurationDialog, so no extra plumbing is needed. -->
+                <TabControl Grid.Row="1" Classes="AppSettingsTabs" TabStripPlacement="Left"
+                            Background="{DynamicResource SystemControlBackgroundListLowBrush}"
+                            HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <TabItem ToolTip.Tip="Display">
+                        <TabItem.Header>
+                            <Border Width="40" Height="40" Background="{DynamicResource IconDisplay}"/>
+                        </TabItem.Header>
+                        <config:DisplayConfigTab/>
+                    </TabItem>
+                    <TabItem ToolTip.Tip="Additional Options">
+                        <TabItem.Header>
+                            <Border Width="40" Height="40" Background="{DynamicResource IconFeatures}"/>
+                        </TabItem.Header>
+                        <config:AdditionalOptionsConfigTab/>
+                    </TabItem>
+                </TabControl>
+
+                <!-- Footer -->
+                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,12">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <Button Grid.Column="1" Width="48" Height="48"
+                                Background="#4A9A7E" CornerRadius="24"
+                                Command="{Binding ApplyCommand}"
+                                ToolTip.Tip="Apply and Close">
+                            <TextBlock Text="✓" FontSize="24" FontWeight="Bold"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Button>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
@@ -110,8 +110,8 @@ GNU General Public License for more details.
                     <Grid ColumnDefinitions="*,Auto">
                         <Button Grid.Column="1" Width="48" Height="48"
                                 Background="#4A9A7E" CornerRadius="24"
-                                Command="{Binding ApplyCommand}"
-                                ToolTip.Tip="Apply and Close">
+                                Command="{Binding $parent[UserControl].DataContext.CloseAppSettingsDialogCommand}"
+                                ToolTip.Tip="Close">
                             <TextBlock Text="✓" FontSize="24" FontWeight="Bold"
                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                        HorizontalAlignment="Center" VerticalAlignment="Center"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml.cs
@@ -1,0 +1,25 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class AppSettingsDialogPanel : UserControl
+{
+    public AppSettingsDialogPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CloseAppSettingsDialogCommand?.Execute(null);
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -169,21 +169,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <config:SourcesConfigTab/>
                     </TabItem>
 
-                    <!-- Display Tab -->
-                    <TabItem ToolTip.Tip="Display">
-                        <TabItem.Header>
-                            <Border Width="40" Height="40" Background="{DynamicResource IconDisplay}"/>
-                        </TabItem.Header>
-                        <config:DisplayConfigTab/>
-                    </TabItem>
-
-                    <!-- Additional Options Tab -->
-                    <TabItem ToolTip.Tip="Additional Options">
-                        <TabItem.Header>
-                            <Border Width="40" Height="40" Background="{DynamicResource IconFeatures}"/>
-                        </TabItem.Header>
-                        <config:AdditionalOptionsConfigTab/>
-                    </TabItem>
+                    <!-- Display + Additional Options moved to the top-level
+                         AppSettings dialog (PR #app-settings-dialog). They're
+                         device-/user-scoped, not vehicle-scoped — opening
+                         them via the wrench made them feel like vehicle
+                         settings. -->
                 </TabControl>
 
                 <!-- Numeric Input Overlay -->

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -52,6 +52,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- App Configuration -->
+                <Button Classes="MenuListButton" Content="App Settings…"                   HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowAppSettingsDialogCommand}"/>
                 <Button Classes="MenuListButton" Content="{loc:Localize ViewAllSettings}"  HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowViewSettingsDialogCommand}"/>
                 <Button Classes="MenuListButton" Content="{loc:Localize AppDirectories}"   HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowAppDirectoriesDialogCommand}"/>
                 <Button Classes="MenuListButton" Content="{loc:Localize LogViewer}"        HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowLogViewerDialogCommand}"/>

--- a/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ConfigurationServiceMappingTests.cs
@@ -597,6 +597,10 @@ public class ConfigurationServiceMappingTests
             "LastUsedToolProfile",    // Mapped via ActiveToolProfileName (different name) — #346
             "HotkeyBindings",       // Mapped via Hotkeys.LoadFromDictionary (special handling)
             "Language",              // Used directly from AppSettings for localization
+            "HasMigratedIsMetric",   // One-shot migration latch — written by
+                                     // ReconcileIsMetricAfterProfileLoad, not by
+                                     // the Load/Save round-trip the rest of these
+                                     // properties go through.
         };
 
         // Set every non-excluded property to a non-default value
@@ -648,6 +652,7 @@ public class ConfigurationServiceMappingTests
         _settings.SimulatorSteerAngle = 9999;
         _settings.FieldTextureVisible = false; // default is true, set to non-default
         _settings.FieldTextureMoveable = true; // default is false, set to non-default
+        _settings.IsMetric = true; // default is false, set to non-default
 
         _service.LoadAppSettings();
 
@@ -677,5 +682,56 @@ public class ConfigurationServiceMappingTests
 
         Assert.That(unmapped, Is.Empty,
             $"These AppSettings properties appear unmapped in ConfigurationService: {string.Join(", ", unmapped)}");
+    }
+
+    // =====================================================================
+    // IsMetric one-shot migration from legacy vehicle profile
+    // =====================================================================
+
+    [Test]
+    public void ReconcileIsMetricAfterProfileLoad_FirstCall_MigratesProfileValueToAppSettings()
+    {
+        // Pre-migration state: AppSettings has the default (imperial), the
+        // migration latch hasn't been flipped, and the profile load has
+        // just written its legacy IsMetric=true into the store.
+        _settings.IsMetric = false;
+        _settings.HasMigratedIsMetric = false;
+        _service.Store.IsMetric = true;
+
+        _service.ReconcileIsMetricAfterProfileLoad();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_settings.IsMetric, Is.True,
+                "First reconcile must migrate the profile value to AppSettings.");
+            Assert.That(_settings.HasMigratedIsMetric, Is.True,
+                "Migration latch must flip so subsequent profile loads don't repeat.");
+            Assert.That(_service.Store.IsMetric, Is.True,
+                "Store value remains the migrated value.");
+        });
+    }
+
+    [Test]
+    public void ReconcileIsMetricAfterProfileLoad_SubsequentCall_AppSettingsOverridesProfile()
+    {
+        // Post-migration state: AppSettings is authoritative and the user
+        // has chosen metric. A profile load just wrote IsMetric=false into
+        // the store (legacy field still present in the file). Reconcile
+        // must put the store back on AppSettings' value.
+        _settings.IsMetric = true;
+        _settings.HasMigratedIsMetric = true;
+        _service.Store.IsMetric = false;
+
+        _service.ReconcileIsMetricAfterProfileLoad();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_service.Store.IsMetric, Is.True,
+                "Post-migration, AppSettings overrides whatever the profile wrote.");
+            Assert.That(_settings.IsMetric, Is.True,
+                "AppSettings value is unchanged on subsequent reconciles.");
+            Assert.That(_settings.HasMigratedIsMetric, Is.True,
+                "Migration latch stays set.");
+        });
     }
 }


### PR DESCRIPTION
Splits device/user-level settings away from the vehicle profile in two steps.

## Part 1 (\`d13bb7f1\`) — \`IsMetric\` source-of-truth on AppSettings

\`IsMetric\` was per-vehicle-profile despite controlling app-wide UX (area display, simulator units, etc). Moves source-of-truth to \`AppSettings\` with a one-shot migration latch so old profiles still seed the value on first load, then never again.

- \`AppSettings.IsMetric\` + \`HasMigratedIsMetric\` latch.
- \`ConfigurationService.ReconcileIsMetricAfterProfileLoad()\` invoked after profile + tool + autosteer load. First call migrates; latch flips; subsequent loads have AppSettings override profile.
- \`GeneralDto.IsMetric\` is now \`bool?\` and elided from new writes via \`JsonIgnoreCondition.WhenWritingNull\`.
- Legacy XML import (\`setMenu_isMetric\`) only writes when key present — same reconcile path applies.
- New focused tests pin the one-shot semantics: first call migrates + flips latch; subsequent loads have AppSettings win. 44/44 mapping tests pass.

## Part 2 (\`cfdfadae\`) — top-level App Settings dialog

The Configuration dialog opens with the Vehicle tab and previously included Display + Additional Options tabs, making them feel vehicle-scoped though they aren't. Promoted to a new top-level dialog so the grouping matches the data layout.

- New \`AppSettingsDialogPanel.axaml\` (900x720 overlay shell, two tabs: \`<config:DisplayConfigTab/>\` and \`<config:AdditionalOptionsConfigTab/>\`).
- \`DialogType.AppSettings\` + visibility plumbing in \`UIState\`.
- Registered in \`DialogOverlayHost\`.
- \`ShowAppSettingsDialogCommand\` / \`CloseAppSettingsDialogCommand\` in \`MainViewModel\`.
- New "App Settings…" button at the top of the App Configuration section in \`FileMenuPanel.axaml\` (minimal UI churn).
- Removed Display + Additional Options TabItems from \`ConfigurationDialog.axaml\`; replaced with a code comment pointing at the new dialog.

### Note on orphan
\`HardwareConfigTab.axaml\` exists but is not wired into any dialog. Left as-is for a follow-up cleanup; mentioned in commit message.

## Test plan
- [x] \`Tests/AgValoniaGPS.Services.Tests\`: 847 pass, 1 fail (pre-existing Windows file-lock flake on \`ProfileJsonServiceV1Tests.Load_OlderProfileWithoutNewFields_KeepsModelDefaults\`, unrelated), 2 skip.
- [x] Desktop build clean.
- [ ] Bench-test: open old vehicle profile that had \`IsMetric=true\` while AppSettings default false → first load migrates correctly, subsequent loads stable.
- [ ] Bench-test: open new App Settings dialog from FileMenu, verify Display + Additional Options tabs render with all their existing bindings intact; toggles persist; tap backdrop closes; dialog doesn't leak into the Configuration dialog.