### PR TITLE
Vehicle Simulator: 4-column semantic layout + virtual WAS hardware-truth model

### DIFF
--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/PgnProtocol.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/PgnProtocol.cs
@@ -146,6 +146,52 @@ public static class PgnProtocol
     }
 
     /// <summary>
+    /// Parse PGN 252 (SteerSettings from host). Layout mirrors AgOpenGPS ModSim
+    /// and the Teensy AutoSteer firmware: Kp, highPWM, lowPWM, minPWM,
+    /// steerSensorCounts (counts/deg), wasOffset (int16 LE), AckermannFix*100.
+    /// </summary>
+    public static SteerSettingsPacket ParseSteerSettings(byte[] data)
+    {
+        return new SteerSettingsPacket
+        {
+            Kp = data[5],
+            HighPWM = data[6],
+            LowPWM = data[7],
+            MinPWM = data[8],
+            CountsPerDegree = data[9],
+            WasOffset = (short)(data[10] | (data[11] << 8)),
+            AckermannFix = data[12] / 100.0,
+        };
+    }
+
+    /// <summary>
+    /// Parse PGN 251 (SteerConfig from host). Two bit-packed setting bytes plus
+    /// PulseCountMax and MinSpeed.
+    /// </summary>
+    public static SteerConfigPacket ParseSteerConfig(byte[] data)
+    {
+        byte setting0 = data[5];
+        byte setting1 = data[8];
+        return new SteerConfigPacket
+        {
+            InvertWas = (setting0 & 0x01) != 0,
+            IsRelayActiveHigh = (setting0 & 0x02) != 0,
+            MotorDriveDirection = (setting0 & 0x04) != 0,
+            SingleInputWas = (setting0 & 0x08) != 0,
+            CytronDriver = (setting0 & 0x10) != 0,
+            SteerSwitchEnabled = (setting0 & 0x20) != 0,
+            SteerButtonEnabled = (setting0 & 0x40) != 0,
+            ShaftEncoderEnabled = (setting0 & 0x80) != 0,
+            PulseCountMax = data[6],
+            MinSpeed = data[7],
+            IsDanfoss = (setting1 & 0x01) != 0,
+            PressureSensorEnabled = (setting1 & 0x02) != 0,
+            CurrentSensorEnabled = (setting1 & 0x04) != 0,
+            IsUseYAxis = (setting1 & 0x08) != 0,
+        };
+    }
+
+    /// <summary>
     /// Parse PGN 239 (Machine data from host).
     /// </summary>
     public static MachineCommand ParseMachineCommand(byte[] data)
@@ -204,4 +250,44 @@ public struct MachineConfigPacket
 public struct MachinePinConfigPacket
 {
     public byte[] PinAssignments; // 24 bytes
+}
+
+/// <summary>
+/// Decoded payload of PGN 252 (SteerSettings) — PID tuning, PWM bounds,
+/// WAS calibration, Ackermann compensation.
+/// </summary>
+public struct SteerSettingsPacket
+{
+    public byte Kp;
+    public byte HighPWM;
+    public byte LowPWM;
+    public byte MinPWM;
+    public byte CountsPerDegree;
+    public short WasOffset;
+    public double AckermannFix; // unit = ratio (1.0 = 100%)
+}
+
+/// <summary>
+/// Decoded payload of PGN 251 (SteerConfig) — hardware/wiring options.
+/// </summary>
+public struct SteerConfigPacket
+{
+    // setting0 bits
+    public bool InvertWas;
+    public bool IsRelayActiveHigh;
+    public bool MotorDriveDirection;
+    public bool SingleInputWas;
+    public bool CytronDriver;
+    public bool SteerSwitchEnabled;
+    public bool SteerButtonEnabled;
+    public bool ShaftEncoderEnabled;
+
+    public byte PulseCountMax;
+    public byte MinSpeed;
+
+    // setting1 bits
+    public bool IsDanfoss;
+    public bool PressureSensorEnabled;
+    public bool CurrentSensorEnabled;
+    public bool IsUseYAxis;
 }

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -44,8 +44,27 @@ public class VirtualSteerModule : IDisposable
     public double ImuRollDeg { get; set; }
 
     // Simulation behavior
-    public double SteerResponseRate { get; set; } = 0.5; // How fast WAS follows command (0-1)
-    public bool SimulateSteerResponse { get; set; } = true;
+    // Legacy WAS-follow path used by older Services.Tests fixtures: applies a
+    // fraction of the command-vs-actual gap on every PGN 254 receive. The
+    // current default is the PWM-driven tick loop below; this flag stays for
+    // back-compat with tests that opt into the simpler model.
+    public double SteerResponseRate { get; set; } = 0.5;
+    public bool SimulateSteerResponse { get; set; } = false;
+
+    // === Synthetic PWM control loop ===
+    // Modelled after the Teensy AutoSteer firmware: proportional control with
+    // MinPWM dead-band promotion (so the motor can overcome static friction)
+    // and a small commanded-vs-actual deadband to keep the wheel still at the
+    // target. Internal PWM is signed (-HighPWM .. +HighPWM); PGN 253 byte 7
+    // reports magnitude only, with direction handled by the driver pin on real
+    // hardware.
+    public int CurrentPwm { get; private set; }
+
+    /// <summary>Maps PWM duty (1..HighPWM) to deg/sec of WAS movement.</summary>
+    public double PwmToDegPerSec { get; set; } = 0.2;
+
+    /// <summary>Below this absolute error, drive pwm to zero so the wheel can rest.</summary>
+    public double AngleDeadbandDeg { get; set; } = 0.05;
 
     // Counters
     public long ReceivedCommandCount { get; private set; }
@@ -195,16 +214,7 @@ public class VirtualSteerModule : IDisposable
         switch (pgn)
         {
             case PgnProtocol.PGN_AUTOSTEER_TO_MODULE:
-                var cmd = PgnProtocol.ParseAutoSteerCommand(data);
-                CommandedSteerAngleDeg = cmd.SteerAngleDeg;
-                LastCommand = cmd;
-                ReceivedCommandCount++;
-
-                // Simulate WAS response
-                if (SimulateSteerResponse)
-                {
-                    ActualSteerAngleDeg += (CommandedSteerAngleDeg - ActualSteerAngleDeg) * SteerResponseRate;
-                }
+                ApplyAutoSteerCommand(PgnProtocol.ParseAutoSteerCommand(data));
                 // PGN 253 is emitted by the periodic TickLoop, not in response to PGN 254.
                 break;
 
@@ -220,6 +230,25 @@ public class VirtualSteerModule : IDisposable
             case PgnProtocol.PGN_STEER_CONFIG:
                 ApplySteerConfig(PgnProtocol.ParseSteerConfig(data));
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Apply a parsed PGN 254 (AutoSteer command) payload.
+    /// Public so tests can drive the control loop deterministically without
+    /// going over UDP and relying on receive-task timing.
+    /// </summary>
+    public void ApplyAutoSteerCommand(AutoSteerCommand cmd)
+    {
+        CommandedSteerAngleDeg = cmd.SteerAngleDeg;
+        LastCommand = cmd;
+        ReceivedCommandCount++;
+
+        // Legacy WAS-follow: applies a fraction of the gap on every receive.
+        // Disabled by default — the PWM tick loop is the real model.
+        if (SimulateSteerResponse)
+        {
+            ActualSteerAngleDeg += (CommandedSteerAngleDeg - ActualSteerAngleDeg) * SteerResponseRate;
         }
     }
 
@@ -301,7 +330,53 @@ public class VirtualSteerModule : IDisposable
     /// </summary>
     public void Tick()
     {
+        UpdateSteerControl(TickIntervalMs / 1000.0);
         SendSteerFeedback();
+    }
+
+    /// <summary>
+    /// Synthetic PWM control + WAS integration step.
+    /// Proportional law: pwm = error * Kp / 10, clamped to [-HighPWM, +HighPWM].
+    /// Below MinPWM but non-zero, magnitude is promoted to MinPWM (real motors
+    /// need that to break static friction). Below AngleDeadbandDeg of error,
+    /// pwm is forced to zero so the wheel can rest at the commanded angle.
+    /// The WAS is then moved by pwm × PwmToDegPerSec × dt, clamped so a single
+    /// tick can never overshoot the commanded angle. Runs only when the host
+    /// has IsEngaged set in PGN 254 — otherwise the wheel is freely operator-
+    /// controlled and the simulator just holds whatever ActualSteerAngleDeg is.
+    /// </summary>
+    public void UpdateSteerControl(double dt)
+    {
+        bool engaged = LastCommand?.IsEngaged ?? false;
+        double error = CommandedSteerAngleDeg - ActualSteerAngleDeg;
+
+        int pwm;
+        if (!engaged || Math.Abs(error) < AngleDeadbandDeg)
+        {
+            pwm = 0;
+        }
+        else
+        {
+            double raw = error * Kp / 10.0;
+            pwm = (int)raw;
+            if (pwm > HighPWM) pwm = HighPWM;
+            else if (pwm < -HighPWM) pwm = -HighPWM;
+            int absPwm = Math.Abs(pwm);
+            if (absPwm > 0 && absPwm < MinPWM)
+            {
+                pwm = pwm > 0 ? MinPWM : -MinPWM;
+            }
+        }
+
+        CurrentPwm = pwm;
+        PwmDisplay = (byte)Math.Min(255, Math.Abs(pwm));
+
+        if (engaged && pwm != 0)
+        {
+            double dAngle = pwm * PwmToDegPerSec * dt;
+            if (Math.Abs(dAngle) > Math.Abs(error)) dAngle = error;
+            ActualSteerAngleDeg += dAngle;
+        }
     }
 
     public void Dispose()

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -26,6 +26,11 @@ public class VirtualSteerModule : IDisposable
     private CancellationTokenSource? _cts;
     private Task? _receiveTask;
     private Task? _helloTask;
+    private Task? _tickTask;
+
+    // Real Teensy steer modules stream PGN 253 continuously at ~10 Hz regardless
+    // of host activity. The host's autosteer control loop relies on that cadence.
+    public int TickIntervalMs { get; set; } = 100;
 
     // Simulated WAS (Wheel Angle Sensor) state
     public double ActualSteerAngleDeg { get; set; }
@@ -59,6 +64,7 @@ public class VirtualSteerModule : IDisposable
         _cts = new CancellationTokenSource();
         _receiveTask = Task.Run(() => ReceiveLoop(_cts.Token));
         _helloTask = Task.Run(() => HelloLoop(_cts.Token));
+        _tickTask = Task.Run(() => TickLoop(_cts.Token));
     }
 
     public void Stop()
