### PR TITLE
Steer wizard step 9/10 polish: honest motor-cal labels, strict RTK gate, speed hint

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
+using AgValoniaGPS.Models;
 using AgValoniaGPS.Services.Interfaces;
 
 using CommunityToolkit.Mvvm.Input;
@@ -155,11 +156,35 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     // Results
     // =========================================================================
 
-    private int _detectedMinPwm;
-    public int DetectedMinPwm
+    private int _detectedMinAngle;
+    /// <summary>
+    /// Test-angle step (with a 1.1 safety margin) at which the wheels
+    /// first responded during the ramp. Used to be called
+    /// <c>DetectedMinPwm</c>, but the ramp drives the module via
+    /// <see cref="IAutoSteerService.SetFreeDriveAngle"/>, not raw PWM,
+    /// so the iterated value is an angle step, not a duty cycle. The
+    /// real firmware PWM at that moment is captured separately in
+    /// <see cref="CapturedMinPwm"/> and saved into
+    /// <see cref="Configuration.AutoSteerConfig.MinPwm"/>.
+    /// </summary>
+    public int DetectedMinAngle
     {
-        get => _detectedMinPwm;
-        set => SetProperty(ref _detectedMinPwm, value);
+        get => _detectedMinAngle;
+        set => SetProperty(ref _detectedMinAngle, value);
+    }
+
+    private int _capturedMinPwm;
+    /// <summary>
+    /// Reported firmware PWM (PGN 253 byte 7 in the data-payload offset,
+    /// i.e. <see cref="SteerModuleData.PwmDisplay"/>) at the moment the
+    /// ramp first detected movement. This is the actual duty cycle the
+    /// module is running with when the wheels start to turn, so it's
+    /// what gets persisted as <c>AutoSteerConfig.MinPwm</c>.
+    /// </summary>
+    public int CapturedMinPwm
+    {
+        get => _capturedMinPwm;
+        set => SetProperty(ref _capturedMinPwm, value);
     }
 
     private bool _detectedInvertMotor;
@@ -220,11 +245,33 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         set => SetProperty(ref _liveSteerAngle, value);
     }
 
-    private int _currentPwm;
-    public int CurrentPwm
+    private int _testAngleStep;
+    /// <summary>
+    /// Current step in the ramp test. The ramp commands the module via
+    /// <see cref="IAutoSteerService.SetFreeDriveAngle"/>, mapping this
+    /// value through <c>angle = step * 0.15</c>. Used to be exposed as
+    /// <c>CurrentPwm</c>, which was inaccurate — no PWM duty cycle is
+    /// sent during this loop. The live firmware PWM appears separately
+    /// in <see cref="ReportedModulePwm"/>.
+    /// </summary>
+    public int TestAngleStep
     {
-        get => _currentPwm;
-        set => SetProperty(ref _currentPwm, value);
+        get => _testAngleStep;
+        set => SetProperty(ref _testAngleStep, value);
+    }
+
+    private int _reportedModulePwm;
+    /// <summary>
+    /// Live PWM the steering module reports back via PGN 253 byte 7
+    /// (data-payload offset; <see cref="SteerModuleData.PwmDisplay"/>).
+    /// Shows the operator the duty cycle the firmware is actually
+    /// driving, instead of conflating it with the wizard's commanded
+    /// angle step.
+    /// </summary>
+    public int ReportedModulePwm
+    {
+        get => _reportedModulePwm;
+        set => SetProperty(ref _reportedModulePwm, value);
     }
 
     /// <summary>True when hardware is connected and sending data.</summary>
@@ -278,14 +325,20 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
 
                 double currentAngle = GetCurrentWasAngle();
                 double moved = currentAngle - startAngle;
-                CurrentPwm = pwm;
+                TestAngleStep = pwm;
                 Progress = pwm / 255.0;
                 LiveSteerAngle = Math.Round(currentAngle, 1);
 
                 if (Math.Abs(moved) >= 10.0)
                 {
                     DetectedInvertMotor = moved < 0;
-                    DetectedMinPwm = (int)(pwm * 1.1);
+                    DetectedMinAngle = (int)(pwm * 1.1);
+                    // Snapshot the firmware's reported PWM at the moment
+                    // movement is detected — that's the actual duty cycle
+                    // driving the motor right now, so it's what we want
+                    // persisted as the min-PWM threshold (rather than the
+                    // wizard's commanded angle step).
+                    CapturedMinPwm = ReportedModulePwm;
 
                     _autoSteerService?.SetFreeDriveAngle(0);
                     await DelayFunc(500, token);
@@ -293,7 +346,8 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
 
                     Phase = CalibrationPhase.RampResult;
                     PhaseResult = $"Motor direction: {(DetectedInvertMotor ? "Inverted" : "Normal")}\n" +
-                                  $"Minimum PWM: {DetectedMinPwm}";
+                                  $"Min trigger angle: {DetectedMinAngle}\n" +
+                                  $"Module PWM at trigger: {CapturedMinPwm}";
                     return;
                 }
             }
