### PR TITLE
Steer wizard live feedback: roll/WAS push live + motor cal switch gate

### DIFF
--- a/Shared/AgValoniaGPS.Services/NmeaParserServiceFast.cs
+++ b/Shared/AgValoniaGPS.Services/NmeaParserServiceFast.cs
@@ -470,6 +470,7 @@ public class NmeaParserServiceFast
                 && Utf8Parser.TryParse(rollField, out int rawRoll, out _))
             {
                 state.Roll = rawRoll * 0.1;
+                ApplyAhrsRollCalibration(ref state.Roll);
             }
             else
             {
@@ -495,6 +496,7 @@ public class NmeaParserServiceFast
             if (rollField.Length > 0)
             {
                 Utf8Parser.TryParse(rollField, out state.Roll, out _);
+                ApplyAhrsRollCalibration(ref state.Roll);
             }
             else
             {
@@ -560,5 +562,20 @@ public class NmeaParserServiceFast
         }
 
         return degrees;
+    }
+
+    /// <summary>
+    /// Apply the operator-calibrated AHRS roll transform: invert sign if
+    /// <c>IsRollInvert</c> is set, then subtract <c>RollZero</c>. Mirrors
+    /// the WAS post-process in <c>SmartWasCalibrationService</c>. Without
+    /// this, the wizard's roll gauge and the guidance pipeline both see
+    /// raw uncalibrated IMU roll, and the operator's "Zero Roll" tap in
+    /// the Roll-calibration wizard step has no effect on live readings.
+    /// </summary>
+    private static void ApplyAhrsRollCalibration(ref double roll)
+    {
+        var ahrs = Models.Configuration.ConfigurationStore.Instance.Ahrs;
+        if (ahrs.IsRollInvert) roll = -roll;
+        roll -= ahrs.RollZero;
     }
 }

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
@@ -230,6 +230,49 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     /// <summary>True when hardware is connected and sending data.</summary>
     public bool HasHardware => _autoSteerService != null;
 
+    private bool _waitingForPhysicalSwitch;
+    /// <summary>
+    /// True when a physical AutoSteer switch is configured
+    /// (<c>Tool.IsSteerSwitchEnabled</c>) but the module's PGN 253
+    /// reports <c>SteerSwitchActive=false</c>. The operator must flip
+    /// the physical switch ON before motor calibration can begin —
+    /// otherwise the module will ignore the PWM ramp commands and the
+    /// calibration sequence will time out without movement.
+    ///
+    /// When no physical switch is configured (<c>IsSteerSwitchEnabled
+    /// =false</c>), this gate stays false and calibration starts
+    /// immediately. Reflects updates from <c>StateUpdated</c>; the gate
+    /// is bound to <c>StartTestCommand</c>'s CanExecute and to a UI
+    /// hint message in the wizard step's AXAML.
+    /// </summary>
+    public bool WaitingForPhysicalSwitch
+    {
+        get => _waitingForPhysicalSwitch;
+        private set
+        {
+            if (SetProperty(ref _waitingForPhysicalSwitch, value))
+            {
+                OnPropertyChanged(nameof(CanStartCalibration));
+                OnPropertyChanged(nameof(PhysicalSwitchPromptText));
+            }
+        }
+    }
+
+    /// <summary>
+    /// CanExecute predicate for <see cref="StartTestCommand"/>: false
+    /// while waiting for the physical switch to engage.
+    /// </summary>
+    public bool CanStartCalibration => !WaitingForPhysicalSwitch;
+
+    /// <summary>
+    /// Operator-facing hint shown while <see cref="WaitingForPhysicalSwitch"/>
+    /// is true. Empty string otherwise so the wizard step's AXAML can bind
+    /// IsVisible to non-empty.
+    /// </summary>
+    public string PhysicalSwitchPromptText => WaitingForPhysicalSwitch
+        ? "Flip the physical AutoSteer switch ON to continue."
+        : string.Empty;
+
     // =========================================================================
     // Commands
     // =========================================================================
@@ -245,8 +288,8 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         _configService = configService;
         _autoSteerService = autoSteerService;
 
