### PR TITLE
AutoSteer: emit PGN 251/252 on config changes (baseline at startup, debounced re-emit)

### DIFF
--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -15,8 +15,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Base;
 using AgValoniaGPS.Models.Configuration;
@@ -68,6 +70,29 @@ public class AutoSteerService : IAutoSteerService
     private bool _isEnabled;
     private bool _isEngaged;
 
+    // Config-change → PGN 251/252 emission. The wizard and the
+    // AutoSteer config dialog both mutate ConfigStore.AutoSteer (and
+    // Tool.IsSteerSwitchEnabled); previously only the dialog's
+    // Apply/Reset paths emitted the PGNs. Result: wizard-step writes
+    // weren't visible to the module/simulator until the dialog was
+    // opened. This service is the single owner of the emit: subscribe
+    // to PropertyChanged, debounce, and re-emit both PGNs.
+    private readonly Timer _configEmitTimer;
+    private int _configEmitDelayMs = 150;
+    private bool _configSubscribed;
+    private AutoSteerConfig? _subscribedAutoSteer;
+    private ToolConfig? _subscribedTool;
+
+    /// <summary>
+    /// Test seam: lets tests shorten the debounce so they don't have
+    /// to sleep the wall clock to observe coalescing behaviour.
+    /// </summary>
+    internal int ConfigEmitDebounceMilliseconds
+    {
+        get => _configEmitDelayMs;
+        set => _configEmitDelayMs = value;
+    }
+
     public event EventHandler<VehicleStateSnapshot>? StateUpdated;
 
     public bool IsEnabled => _isEnabled;
@@ -89,6 +114,15 @@ public class AutoSteerService : IAutoSteerService
         // Initialize state
         _state = new VehicleState();
         _guidanceInput = new TrackInput();
+
+        // Debounce timer: parked Infinite until a PropertyChanged event
+        // arms it. Coalesces bursts (Reset-to-Defaults touches many
+        // fields in quick succession; we want exactly one PGN emit
+        // pair, not one per field).
+        _configEmitTimer = new Timer(_ => EmitSteerConfigPgns(),
+            state: null,
+            dueTime: Timeout.Infinite,
+            period: Timeout.Infinite);
     }
 
     /// <summary>