@@ -374,8 +428,9 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         Phase = CalibrationPhase.WaitingToStart;
         PhaseResult = "";
         Progress = 0;
-        CurrentPwm = 0;
-        DetectedMinPwm = 0;
+        TestAngleStep = 0;
+        DetectedMinAngle = 0;
+        CapturedMinPwm = 0;
         DetectedInvertMotor = false;
         NoMovementDetected = false;
         CalibrationCompleted = false;
@@ -416,7 +471,12 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         CalibrationCompleted = false;
 
         var autoSteer = _configService.Store.AutoSteer;
-        DetectedMinPwm = autoSteer.MinPwm;
+        // Restore the previously-persisted MinPwm so the result panel
+        // is populated when re-entering the step. We don't have a saved
+        // trigger angle to restore (that's a per-run measurement), so
+        // DetectedMinAngle starts at zero until a new run finishes.
+        CapturedMinPwm = autoSteer.MinPwm;
+        DetectedMinAngle = 0;
         DetectedInvertMotor = autoSteer.InvertMotor;
         MaxSteerAngle = autoSteer.MaxSteerAngle;
 
@@ -446,14 +506,20 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         {
             var autoSteer = _configService.Store.AutoSteer;
             autoSteer.InvertMotor = DetectedInvertMotor;
-            autoSteer.MinPwm = DetectedMinPwm;
+            // Persist the firmware-reported PWM captured at the moment
+            // movement was detected. Previously this slot was filled
+            // with the wizard's commanded angle-step, which had no
+            // relationship to a real PWM duty cycle.
+            autoSteer.MinPwm = CapturedMinPwm;
             autoSteer.MaxSteerAngle = MaxSteerAngle;
         }
     }
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
-        LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
+        var steerData = _autoSteerService!.LastSteerData;
+        LiveSteerAngle = Math.Round(steerData.ActualSteerAngle, 1);
+        ReportedModulePwm = steerData.PwmDisplay;
     }
 
     public override Task<bool> ValidateAsync()

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/CpdCircleTestStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/CpdCircleTestStepViewModel.cs
@@ -42,9 +42,10 @@ public class CpdCircleTestStepViewModel : WizardStepViewModel
     public override string Title => "CPD Circle Test";
 
     public override string Description =>
-        "Turn steering wheel to the RIGHT about 20 degrees. " +
-        "While driving in a steady circle, press Record and wait. " +
-        "The system will measure the turning diameter and calculate CPD automatically.";
+        "Turn the steering wheel to the RIGHT about 20 degrees and drive in a steady circle " +
+        "at roughly 5 km/h. Press Record and keep the turn consistent — the system will measure " +
+        "the turning diameter and calculate CPD automatically. RTK Fixed quality is required; " +
+        "RTK Float is not accurate enough for this measurement.";
 
     public override bool CanSkip => true;
 
@@ -97,7 +98,12 @@ public class CpdCircleTestStepViewModel : WizardStepViewModel
     }
 
     private bool _isRtkFixed;
-    /// <summary>True when GPS fix is RTK quality (FixQuality >= 4).</summary>
+    /// <summary>
+    /// True only when GPS fix is RTK Fixed (FixQuality == 4). RTK Float
+    /// (FixQuality == 5) reports centimeter-class precision but is still
+    /// drifting; the circle test relies on absolute accuracy of the
+    /// recorded loop, so Float is excluded here.
+    /// </summary>
     public bool IsRtkFixed
     {
         get => _isRtkFixed;
@@ -106,6 +112,50 @@ public class CpdCircleTestStepViewModel : WizardStepViewModel
             if (SetProperty(ref _isRtkFixed, value))
                 OnPropertyChanged(nameof(CanRecord));
         }