@@ -66,6 +72,7 @@ public class VirtualSteerModule : IDisposable
         _cts?.Cancel();
         try { _receiveTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
         try { _helloTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        try { _tickTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
     }
 
     /// <summary>
@@ -149,9 +156,7 @@ public class VirtualSteerModule : IDisposable
                 {
                     ActualSteerAngleDeg += (CommandedSteerAngleDeg - ActualSteerAngleDeg) * SteerResponseRate;
                 }
-
-                // Send feedback after receiving command
-                SendSteerFeedback();
+                // PGN 253 is emitted by the periodic TickLoop, not in response to PGN 254.
                 break;
 
             case PgnProtocol.PGN_HELLO_FROM_HOST:
@@ -185,6 +190,29 @@ public class VirtualSteerModule : IDisposable
             }
             catch (OperationCanceledException) { break; }
         }
+    }
+
+    private async Task TickLoop(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                Tick();
+                await Task.Delay(TickIntervalMs, ct);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (SocketException) { break; }
+        }
+    }
+
+    /// <summary>
+    /// Single periodic tick. Public so deterministic tests can drive emission
+    /// without relying on Task.Delay timing.
+    /// </summary>
+    public void Tick()
+    {
+        SendSteerFeedback();
     }
 
     public void Dispose()

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -39,6 +39,20 @@ public class VirtualSteerModule : IDisposable
     public bool WorkSwitchActive { get; set; }
     public byte PwmDisplay { get; set; }
 
+    // === Virtual WAS hardware truth ===
+    // The *real* CPD and off-center counts of the simulated WAS sensor — separate
+    // from the host's Applied* guesses received via PGN 251/252. The host's
+    // wizard tries to discover these values via Zero WAS and CPD calibration;
+    // operator can dial them in to simulate a misconfigured hardware install.
+    public double VirtualCountsPerDegree { get; set; } = 100.0;
+    public short VirtualWasOffset { get; set; }
+
+    /// <summary>
+    /// Raw WAS counts the simulated sensor would output for the current wheel
+    /// angle, before the host applies its own calibration. Useful for debug.
+    /// </summary>
+    public double TruthRawCounts => ActualSteerAngleDeg * VirtualCountsPerDegree + VirtualWasOffset;
+
     // IMU (if separate module, typically embedded in $PANDA now)
     public double ImuHeadingDeg { get; set; }
     public double ImuRollDeg { get; set; }
@@ -128,17 +142,19 @@ public class VirtualSteerModule : IDisposable
 
     /// <summary>
     /// Calibrated WAS angle as a real Teensy would report it in PGN 253.
-    /// Treats ActualSteerAngleDeg as the physical wheel position, converts to
-    /// raw WAS counts, then applies the host's WasOffset / CountsPerDegree /
-    /// InvertWas calibration so any wizard re-zero shows up immediately.
+    /// The simulated sensor emits raw counts using its *virtual hardware truth*
+    /// (VirtualCountsPerDegree + VirtualWasOffset). The host then applies its
+    /// own guess at those values (the Applied* fields from PGN 251/252) plus
+    /// Invert WAS. If the host's guess matches truth, reported == wheel angle;
+    /// if it doesn't, the host sees a misconfigured WAS — which is exactly the
+    /// state the steer wizard's calibration step is supposed to detect and fix.
     /// </summary>
     public double ReportedSteerAngleDeg
     {
         get
         {
-            double cpd = CountsPerDegree > 0 ? CountsPerDegree : 1.0;
-            double rawCounts = ActualSteerAngleDeg * cpd;
-            double calibrated = (rawCounts - WasOffset) / cpd;
+            double appliedCpd = CountsPerDegree > 0 ? CountsPerDegree : 1.0;
+            double calibrated = (TruthRawCounts - WasOffset) / appliedCpd;
             return InvertWas ? -calibrated : calibrated;
         }
     }

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -108,14 +108,31 @@ public class VirtualSteerModule : IDisposable
     }
 
     /// <summary>
+    /// Calibrated WAS angle as a real Teensy would report it in PGN 253.
+    /// Treats ActualSteerAngleDeg as the physical wheel position, converts to
+    /// raw WAS counts, then applies the host's WasOffset / CountsPerDegree /
+    /// InvertWas calibration so any wizard re-zero shows up immediately.
+    /// </summary>
+    public double ReportedSteerAngleDeg
+    {
+        get
+        {
+            double cpd = CountsPerDegree > 0 ? CountsPerDegree : 1.0;
+            double rawCounts = ActualSteerAngleDeg * cpd;
+            double calibrated = (rawCounts - WasOffset) / cpd;
+            return InvertWas ? -calibrated : calibrated;
+        }
+    }
+
+    /// <summary>
     /// Send a single PGN 253 steer feedback packet.
     /// </summary>
     public void SendSteerFeedback()
     {
         var data = new byte[8];
 
-        // Bytes 0-1: Actual steer angle (degrees * 100, int16 LE)
-        short angleRaw = (short)(ActualSteerAngleDeg * 100);
+        // Bytes 0-1: Calibrated WAS angle (degrees * 100, int16 LE)
+        short angleRaw = (short)(ReportedSteerAngleDeg * 100);
         data[0] = (byte)(angleRaw & 0xFF);
         data[1] = (byte)((angleRaw >> 8) & 0xFF);
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -165,10 +165,17 @@ public class VirtualSteerModule : IDisposable
         data[4] = (byte)(rollRaw & 0xFF);
         data[5] = (byte)((rollRaw >> 8) & 0xFF);
 
-        // Byte 6: Switch status
+        // Byte 6: Switch status. When the operator has not wired a physical
+        // switch (the matching config flag is OFF), the simulator always
+        // reports "active" — matching the legacy Teensy convention where an
+        // unwired input is treated as continuously engaged so the host's
+        // autosteer can still arm. When the flag is ON, the UI toggle drives
+        // the bit.
+        bool steerActive = SteerSwitchEnabled ? SteerSwitchActive : true;
+        bool workActive = WorkSwitchEnabled ? WorkSwitchActive : true;
         byte switches = 0;
-        if (!WorkSwitchActive) switches |= 0x01; // bit 0: work switch (inverted: 1=OFF)
-        if (SteerSwitchActive) switches |= 0x02;  // bit 1: steer switch
+        if (!workActive) switches |= 0x01;  // bit 0: work switch (inverted: 1=OFF)
+        if (steerActive) switches |= 0x02;  // bit 1: steer switch
         data[6] = switches;
 
         // Byte 7: PWM display

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -53,6 +53,38 @@ public class VirtualSteerModule : IDisposable
     public long SentHelloCount { get; private set; }
     public AutoSteerCommand? LastCommand { get; private set; }
 
+    // === Applied settings from PGN 252 (SteerSettings) ===
+    // Defaults mirror AgOpenGPS Teensy firmware boot defaults so the simulator
+    // behaves sanely before any host configuration arrives.
+    public byte Kp { get; private set; } = 40;
+    public byte HighPWM { get; private set; } = 160;
+    public byte LowPWM { get; private set; } = 30;
+    public byte MinPWM { get; private set; } = 25;
+    public byte CountsPerDegree { get; private set; } = 100;
+    public short WasOffset { get; private set; }
+    public double AckermannFix { get; private set; } = 1.0;
+
+    // === Applied config from PGN 251 (SteerConfig) ===
+    public bool InvertWas { get; private set; }
+    public bool IsRelayActiveHigh { get; private set; }
+    public bool MotorDriveDirection { get; private set; }
+    public bool SingleInputWas { get; private set; } = true;
+    public bool CytronDriver { get; private set; } = true;
+    public bool SteerSwitchEnabled { get; private set; }
+    public bool SteerButtonEnabled { get; private set; }
+    public bool ShaftEncoderEnabled { get; private set; }
+    public byte PulseCountMax { get; private set; } = 5;
+    public byte MinSpeed { get; private set; }
+    public bool IsDanfoss { get; private set; }
+    public bool PressureSensorEnabled { get; private set; }
+    public bool CurrentSensorEnabled { get; private set; }
+    public bool IsUseYAxis { get; private set; }
+
+    // Whether the operator has wired a physical work switch. Reported via
+    // PGN 253 byte 6 bit 0; not configurable through PGN 251 directly, so the
+    // simulator exposes it as a settable flag.
+    public bool WorkSwitchEnabled { get; set; }
+
     public VirtualSteerModule(int listenPort = 8888, int hostPort = 9999, string hostIp = "127.0.0.1")
     {
         _udp = new UdpClient(new IPEndPoint(IPAddress.Any, listenPort));
@@ -165,10 +197,50 @@ public class VirtualSteerModule : IDisposable
                 break;
 
             case PgnProtocol.PGN_STEER_SETTINGS:
+                ApplySteerSettings(PgnProtocol.ParseSteerSettings(data));
+                break;
+
             case PgnProtocol.PGN_STEER_CONFIG:
-                // Acknowledge config packets (no response needed per protocol)
+                ApplySteerConfig(PgnProtocol.ParseSteerConfig(data));
                 break;
         }
+    }
+
+    /// <summary>
+    /// Apply a freshly received PGN 252 (SteerSettings) payload.
+    /// Public so tests can drive the parse/apply path without going over UDP.
+    /// </summary>
+    public void ApplySteerSettings(SteerSettingsPacket s)
+    {
+        Kp = s.Kp;
+        HighPWM = s.HighPWM;
+        LowPWM = s.LowPWM;
+        MinPWM = s.MinPWM;
+        CountsPerDegree = s.CountsPerDegree;
+        WasOffset = s.WasOffset;
+        AckermannFix = s.AckermannFix;
+    }
+
+    /// <summary>
+    /// Apply a freshly received PGN 251 (SteerConfig) payload.
+    /// Public so tests can drive the parse/apply path without going over UDP.
+    /// </summary>
+    public void ApplySteerConfig(SteerConfigPacket c)
+    {
+        InvertWas = c.InvertWas;
+        IsRelayActiveHigh = c.IsRelayActiveHigh;
+        MotorDriveDirection = c.MotorDriveDirection;
+        SingleInputWas = c.SingleInputWas;
+        CytronDriver = c.CytronDriver;
+        SteerSwitchEnabled = c.SteerSwitchEnabled;
+        SteerButtonEnabled = c.SteerButtonEnabled;
+        ShaftEncoderEnabled = c.ShaftEncoderEnabled;
+        PulseCountMax = c.PulseCountMax;
+        MinSpeed = c.MinSpeed;
+        IsDanfoss = c.IsDanfoss;
+        PressureSensorEnabled = c.PressureSensorEnabled;
+        CurrentSensorEnabled = c.CurrentSensorEnabled;
+        IsUseYAxis = c.IsUseYAxis;
     }
 
     private void SendHello()

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -61,6 +61,13 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private bool _appliedWorkSwitchEnabled;
     private double _reportedSteerAngle;
 