-        StartTestCommand = new AsyncRelayCommand(RunPwmRampAsync);
-        ContinueToMaxAngleCommand = new AsyncRelayCommand(RunMaxAngleMeasurementAsync);
+        StartTestCommand = new AsyncRelayCommand(RunPwmRampAsync, () => CanStartCalibration);
+        ContinueToMaxAngleCommand = new AsyncRelayCommand(RunMaxAngleMeasurementAsync, () => CanStartCalibration);
         RedoPhaseACommand = new AsyncRelayCommand(RedoPhaseA);
         RedoPhaseBCommand = new AsyncRelayCommand(RedoPhaseB);
     }
@@ -420,6 +463,10 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         DetectedInvertMotor = autoSteer.InvertMotor;
         MaxSteerAngle = autoSteer.MaxSteerAngle;
 
+        // Seed the gate from current state so the UI doesn't briefly
+        // show CanStart=true before the first PGN 253 arrives.
+        UpdatePhysicalSwitchGate();
+
         if (_autoSteerService != null)
             _autoSteerService.StateUpdated += OnStateUpdated;
     }
@@ -454,6 +501,29 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
         LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
+        UpdatePhysicalSwitchGate();
+    }
+
+    private void UpdatePhysicalSwitchGate()
+    {
+        bool requiresSwitch = _configService.Store.Tool.IsSteerSwitchEnabled;
+        if (!requiresSwitch)
+        {
+            WaitingForPhysicalSwitch = false;
+            return;
+        }
+        // The module's PGN 253 status bit 2 (SteerSwitchActive) reflects
+        // the physical AutoSteer switch on the operator's console. With a
+        // physical switch configured we must wait for the module to
+        // report it engaged before commanding a PWM ramp.
+        bool moduleReportsEngaged =
+            _autoSteerService?.LastSteerData.SteerSwitchActive ?? false;
+        WaitingForPhysicalSwitch = !moduleReportsEngaged;
+
+        // Bound commands need to re-evaluate CanExecute when the gate
+        // changes. AsyncRelayCommand exposes NotifyCanExecuteChanged.
+        (StartTestCommand as IRelayCommand)?.NotifyCanExecuteChanged();
+        (ContinueToMaxAngleCommand as IRelayCommand)?.NotifyCanExecuteChanged();
     }
 
     public override Task<bool> ValidateAsync()

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/RollCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/RollCalibrationStepViewModel.cs
@@ -42,14 +42,31 @@ public class RollCalibrationStepViewModel : WizardStepViewModel
     public bool IsRollInvert
     {
         get => _isRollInvert;
-        set => SetProperty(ref _isRollInvert, value);
+        set
+        {
+            // Push the new value into the store immediately so the next
+            // NMEA parse uses it. NmeaParserServiceFast post-processes
+            // roll with `if (IsRollInvert) roll = -roll; roll -= RollZero;`
+            // — without the live store-write, the gauge keeps showing
+            // raw uncalibrated roll until the operator advances past
+            // the step and OnLeaving fires.
+            if (SetProperty(ref _isRollInvert, value))
+                _configService.Store.Ahrs.IsRollInvert = value;
+        }
     }
 
     private double _rollZero;
     public double RollZero
     {
         get => _rollZero;
-        set => SetProperty(ref _rollZero, value);
+        set
+        {
+            // Same live-feedback push as IsRollInvert. The Zero Roll
+            // button captures LiveRoll into this setter; the next NMEA
+            // parse subtracts it from raw roll so the gauge centres.
+            if (SetProperty(ref _rollZero, value))
+                _configService.Store.Ahrs.RollZero = value;
+        }
     }
 
     private double _liveRoll;

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/WasCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/WasCalibrationStepViewModel.cs
@@ -50,14 +50,32 @@ public class WasCalibrationStepViewModel : WizardStepViewModel
     public bool InvertWas
     {
         get => _invertWas;
-        set => SetProperty(ref _invertWas, value);
+        set
+        {
+            // Push to the store immediately so PGN 251/252 emit the new
+            // setting on the next AutoSteer config cycle. Without the
+            // live write, the operator's toggle takes effect only when
+            // they advance past the wizard step (OnLeaving), so live
+            // WAS bar feedback in the gauge above doesn't match the
+            // toggle state.
+            if (SetProperty(ref _invertWas, value))
+                _configService.Store.AutoSteer.InvertWas = value;
+        }
     }
 
     private int _wasOffset;
     public int WasOffset
     {
         get => _wasOffset;
-        set => SetProperty(ref _wasOffset, value);
+        set
+        {
+            // Same live push as InvertWas. The Zero WAS button captures
+            // the current angle into this setter; the host then emits
+            // PGN 251 with the new WasOffset on the next config cycle
+            // so the module starts subtracting it from raw counts.
+            if (SetProperty(ref _wasOffset, value))
+                _configService.Store.AutoSteer.WasOffset = value;
+        }
     }
 
     private double _liveSteerAngle;