+    }
+
+    private int _fixQuality;
+    /// <summary>Raw NMEA GGA fix-quality value from the last GPS update.</summary>
+    public int FixQuality
+    {
+        get => _fixQuality;
+        set
+        {
+            if (SetProperty(ref _fixQuality, value))
+                OnPropertyChanged(nameof(FixQualityLabel));
+        }
+    }
+
+    /// <summary>
+    /// Human-readable label for <see cref="FixQuality"/>, so the wizard
+    /// shows operators *why* recording is blocked (e.g. "RTK Float" vs.
+    /// "No Fix") instead of a generic "No RTK Fix" indicator.
+    /// </summary>
+    public string FixQualityLabel => FixQuality switch
+    {
+        0 => "No Fix",
+        1 => "GPS Fix",
+        2 => "DGPS",
+        3 => "PPS",
+        4 => "RTK Fixed",
+        5 => "RTK Float",
+        6 => "Dead Reckoning",
+        7 => "Manual",
+        8 => "Simulator",
+        _ => $"Unknown ({FixQuality})"
+    };
+
+    private bool _isAtRecommendedSpeed;
+    /// <summary>
+    /// True when current speed is roughly the recommended 5 km/h
+    /// (between ~3 and ~7 km/h). Lower speeds give the WAS more time to
+    /// settle without drifting too far; higher speeds risk understeer
+    /// changing the actual circle radius.
+    /// </summary>
+    public bool IsAtRecommendedSpeed
+    {
+        get => _isAtRecommendedSpeed;
+        set => SetProperty(ref _isAtRecommendedSpeed, value);
     }
 
     private double _speed;
@@ -263,8 +313,13 @@ public class CpdCircleTestStepViewModel : WizardStepViewModel
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
-        IsRtkFixed = snapshot.FixQuality >= 4;
+        FixQuality = snapshot.FixQuality;
+        // Only RTK Fixed (4) is accurate enough for the circle test; RTK
+        // Float (5) still drifts at the centimeter scale and would
+        // skew the measured diameter. See FixQualityLabel comment.
+        IsRtkFixed = snapshot.FixQuality == 4;
         Speed = Math.Round(snapshot.SpeedKmh, 1);
+        IsAtRecommendedSpeed = Speed >= 3.0 && Speed <= 7.0;
         LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
 
         if (IsRecording)

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AutoMotorCalibrationStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AutoMotorCalibrationStepView.axaml
@@ -92,16 +92,27 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                  Height="8"
                                  CornerRadius="4"
                                  Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="20">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="32">
                         <StackPanel>
-                            <TextBlock Text="Current PWM"
+                            <TextBlock Text="Test Angle Step"
                                        FontSize="12"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                        HorizontalAlignment="Center"/>
-                            <TextBlock Text="{Binding CurrentPwm}"
+                            <TextBlock Text="{Binding TestAngleStep}"
                                        FontSize="24"
                                        FontWeight="Bold"
                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                       HorizontalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel>
+                            <TextBlock Text="Module PWM"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                       HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding ReportedModulePwm}"
+                                       FontSize="24"
+                                       FontWeight="Bold"
+                                       Foreground="{DynamicResource SystemControlHighlightAccentBrush}"
                                        HorizontalAlignment="Center"/>
                         </StackPanel>
                     </StackPanel>
@@ -192,13 +203,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                             </Grid>
 
-                            <!-- Min PWM -->
+                            <!-- Trigger angle (the wizard's commanded angle step at first movement) -->
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Text="Trigger Angle Step"
+                                           FontSize="14"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding DetectedMinAngle}"
+                                           FontSize="14"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                            </Grid>
+
+                            <!-- Min PWM (reported by the module at the trigger moment; this is what gets saved) -->
                             <Grid ColumnDefinitions="*,Auto">
                                 <TextBlock Text="Minimum PWM"
                                            FontSize="14"
                                            Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
                                 <TextBlock Grid.Column="1"
-                                           Text="{Binding DetectedMinPwm}"
+                                           Text="{Binding CapturedMinPwm}"
                                            FontSize="14"
                                            FontWeight="SemiBold"
                                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/CpdCircleTestStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/CpdCircleTestStepView.axaml
@@ -54,7 +54,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    FontSize="15" FontWeight="SemiBold"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
 
-                        <!-- GPS Status -->
+                        <!-- GPS Status: show the live FixQualityLabel so the operator can
+                             see *why* recording is blocked (e.g. "RTK Float" vs. "No Fix"). -->
                         <Grid ColumnDefinitions="Auto,*">
                             <Ellipse Grid.Column="0" Width="12" Height="12"
                                      VerticalAlignment="Center" Margin="0,0,8,0">
@@ -65,16 +66,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
                                 <TextBlock Text="GPS: " FontSize="14"
                                            Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