+    // Virtual WAS hardware truth — operator-adjustable knobs that simulate the
+    // real CPD and off-center of the pretend WAS sensor. Persisted on the
+    // ViewModel so values survive Stop/Start cycles of the module.
+    private double _virtualCountsPerDegree = 100.0;
+    private short _virtualWasOffset;
+    private double _truthRawCounts;
+
     public double Speed
     {
         get => _speed;
@@ -219,6 +226,36 @@ public class MainWindowViewModel : INotifyPropertyChanged
         private set { _reportedSteerAngle = value; OnPropertyChanged(); }
     }
 
+    // === Virtual WAS hardware truth (operator-adjustable knobs) ===
+
+    public double VirtualCountsPerDegree
+    {
+        get => _virtualCountsPerDegree;
+        set
+        {
+            _virtualCountsPerDegree = Math.Clamp(value, 1.0, 255.0);
+            OnPropertyChanged();
+            if (_hub != null) _hub.Steer.VirtualCountsPerDegree = _virtualCountsPerDegree;
+        }
+    }
+
+    public short VirtualWasOffset
+    {
+        get => _virtualWasOffset;
+        set
+        {
+            _virtualWasOffset = (short)Math.Clamp(value, -2000, 2000);
+            OnPropertyChanged();
+            if (_hub != null) _hub.Steer.VirtualWasOffset = _virtualWasOffset;
+        }
+    }
+
+    public double TruthRawCounts
+    {
+        get => _truthRawCounts;
+        private set { _truthRawCounts = value; OnPropertyChanged(); }
+    }
+
     /// <summary>
     /// Whether the UI's Steer-Switch toggle should accept input. When the host
     /// has not configured a physical steer switch, the module reports the bit
@@ -267,6 +304,11 @@ public class MainWindowViewModel : INotifyPropertyChanged
             // The module's synthetic PWM tick loop drives WAS when autosteer
             // is engaged; the legacy on-receive WAS-follow stays off.
             _hub.Steer.SimulateSteerResponse = false;
+            // Seed the module's virtual hardware truth from the operator-set VM
+            // values, so PGN 253 picks up the correct calibration on the first
+            // emit after Start (rather than the module defaults).
+            _hub.Steer.VirtualCountsPerDegree = VirtualCountsPerDegree;
+            _hub.Steer.VirtualWasOffset = VirtualWasOffset;
 
             _hub.Start();
 
@@ -380,6 +422,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
         AppliedSteerSwitchEnabled = _hub.Steer.SteerSwitchEnabled;
         AppliedWorkSwitchEnabled = _hub.Steer.WorkSwitchEnabled;
         ReportedSteerAngle = _hub.Steer.ReportedSteerAngleDeg;
+        TruthRawCounts = _hub.Steer.TruthRawCounts;
 
         StatusText = $"Running, {_packetCount} packets sent";
     }

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -244,7 +244,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
         get => _virtualWasOffset;
         set
         {
-            _virtualWasOffset = (short)Math.Clamp(value, -2000, 2000);
+            _virtualWasOffset = (short)Math.Clamp((int)value, -2000, 2000);
             OnPropertyChanged();
             if (_hub != null) _hub.Steer.VirtualWasOffset = _virtualWasOffset;
         }

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -181,7 +181,9 @@ public class MainWindowViewModel : INotifyPropertyChanged
             _hub.Gps.Satellites = SatelliteCount;
             _hub.Gps.RollDegrees = RollAngle;
             _hub.Steer.ActualSteerAngleDeg = WasAngle;
-            _hub.Steer.SimulateSteerResponse = false; // We control WAS directly
+            // The module's synthetic PWM tick loop drives WAS when autosteer
+            // is engaged; the legacy on-receive WAS-follow stays off.
+            _hub.Steer.SimulateSteerResponse = false;
 
             _hub.Start();
 
@@ -220,14 +222,15 @@ public class MainWindowViewModel : INotifyPropertyChanged
         if (_hub == null) return;
 
         // Mirror host's autosteer engagement to the read-only indicator. When
-        // engaged, the simulated WAS follows the commanded angle with lag.
+        // engaged, the module's synthetic PWM loop owns the WAS angle; reflect
+        // it back into the UI slider so the operator sees the simulated motor
+        // turning the wheel. When not engaged, the slider is the source of
+        // truth and we push it down to the module further below.
         bool engaged = _hub.Steer.LastCommand?.IsEngaged ?? false;
         AutoSteerEngaged = engaged;
         if (engaged)
         {
-            double commanded = _hub.Steer.CommandedSteerAngleDeg;
-            double responseRate = 0.3;
-            WasAngle += (commanded - WasAngle) * responseRate;
+            WasAngle = _hub.Steer.ActualSteerAngleDeg;
         }
 
         const double dt = 0.1; // 10 Hz tick
@@ -266,7 +269,13 @@ public class MainWindowViewModel : INotifyPropertyChanged
         _hub.Gps.FixQuality = FixQuality;
         _hub.Gps.Satellites = SatelliteCount;
         _hub.Gps.RollDegrees = RollAngle;
-        _hub.Steer.ActualSteerAngleDeg = WasAngle;
+        // Only push slider → WAS when not engaged. When engaged the module's
+        // PWM loop is the source of truth (we already pulled it into WasAngle
+        // above), and pushing the slider value back would fight that loop.
+        if (!engaged)
+        {
+            _hub.Steer.ActualSteerAngleDeg = WasAngle;
+        }
         _hub.Steer.SteerSwitchActive = SteerSwitchOn;
 
         // Send GPS data

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -50,6 +50,17 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private DriveMode _driveMode = DriveMode.Bicycle;
     private string _statusText = "Stopped";
 
+    // Applied module settings (mirrored from VirtualSteerModule for UI display)
+    private byte _appliedKp;
+    private byte _appliedCountsPerDegree;
+    private short _appliedWasOffset;
+    private byte _appliedHighPwm;
+    private bool _appliedInvertWas;
+    private bool _appliedIsDanfoss;
+    private bool _appliedSteerSwitchEnabled;
+    private bool _appliedWorkSwitchEnabled;
+    private double _reportedSteerAngle;
+
     public double Speed
     {
         get => _speed;
@@ -143,6 +154,78 @@ public class MainWindowViewModel : INotifyPropertyChanged
         get => _statusText;
         set { _statusText = value; OnPropertyChanged(); }
     }