--- a/Tests/AgValoniaGPS.Services.Tests/NmeaParserServiceFastTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/NmeaParserServiceFastTests.cs
@@ -230,6 +230,118 @@ public class NmeaParserServiceFastTests
     }
 
     [Test]
+    public void ParseIntoState_PANDA_AppliesAhrsIsRollInvert()
+    {
+        // The Roll-calibration wizard step's IsRollInvert toggle must
+        // take effect on live NMEA roll, not just on the values the
+        // wizard captures via OnLeaving. Without this post-process the
+        // operator's "Invert Roll" toggle has no visible effect on the
+        // gauge.
+        var prior = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(
+            new AgValoniaGPS.Models.Configuration.ConfigurationStore());
+        try
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Ahrs.IsRollInvert = true;
+
+            byte[] sentence = BuildPandaBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5,
+                heading: 90.0, roll: 5.7, pitch: 0, yawRate: 0);
+            var state = new VehicleState();
+            NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+            Assert.That(state.Roll, Is.EqualTo(-5.7).Within(1e-6),
+                "IsRollInvert flips the sign of the parsed roll before downstream consumers.");
+        }
+        finally
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(prior);
+        }
+    }
+
+    [Test]
+    public void ParseIntoState_PANDA_SubtractsAhrsRollZero()
+    {
+        // Zero Roll calibration captures the current reading as the
+        // zero point; subsequent parses subtract it so the gauge centres.
+        var prior = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(
+            new AgValoniaGPS.Models.Configuration.ConfigurationStore());
+        try
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Ahrs.RollZero = 2.0;
+
+            byte[] sentence = BuildPandaBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5,
+                heading: 90.0, roll: 5.7, pitch: 0, yawRate: 0);
+            var state = new VehicleState();
+            NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+            Assert.That(state.Roll, Is.EqualTo(3.7).Within(1e-6),
+                "RollZero offset is subtracted from the raw IMU roll.");
+        }
+        finally
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(prior);
+        }
+    }
+
+    [Test]
+    public void ParseIntoState_PANDA_InvertAndZero_CompositeOrder()
+    {
+        // Order matters: invert first, then subtract zero. Mirrors the
+        // legacy AiO firmware pipeline so the operator's calibration
+        // gives the same readings as the original hardware path.
+        var prior = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(
+            new AgValoniaGPS.Models.Configuration.ConfigurationStore());
+        try
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Ahrs.IsRollInvert = true;
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Ahrs.RollZero = 2.0;
+
+            byte[] sentence = BuildPandaBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5,
+                heading: 90.0, roll: 5.7, pitch: 0, yawRate: 0);
+            var state = new VehicleState();
+            NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+            // -5.7 - 2.0 = -7.7
+            Assert.That(state.Roll, Is.EqualTo(-7.7).Within(1e-6),
+                "Composite: invert first (-5.7), then subtract zero (-7.7).");
+        }
+        finally
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(prior);
+        }
+    }
+
+    [Test]
+    public void ParseIntoState_PAOGI_AlsoAppliesAhrsCalibration()
+    {
+        // Same post-process must mirror in the PAOGI branch — its roll
+        // field is float decimal degrees but the calibration semantics
+        // are identical.
+        var prior = AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance;
+        AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(
+            new AgValoniaGPS.Models.Configuration.ConfigurationStore());
+        try
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Ahrs.IsRollInvert = true;
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.Instance.Ahrs.RollZero = 1.0;
+
+            byte[] sentence = BuildPaogiBytes(4807.038, "N", 01131.000, "E", 4, 12, 0.9, 100, 0, 5.5,
+                heading: 90.5, roll: 1.25, pitch: 0, yawRate: 0);
+            var state = new VehicleState();
+            NmeaParserServiceFast.ParseIntoState(sentence, ref state);
+
+            // -1.25 - 1.0 = -2.25
+            Assert.That(state.Roll, Is.EqualTo(-2.25).Within(1e-6));
+        }
+        finally
+        {
+            AgValoniaGPS.Models.Configuration.ConfigurationStore.SetInstance(prior);
+        }
+    }
+
+    [Test]
     public void ParseIntoState_PAOGI_HeadingAsFloatNoScaling_ImuStaysInvalid()
     {
         // PAOGI emits heading as float decimal degrees — no ×10 scaling.

--- a/Tests/AgValoniaGPS.Services.Tests/SteerWizardLiveFeedbackTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SteerWizardLiveFeedbackTests.cs
@@ -1,0 +1,223 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using CommunityToolkit.Mvvm.Input;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the live-feedback wiring added across the Roll / WAS / Motor
+/// calibration wizard steps. The operator's perception bug was "I move
+/// the slider but the gauge doesn't change": pre-fix, the steps only
+/// wrote their settings into ConfigurationStore on OnLeaving, so the
+/// downstream NMEA roll post-process and the PGN 251/252 emit cycle
+/// didn't see the operator's changes until the next step was visited.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore is a singleton.
+public class SteerWizardLiveFeedbackTests
+{
+    private IConfigurationService _configService = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Each test starts with a fresh store so the assertions about
+        // "store flipped to X" are independent of any prior test's
+        // leftover state.
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(ConfigurationStore.Instance);
+    }
+
+    // ── Area 2: Roll calibration step pushes to store live ─────────────
+
+    [Test]
+    public void RollStep_SettingIsRollInvert_WritesToStoreImmediately()
+    {
+        var step = new RollCalibrationStepViewModel(_configService);
+        Assume.That(_configService.Store.Ahrs.IsRollInvert, Is.False);
+
+        step.IsRollInvert = true;
+
+        Assert.That(_configService.Store.Ahrs.IsRollInvert, Is.True,
+            "IsRollInvert setter must push to ConfigStore immediately so "
+            + "NmeaParserServiceFast's roll post-process picks up the new "
+            + "value on the next parse — not at OnLeaving.");
+    }
+
+    [Test]
+    public void RollStep_SettingRollZero_WritesToStoreImmediately()
+    {
+        var step = new RollCalibrationStepViewModel(_configService);
+        Assume.That(_configService.Store.Ahrs.RollZero, Is.EqualTo(0));
+
+        step.RollZero = 2.5;
+
+        Assert.That(_configService.Store.Ahrs.RollZero, Is.EqualTo(2.5),
+            "RollZero setter must push to ConfigStore so the next NMEA "
+            + "parse subtracts it from raw roll.");
+    }
+
+    [Test]
+    public void RollStep_ZeroRollCommand_PushesLiveRollIntoStore()
+    {
+        // ZeroRollCommand captures LiveRoll into the setter. Combined with
+        // the live-push, the operator's tap on Zero Roll lands in the
+        // store within the same cycle.
+        var step = new RollCalibrationStepViewModel(_configService);
+        // Seed a live reading from the IMU feed (simulate a snapshot).
+        InvokeNonPublic(step, "OnStateUpdated",
+            new object?[] { this, BuildSnapshot(roll: 3.2) });
+
+        ((IRelayCommand)step.ZeroRollCommand).Execute(null);
+
+        Assert.That(step.RollZero, Is.EqualTo(3.2).Within(1e-6));
+        Assert.That(_configService.Store.Ahrs.RollZero, Is.EqualTo(3.2).Within(1e-6),
+            "Zero Roll button captures LiveRoll into the RollZero setter, "
+            + "which forwards to the store — the gauge centres on the next "
+            + "tick rather than waiting for the wizard step to be left.");
+    }
+
+    // ── Area 3: WAS calibration step pushes to store live ──────────────
+
+    [Test]
+    public void WasStep_SettingInvertWas_WritesToStoreImmediately()
+    {
+        var step = new WasCalibrationStepViewModel(_configService);
+        Assume.That(_configService.Store.AutoSteer.InvertWas, Is.False);
+
+        step.InvertWas = true;
+
+        Assert.That(_configService.Store.AutoSteer.InvertWas, Is.True,
+            "InvertWas setter must push to ConfigStore so the next PGN 251 "
+            + "the host emits carries the new flag — not at OnLeaving.");
+    }
+
+    [Test]
+    public void WasStep_SettingWasOffset_WritesToStoreImmediately()
+    {
+        var step = new WasCalibrationStepViewModel(_configService);
+        Assume.That(_configService.Store.AutoSteer.WasOffset, Is.EqualTo(0));
+
+        step.WasOffset = 42;
+
+        Assert.That(_configService.Store.AutoSteer.WasOffset, Is.EqualTo(42),
+            "WasOffset setter must push to ConfigStore so PGN 252 carries "
+            + "the new offset — Zero WAS button picks the angle * CPD and "
+            + "the module starts subtracting it from raw counts.");
+    }
+
+    // ── Area 4: Motor calibration gates on physical switch engagement ──
+
+    [Test]
+    public void MotorCalStep_NoPhysicalSwitchConfigured_StartsImmediately()
+    {
+        _configService.Store.Tool.IsSteerSwitchEnabled = false;
+        var autoSteer = Substitute.For<IAutoSteerService>();
+        autoSteer.LastSteerData.Returns(default(SteerModuleData));
+        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteer);
+
+        InvokeNonPublic(step, "OnEntering", null);
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False,
+            "Without a physical AutoSteer switch configured, the wizard "
+            + "must not gate on engagement — engagement is managed by the "
+            + "host's AutoSteer button alone.");
+        Assert.That(step.CanStartCalibration, Is.True);
+    }
+
+    [Test]
+    public void MotorCalStep_PhysicalSwitchConfiguredButOff_BlocksCalibration()
+    {
+        _configService.Store.Tool.IsSteerSwitchEnabled = true;
+        var autoSteer = Substitute.For<IAutoSteerService>();
+        // Module reports SteerSwitchActive=false → physical switch is OFF.
+        autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0,
+            ImuHeading: 0,
+            ImuRoll: 0,
+            WorkSwitchActive: false,
+            SteerSwitchActive: false,
+            RemoteButtonPressed: false,
+            VwasFusionActive: false,
+            PwmDisplay: 0));
+        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteer);
+
+        InvokeNonPublic(step, "OnEntering", null);
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.True,
+            "Physical switch is configured but module reports it OFF: "
+            + "calibration must wait so the operator-flips-switch prompt "
+            + "is visible and StartTestCommand's CanExecute is false.");
+        Assert.That(step.CanStartCalibration, Is.False);
+        Assert.That(step.PhysicalSwitchPromptText,
+            Does.Contain("AutoSteer switch"));
+    }
+
+    [Test]
+    public void MotorCalStep_PhysicalSwitchFlipsOn_UnblocksCalibration()
+    {
+        _configService.Store.Tool.IsSteerSwitchEnabled = true;
+        var autoSteer = Substitute.For<IAutoSteerService>();
+        autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0,
+            ImuHeading: 0,
+            ImuRoll: 0,
+            WorkSwitchActive: false,
+            SteerSwitchActive: false,
+            RemoteButtonPressed: false,
+            VwasFusionActive: false,
+            PwmDisplay: 0));
+        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteer);
+
+        InvokeNonPublic(step, "OnEntering", null);
+        Assume.That(step.WaitingForPhysicalSwitch, Is.True);
+
+        // Operator flips the physical switch — module's next PGN 253
+        // reports SteerSwitchActive=true.
+        autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0,
+            ImuHeading: 0,
+            ImuRoll: 0,
+            WorkSwitchActive: false,
+            SteerSwitchActive: true,
+            RemoteButtonPressed: false,
+            VwasFusionActive: false,
+            PwmDisplay: 0));
+        // VehicleStateSnapshot is a plain struct (not EventArgs), so
+        // EventWith<T> won't accept it — use the generic-delegate form
+        // and invoke with positional args.
+        autoSteer.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteer, BuildSnapshot(isAutoSteerEngaged: true));
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False,
+            "After the module's PGN 253 reports SteerSwitchActive=true, "
+            + "the gate clears and calibration can start.");
+        Assert.That(step.CanStartCalibration, Is.True);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static VehicleStateSnapshot BuildSnapshot(
+        double roll = 0, bool isAutoSteerEngaged = false) => new()
+    {
+        Roll = roll,
+        IsAutoSteerEngaged = isAutoSteerEngaged,
+    };
+
+    private static void InvokeNonPublic(object target, string name, object?[]? args)
+    {
+        var m = target.GetType().GetMethod(name,
+            System.Reflection.BindingFlags.Instance
+            | System.Reflection.BindingFlags.NonPublic);
+        m!.Invoke(target, args);
+    }
+}