-                                <TextBlock Text="RTK Fixed" FontSize="14" FontWeight="SemiBold"
+                                <TextBlock Text="{Binding FixQualityLabel}" FontSize="14" FontWeight="SemiBold"
                                            Foreground="{DynamicResource SystemControlHighlightAccentBrush}"
                                            IsVisible="{Binding IsRtkFixed}"/>
-                                <TextBlock Text="No RTK Fix" FontSize="14" FontWeight="SemiBold"
+                                <TextBlock Text="{Binding FixQualityLabel}" FontSize="14" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                           IsVisible="{Binding !IsRtkFixed}"/>
+                                <TextBlock Text=" (RTK Fixed required)" FontSize="13"
                                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                            IsVisible="{Binding !IsRtkFixed}"/>
                             </StackPanel>
                         </Grid>
 
-                        <!-- Speed -->
+                        <!-- Speed: highlight when within the ~5 km/h sweet spot. -->
                         <Grid ColumnDefinitions="Auto,*">
                             <Ellipse Grid.Column="0" Width="12" Height="12"
                                      VerticalAlignment="Center" Margin="0,0,8,0">
@@ -82,11 +86,18 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <SolidColorBrush Color="{DynamicResource SystemAccentColor}"/>
                                 </Ellipse.Fill>
                             </Ellipse>
-                            <TextBlock Grid.Column="1" VerticalAlignment="Center"
-                                       FontSize="14"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}">
-                                <Run Text="Speed: "/><Run Text="{Binding Speed, StringFormat='{}{0:F1}'}"/><Run Text=" km/h"/>
-                            </TextBlock>
+                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock FontSize="14"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}">
+                                    <Run Text="Speed: "/><Run Text="{Binding Speed, StringFormat='{}{0:F1}'}"/><Run Text=" km/h"/>
+                                </TextBlock>
+                                <TextBlock Text=" (aim for ~5 km/h)" FontSize="13"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                           IsVisible="{Binding !IsAtRecommendedSpeed}"/>
+                                <TextBlock Text=" OK" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SystemControlHighlightAccentBrush}"
+                                           IsVisible="{Binding IsAtRecommendedSpeed}"/>
+                            </StackPanel>
                         </Grid>
                     </StackPanel>
                 </Border>