+
+    // === Applied-settings panel (read-only mirrors of VirtualSteerModule state) ===
+    // These reflect the most recent values applied from PGN 251 / 252 plus the
+    // live PWM and post-calibration angle, so the operator can sanity-check
+    // that the host's wizard config landed on the module.
+
+    public byte AppliedKp
+    {
+        get => _appliedKp;
+        private set { _appliedKp = value; OnPropertyChanged(); }
+    }
+
+    public byte AppliedCountsPerDegree
+    {
+        get => _appliedCountsPerDegree;
+        private set { _appliedCountsPerDegree = value; OnPropertyChanged(); }
+    }
+
+    public short AppliedWasOffset
+    {
+        get => _appliedWasOffset;
+        private set { _appliedWasOffset = value; OnPropertyChanged(); }
+    }
+
+    public byte AppliedHighPwm
+    {
+        get => _appliedHighPwm;
+        private set { _appliedHighPwm = value; OnPropertyChanged(); }
+    }
+
+    public bool AppliedInvertWas
+    {
+        get => _appliedInvertWas;
+        private set { _appliedInvertWas = value; OnPropertyChanged(); }
+    }
+
+    public bool AppliedIsDanfoss
+    {
+        get => _appliedIsDanfoss;
+        private set { _appliedIsDanfoss = value; OnPropertyChanged(); }
+    }
+
+    public bool AppliedSteerSwitchEnabled
+    {
+        get => _appliedSteerSwitchEnabled;
+        private set
+        {
+            _appliedSteerSwitchEnabled = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(SteerSwitchToggleEnabled));
+        }
+    }
+
+    public bool AppliedWorkSwitchEnabled
+    {
+        get => _appliedWorkSwitchEnabled;
+        private set { _appliedWorkSwitchEnabled = value; OnPropertyChanged(); }
+    }
+
+    public double ReportedSteerAngle
+    {
+        get => _reportedSteerAngle;
+        private set { _reportedSteerAngle = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Whether the UI's Steer-Switch toggle should accept input. When the host
+    /// has not configured a physical steer switch, the module reports the bit
+    /// as continuously active regardless of the toggle, so the toggle is
+    /// disabled in the UI to make that explicit.
+    /// </summary>
+    public bool SteerSwitchToggleEnabled => _appliedSteerSwitchEnabled;
 
     public string StartStopLabel => IsRunning ? "Stop" : "Start";
 
@@ -285,6 +368,18 @@ public class MainWindowViewModel : INotifyPropertyChanged
         // Read back commanded angle from steer module
         CommandedAngle = _hub.Steer.CommandedSteerAngleDeg;
         PwmDisplay = _hub.Steer.PwmDisplay;
+
+        // Refresh the applied-settings panel so operators can see PGN 251 / 252
+        // values landing on the module in real time.
+        AppliedKp = _hub.Steer.Kp;
+        AppliedCountsPerDegree = _hub.Steer.CountsPerDegree;
+        AppliedWasOffset = _hub.Steer.WasOffset;
+        AppliedHighPwm = _hub.Steer.HighPWM;
+        AppliedInvertWas = _hub.Steer.InvertWas;
+        AppliedIsDanfoss = _hub.Steer.IsDanfoss;
+        AppliedSteerSwitchEnabled = _hub.Steer.SteerSwitchEnabled;
+        AppliedWorkSwitchEnabled = _hub.Steer.WorkSwitchEnabled;
+        ReportedSteerAngle = _hub.Steer.ReportedSteerAngleDeg;
 
         StatusText = $"Running, {_packetCount} packets sent";
     }

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -84,7 +84,14 @@
                     <NumericUpDown Value="{Binding SatelliteCount}" Increment="1"
                                    Minimum="0" Maximum="30" />
 
-                    <CheckBox Content="Steer Switch ON" IsChecked="{Binding SteerSwitchOn}" />
+                    <!-- Disabled when the host has not configured a physical
+                         steer switch (PGN 251 SteerSwitch flag = 0). In that
+                         case the module reports the switch as continuously
+                         active regardless of this toggle. -->
+                    <CheckBox Content="Steer Switch ON"
+                              IsChecked="{Binding SteerSwitchOn}"
+                              IsEnabled="{Binding SteerSwitchToggleEnabled}"
+                              ToolTip.Tip="No physical steer switch configured on the host — the module reports SteerSwitch as always active." />
 
                     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <Panel Width="14" Height="14">
@@ -109,9 +116,27 @@
 
                     <TextBlock Text="{Binding CommandedAngle, StringFormat='Commanded Angle: {0:F1} deg'}" />
 
+                    <TextBlock Text="{Binding ReportedSteerAngle, StringFormat='Reported WAS: {0:F2} deg'}" />
+
                     <TextBlock Text="{Binding PwmDisplay, StringFormat='PWM: {0}'}" />
 
                     <TextBlock Text="{Binding SteerSwitchOn, StringFormat='Steer Switch: {0}'}" />
+
+                    <Separator Margin="0,8" />
+
+                    <!-- Applied settings: the most recently received-and-applied
+                         values from PGN 251 (SteerConfig) and PGN 252 (SteerSettings).
+                         Lets the operator confirm the host's wizard config landed
+                         on the module before driving. -->
+                    <TextBlock Text="Applied Settings" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding AppliedKp, StringFormat='Kp: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedCountsPerDegree, StringFormat='Counts/Deg: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedWasOffset, StringFormat='WAS Offset: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedHighPwm, StringFormat='Max PWM: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedInvertWas, StringFormat='Invert WAS: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedIsDanfoss, StringFormat='Danfoss: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedSteerSwitchEnabled, StringFormat='Steer Switch wired: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedWorkSwitchEnabled, StringFormat='Work Switch wired: {0}'}" FontSize="12" />
 
                     <Separator Margin="0,8" />
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -4,7 +4,7 @@
         x:Class="AgValoniaGPS.VehicleSimulator.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="AgValoniaGPS Vehicle Simulator"
-        Width="750" Height="480"
+        Width="1024" Height="540"
         MinWidth="400" MinHeight="200">
 
     <Design.DataContext>
@@ -18,18 +18,23 @@
                    FontSize="20" FontWeight="Bold"
                    Margin="0,0,0,12" />
 
-        <!-- Main content: three columns, scrollable when window is too small -->
+        <!-- Four-column semantic layout, matching the real-hardware mental model:
+                 [Bicycle Model] = physics inputs (operator drives the vehicle)
+                 [GPS]           = position + IMU sensor outputs
+                 [WAS]           = simulated WAS hardware truth + host's applied calibration
+                 [Module Status] = outgoing PGN 253 state + switch toggles
+             Stays scrollable when the window is narrower than the natural width. -->
         <ScrollViewer Grid.Row="1" Margin="0,0,0,12"
-                      HorizontalScrollBarVisibility="Disabled"
+                      HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto">
-        <Grid ColumnDefinitions="*,*,*">
+        <Grid ColumnDefinitions="*,*,*,*" MinWidth="900">
 
-            <!-- Column 1: Vehicle -->
+            <!-- Column 1: Bicycle Model (physics inputs) -->
             <Border Grid.Column="0" Margin="0,0,6,0" Padding="12"
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                     BorderThickness="1" CornerRadius="4">
                 <StackPanel Spacing="8">
-                    <TextBlock Text="Vehicle" FontWeight="SemiBold" FontSize="14" />
+                    <TextBlock Text="Bicycle Model" FontWeight="SemiBold" FontSize="14" />
 
                     <TextBlock Text="Drive Mode" />
                     <ComboBox SelectedItem="{Binding DriveMode}" HorizontalAlignment="Stretch">
@@ -41,9 +46,27 @@
                     <Slider Minimum="0" Maximum="30" Value="{Binding Speed}"
                             TickFrequency="1" IsSnapToTickEnabled="False" />
 
+                    <TextBlock Text="{Binding WasAngle, StringFormat='Wheel Angle: {0:F1} deg'}" />
+                    <Slider Minimum="-45" Maximum="45" Value="{Binding WasAngle}"
+                            TickFrequency="1" IsSnapToTickEnabled="False"
+                            ToolTip.Tip="Physical wheel angle. The simulated WAS reads this and applies the virtual hardware calibration before PGN 253 reports it." />
+
+                    <!-- Heading is only an operator input in Raw mode; in Bicycle
+                         mode it's an output of the kinematic integrator. Kept
+                         in this column because Raw mode needs operator control. -->
                     <TextBlock Text="{Binding Heading, StringFormat='Heading: {0:F1} deg'}" />
                     <Slider Minimum="0" Maximum="359.9" Value="{Binding Heading}"
-                            TickFrequency="1" IsSnapToTickEnabled="False" />
+                            TickFrequency="1" IsSnapToTickEnabled="False"
+                            ToolTip.Tip="Raw mode: operator-controlled heading. Bicycle mode: computed from speed × wheel angle." />
+                </StackPanel>
+            </Border>
+
+            <!-- Column 2: GPS (position + IMU sensor outputs) -->
+            <Border Grid.Column="1" Margin="3,0,3,0" Padding="12"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                    BorderThickness="1" CornerRadius="4">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="GPS" FontWeight="SemiBold" FontSize="14" />
 
                     <TextBlock Text="{Binding Latitude, StringFormat='Latitude: {0:F6}'}" />
                     <NumericUpDown Value="{Binding Latitude}" Increment="0.0001"
@@ -52,23 +75,10 @@
                     <TextBlock Text="{Binding Longitude, StringFormat='Longitude: {0:F6}'}" />
                     <NumericUpDown Value="{Binding Longitude}" Increment="0.0001"
                                    FormatString="F6" Minimum="-180" Maximum="180" />
-                </StackPanel>
-            </Border>
 
-            <!-- Column 2: Sensors -->
-            <Border Grid.Column="1" Margin="3,0,3,0" Padding="12"
-                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                    BorderThickness="1" CornerRadius="4">
-                <StackPanel Spacing="8">
-                    <TextBlock Text="Sensors" FontWeight="SemiBold" FontSize="14" />
-
-                    <TextBlock Text="{Binding WasAngle, StringFormat='WAS Angle: {0:F1} deg'}" />
-                    <Slider Minimum="-45" Maximum="45" Value="{Binding WasAngle}"
-                            TickFrequency="1" IsSnapToTickEnabled="False" />
-
-                    <TextBlock Text="{Binding RollAngle, StringFormat='Roll: {0:F1} deg'}" />
-                    <Slider Minimum="-15" Maximum="15" Value="{Binding RollAngle}"
-                            TickFrequency="0.5" IsSnapToTickEnabled="False" />
+                    <TextBlock Text="{Binding SatelliteCount, StringFormat='Satellites: {0}'}" />
+                    <NumericUpDown Value="{Binding SatelliteCount}" Increment="1"
+                                   Minimum="0" Maximum="30" />
 
                     <TextBlock Text="{Binding FixQuality, StringFormat='GPS Fix Quality: {0}'}" />
                     <ComboBox SelectedIndex="{Binding FixQuality}" HorizontalAlignment="Stretch">
@@ -80,14 +90,52 @@
                         <ComboBoxItem Content="5 - RTK Float" />
                     </ComboBox>
 
-                    <TextBlock Text="{Binding SatelliteCount, StringFormat='Satellites: {0}'}" />
-                    <NumericUpDown Value="{Binding SatelliteCount}" Increment="1"
-                                   Minimum="0" Maximum="30" />
+                    <!-- Roll lives here because it's the IMU's sensor output,
+                         carried by $PANDA alongside the GPS-side data. -->
+                    <TextBlock Text="{Binding RollAngle, StringFormat='Roll (IMU): {0:F1} deg'}" />
+                    <Slider Minimum="-15" Maximum="15" Value="{Binding RollAngle}"
+                            TickFrequency="0.5" IsSnapToTickEnabled="False" />
+                </StackPanel>
+            </Border>
 
-                    <!-- Disabled when the host has not configured a physical
-                         steer switch (PGN 251 SteerSwitch flag = 0). In that
-                         case the module reports the switch as continuously
-                         active regardless of this toggle. -->
+            <!-- Column 3: WAS (simulated hardware truth + host's applied calibration) -->
+            <Border Grid.Column="2" Margin="3,0,3,0" Padding="12"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                    BorderThickness="1" CornerRadius="4">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="WAS" FontWeight="SemiBold" FontSize="14" />
+
+                    <!-- Host's guess at WAS hardware values + tuning, received
+                         via PGN 251/252. Hardware-truth knobs are added in the
+                         next commit (operator-controlled CPD / off-center). -->
+                    <TextBlock Text="Host's Guess (PGN 251/252)" FontWeight="SemiBold" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedCountsPerDegree, StringFormat='Counts/Deg: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedWasOffset, StringFormat='WAS Offset: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedInvertWas, StringFormat='Invert WAS: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedKp, StringFormat='Kp: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedHighPwm, StringFormat='Max PWM: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedIsDanfoss, StringFormat='Danfoss: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedSteerSwitchEnabled, StringFormat='Steer Switch wired: {0}'}" FontSize="12" />
+                    <TextBlock Text="{Binding AppliedWorkSwitchEnabled, StringFormat='Work Switch wired: {0}'}" FontSize="12" />
+                </StackPanel>
+            </Border>
+
+            <!-- Column 4: Module Status (outgoing PGN 253 + switch toggles) -->
+            <Border Grid.Column="3" Margin="6,0,0,0" Padding="12"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                    BorderThickness="1" CornerRadius="4">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="Module Status" FontWeight="SemiBold" FontSize="14" />
+
+                    <TextBlock Text="{Binding CommandedAngle, StringFormat='Commanded Angle: {0:F1} deg'}" />
+                    <TextBlock Text="{Binding ReportedSteerAngle, StringFormat='Reported WAS: {0:F2} deg'}" />
+                    <TextBlock Text="{Binding PwmDisplay, StringFormat='PWM: {0}'}" />
+
+                    <Separator Margin="0,8" />
+
+                    <!-- Steer switch toggle is operator-driven; lives next to
+                         the read-out so cause and effect are colocated. Greyed
+                         out when the host has not wired a physical switch. -->
                     <CheckBox Content="Steer Switch ON"
                               IsChecked="{Binding SteerSwitchOn}"
                               IsEnabled="{Binding SteerSwitchToggleEnabled}"
@@ -104,39 +152,6 @@
                         </Panel>
                         <TextBlock Text="AutoSteer Engaged (from host)" VerticalAlignment="Center" />
                     </StackPanel>
-                </StackPanel>
-            </Border>
-
-            <!-- Column 3: Module Status -->
-            <Border Grid.Column="2" Margin="6,0,0,0" Padding="12"
-                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                    BorderThickness="1" CornerRadius="4">
-                <StackPanel Spacing="8">
-                    <TextBlock Text="Module Status" FontWeight="SemiBold" FontSize="14" />
-
-                    <TextBlock Text="{Binding CommandedAngle, StringFormat='Commanded Angle: {0:F1} deg'}" />
-
-                    <TextBlock Text="{Binding ReportedSteerAngle, StringFormat='Reported WAS: {0:F2} deg'}" />
-
-                    <TextBlock Text="{Binding PwmDisplay, StringFormat='PWM: {0}'}" />
-
-                    <TextBlock Text="{Binding SteerSwitchOn, StringFormat='Steer Switch: {0}'}" />
-
-                    <Separator Margin="0,8" />
-
-                    <!-- Applied settings: the most recently received-and-applied
-                         values from PGN 251 (SteerConfig) and PGN 252 (SteerSettings).
-                         Lets the operator confirm the host's wizard config landed
-                         on the module before driving. -->
-                    <TextBlock Text="Applied Settings" FontWeight="SemiBold" />
-                    <TextBlock Text="{Binding AppliedKp, StringFormat='Kp: {0}'}" FontSize="12" />
-                    <TextBlock Text="{Binding AppliedCountsPerDegree, StringFormat='Counts/Deg: {0}'}" FontSize="12" />
-                    <TextBlock Text="{Binding AppliedWasOffset, StringFormat='WAS Offset: {0}'}" FontSize="12" />
-                    <TextBlock Text="{Binding AppliedHighPwm, StringFormat='Max PWM: {0}'}" FontSize="12" />
-                    <TextBlock Text="{Binding AppliedInvertWas, StringFormat='Invert WAS: {0}'}" FontSize="12" />
-                    <TextBlock Text="{Binding AppliedIsDanfoss, StringFormat='Danfoss: {0}'}" FontSize="12" />
-                    <TextBlock Text="{Binding AppliedSteerSwitchEnabled, StringFormat='Steer Switch wired: {0}'}" FontSize="12" />
-                    <TextBlock Text="{Binding AppliedWorkSwitchEnabled, StringFormat='Work Switch wired: {0}'}" FontSize="12" />
 
                     <Separator Margin="0,8" />
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -105,9 +105,33 @@
                 <StackPanel Spacing="8">
                     <TextBlock Text="WAS" FontWeight="SemiBold" FontSize="14" />
 
-                    <!-- Host's guess at WAS hardware values + tuning, received
-                         via PGN 251/252. Hardware-truth knobs are added in the
-                         next commit (operator-controlled CPD / off-center). -->
+                    <!-- Ground-truth hardware values: the *real* CPD and offset
+                         of the simulated WAS sensor. Operator-adjustable so the
+                         steer-wizard calibration step is testable end-to-end:
+                         dial the host's PGN 251/252 values until the reported
+                         angle in the Module Status column matches the wheel
+                         angle in the Bicycle Model column. -->
+                    <TextBlock Text="Hardware Truth" FontWeight="SemiBold" FontSize="12" />
+
+                    <TextBlock Text="{Binding VirtualCountsPerDegree, StringFormat='Virtual Counts/Deg: {0:F0}'}" />
+                    <NumericUpDown Value="{Binding VirtualCountsPerDegree}" Increment="1"
+                                   Minimum="1" Maximum="255"
+                                   ToolTip.Tip="The simulated WAS sensor's real counts-per-degree. The host's wizard tries to discover this value." />
+
+                    <TextBlock Text="{Binding VirtualWasOffset, StringFormat='Virtual Off-center: {0}'}" />
+                    <NumericUpDown Value="{Binding VirtualWasOffset}" Increment="1"
+                                   Minimum="-2000" Maximum="2000"
+                                   ToolTip.Tip="The simulated WAS sensor's real off-center counts. The host's wizard tries to discover this via Zero WAS." />
+
+                    <TextBlock Text="{Binding TruthRawCounts, StringFormat='Truth raw counts: {0:F0}'}"
+                               FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+
+                    <Separator Margin="0,8" />
+
+                    <!-- Host's guess at the same values, received via PGN 251/252.
+                         Sits next to the truth values so operator can spot a
+                         miscalibration at a glance. -->
                     <TextBlock Text="Host's Guess (PGN 251/252)" FontWeight="SemiBold" FontSize="12" />
                     <TextBlock Text="{Binding AppliedCountsPerDegree, StringFormat='Counts/Deg: {0}'}" FontSize="12" />
                     <TextBlock Text="{Binding AppliedWasOffset, StringFormat='WAS Offset: {0}'}" FontSize="12" />

--- a/Tests/AgValoniaGPS.IntegrationTests/AgValoniaGPS.IntegrationTests.csproj
+++ b/Tests/AgValoniaGPS.IntegrationTests/AgValoniaGPS.IntegrationTests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <LangVersion>14</LangVersion>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -24,6 +25,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/AgValoniaGPS.IntegrationTests/AgValoniaGPS.IntegrationTests.csproj
+++ b/Tests/AgValoniaGPS.IntegrationTests/AgValoniaGPS.IntegrationTests.csproj
@@ -7,6 +7,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Keep Program.Main for `dotnet run` field-test entry; the test SDK
+         auto-generates a Main, so disable that to avoid CS0017. -->
+    <GenerateProgramFile>false</GenerateProgramFile>
     <LangVersion>14</LangVersion>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/PgnProtocol.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/PgnProtocol.cs
@@ -146,6 +146,52 @@ public static class PgnProtocol
     }
 
     /// <summary>