@@ -113,13 +147,75 @@ public class AutoSteerService : IAutoSteerService
     {
         _isEnabled = true;
         _udpService.DataReceived += OnUdpDataReceived;
+
+        // Subscribe before the initial emission so a settings write that
+        // races against startup still re-fires through the debounce.
+        SubscribeToConfigChanges();
+
+        // Initial baseline: send current ConfigStore.AutoSteer values
+        // once so the module / simulator sees them without waiting for
+        // the operator to touch a setting. Prevents the "simulator's
+        // Steer Switch toggle stays greyed until I open the AutoSteer
+        // config dialog" symptom — the simulator reads switch-type from
+        // PGN 251 byte 5 and we'd previously never send it on startup.
+        EmitSteerConfigPgns();
     }
 
     public void Stop()
     {
         _udpService.DataReceived -= OnUdpDataReceived;
+        UnsubscribeFromConfigChanges();
         _isEnabled = false;
         _isEngaged = false;
+    }
+
+    private void SubscribeToConfigChanges()
+    {
+        if (_configSubscribed) return;
+        _subscribedAutoSteer = ConfigurationStore.Instance.AutoSteer;
+        _subscribedTool = ConfigurationStore.Instance.Tool;
+        _subscribedAutoSteer.PropertyChanged += OnConfigPropertyChanged;
+        _subscribedTool.PropertyChanged += OnConfigPropertyChanged;
+        _configSubscribed = true;
+    }
+
+    private void UnsubscribeFromConfigChanges()
+    {
+        if (!_configSubscribed) return;
+        if (_subscribedAutoSteer != null)
+            _subscribedAutoSteer.PropertyChanged -= OnConfigPropertyChanged;
+        if (_subscribedTool != null)
+            _subscribedTool.PropertyChanged -= OnConfigPropertyChanged;
+        _configSubscribed = false;
+    }
+
+    /// <summary>
+    /// PropertyChanged handler for AutoSteer / Tool config. Any change
+    /// re-arms the debounce timer; the timer fires the actual PGN
+    /// emission once the storm subsides. PGN 251 and 252 are always
+    /// emitted as a pair — the cost is two small UDP packets, and
+    /// splitting "which PGN does this property belong to" would
+    /// duplicate the bit-packing knowledge from <c>PgnBuilder</c>.
+    /// </summary>
+    private void OnConfigPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        _configEmitTimer.Change(_configEmitDelayMs, Timeout.Infinite);
+    }
+
+    private void EmitSteerConfigPgns()
+    {
+        if (!_isEnabled) return; // raced past Stop()
+        try
+        {
+            var cfg = ConfigurationStore.Instance.AutoSteer;
+            _udpService.SendToModules(PgnBuilder.BuildSteerConfigPgn(cfg));
+            _udpService.SendToModules(PgnBuilder.BuildSteerSettingsPgn(cfg));
+        }
+        catch (Exception ex)
+        {
+            // Don't let an emit failure tear down the timer / service.
+            Debug.WriteLine($"[AutoSteerService] PGN emit failed: {ex.Message}");
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/Tests/AgValoniaGPS.Services.Tests/AutoSteerConfigEmitTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoSteerConfigEmitTests.cs
@@ -1,0 +1,163 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Threading;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the plumbing that lets the wizard's live setters and the
+/// AutoSteer config dialog's writes both reach the module/simulator
+/// without depending on the dialog being open. The service is the
+/// single owner of PGN 251 + PGN 252 emission: subscribes to
+/// ConfigurationStore.AutoSteer + Tool PropertyChanged, debounces, and
+/// re-emits both packets. On Start() it also emits a baseline so the
+/// module sees current settings without waiting for the operator to
+/// touch anything.
+///
+/// Pre-fix bug surfaced on PR #380's bench-test: wizard step 8 wrote
+/// InvertWas / WasOffset into ConfigStore.AutoSteer live, but nothing
+/// in the host pushed PGN 251/252 to the module. Simulator never
+/// received the updated config; Zero WAS / Invert WAS appeared to do
+/// nothing; the simulator's Steer Switch toggle stayed greyed because
+/// IsSteerSwitchEnabled never flowed through PGN 251.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore is a singleton.
+public class AutoSteerConfigEmitTests
+{
+    private IUdpCommunicationService _udp = null!;
+    private AutoSteerService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Fresh ConfigurationStore so PropertyChanged subscriptions hit
+        // a clean baseline, and so the [NonParallelizable] mutations
+        // from prior tests don't bleed in.
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+
+        _udp = Substitute.For<IUdpCommunicationService>();
+        var guidance = Substitute.For<ITrackGuidanceService>();
+        var gps = Substitute.For<IGpsService>();
+        var appState = new ApplicationState();
+        _service = new AutoSteerService(guidance, _udp, gps, appState);
+
+        // Shorten the debounce so tests don't have to sleep 150 ms
+        // wall-clock per assertion. 20 ms is well over the timer's
+        // resolution and well under any sensible test budget.
+        _service.ConfigEmitDebounceMilliseconds = 20;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _service.Stop();
+    }
+
+    [Test]
+    public void Start_EmitsBaselinePgn251AndPgn252()
+    {
+        // Start() must push the current ConfigStore.AutoSteer values
+        // immediately so the module sees them without waiting for the
+        // operator to mutate something.
+        _service.Start();
+
+        // PGN 251 is 0xFB, PGN 252 is 0xFC (byte 3 in the wire format).
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFB));
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFC));
+    }
+
+    [Test]
+    public void AutoSteerPropertyChange_ReemitsBothPgns_AfterDebounce()
+    {
+        _service.Start();
+        _udp.ClearReceivedCalls();
+
+        ConfigurationStore.Instance.AutoSteer.InvertWas = true;
+
+        // Wait past the debounce window. Tight upper bound — the timer
+        // fires once the storm ends; 100 ms is plenty even on a loaded
+        // CI runner with a 20 ms debounce.
+        WaitForEmit();
+
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFB));
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFC));
+    }
+
+    [Test]
+    public void RapidPropertyChanges_CoalesceIntoSingleEmit()
+    {
+        _service.Start();
+        _udp.ClearReceivedCalls();
+
+        // Burst-mutate five properties tightly. With a 20 ms debounce
+        // and back-to-back sets the timer must coalesce these into a
+        // single emit pair.
+        var auto = ConfigurationStore.Instance.AutoSteer;
+        auto.InvertWas = true;
+        auto.WasOffset = 100;
+        auto.CountsPerDegree = 50;
+        auto.MinPwm = 35;
+        auto.MaxPwm = 240;
+
+        WaitForEmit();
+
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFB));
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFC));
+    }
+
+    [Test]
+    public void ToolPropertyChange_ReemitsConfig()
+    {
+        _service.Start();
+        _udp.ClearReceivedCalls();
+
+        // Tool.IsSteerSwitchEnabled is the operator-console wiring flag
+        // the lead called out specifically. Per spec, flipping it must
+        // re-emit so the module sees the new switch-mode in PGN 251.
+        ConfigurationStore.Instance.Tool.IsSteerSwitchEnabled =
+            !ConfigurationStore.Instance.Tool.IsSteerSwitchEnabled;
+
+        WaitForEmit();
+
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFB));
+        _udp.Received(1).SendToModules(Arg.Is<byte[]>(b => b.Length > 4 && b[3] == 0xFC));
+    }
+
+    [Test]
+    public void PropertyChangeAfterStop_DoesNotEmit()
+    {
+        // Sanity guard: a property write that races past Stop() must
+        // not cause a phantom emit. Unsubscribed handlers + the
+        // _isEnabled gate inside EmitSteerConfigPgns both contribute.
+        _service.Start();
+        _service.Stop();
+        _udp.ClearReceivedCalls();
+
+        ConfigurationStore.Instance.AutoSteer.InvertWas = true;
+        WaitForEmit();
+
+        _udp.DidNotReceiveWithAnyArgs().SendToModules(default!);
+    }
+
+    /// <summary>
+    /// Spin until either the debounce should have fired or we've
+    /// waited well past it. Faster than a fixed sleep when the timer
+    /// fires earlier; bounded so a stuck timer doesn't hang the suite.
+    /// </summary>
+    private void WaitForEmit()
+    {
+        // 200 ms is ~10× the configured debounce; tests fail fast if
+        // the timer never fires.
+        Thread.Sleep(200);
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/Pipeline/AutoSteerControlTickTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/Pipeline/AutoSteerControlTickTests.cs
@@ -36,6 +36,12 @@ public class AutoSteerControlTickTests
         gps.Start();
         _autoSteer = new AutoSteerService(new TrackGuidanceService(), _udp, gps, appState);
         _autoSteer.Start();
+
+        // AutoSteerService now emits a baseline PGN 251 + PGN 252 pair on
+        // Start() so the module sees current settings without waiting for
+        // the operator. These tests only care about the per-tick
+        // PGN 254 + PGN 239 traffic, so drop the baseline from the count.
+        _udp.ClearReceivedCalls();
     }
 
     [Test]