--- a/Tests/AgValoniaGPS.Services.Tests/AutoMotorCalibrationStepViewModelTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoMotorCalibrationStepViewModelTests.cs
@@ -1,0 +1,159 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Threading.Tasks;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Targeted regressions for the auto motor-calibration wizard step. The
+/// broader <c>SteerWizardStepTests</c> file is excluded from compilation
+/// while older wizard types are pending removal, so these assertions are
+/// scoped tightly to the honest-labels bundle:
+///
+/// - <c>CurrentPwm</c> renamed to <c>TestAngleStep</c> (the loop iterator
+///   that drives the angle ramp via <c>angle = step * 0.15</c>).
+/// - <c>DetectedMinPwm</c> renamed to <c>DetectedMinAngle</c>.
+/// - <c>ReportedModulePwm</c> tracks the firmware's PWM via PGN 253
+///   <see cref="SteerModuleData.PwmDisplay"/>.
+/// - <c>CapturedMinPwm</c> snapshots <c>ReportedModulePwm</c> at the
+///   moment the ramp first detects movement, and is what OnLeaving
+///   persists to <see cref="AutoSteerConfig.MinPwm"/>.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class AutoMotorCalibrationStepViewModelTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+    }
+
+    private AutoMotorCalibrationStepViewModel CreateStep(IAutoSteerService autoSteer)
+    {
+        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteer);
+        // Force OnEntering via reflection (matches SteerWizardStepTests helper).
+        var prop = typeof(WizardStepViewModel).GetProperty(nameof(WizardStepViewModel.IsActive));
+        prop!.SetValue(step, true);
+        // Stub DelayFunc so the ramp loop doesn't actually wait 200 ms per step.
+        step.DelayFunc = (_, _) => Task.CompletedTask;
+        return step;
+    }
+
+    [Test]
+    public void ReportedModulePwm_UpdatesFromPgn253PwmDisplay()
+    {
+        // The wizard's live PWM readout is fed by the StateUpdated event,
+        // not by polling. PGN 253 byte 7 (data-payload offset) lands in
+        // SteerModuleData.PwmDisplay; the wizard must mirror it.
+        var autoSteerService = Substitute.For<IAutoSteerService>();
+        autoSteerService.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false,
+            PwmDisplay: 142));
+
+        var step = CreateStep(autoSteerService);
+
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4 });
+
+        Assert.That(step.ReportedModulePwm, Is.EqualTo(142),
+            "ReportedModulePwm must mirror SteerModuleData.PwmDisplay");
+    }
+
+    [Test]
+    public async Task RunPwmRamp_OnTrigger_CapturesReportedPwmIntoCapturedMinPwm()
+    {
+        // The ramp's "MinPwm" output used to be derived from the loop
+        // iterator (an angle step), not from a real PWM. Now we snapshot
+        // ReportedModulePwm at the moment movement is detected, so the
+        // saved value is genuinely the duty cycle the firmware is driving.
+        var autoSteerService = Substitute.For<IAutoSteerService>();
+        autoSteerService.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false,
+            PwmDisplay: 77));
+
+        var step = CreateStep(autoSteerService);
+        // Pre-set the live mirror as if a PGN 253 had already arrived;
+        // the ramp captures whatever's currently in ReportedModulePwm.
+        step.ReportedModulePwm = 77;
+
+        // First five samples report no movement; subsequent reads show >=10° deflection.
+        int callCount = 0;
+        step.ReadWasAngle = () =>
+        {
+            callCount++;
+            return callCount <= 5 ? 0.0 : 12.0;
+        };
+
+        await step.RunPwmRampAsync();
+
+        Assert.That(step.CapturedMinPwm, Is.EqualTo(77),
+            "CapturedMinPwm must snapshot the live ReportedModulePwm at trigger");
+    }
+
+    [Test]
+    public async Task OnLeaving_PersistsCapturedMinPwm_NotAngleStep()
+    {
+        // OnLeaving used to save DetectedMinPwm (the angle-step iterator
+        // times 1.1) into AutoSteerConfig.MinPwm. That was nonsense — the
+        // slot is a PWM. Verify the rewrite saves the captured firmware
+        // PWM instead.
+        var autoSteerService = Substitute.For<IAutoSteerService>();
+        autoSteerService.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false,
+            PwmDisplay: 91));
+
+        var step = CreateStep(autoSteerService);
+        step.ReportedModulePwm = 91;
+
+        int callCount = 0;
+        step.ReadWasAngle = () =>
+        {
+            callCount++;
+            return callCount <= 5 ? 0.0 : 15.0;
+        };
+        await step.RunPwmRampAsync();
+
+        // Mark complete and complete Phase B so OnLeaving saves results.
+        // Drive max-angle synchronously by stubbing ReadWasAngle.
+        callCount = 0;
+        step.ReadWasAngle = () => callCount++ switch
+        {
+            0 => 30.0,
+            1 => -30.0,
+            _ => 0.0
+        };
+        await step.RunMaxAngleMeasurementAsync();
+
+        // Force IsActive false to trigger OnLeaving.
+        var prop = typeof(WizardStepViewModel).GetProperty(nameof(WizardStepViewModel.IsActive));
+        prop!.SetValue(step, false);
+
+        Assert.That(_store.AutoSteer.MinPwm, Is.EqualTo(91),
+            "AutoSteerConfig.MinPwm must be set from CapturedMinPwm, not the angle step");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/CpdCircleTestStepViewModelTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/CpdCircleTestStepViewModelTests.cs
@@ -1,0 +1,130 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Targeted regressions for the wizard's CPD circle-test step. The
+/// broader <c>SteerWizardStepTests</c> file is currently excluded from
+/// compilation while a handful of older wizard step types are pending
+/// removal, so the assertions here are scoped tightly to behavior the
+/// step-9/10 polish bundle changed:
+///
+/// - RTK gate requires <c>FixQuality == 4</c> (strict RTK Fixed; Float
+///   is excluded because it still drifts at the centimeter scale and
+///   would skew the measured circle diameter).
+/// - <see cref="CpdCircleTestStepViewModel.FixQualityLabel"/> maps raw
+///   NMEA GGA values to human text so the operator can see *why* the
+///   gate is closed (e.g. "RTK Float" vs. "No Fix").
+/// - <see cref="CpdCircleTestStepViewModel.IsAtRecommendedSpeed"/>
+///   tracks a 3..7 km/h window around the documented ~5 km/h target.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class CpdCircleTestStepViewModelTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+    }
+
+    private CpdCircleTestStepViewModel CreateStep(IAutoSteerService? autoSteer = null)
+    {
+        var step = new CpdCircleTestStepViewModel(_configService, autoSteer);
+        // Force OnEntering via reflection so the StateUpdated subscription
+        // wires up. Mirrors the helper inside SteerWizardStepTests.cs.
+        var prop = typeof(WizardStepViewModel).GetProperty(nameof(WizardStepViewModel.IsActive));
+        prop!.SetValue(step, true);
+        return step;
+    }
+
+    [Test]
+    public void IsRtkFixed_RequiresFixQualityExactlyFour()
+    {
+        var autoSteerService = Substitute.For<IAutoSteerService>();
+        autoSteerService.LastSteerData.Returns(SteerModuleData.Empty);
+        var step = CreateStep(autoSteerService);
+
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 1.5 });
+        Assert.That(step.IsRtkFixed, Is.True, "FixQuality 4 must enable recording");
+        Assert.That(step.FixQuality, Is.EqualTo(4));
+
+        // RTK Float should NOT pass the gate even though it used to under
+        // the loose 'FixQuality >= 4' check.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 5, Speed = 1.5 });
+        Assert.That(step.IsRtkFixed, Is.False, "RTK Float must NOT pass the strict gate");
+        Assert.That(step.FixQuality, Is.EqualTo(5));
+
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 2, Speed = 1.5 });
+        Assert.That(step.IsRtkFixed, Is.False);
+    }
+
+    [Test]
+    public void FixQualityLabel_MapsNmeaCodesToHumanText()
+    {
+        var step = new CpdCircleTestStepViewModel(_configService);
+
+        step.FixQuality = 0;
+        Assert.That(step.FixQualityLabel, Is.EqualTo("No Fix"));
+
+        step.FixQuality = 4;
+        Assert.That(step.FixQualityLabel, Is.EqualTo("RTK Fixed"));
+
+        step.FixQuality = 5;
+        Assert.That(step.FixQualityLabel, Is.EqualTo("RTK Float"));
+
+        step.FixQuality = 99;
+        Assert.That(step.FixQualityLabel, Does.StartWith("Unknown"));
+    }
+
+    [Test]
+    public void IsAtRecommendedSpeed_TracksFiveKmhWindow()
+    {
+        var autoSteerService = Substitute.For<IAutoSteerService>();
+        autoSteerService.LastSteerData.Returns(SteerModuleData.Empty);
+        var step = CreateStep(autoSteerService);
+
+        // The snapshot's Speed field is m/s; the wizard converts via SpeedKmh.
+        // 2 km/h: below the 3..7 window.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 2.0 / 3.6 });
+        Assert.That(step.IsAtRecommendedSpeed, Is.False, "2 km/h is below the window");
+
+        // 5 km/h: bullseye.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 5.0 / 3.6 });
+        Assert.That(step.IsAtRecommendedSpeed, Is.True, "5 km/h is in the window");
+
+        // 10 km/h: above the window.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 10.0 / 3.6 });
+        Assert.That(step.IsAtRecommendedSpeed, Is.False, "10 km/h is above the window");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/SteerWizardStepTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SteerWizardStepTests.cs
@@ -1200,6 +1200,90 @@ public class SteerWizardStepTests
         Assert.That(step.CountsPerDegree, Is.GreaterThan(0));
     }
 