+    /// Parse PGN 252 (SteerSettings from host). Layout mirrors AgOpenGPS ModSim
+    /// and the Teensy AutoSteer firmware: Kp, highPWM, lowPWM, minPWM,
+    /// steerSensorCounts (counts/deg), wasOffset (int16 LE), AckermannFix*100.
+    /// </summary>
+    public static SteerSettingsPacket ParseSteerSettings(byte[] data)
+    {
+        return new SteerSettingsPacket
+        {
+            Kp = data[5],
+            HighPWM = data[6],
+            LowPWM = data[7],
+            MinPWM = data[8],
+            CountsPerDegree = data[9],
+            WasOffset = (short)(data[10] | (data[11] << 8)),
+            AckermannFix = data[12] / 100.0,
+        };
+    }
+
+    /// <summary>
+    /// Parse PGN 251 (SteerConfig from host). Two bit-packed setting bytes plus
+    /// PulseCountMax and MinSpeed.
+    /// </summary>
+    public static SteerConfigPacket ParseSteerConfig(byte[] data)
+    {
+        byte setting0 = data[5];
+        byte setting1 = data[8];
+        return new SteerConfigPacket
+        {
+            InvertWas = (setting0 & 0x01) != 0,
+            IsRelayActiveHigh = (setting0 & 0x02) != 0,
+            MotorDriveDirection = (setting0 & 0x04) != 0,
+            SingleInputWas = (setting0 & 0x08) != 0,
+            CytronDriver = (setting0 & 0x10) != 0,
+            SteerSwitchEnabled = (setting0 & 0x20) != 0,
+            SteerButtonEnabled = (setting0 & 0x40) != 0,
+            ShaftEncoderEnabled = (setting0 & 0x80) != 0,
+            PulseCountMax = data[6],
+            MinSpeed = data[7],
+            IsDanfoss = (setting1 & 0x01) != 0,
+            PressureSensorEnabled = (setting1 & 0x02) != 0,
+            CurrentSensorEnabled = (setting1 & 0x04) != 0,
+            IsUseYAxis = (setting1 & 0x08) != 0,
+        };
+    }
+
+    /// <summary>
     /// Parse PGN 239 (Machine data from host).
     /// </summary>
     public static MachineCommand ParseMachineCommand(byte[] data)
@@ -204,4 +250,44 @@ public struct MachineConfigPacket
 public struct MachinePinConfigPacket
 {
     public byte[] PinAssignments; // 24 bytes
+}
+
+/// <summary>
+/// Decoded payload of PGN 252 (SteerSettings) — PID tuning, PWM bounds,
+/// WAS calibration, Ackermann compensation.
+/// </summary>
+public struct SteerSettingsPacket
+{
+    public byte Kp;
+    public byte HighPWM;
+    public byte LowPWM;
+    public byte MinPWM;
+    public byte CountsPerDegree;
+    public short WasOffset;
+    public double AckermannFix; // unit = ratio (1.0 = 100%)
+}
+
+/// <summary>
+/// Decoded payload of PGN 251 (SteerConfig) — hardware/wiring options.
+/// </summary>
+public struct SteerConfigPacket
+{
+    // setting0 bits
+    public bool InvertWas;
+    public bool IsRelayActiveHigh;
+    public bool MotorDriveDirection;
+    public bool SingleInputWas;
+    public bool CytronDriver;
+    public bool SteerSwitchEnabled;
+    public bool SteerButtonEnabled;
+    public bool ShaftEncoderEnabled;
+
+    public byte PulseCountMax;
+    public byte MinSpeed;
+
+    // setting1 bits
+    public bool IsDanfoss;
+    public bool PressureSensorEnabled;
+    public bool CurrentSensorEnabled;
+    public bool IsUseYAxis;
 }

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -44,8 +44,27 @@ public class VirtualSteerModule : IDisposable
     public double ImuRollDeg { get; set; }
 
     // Simulation behavior
-    public double SteerResponseRate { get; set; } = 0.5; // How fast WAS follows command (0-1)
-    public bool SimulateSteerResponse { get; set; } = true;
+    // Legacy WAS-follow path used by older Services.Tests fixtures: applies a
+    // fraction of the command-vs-actual gap on every PGN 254 receive. The
+    // current default is the PWM-driven tick loop below; this flag stays for
+    // back-compat with tests that opt into the simpler model.
+    public double SteerResponseRate { get; set; } = 0.5;
+    public bool SimulateSteerResponse { get; set; } = false;
+
+    // === Synthetic PWM control loop ===
+    // Modelled after the Teensy AutoSteer firmware: proportional control with
+    // MinPWM dead-band promotion (so the motor can overcome static friction)
+    // and a small commanded-vs-actual deadband to keep the wheel still at the
+    // target. Internal PWM is signed (-HighPWM .. +HighPWM); PGN 253 byte 7
+    // reports magnitude only, with direction handled by the driver pin on real
+    // hardware.
+    public int CurrentPwm { get; private set; }
+
+    /// <summary>Maps PWM duty (1..HighPWM) to deg/sec of WAS movement.</summary>
+    public double PwmToDegPerSec { get; set; } = 0.2;
+
+    /// <summary>Below this absolute error, drive pwm to zero so the wheel can rest.</summary>
+    public double AngleDeadbandDeg { get; set; } = 0.05;
 
     // Counters
     public long ReceivedCommandCount { get; private set; }
