### PR TITLE
Vehicle simulator: stop SendLoop so host tick is the sole GPS emitter

### DIFF
--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualModuleHub.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualModuleHub.cs
@@ -46,7 +46,14 @@ public class VirtualModuleHub : IDisposable
     {
         Steer.Start();
         Machine.Start();
-        Gps.Start();
+        // Don't start Gps.SendLoop. The host's SimulationTick at 10 Hz
+        // advances Lat/Lon/Heading and explicitly calls Gps.SendOnce()
+        // after each physics step. Starting the receiver's own 10 Hz
+        // SendLoop here adds a parallel emitter that reads the same
+        // fields between ticks, producing duplicate packets where every
+        // pair carries identical position data — visible to the host
+        // as stuttering / jumpy tractor motion.
+        // SendOnce() remains available for tests that drive emission.
     }
 
     public void Stop()


### PR DESCRIPTION
Operator reported jumpy / stuttering tractor motion when running the external Vehicle Simulator. Captured dump (bugreport \`simulator_20260514_113745.zip\`) shows the exact symptom:

\`\`\`
07.534  e=24.070 n=76.863 h=332.20
07.568  e=24.070 n=76.863 h=332.20   ← same (34ms later)
07.639  e=23.946 n=77.085 h=331.80   ← moved (71ms later)
07.674  e=23.946 n=77.085 h=331.80   ← same again
07.750  e=23.822 n=77.326 h=331.40   ← moved
\`\`\`

Every pair of consecutive samples carries identical position data, then the next pair shows the move. The pattern is ~33 ms apart in each pair, ~100 ms between pairs.

## Cause
Two parallel GPS emitters, both 10 Hz, both reading the same \`Lat/Lon/Heading\` fields:

1. \`VirtualGpsReceiver.SendLoop\` — kicked off by \`VirtualModuleHub.Start()\`, fires PANDA every 100 ms on a thread pool.
2. The host's \`SimulationTick\` — \`DispatcherTimer\` at 10 Hz, advances Lat/Lon/Heading per physics step, then calls \`Gps.SendOnce()\`.

Only the tick advances the fields. \`SendLoop\` reads stale values until the next tick. The host's receiver sees ~20 packets/sec where every pair is identical → renderer steps once per pair and sits still on the duplicate. Visible as jumpy / stuttering motion.

## Fix
Drop \`Gps.Start()\` from \`VirtualModuleHub.Start()\`. The host's tick is the sole emitter — which it was designed to be. \`SendOnce()\` remains available for tests that drive emission explicitly.

## History
This is the second half of closed PR #321. The PANDA heading scaling half landed via #363; the duplicate-packets fix was never re-submitted as a focused PR. Doing that now.

## Test plan
- [x] Build clean.
- [ ] Launch Vehicle Simulator, point Desktop at it, drive in a circle. Tractor moves smoothly with no stuttering.
- [ ] No regression to integration tests using \`VirtualGpsReceiver\` (\`SendOnce\` is unchanged; \`SendLoop\` was only wired through \`Start()\`).