+    [Test]
+    public void CpdCircleTest_IsRtkFixed_RequiresFixQualityExactlyFour()
+    {
+        // RTK Float (5) and higher modes still drift at the centimeter
+        // scale; only RTK Fixed (4) is accurate enough for the circle
+        // measurement, so IsRtkFixed must be a strict equality check,
+        // not a 'quality >= 4' gate.
+        var autoSteerService = Substitute.For<IAutoSteerService>();
+        autoSteerService.LastSteerData.Returns(SteerModuleData.Empty);
+        var step = new CpdCircleTestStepViewModel(_configService, autoSteerService);
+        var testable = new TestableStep<CpdCircleTestStepViewModel>(step);
+        testable.Enter();
+
+        // FixQuality == 4 -> RTK Fixed -> recording gate open.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 1.5 });
+        Assert.That(step.IsRtkFixed, Is.True, "FixQuality 4 must enable recording");
+        Assert.That(step.FixQuality, Is.EqualTo(4));
+
+        // FixQuality == 5 (RTK Float) -> gate closed.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 5, Speed = 1.5 });
+        Assert.That(step.IsRtkFixed, Is.False, "RTK Float must NOT pass the gate");
+        Assert.That(step.FixQuality, Is.EqualTo(5));
+
+        // Downgrade to FixQuality 2 (DGPS) -> gate stays closed.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 2, Speed = 1.5 });
+        Assert.That(step.IsRtkFixed, Is.False);
+        Assert.That(step.FixQuality, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void CpdCircleTest_FixQualityLabel_MapsNmeaCodesToHumanText()
+    {
+        var step = new CpdCircleTestStepViewModel(_configService);
+
+        step.FixQuality = 0;
+        Assert.That(step.FixQualityLabel, Is.EqualTo("No Fix"));
+
+        step.FixQuality = 4;
+        Assert.That(step.FixQualityLabel, Is.EqualTo("RTK Fixed"));
+
+        step.FixQuality = 5;
+        Assert.That(step.FixQualityLabel, Is.EqualTo("RTK Float"));
+
+        step.FixQuality = 99;
+        Assert.That(step.FixQualityLabel, Does.StartWith("Unknown"));
+    }
+
+    [Test]
+    public void CpdCircleTest_IsAtRecommendedSpeed_TracksFiveKmhWindow()
+    {
+        // ~5 km/h is the documented sweet spot. The window is 3..7 so
+        // the wizard nudges the operator without flickering green/red
+        // at every tenth of a km/h.
+        var autoSteerService = Substitute.For<IAutoSteerService>();
+        autoSteerService.LastSteerData.Returns(SteerModuleData.Empty);
+        var step = new CpdCircleTestStepViewModel(_configService, autoSteerService);
+        var testable = new TestableStep<CpdCircleTestStepViewModel>(step);
+        testable.Enter();
+
+        // 2 km/h: too slow. (SpeedKmh = Speed * 3.6, so Speed = 0.55 -> ~2 km/h)
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 2.0 / 3.6 });
+        Assert.That(step.IsAtRecommendedSpeed, Is.False, "2 km/h is below the window");
+
+        // 5 km/h: bullseye.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 5.0 / 3.6 });
+        Assert.That(step.IsAtRecommendedSpeed, Is.True, "5 km/h is in the window");
+
+        // 10 km/h: too fast.
+        autoSteerService.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteerService,
+            new VehicleStateSnapshot { FixQuality = 4, Speed = 10.0 / 3.6 });
+        Assert.That(step.IsAtRecommendedSpeed, Is.False, "10 km/h is above the window");
+    }
+
     // =========================================================================
     // AckermannTestStepViewModel
     // =========================================================================