@@ -195,16 +214,7 @@ public class VirtualSteerModule : IDisposable
         switch (pgn)
         {
             case PgnProtocol.PGN_AUTOSTEER_TO_MODULE:
-                var cmd = PgnProtocol.ParseAutoSteerCommand(data);
-                CommandedSteerAngleDeg = cmd.SteerAngleDeg;
-                LastCommand = cmd;
-                ReceivedCommandCount++;
-
-                // Simulate WAS response
-                if (SimulateSteerResponse)
-                {
-                    ActualSteerAngleDeg += (CommandedSteerAngleDeg - ActualSteerAngleDeg) * SteerResponseRate;
-                }
+                ApplyAutoSteerCommand(PgnProtocol.ParseAutoSteerCommand(data));
                 // PGN 253 is emitted by the periodic TickLoop, not in response to PGN 254.
                 break;
 
@@ -220,6 +230,25 @@ public class VirtualSteerModule : IDisposable
             case PgnProtocol.PGN_STEER_CONFIG:
                 ApplySteerConfig(PgnProtocol.ParseSteerConfig(data));
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Apply a parsed PGN 254 (AutoSteer command) payload.
+    /// Public so tests can drive the control loop deterministically without
+    /// going over UDP and relying on receive-task timing.
+    /// </summary>
+    public void ApplyAutoSteerCommand(AutoSteerCommand cmd)
+    {
+        CommandedSteerAngleDeg = cmd.SteerAngleDeg;
+        LastCommand = cmd;
+        ReceivedCommandCount++;
+
+        // Legacy WAS-follow: applies a fraction of the gap on every receive.
+        // Disabled by default — the PWM tick loop is the real model.
+        if (SimulateSteerResponse)
+        {
+            ActualSteerAngleDeg += (CommandedSteerAngleDeg - ActualSteerAngleDeg) * SteerResponseRate;
         }
     }
 
@@ -301,7 +330,53 @@ public class VirtualSteerModule : IDisposable
     /// </summary>
     public void Tick()
     {
+        UpdateSteerControl(TickIntervalMs / 1000.0);
         SendSteerFeedback();
+    }
+
+    /// <summary>
+    /// Synthetic PWM control + WAS integration step.
+    /// Proportional law: pwm = error * Kp / 10, clamped to [-HighPWM, +HighPWM].
+    /// Below MinPWM but non-zero, magnitude is promoted to MinPWM (real motors
+    /// need that to break static friction). Below AngleDeadbandDeg of error,
+    /// pwm is forced to zero so the wheel can rest at the commanded angle.
+    /// The WAS is then moved by pwm × PwmToDegPerSec × dt, clamped so a single
+    /// tick can never overshoot the commanded angle. Runs only when the host
+    /// has IsEngaged set in PGN 254 — otherwise the wheel is freely operator-
+    /// controlled and the simulator just holds whatever ActualSteerAngleDeg is.
+    /// </summary>
+    public void UpdateSteerControl(double dt)
+    {
+        bool engaged = LastCommand?.IsEngaged ?? false;
+        double error = CommandedSteerAngleDeg - ActualSteerAngleDeg;
+
+        int pwm;
+        if (!engaged || Math.Abs(error) < AngleDeadbandDeg)
+        {
+            pwm = 0;
+        }
+        else
+        {
+            double raw = error * Kp / 10.0;
+            pwm = (int)raw;
+            if (pwm > HighPWM) pwm = HighPWM;
+            else if (pwm < -HighPWM) pwm = -HighPWM;
+            int absPwm = Math.Abs(pwm);
+            if (absPwm > 0 && absPwm < MinPWM)
+            {
+                pwm = pwm > 0 ? MinPWM : -MinPWM;
+            }
+        }
+
+        CurrentPwm = pwm;
+        PwmDisplay = (byte)Math.Min(255, Math.Abs(pwm));
+
+        if (engaged && pwm != 0)
+        {
+            double dAngle = pwm * PwmToDegPerSec * dt;
+            if (Math.Abs(dAngle) > Math.Abs(error)) dAngle = error;
+            ActualSteerAngleDeg += dAngle;
+        }
     }
 
     public void Dispose()

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -26,6 +26,11 @@ public class VirtualSteerModule : IDisposable
     private CancellationTokenSource? _cts;
     private Task? _receiveTask;
     private Task? _helloTask;
+    private Task? _tickTask;
+
+    // Real Teensy steer modules stream PGN 253 continuously at ~10 Hz regardless
+    // of host activity. The host's autosteer control loop relies on that cadence.
+    public int TickIntervalMs { get; set; } = 100;
 
     // Simulated WAS (Wheel Angle Sensor) state
     public double ActualSteerAngleDeg { get; set; }
@@ -59,6 +64,7 @@ public class VirtualSteerModule : IDisposable
         _cts = new CancellationTokenSource();
         _receiveTask = Task.Run(() => ReceiveLoop(_cts.Token));
         _helloTask = Task.Run(() => HelloLoop(_cts.Token));
+        _tickTask = Task.Run(() => TickLoop(_cts.Token));
     }
 
     public void Stop()
@@ -66,6 +72,7 @@ public class VirtualSteerModule : IDisposable
         _cts?.Cancel();
         try { _receiveTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
         try { _helloTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        try { _tickTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
     }
 
     /// <summary>
@@ -149,9 +156,7 @@ public class VirtualSteerModule : IDisposable
                 {
                     ActualSteerAngleDeg += (CommandedSteerAngleDeg - ActualSteerAngleDeg) * SteerResponseRate;
                 }
-
-                // Send feedback after receiving command
-                SendSteerFeedback();
+                // PGN 253 is emitted by the periodic TickLoop, not in response to PGN 254.
                 break;
 
             case PgnProtocol.PGN_HELLO_FROM_HOST:
@@ -185,6 +190,29 @@ public class VirtualSteerModule : IDisposable
             }
             catch (OperationCanceledException) { break; }
         }
+    }
+
+    private async Task TickLoop(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                Tick();
+                await Task.Delay(TickIntervalMs, ct);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (SocketException) { break; }
+        }
+    }
+
+    /// <summary>
+    /// Single periodic tick. Public so deterministic tests can drive emission
+    /// without relying on Task.Delay timing.
+    /// </summary>
+    public void Tick()
+    {
+        SendSteerFeedback();
     }
 
     public void Dispose()

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -39,6 +39,20 @@ public class VirtualSteerModule : IDisposable
     public bool WorkSwitchActive { get; set; }
     public byte PwmDisplay { get; set; }
 
+    // === Virtual WAS hardware truth ===
+    // The *real* CPD and off-center counts of the simulated WAS sensor — separate
+    // from the host's Applied* guesses received via PGN 251/252. The host's
+    // wizard tries to discover these values via Zero WAS and CPD calibration;
+    // operator can dial them in to simulate a misconfigured hardware install.
+    public double VirtualCountsPerDegree { get; set; } = 100.0;
+    public short VirtualWasOffset { get; set; }
+
+    /// <summary>
+    /// Raw WAS counts the simulated sensor would output for the current wheel
+    /// angle, before the host applies its own calibration. Useful for debug.
+    /// </summary>
+    public double TruthRawCounts => ActualSteerAngleDeg * VirtualCountsPerDegree + VirtualWasOffset;
+
     // IMU (if separate module, typically embedded in $PANDA now)
     public double ImuHeadingDeg { get; set; }
     public double ImuRollDeg { get; set; }
@@ -128,17 +142,19 @@ public class VirtualSteerModule : IDisposable
 
     /// <summary>
     /// Calibrated WAS angle as a real Teensy would report it in PGN 253.
-    /// Treats ActualSteerAngleDeg as the physical wheel position, converts to
-    /// raw WAS counts, then applies the host's WasOffset / CountsPerDegree /
-    /// InvertWas calibration so any wizard re-zero shows up immediately.
+    /// The simulated sensor emits raw counts using its *virtual hardware truth*
+    /// (VirtualCountsPerDegree + VirtualWasOffset). The host then applies its
+    /// own guess at those values (the Applied* fields from PGN 251/252) plus
+    /// Invert WAS. If the host's guess matches truth, reported == wheel angle;
+    /// if it doesn't, the host sees a misconfigured WAS — which is exactly the
+    /// state the steer wizard's calibration step is supposed to detect and fix.
     /// </summary>
     public double ReportedSteerAngleDeg
     {
         get
         {
-            double cpd = CountsPerDegree > 0 ? CountsPerDegree : 1.0;
-            double rawCounts = ActualSteerAngleDeg * cpd;
-            double calibrated = (rawCounts - WasOffset) / cpd;
+            double appliedCpd = CountsPerDegree > 0 ? CountsPerDegree : 1.0;
+            double calibrated = (TruthRawCounts - WasOffset) / appliedCpd;
             return InvertWas ? -calibrated : calibrated;
         }
     }

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -108,14 +108,31 @@ public class VirtualSteerModule : IDisposable
     }
 
     /// <summary>