### PR DESCRIPTION
Half of a two-PR effort. The companion PR #381 ships matching Vehicle Simulator behaviour so the wizard's roll/WAS calibration and motor-cal steps work end-to-end. The two are independent and can merge in either order.

## Areas in this PR

### 1. Host applies AHRS roll calibration in NMEA parser
`NmeaParserServiceFast` now post-processes the raw IMU roll with `ConfigStore.Ahrs.IsRollInvert` and `RollZero` in **both** PANDA and PAOGI branches. Order matches legacy: invert sign first, then subtract zero offset. Mirrors the WAS post-process pattern already in `SmartWasCalibrationService`. Before this, the wizard's roll calibration toggle/Zero-Roll button had no live effect because nothing in the host pipeline read the settings.

### 2. Roll wizard step (`RollCalibrationStepViewModel`) pushes live
Setters for `IsRollInvert` and `RollZero` write through to `_configService.Store.Ahrs` immediately. `OnLeaving` writes dropped — the live setter is the single writer. Operator's toggle / Zero-Roll tap reaches the store before the next NMEA parse.

### 3. WAS wizard step (`WasCalibrationStepViewModel`) pushes live
Same shape: `InvertWas` and `WasOffset` setters write to `_configService.Store.AutoSteer` immediately. Host's AutoSteer service emits PGN 251/252 on the next config cycle so the module (or the simulator) picks them up promptly.