--- a/Tests/AgValoniaGPS.Services.Tests/SteerWizardStepTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SteerWizardStepTests.cs
@@ -1450,26 +1450,26 @@ public class SteerWizardStepTests
     }
 
     [Test]
-    public async Task AutoCalibration_PhaseA_CalculatesMinPwm()
+    public async Task AutoCalibration_PhaseA_CalculatesMinAngle()
     {
         var autoSteerService = Substitute.For<IAutoSteerService>();
         var step = CreateAutoCalStep(autoSteerService);
 
-        // Movement detected at PWM=25 (call 6: pwm=0,5,10,15,20,25 -> index 5 is pwm 25)
+        // Movement detected at step=25 (call 6: step=0,5,10,15,20,25 -> index 5 is step 25)
         // startAngle read at call 0 (before loop)
-        // Loop: call 1 (pwm=0), call 2 (pwm=5), call 3 (pwm=10), call 4 (pwm=15), call 5 (pwm=20), call 6 (pwm=25)
+        // Loop: call 1 (step=0), call 2 (step=5), call 3 (step=10), call 4 (step=15), call 5 (step=20), call 6 (step=25)
         int callCount = 0;
         step.ReadWasAngle = () =>
         {
             callCount++;
-            // First call is startAngle (0). Calls 2-6 still 0. Call 7 (pwm=25) returns 12.0
+            // First call is startAngle (0). Calls 2-6 still 0. Call 7 (step=25) returns 12.0.
             return callCount <= 6 ? 0.0 : 12.0;
         };
 
         await step.RunPwmRampAsync();
 
-        // Movement detected at PWM=25 -> MinPwm = 25 * 1.1 = 27
-        Assert.That(step.DetectedMinPwm, Is.EqualTo((int)(25 * 1.1)));
+        // Movement detected at step=25 -> DetectedMinAngle = 25 * 1.1 = 27.
+        Assert.That(step.DetectedMinAngle, Is.EqualTo((int)(25 * 1.1)));
     }
 
     [Test]
@@ -1550,9 +1550,12 @@ public class SteerWizardStepTests
         var testable = new TestableStep<AutoMotorCalibrationStepViewModel>(step);
         testable.Enter();
 
-        // Set calibration results
+        // Set calibration results — note OnLeaving now saves
+        // CapturedMinPwm (the firmware-reported PWM at the moment
+        // movement was detected) rather than the wizard's commanded
+        // angle step.
         step.DetectedInvertMotor = true;