+    /// Calibrated WAS angle as a real Teensy would report it in PGN 253.
+    /// Treats ActualSteerAngleDeg as the physical wheel position, converts to
+    /// raw WAS counts, then applies the host's WasOffset / CountsPerDegree /
+    /// InvertWas calibration so any wizard re-zero shows up immediately.
+    /// </summary>
+    public double ReportedSteerAngleDeg
+    {
+        get
+        {
+            double cpd = CountsPerDegree > 0 ? CountsPerDegree : 1.0;
+            double rawCounts = ActualSteerAngleDeg * cpd;
+            double calibrated = (rawCounts - WasOffset) / cpd;
+            return InvertWas ? -calibrated : calibrated;
+        }
+    }
+
+    /// <summary>
     /// Send a single PGN 253 steer feedback packet.
     /// </summary>
     public void SendSteerFeedback()
     {
         var data = new byte[8];
 
-        // Bytes 0-1: Actual steer angle (degrees * 100, int16 LE)
-        short angleRaw = (short)(ActualSteerAngleDeg * 100);
+        // Bytes 0-1: Calibrated WAS angle (degrees * 100, int16 LE)
+        short angleRaw = (short)(ReportedSteerAngleDeg * 100);
         data[0] = (byte)(angleRaw & 0xFF);
         data[1] = (byte)((angleRaw >> 8) & 0xFF);
 

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -165,10 +165,17 @@ public class VirtualSteerModule : IDisposable
         data[4] = (byte)(rollRaw & 0xFF);
         data[5] = (byte)((rollRaw >> 8) & 0xFF);
 
-        // Byte 6: Switch status
+        // Byte 6: Switch status. When the operator has not wired a physical
+        // switch (the matching config flag is OFF), the simulator always
+        // reports "active" — matching the legacy Teensy convention where an
+        // unwired input is treated as continuously engaged so the host's
+        // autosteer can still arm. When the flag is ON, the UI toggle drives
+        // the bit.
+        bool steerActive = SteerSwitchEnabled ? SteerSwitchActive : true;
+        bool workActive = WorkSwitchEnabled ? WorkSwitchActive : true;
         byte switches = 0;
-        if (!WorkSwitchActive) switches |= 0x01; // bit 0: work switch (inverted: 1=OFF)
-        if (SteerSwitchActive) switches |= 0x02;  // bit 1: steer switch
+        if (!workActive) switches |= 0x01;  // bit 0: work switch (inverted: 1=OFF)
+        if (steerActive) switches |= 0x02;  // bit 1: steer switch
         data[6] = switches;
 
         // Byte 7: PWM display

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -53,6 +53,38 @@ public class VirtualSteerModule : IDisposable
     public long SentHelloCount { get; private set; }
     public AutoSteerCommand? LastCommand { get; private set; }
 
+    // === Applied settings from PGN 252 (SteerSettings) ===
+    // Defaults mirror AgOpenGPS Teensy firmware boot defaults so the simulator
+    // behaves sanely before any host configuration arrives.
+    public byte Kp { get; private set; } = 40;
+    public byte HighPWM { get; private set; } = 160;
+    public byte LowPWM { get; private set; } = 30;
+    public byte MinPWM { get; private set; } = 25;
+    public byte CountsPerDegree { get; private set; } = 100;
+    public short WasOffset { get; private set; }
+    public double AckermannFix { get; private set; } = 1.0;
+
+    // === Applied config from PGN 251 (SteerConfig) ===
+    public bool InvertWas { get; private set; }
+    public bool IsRelayActiveHigh { get; private set; }
+    public bool MotorDriveDirection { get; private set; }
+    public bool SingleInputWas { get; private set; } = true;
+    public bool CytronDriver { get; private set; } = true;
+    public bool SteerSwitchEnabled { get; private set; }
+    public bool SteerButtonEnabled { get; private set; }
+    public bool ShaftEncoderEnabled { get; private set; }
+    public byte PulseCountMax { get; private set; } = 5;
+    public byte MinSpeed { get; private set; }
+    public bool IsDanfoss { get; private set; }
+    public bool PressureSensorEnabled { get; private set; }
+    public bool CurrentSensorEnabled { get; private set; }
+    public bool IsUseYAxis { get; private set; }
+
+    // Whether the operator has wired a physical work switch. Reported via
+    // PGN 253 byte 6 bit 0; not configurable through PGN 251 directly, so the
+    // simulator exposes it as a settable flag.
+    public bool WorkSwitchEnabled { get; set; }
+
     public VirtualSteerModule(int listenPort = 8888, int hostPort = 9999, string hostIp = "127.0.0.1")
     {
         _udp = new UdpClient(new IPEndPoint(IPAddress.Any, listenPort));
@@ -165,10 +197,50 @@ public class VirtualSteerModule : IDisposable
                 break;
 
             case PgnProtocol.PGN_STEER_SETTINGS:
+                ApplySteerSettings(PgnProtocol.ParseSteerSettings(data));
+                break;
+
             case PgnProtocol.PGN_STEER_CONFIG:
-                // Acknowledge config packets (no response needed per protocol)
+                ApplySteerConfig(PgnProtocol.ParseSteerConfig(data));
                 break;
         }
+    }
+
+    /// <summary>
+    /// Apply a freshly received PGN 252 (SteerSettings) payload.
+    /// Public so tests can drive the parse/apply path without going over UDP.
+    /// </summary>
+    public void ApplySteerSettings(SteerSettingsPacket s)
+    {
+        Kp = s.Kp;
+        HighPWM = s.HighPWM;
+        LowPWM = s.LowPWM;
+        MinPWM = s.MinPWM;
+        CountsPerDegree = s.CountsPerDegree;
+        WasOffset = s.WasOffset;
+        AckermannFix = s.AckermannFix;
+    }
+
+    /// <summary>
+    /// Apply a freshly received PGN 251 (SteerConfig) payload.
+    /// Public so tests can drive the parse/apply path without going over UDP.
+    /// </summary>
+    public void ApplySteerConfig(SteerConfigPacket c)
+    {
+        InvertWas = c.InvertWas;
+        IsRelayActiveHigh = c.IsRelayActiveHigh;
+        MotorDriveDirection = c.MotorDriveDirection;
+        SingleInputWas = c.SingleInputWas;
+        CytronDriver = c.CytronDriver;
+        SteerSwitchEnabled = c.SteerSwitchEnabled;
+        SteerButtonEnabled = c.SteerButtonEnabled;
+        ShaftEncoderEnabled = c.ShaftEncoderEnabled;
+        PulseCountMax = c.PulseCountMax;
+        MinSpeed = c.MinSpeed;
+        IsDanfoss = c.IsDanfoss;
+        PressureSensorEnabled = c.PressureSensorEnabled;
+        CurrentSensorEnabled = c.CurrentSensorEnabled;
+        IsUseYAxis = c.IsUseYAxis;
     }
 
     private void SendHello()

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
@@ -100,6 +100,53 @@ public class VirtualSteerModuleTests
     }
 
     [Test]
+    public void WasGroundTruth_OperatorChangesVirtualCpd_ReportedAngleScales()
+    {
+        // Misconfigured WAS: real hardware has 85 counts/deg, but the host
+        // believes it's 100 counts/deg. Wheel at 10° → 850 raw counts →
+        // host applies its (wrong) calibration: 850 / 100 = 8.5° reported.
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 11, hostPort: HostPort + 11, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings(cpd: 100, wasOffset: 0));
+        steer.ApplySteerConfig(DefaultConfig());
+        steer.VirtualCountsPerDegree = 85.0;
+        steer.VirtualWasOffset = 0;
+        steer.ActualSteerAngleDeg = 10.0;
+
+        Assert.That(steer.ReportedSteerAngleDeg, Is.EqualTo(8.5).Within(1e-9));
+    }
+
+    [Test]
+    public void WasGroundTruth_CalibrationMatch_ReportedEqualsTruth()
+    {
+        // Host's guess matches reality — reported angle equals the wheel angle.
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 12, hostPort: HostPort + 12, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings(cpd: 85, wasOffset: 0));
+        steer.ApplySteerConfig(DefaultConfig());
+        steer.VirtualCountsPerDegree = 85.0;
+        steer.VirtualWasOffset = 0;
+        steer.ActualSteerAngleDeg = 10.0;
+
+        Assert.That(steer.ReportedSteerAngleDeg, Is.EqualTo(10.0).Within(1e-9));
+    }
+
+    [Test]
+    public void WasGroundTruth_OffsetApplied()
+    {
+        // Real WAS is off-centre by 20 counts; host hasn't run Zero WAS yet
+        // (applied offset = 0). At 5° wheel angle: rawCounts = 5*100 + 20 = 520,
+        // host's inverse: (520 - 0) / 100 = 5.2° — apparent bias the operator
+        // is supposed to dial out with the wizard's Zero WAS step.
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 13, hostPort: HostPort + 13, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings(cpd: 100, wasOffset: 0));
+        steer.ApplySteerConfig(DefaultConfig());
+        steer.VirtualCountsPerDegree = 100.0;
+        steer.VirtualWasOffset = 20;
+        steer.ActualSteerAngleDeg = 5.0;
+
+        Assert.That(steer.ReportedSteerAngleDeg, Is.EqualTo(5.2).Within(1e-9));
+    }
+
+    [Test]
     public void AppliesWasOffsetToReportedAngle()
     {
         // Slider at 1.0° with CountsPerDegree=100 → 100 raw WAS counts.

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
@@ -123,6 +123,40 @@ public class VirtualSteerModuleTests
         Assert.That(steer.ReportedSteerAngleDeg, Is.EqualTo(-5.0).Within(1e-9));
     }
 
+    private static AutoSteerCommand SteerCommand(double angleDeg, bool engaged)
+    {
+        byte status = engaged ? (byte)0x0C : (byte)0x00; // bit 2 = engaged, bit 3 = gps valid
+        return new AutoSteerCommand
+        {
+            SpeedKmh = 10.0,
+            Status = status,
+            SteerAngleDeg = angleDeg,
+            IsEngaged = engaged,
+            IsGpsValid = true,
+        };
+    }
+
+    [Test]
+    public void ProportionalControl_ConvergesToCommand()
+    {
+        // 10 deg command + IsEngaged, tick the synthetic PWM control loop for
+        // ~5 simulated seconds. ActualSteerAngleDeg should converge to within
+        // 0.5 deg of the command.
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 3, hostPort: HostPort + 3, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings());
+        steer.ApplySteerConfig(DefaultConfig());
+        steer.ActualSteerAngleDeg = 0;
+        steer.ApplyAutoSteerCommand(SteerCommand(angleDeg: 10.0, engaged: true));
+
+        for (int i = 0; i < 50; i++)
+        {
+            steer.UpdateSteerControl(0.1);
+        }
+
+        Assert.That(steer.ActualSteerAngleDeg, Is.EqualTo(10.0).Within(0.5),
+            $"Expected PWM loop to converge to 10 deg within 5 s, got {steer.ActualSteerAngleDeg}");
+    }
+
     [Test]
     public void PeriodicEmission_FiresAt10Hz()
     {

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
@@ -78,6 +78,51 @@ public class VirtualSteerModuleTests
         }
     }
 