--- a/Tests/AgValoniaGPS.Services.Tests/Pipeline/UnifiedPipelineTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/Pipeline/UnifiedPipelineTests.cs
@@ -52,6 +52,11 @@ public class UnifiedPipelineTests
 
         var autoSteer = new AutoSteerService(mockGuidance, mockUdp, mockGps, appState);
         autoSteer.Start();
+        // Start() now emits a baseline PGN 251 + PGN 252 pair; that
+        // happens off the receive thread so it doesn't violate C4, but
+        // it does show up on the UDP mock. Clear it so the SendToModules
+        // assertion below only counts receive-thread sends.
+        mockUdp.ClearReceivedCalls();
         autoSteer.SetCurrentTrack(new Models.Track.Track
         {
             Name = "test",


### PR DESCRIPTION
Live wizard / config-dialog setting changes weren't reaching the steer module. The send methods existed (`PgnBuilder.BuildSteerConfigPgn`, `BuildSteerSettingsPgn`) but were only invoked from `AutoSteerConfigViewModel` on Apply/Reset/Save. The wizard's step-7/step-8 live writes to `ConfigStore.AutoSteer` had no effect on the wire.

Visible symptoms:
- **Zero WAS / Invert WAS toggles in the wizard didn't change the simulator's reported angle** — simulator never received a fresh PGN 251/252 so it kept using stale calibration.
- **Vehicle Simulator's Steer Switch toggle stayed greyed out** — module never learned that `Tool.IsSteerSwitchEnabled=true`, so its UI defaulted to "no physical switch wired."

## Fix
`AutoSteerService` becomes the single owner of PGN 251 + PGN 252 emission:

- **`Start()` pushes a baseline pair** so the module sees current `ConfigStore.AutoSteer` / `ConfigStore.Tool` state immediately, without operator interaction.
- **Subscribes to `PropertyChanged`** on `ConfigStore.AutoSteer` and `ConfigStore.Tool`. Debounces ~150 ms (test seam `ConfigEmitDebounceMilliseconds`) so a burst of writes coalesces into one re-emission.
- **`Stop()` unsubscribes** and gates emission on `_isEnabled` so post-Stop races don't fire phantom sends.
- Existing `AutoSteerConfigViewModel` Apply/Reset PGN sends stay as belt-and-suspenders on the dialog path.

## Tests
- New `AutoSteerConfigEmitTests` (5 tests): baseline emit on Start; AutoSteer `PropertyChanged` debounced re-emit; rapid-change coalescing; `Tool.IsSteerSwitchEnabled` re-emit; no-emit-after-Stop.
- Updated `AutoSteerControlTickTests` and `UnifiedPipelineTests` to `ClearReceivedCalls()` after `Start()` so the baseline pair doesn't bleed into per-tick send-count assertions.

Full suite: 852 pass / 1 fail / 2 skip. The lone failure is the pre-existing Windows file-lock flake in `ProfileJsonServiceV1Tests.Load_OlderProfileWithoutNewFields_KeepsModelDefaults`, unrelated.

## Test plan
- [x] Build clean.
- [x] New tests green.
- [ ] Bench: open Vehicle Simulator + Desktop. Verify simulator's Steer Switch toggle becomes interactable once `Tool.IsSteerSwitchEnabled=true` in the app config.
- [ ] Bench: open steer wizard step 8. Drag simulator's wheel slider to 10°. In the wizard, press Zero WAS — simulator's reported WAS snaps to 0. Toggle Invert WAS — sign flips.