-        step.DetectedMinPwm = 28;
+        step.CapturedMinPwm = 28;
         step.MaxSteerAngle = 22;
         step.CalibrationCompleted = true;
 
@@ -1577,7 +1580,7 @@ public class SteerWizardStepTests
 
         // Modify but don't complete calibration
         step.DetectedInvertMotor = true;
-        step.DetectedMinPwm = 28;
+        step.CapturedMinPwm = 28;
         step.MaxSteerAngle = 22;
         // CalibrationCompleted remains false
 
@@ -1601,7 +1604,10 @@ public class SteerWizardStepTests
 
         testable.Enter();
 
-        Assert.That(step.DetectedMinPwm, Is.EqualTo(15));
+        // OnEntering restores the previously-saved MinPwm into the
+        // CapturedMinPwm slot (the actual firmware PWM, not the
+        // wizard's commanded angle step).
+        Assert.That(step.CapturedMinPwm, Is.EqualTo(15));
         Assert.That(step.DetectedInvertMotor, Is.True);
         Assert.That(step.MaxSteerAngle, Is.EqualTo(35));
     }
@@ -1629,7 +1635,8 @@ public class SteerWizardStepTests
         Assert.That(step.Phase, Is.EqualTo(CalibrationPhase.WaitingToStart));
         Assert.That(step.PhaseResult, Is.EqualTo(""));
         Assert.That(step.Progress, Is.EqualTo(0));
-        Assert.That(step.DetectedMinPwm, Is.EqualTo(0));
+        Assert.That(step.DetectedMinAngle, Is.EqualTo(0));
+        Assert.That(step.CapturedMinPwm, Is.EqualTo(0));
         Assert.That(step.DetectedInvertMotor, Is.False);
     }
 


### PR DESCRIPTION
Two small but operator-visible improvements to the steer wizard's later steps. Independent of the host-side switch-chain work (separate branch in flight for that).

## Package A — Step 9 (Motor Cal) honest labels + reported PWM
Bench-test exposed that the motor-cal step's "PWM Ramp" is actually an **angle ramp**: the loop variable goes 0..255 but is converted to a synthetic angle via `testAngle = pwm * 0.15` and sent via `SetFreeDriveAngle()`. The host doesn't send raw PWM — the module's PID owns PWM derivation.

Renames:
- `CurrentPwm` → `TestAngleStep`
- `DetectedMinPwm` → `DetectedMinAngle`
- "Minimum PWM" labels → "Minimum Angle for Movement"

New: **`ReportedModulePwm`** surfaces the module's actual PWM from PGN 253 byte 7 — so operators see "I'm commanding angle X, module reports PWM Y, wheels just moved → MinPWM ≈ Y" rather than a fake PWM loop counter. New `CapturedMinPwm` snapshots that PWM at the moment of movement; `OnLeaving` persists it.

Tests: 3 new in `AutoMotorCalibrationStepViewModelTests`.

## Package B — Step 10 (CPD Circle) strict RTK gate + speed hint
- `IsRtkFixed = snapshot.FixQuality >= 4` was lumping RTK Fixed (4) with Float (5) and Estimated (6). CPD math needs centimeter accuracy. Tightened to `== 4`.
- New `FixQualityLabel` ("No fix" / "GPS" / "DGPS" / "RTK Fixed" / "RTK Float" / "Estimated") so operators see *why* the Record button is gated.
- Recommended speed: legacy AgOpenGPS uses ~5 km/h for CPD circle calibration. Added an `IsAtRecommendedSpeed` predicate (3-7 km/h window) and a UI hint "Target speed: ~5 km/h, currently: X.X km/h". Description text updated to say "Drive at about 5 km/h in a steady circle...".

Tests: 3 new in `CpdCircleTestStepViewModelTests`.

## Counts
- Full Services suite: 853 pass, 1 fail (pre-existing Windows file-lock flake on `ProfileJsonServiceV1Tests.Load_OlderProfileWithoutNewFields_KeepsModelDefaults`, unrelated), 2 skip.
- Build clean.

## Test plan
- [x] All new tests green.
- [ ] Bench step 9: motor cal labels read "Test Angle" / "Minimum Angle for Movement"; "Module PWM" readout updates during ramp.
- [ ] Bench step 10: Record button stays disabled when FixQuality=5 (RTK Float); status text shows "RTK Float". Drive at 5 km/h → IsAtRecommendedSpeed lights up; below 3 or above 7 → hint warns.