+    private static SteerSettingsPacket DefaultSettings(byte cpd = 100, short wasOffset = 0)
+    {
+        return new SteerSettingsPacket
+        {
+            Kp = 40, HighPWM = 160, LowPWM = 30, MinPWM = 25,
+            CountsPerDegree = cpd, WasOffset = wasOffset, AckermannFix = 1.0,
+        };
+    }
+
+    private static SteerConfigPacket DefaultConfig(bool invertWas = false, bool steerSwitch = false, bool workSwitch = false)
+    {
+        return new SteerConfigPacket
+        {
+            InvertWas = invertWas,
+            SingleInputWas = true,
+            CytronDriver = true,
+            SteerSwitchEnabled = steerSwitch,
+            // PGN 251 has no WorkSwitchEnabled bit; tests set it directly on the module.
+        };
+    }
+
+    [Test]
+    public void AppliesWasOffsetToReportedAngle()
+    {
+        // Slider at 1.0° with CountsPerDegree=100 → 100 raw WAS counts.
+        // After offset of 20: (100 − 20) / 100 = 0.8°.
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 1, hostPort: HostPort + 1, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings(cpd: 100, wasOffset: 20));
+        steer.ApplySteerConfig(DefaultConfig());
+        steer.ActualSteerAngleDeg = 1.0;
+
+        Assert.That(steer.ReportedSteerAngleDeg, Is.EqualTo(0.8).Within(1e-9));
+    }
+
+    [Test]
+    public void AppliesInvertWasToReportedAngle()
+    {
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 2, hostPort: HostPort + 2, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings());
+        steer.ApplySteerConfig(DefaultConfig(invertWas: true));
+        steer.ActualSteerAngleDeg = 5.0;
+
+        Assert.That(steer.ReportedSteerAngleDeg, Is.EqualTo(-5.0).Within(1e-9));
+    }
+
     [Test]
     public void PeriodicEmission_FiresAt10Hz()
     {

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
@@ -157,6 +157,59 @@ public class VirtualSteerModuleTests
             $"Expected PWM loop to converge to 10 deg within 5 s, got {steer.ActualSteerAngleDeg}");
     }
 
+    /// <summary>
+    /// Decode PGN 253 byte 6 (switch status) from a captured packet.
+    /// Bit 1 = steer switch active; bit 0 = work switch inverted (1 = off).
+    /// </summary>
+    private static (bool steerActive, bool workActive) DecodeSwitchByte(byte[] packet)
+    {
+        byte b = packet[11]; // header(5) + data[6] = byte 6 of payload
+        bool steer = (b & 0x02) != 0;
+        bool work = (b & 0x01) == 0; // bit 0 inverted
+        return (steer, work);
+    }
+
+    [Test]
+    public void SwitchConfigured_RespectsUiToggle()
+    {
+        using var listener = new HostListener(HostPort + 4);
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 4, hostPort: HostPort + 4, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings());
+        steer.ApplySteerConfig(DefaultConfig(steerSwitch: true));
+        // Operator has the physical switch wired and has flipped it off.
+        steer.SteerSwitchActive = false;
+
+        steer.Tick();
+        Thread.Sleep(30);
+
+        var packet = listener.LatestSteerPacket();
+        Assert.That(packet, Is.Not.Null, "Expected a PGN 253 packet");
+        var (steerBit, _) = DecodeSwitchByte(packet!);
+        Assert.That(steerBit, Is.False,
+            "When SteerSwitch is wired and operator has toggled OFF, PGN 253 should report SteerSwitchActive=false.");
+    }
+
+    [Test]
+    public void SwitchNotConfigured_AlwaysEngaged()
+    {
+        using var listener = new HostListener(HostPort + 5);
+        using var steer = new VirtualSteerModule(listenPort: ModulePort + 5, hostPort: HostPort + 5, hostIp: LoopbackIp);
+        steer.ApplySteerSettings(DefaultSettings());
+        steer.ApplySteerConfig(DefaultConfig(steerSwitch: false));
+        // Even if the UI toggle says "off", with no physical switch wired the
+        // module should report it as continuously engaged.
+        steer.SteerSwitchActive = false;
+
+        steer.Tick();
+        Thread.Sleep(30);
+
+        var packet = listener.LatestSteerPacket();
+        Assert.That(packet, Is.Not.Null, "Expected a PGN 253 packet");
+        var (steerBit, _) = DecodeSwitchByte(packet!);
+        Assert.That(steerBit, Is.True,
+            "When SteerSwitch is not wired, PGN 253 should always report SteerSwitchActive=true regardless of UI toggle.");
+    }
+
     [Test]
     public void PeriodicEmission_FiresAt10Hz()
     {

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModuleTests.cs
@@ -1,0 +1,103 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.IntegrationTests.VirtualModules;
+
+/// <summary>
+/// Unit tests for VirtualSteerModule — verifies that the simulator emulates
+/// a real Teensy steer module end-to-end (periodic PGN 253 emission, PGN 251/252
+/// parsing, WAS calibration, synthetic PWM loop, switch handling).
+/// </summary>
+[TestFixture]
+[NonParallelizable] // Tests open UDP sockets on fixed ports
+public class VirtualSteerModuleTests
+{
+    private const int HostPort = 19999;
+    private const int ModulePort = 18888;
+    private const string LoopbackIp = "127.0.0.1";
+
+    /// <summary>
+    /// Lightweight UDP listener that captures PGN 253 packets sent to the host port.
+    /// </summary>
+    private sealed class HostListener : IDisposable
+    {
+        private readonly UdpClient _udp;
+        private readonly CancellationTokenSource _cts = new();
+        public List<byte[]> SteerPackets { get; } = new();
+
+        public HostListener(int port)
+        {
+            _udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, port));
+            _ = ReceiveLoopAsync();
+        }
+
+        private async System.Threading.Tasks.Task ReceiveLoopAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    var res = await _udp.ReceiveAsync(_cts.Token);
+                    if (res.Buffer.Length >= 6
+                        && res.Buffer[0] == 0x80 && res.Buffer[1] == 0x81
+                        && res.Buffer[3] == PgnProtocol.PGN_STEER_DATA)
+                    {
+                        lock (SteerPackets) SteerPackets.Add(res.Buffer);
+                    }
+                }
+                catch (OperationCanceledException) { break; }
+                catch (SocketException) { break; }
+            }
+        }
+
+        public byte[]? LatestSteerPacket()
+        {
+            lock (SteerPackets)
+            {
+                return SteerPackets.Count == 0 ? null : SteerPackets[^1];
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _udp.Dispose();
+            _cts.Dispose();
+        }
+    }
+
+    [Test]
+    public void PeriodicEmission_FiresAt10Hz()
+    {
+        using var listener = new HostListener(HostPort);
+        using var steer = new VirtualSteerModule(listenPort: ModulePort, hostPort: HostPort, hostIp: LoopbackIp);
+        steer.Start();
+        try
+        {
+            // Wait 600 ms with no incoming PGN 254. Expect >= 5 PGN 253 packets
+            // (real Teensy hardware streams at ~10 Hz unconditionally).
+            Thread.Sleep(650);
+        }
+        finally
+        {
+            steer.Stop();
+        }
+
+        int count;
+        lock (listener.SteerPackets) count = listener.SteerPackets.Count;
+        Assert.That(count, Is.GreaterThanOrEqualTo(5),
+            $"Expected periodic PGN 253 emission at ~10 Hz, got {count} packets in 650 ms.");
+    }
+}


### PR DESCRIPTION
**Stacks on #381** (still open at time of authoring). The Applied* properties this branch uses for the new WAS column come from #381's `b70c2bff`. Once #381 merges, GitHub will fast-forward this onto develop; otherwise rebase needed.

## Layout restructure (`964d64a4`)
Old: two-column stack mixing Vehicle controls and Sensors and Module Status. New: four semantic columns that match the real-hardware mental model.

| Column | Contents |
|---|---|
| **Bicycle Model** | Drive Mode, Speed, Heading, Wheel angle |
| **GPS** | Position (Lat/Lon), Satellites, Fix Quality, Roll (IMU) |
| **WAS** | Virtual CountsPerDegree (truth), Virtual Off-center (truth), Truth raw counts (readout), host's applied calibration (readout) |
| **Module Status** | Commanded Angle, Reported WAS, PWM, switch states, applied-settings detail |

Window grew from 750×540 to 1024×540 to fit the four columns; ScrollViewer handles narrower widths. Steer Switch toggle and AutoSteer indicator moved into Module Status. Roll moved out of the catch-all Sensors stack into GPS column under "Roll (IMU)". Heading slider stayed in Bicycle Model with a tooltip noting it's only operator-driven in Raw mode.

## Virtual WAS hardware-truth model (`e73cf8f4`)

Adds `VirtualCountsPerDegree` (double, default 100) + `VirtualWasOffset` (short, default 0) on `VirtualSteerModule`. These represent the **real hardware** the simulator pretends to be — a WAS sensor that's mounted slightly off-center with a particular counts/degree from installation geometry.

When emitting PGN 253:
1. Compute raw counts from wheel angle: `rawCounts = wheelAngleDeg × VirtualCountsPerDegree + VirtualWasOffset`.
2. Apply the inverse of the **host's configured** calibration: `reportedDeg = ((rawCounts - AppliedWasOffset) / AppliedCountsPerDegree) × (AppliedInvertWas ? -1 : +1)`.

If host's guess matches truth, `reportedDeg == wheelAngleDeg`. If guess is wrong, the host sees a misconfigured WAS — exactly what real field hardware does when it's been freshly installed. The operator's wizard calibration job is to dial the host's CPD/Offset until reported matches truth.

Tooltips on the virtual knobs flag them as "what the host's wizard is trying to discover."

## Build fixes (`9ab6c1a7`)
- `(int)` cast on `Math.Clamp(value, -2000, 2000)` for `short value` to disambiguate the overload.
- Re-applied `<GenerateProgramFile>false</GenerateProgramFile>` in IntegrationTests csproj (lost during rebase; same fix as #381).

## Tests
3 new tests in `VirtualSteerModuleTests`:
- `WasGroundTruth_OperatorChangesVirtualCpd_ReportedAngleScales`
- `WasGroundTruth_CalibrationMatch_ReportedEqualsTruth`
- `WasGroundTruth_OffsetApplied`

Plus the existing 6 from #381 still pass: 9/9 green locally.

## Test plan
- [x] Build clean.
- [x] All 9 simulator tests pass.
- [ ] Bench: launch simulator. Window shows 4 columns with the new groupings.
- [ ] Bench (paired with #380): wizard step 8. Set simulator's `Virtual CPD=85`, `Virtual Offset=20`. Wizard initially shows mis-calibrated reading. Operator tunes wizard's CPD/Offset until simulator's "Reported WAS" matches "Wheel angle" — that's calibration convergence working.