### 4. Motor calibration step gates on physical-switch engagement
When `Tool.IsSteerSwitchEnabled=true`, `AutoMotorCalibrationStepViewModel` blocks the calibration start commands until the module reports `SteerSwitchActive=true` via PGN 253. `WaitingForPhysicalSwitch` + `PhysicalSwitchPromptText` drive the UI hint. When the config flag is false (no physical switch wired), the gate is bypassed — existing flow preserved.

## Tests
- 4 new NMEA-parser tests pin the roll-calibration arithmetic across PANDA + PAOGI (invert alone, zero alone, composite, PAOGI parity). Each test scopes `ConfigurationStore.SetInstance` so singleton mutation doesn't leak.
- 8 new wizard tests cover roll/WAS live-push semantics, motor-cal no-switch passthrough, motor-cal switch-OFF blocking, and PGN-253 engagement unblocking.
- `Tests/AgValoniaGPS.Services.Tests` full suite: 859 pass, 1 fail (pre-existing Windows file-lock flake on `ProfileJsonServiceV1Tests.Load_OlderProfileWithoutNewFields_KeepsModelDefaults`, unrelated), 2 skip.

## Test plan
- [x] All targeted filters green.
- [x] Build clean.
- [ ] Bench: open wizard, navigate to step 7 (Roll). Toggle Invert Roll — gauge needle flips sign immediately. Tilt vehicle, press Zero Roll — needle snaps to 0.
- [ ] Bench: step 8 (WAS). With #381 merged, toggle Invert WAS — bar flips sign. Move simulator's steer slider, press Zero WAS — bar snaps to 0.
- [ ] Bench: step 9 (Motor cal) with `Tool.IsSteerSwitchEnabled=true`. Calibration start is blocked, hint shown. Flip simulator's Steer Switch toggle ON — calibration unblocks.
- [ ] Bench: same step with `IsSteerSwitchEnabled=false` — calibration starts immediately, no hint.