### PR TITLE
Steer wizard switch-state chain: gate UI, PGN 253 transitions, free-drive engage bit

### DIFF
--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -170,6 +170,17 @@ public class AutoSteerService : IAutoSteerService
         if (!PgnBuilder.TryParseSteerData(data, out var steerData))
             return;
 
+        // Track whether anything UI-relevant changed so we only burn a
+        // snapshot allocation + handler dispatch when there's news.
+        // The motor calibration wizard's physical-switch gate is the
+        // motivating case: without firing StateUpdated here, the gate
+        // would only re-evaluate on the next GPS packet, leaving the
+        // operator waiting for several ticks after flipping the switch.
+        bool switchChanged =
+            _lastSteerData.SteerSwitchActive != steerData.SteerSwitchActive ||
+            _lastSteerData.WorkSwitchActive != steerData.WorkSwitchActive ||
+            _lastSteerData.RemoteButtonPressed != steerData.RemoteButtonPressed;
+
         _lastSteerData = steerData;
 
         // Update vehicle state with actual angle from WAS
@@ -178,6 +189,19 @@ public class AutoSteerService : IAutoSteerService
         _state.WorkSwitchActive = steerData.WorkSwitchActive;
 
         _smartWas?.AddSample(steerData.ActualSteerAngle);
+
+        if (switchChanged)
+        {
+            Debug.WriteLine(
+                $"[AutoSteer] PGN 253 switch change: SteerSwitchActive={steerData.SteerSwitchActive} " +
+                $"WorkSwitchActive={steerData.WorkSwitchActive} " +
+                $"Remote={steerData.RemoteButtonPressed} Pwm={steerData.PwmDisplay}");
+
+            // Fire the standard cycle event so UI subscribers (wizard gates,
+            // config dialog indicators, chart series) see the new switch
+            // state without waiting for the next GPS packet.
+            NotifyStateUpdated();
+        }
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
@@ -80,7 +80,11 @@ public static class PgnBuilder
     ///
     /// When IsInFreeDriveMode is true, overrides speed/status/angle for testing:
     /// - Speed set to 8.0 km/h (fake speed to allow motor operation)
-    /// - Status set to 1 (autosteer enabled)
+    /// - Status set to SteerSwitchActive (0x01) + AutoSteerEngaged (0x04)
+    ///   so the firmware/simulator PID actually drives toward the
+    ///   commanded angle. The previous value (0x01 alone) left
+    ///   IsEngaged=false on the receiver, so the wizard's motor ramp
+    ///   commands were silently dropped.
     /// - SteerAngle from FreeDriveSteerAngle instead of guidance
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -106,8 +110,11 @@ public static class PgnBuilder
             buf[5] = (byte)(freeSpeed & 0xFF);        // low byte
             buf[6] = (byte)(freeSpeed >> 8);          // high byte
 
-            // Status = 1 (autosteer enabled for testing)
-            buf[7] = 1;
+            // Status: SteerSwitchActive (0x01) + AutoSteerEngaged (0x04).
+            // The receiver's PID gates on bit 0x04; the lone bit 0x01
+            // alone (former value) was insufficient and left free-drive
+            // commands as no-ops on the simulator.
+            buf[7] = 0x01 | 0x04;
 
             // Use free drive steer angle instead of guidance angle
             // Little-endian: low byte first

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
@@ -22,6 +22,7 @@ using System.Windows.Input;
 
 using AgValoniaGPS.Services.Interfaces;
 
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
 
 namespace AgValoniaGPS.ViewModels.Wizards.SteerWizard;
@@ -514,6 +515,19 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
+        // StateUpdated fires from the UDP receive thread (PGN 253 parser),
+        // so the property writes that follow would post PropertyChanged
+        // off the UI thread. Avalonia's bindings — especially the Start
+        // button's IsEnabled gate — don't refresh from a background-
+        // thread notification, which is what caused Issue I on bench-test
+        // of #381: the physical-switch toggle reached LastSteerData and
+        // the gate logic ran, but the button stayed greyed until the
+        // operator navigated away from the step and back.
+        DispatchToUI(ApplyLiveUpdate);
+    }
+
+    private void ApplyLiveUpdate()
+    {
         LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
         UpdatePhysicalSwitchGate();
     }
@@ -522,8 +536,29 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     {
         // Only re-evaluate when the gate-input flag changes; ignore the
         // dozens of unrelated tool config notifications.
-        if (e.PropertyName == nameof(_configService.Store.Tool.IsSteerSwitchEnabled))
-            UpdatePhysicalSwitchGate();
+        if (e.PropertyName != nameof(_configService.Store.Tool.IsSteerSwitchEnabled))
+            return;
+
+        // Operator-driven config changes typically come in on the UI
+        // thread, but wrap defensively — a future emitter that fires
+        // PropertyChanged from a worker would otherwise reintroduce
+        // Issue I from the config-dialog side.
+        DispatchToUI(UpdatePhysicalSwitchGate);
+    }
+
+    /// <summary>
+    /// Run <paramref name="action"/> on the UI thread, synchronously if
+    /// already there. In test contexts where the UI dispatcher pumps
+    /// inline on the test thread, <c>CheckAccess</c> returns true and
+    /// the work executes immediately — the existing
+    /// <c>Raise.Event</c>-based gate tests keep passing.
+    /// </summary>
+    private static void DispatchToUI(Action action)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            action();
+        else
+            Dispatcher.UIThread.Post(action);
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -231,6 +232,57 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     public bool HasHardware => _autoSteerService != null;
 
     // =========================================================================
+    // Physical-switch gate
+    // =========================================================================
+    //
+    // If the operator has Tool.IsSteerSwitchEnabled configured, the host
+    // requires the physical Steer Switch on the operator console to be
+    // ON before AutoSteer (and therefore this test) can run. Without an
+    // explicit hint the wizard's Start button just sits there greyed and
+    // the operator has no idea why; bench-test #381 caught exactly this.
+
+    private bool _waitingForPhysicalSwitch;
+    /// <summary>
+    /// True when the operator has the steer-switch gate enabled in tool
+    /// config but the live PGN 253 feedback says the physical switch is
+    /// OFF. The Start button binds <c>IsEnabled</c> to the inverse of
+    /// this, and the AXAML view shows
+    /// <see cref="PhysicalSwitchPromptText"/> below the button so the
+    /// operator knows what to do.
+    /// </summary>
+    public bool WaitingForPhysicalSwitch
+    {
+        get => _waitingForPhysicalSwitch;
+        private set
+        {
+            if (SetProperty(ref _waitingForPhysicalSwitch, value))
+            {
+                OnPropertyChanged(nameof(CanStartTest));
+                OnPropertyChanged(nameof(PhysicalSwitchPromptText));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Operator-facing prompt explaining why <see cref="CanStartTest"/>
+    /// is false when the physical switch is needed but inactive. Empty
+    /// string while the gate is open so the AXAML can use
+    /// <c>StringConverters.IsNotNullOrEmpty</c> for visibility.
+    /// </summary>
+    public string PhysicalSwitchPromptText => WaitingForPhysicalSwitch
+        ? "Turn the Steer Switch ON to start. The host is configured to require the physical switch."
+        : string.Empty;
+
+    /// <summary>
+    /// Composite gate for the Start button: hardware connected and
+    /// (if applicable) physical switch active. Separate from the
+    /// per-phase visibility flags so the AXAML can both hide the
+    /// button (no hardware) and grey it (waiting for switch) with
+    /// distinct UX.
+    /// </summary>
+    public bool CanStartTest => HasHardware && !WaitingForPhysicalSwitch;
+
+    // =========================================================================
     // Commands
     // =========================================================================
 
@@ -422,6 +474,13 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
 
         if (_autoSteerService != null)
             _autoSteerService.StateUpdated += OnStateUpdated;
+
+        // Listen for the operator flipping Tool.IsSteerSwitchEnabled
+        // (config UI) while the wizard is on-screen, so the gate text
+        // reacts without needing a fresh PGN 253 to trigger reevaluation.
+        _configService.Store.Tool.PropertyChanged += OnToolPropertyChanged;
+
+        UpdatePhysicalSwitchGate();
     }
 
     protected override void OnLeaving()
@@ -441,6 +500,8 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
             }
         }
 
+        _configService.Store.Tool.PropertyChanged -= OnToolPropertyChanged;
+
         // Save results if calibration was completed
         if (CalibrationCompleted)
         {
@@ -454,6 +515,28 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
         LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
+        UpdatePhysicalSwitchGate();
+    }
+
+    private void OnToolPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // Only re-evaluate when the gate-input flag changes; ignore the
+        // dozens of unrelated tool config notifications.
+        if (e.PropertyName == nameof(_configService.Store.Tool.IsSteerSwitchEnabled))
+            UpdatePhysicalSwitchGate();
+    }
+
+    /// <summary>
+    /// Recompute <see cref="WaitingForPhysicalSwitch"/> from the current
+    /// config + live module feedback. The gate is closed (i.e. waiting)
+    /// only when the operator has the steer-switch requirement enabled
+    /// AND the live PGN 253 says the physical switch is OFF.
+    /// </summary>
+    private void UpdatePhysicalSwitchGate()
+    {
+        bool requireSwitch = _configService.Store.Tool.IsSteerSwitchEnabled;
+        bool switchActive = _autoSteerService?.LastSteerData.SteerSwitchActive ?? false;
+        WaitingForPhysicalSwitch = requireSwitch && !switchActive;
     }
 
     public override Task<bool> ValidateAsync()

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/RollCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/RollCalibrationStepViewModel.cs
@@ -77,8 +77,14 @@ public class RollCalibrationStepViewModel : WizardStepViewModel
 
         ZeroRollCommand = new RelayCommand(() =>
         {
-            // Capture current roll as zero offset
-            RollZero = LiveRoll;
+            // LiveRoll is the *post-calibration* angle: the NMEA parser
+            // already applies IsRollInvert and subtracts the current
+            // RollZero before publishing. Replacing the offset would
+            // throw away the prior calibration on a second press —
+            // matches the WAS Zero accumulator bug (#385 F/G). The
+            // invert sign is already baked in upstream, so the Zero
+            // formula here is plain addition.
+            RollZero = _configService.Store.Ahrs.RollZero + LiveRoll;
         });
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/RollCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/RollCalibrationStepViewModel.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 
 using AgValoniaGPS.Services.Interfaces;
 
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -110,7 +111,27 @@ public class RollCalibrationStepViewModel : WizardStepViewModel
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
-        LiveRoll = Math.Round(snapshot.Roll, 2);
+        // StateUpdated fires from the UDP receive thread; off-thread
+        // PropertyChanged doesn't refresh Avalonia bindings, so the
+        // LiveRoll gauge would freeze until the operator navigated
+        // away and back. CheckAccess keeps synchronous-on-test-thread
+        // callers (Raise.Event in NSubstitute) running inline.
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            ApplyLiveUpdate(snapshot.Roll);
+        }
+        else
+        {
+            // Capture Roll into a local so the closure doesn't observe
+            // a mutated 'snapshot' if the parser reuses the struct.
+            double roll = snapshot.Roll;
+            Dispatcher.UIThread.Post(() => ApplyLiveUpdate(roll));
+        }
+    }
+
+    private void ApplyLiveUpdate(double roll)
+    {
+        LiveRoll = Math.Round(roll, 2);
         HasLiveData = true;
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/WasCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/WasCalibrationStepViewModel.cs
@@ -89,16 +89,30 @@ public class WasCalibrationStepViewModel : WizardStepViewModel
 
     private void ZeroWas()
     {
-        // Capture the current live angle as the new zero offset
-        // The WAS offset is applied so that the current reading becomes 0
-        if (_autoSteerService != null)
-        {
-            // Use actual WAS angle from PGN 253 (hardware sensor reading)
-            double actualAngle = _autoSteerService.LastSteerData.ActualSteerAngle;
-            // The actual angle * CPD gives approximate raw counts to zero
-            double cpd = _configService.Store.AutoSteer.CountsPerDegree;
-            WasOffset = (int)(actualAngle * cpd);
-        }
+        if (_autoSteerService == null)
+            return;
+
+        // ActualSteerAngle from PGN 253 is the wheel angle the module
+        // has already post-processed: rawCounts -> subtract WasOffset ->
+        // divide by CountsPerDegree -> apply InvertWas sign. To drive
+        // that reported angle back to zero we need a new offset that
+        // accounts for the prior calibration, not one that replaces it.
+        //
+        // Forward direction (InvertWas = false):
+        //     reported = (raw - offset) / cpd
+        //     desired:  0 = (raw - offset') / cpd
+        //          =>   offset' = raw = offset + reported * cpd
+        //
+        // Inverted direction (InvertWas = true):
+        //     reported = -(raw - offset) / cpd
+        //          =>   raw = offset - reported * cpd
+        //          =>   offset' = offset - reported * cpd
+        //
+        // Unifying with a sign factor: offset' = offset + sign * reported * cpd
+        double actualAngle = _autoSteerService.LastSteerData.ActualSteerAngle;
+        var autoSteer = _configService.Store.AutoSteer;
+        int sign = autoSteer.InvertWas ? -1 : +1;
+        WasOffset = autoSteer.WasOffset + sign * (int)(actualAngle * autoSteer.CountsPerDegree);
     }
 
     protected override void OnEntering()

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/WasCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/WasCalibrationStepViewModel.cs
@@ -20,6 +20,7 @@ using System.Windows.Input;
 
 using AgValoniaGPS.Services.Interfaces;
 
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
 
 namespace AgValoniaGPS.ViewModels.Wizards.SteerWizard;
@@ -138,6 +139,25 @@ public class WasCalibrationStepViewModel : WizardStepViewModel
     }
 
     private void OnAutoSteerStateUpdated(object? sender, VehicleStateSnapshot snapshot)
+    {
+        // StateUpdated fires from the UDP receive thread (PGN 253
+        // parser). PropertyChanged raised off the UI thread doesn't
+        // refresh Avalonia bindings, so the LiveSteerAngle TextBlock
+        // would stay stale until the operator left and re-entered the
+        // step. Marshal to the UI thread; CheckAccess keeps tests
+        // (which fire StateUpdated synchronously on the test thread)
+        // running inline.
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            ApplyLiveUpdate();
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(ApplyLiveUpdate);
+        }
+    }
+
+    private void ApplyLiveUpdate()
     {
         // Show actual WAS angle from hardware (PGN 253), not commanded angle
         LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AutoMotorCalibrationStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/AutoMotorCalibrationStepView.axaml
@@ -64,8 +64,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
                 </Border>
 
-                <!-- ===== Phase A0: Start button ===== -->
-                <StackPanel IsVisible="{Binding IsPhaseA0}" Spacing="16">
+                <!-- ===== Phase A0: Start button + gate hints ===== -->
+                <StackPanel IsVisible="{Binding IsPhaseA0}" Spacing="12">
                     <Button Command="{Binding StartTestCommand}"
                             Content="Start Motor Test"
                             HorizontalAlignment="Center"
@@ -76,7 +76,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             CornerRadius="8"
                             Cursor="Hand"
-                            IsVisible="{Binding HasHardware}"/>
+                            IsVisible="{Binding HasHardware}"
+                            IsEnabled="{Binding CanStartTest}"/>
+
+                    <!-- Physical-switch gate prompt: shows below the (disabled) Start
+                         button when Tool.IsSteerSwitchEnabled is true and the live
+                         PGN 253 says the switch is currently OFF. -->
+                    <TextBlock Text="{Binding PhysicalSwitchPromptText}"
+                               FontSize="14"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                               HorizontalAlignment="Center"
+                               TextWrapping="Wrap"
+                               IsVisible="{Binding WaitingForPhysicalSwitch}"/>
+
                     <TextBlock Text="No hardware connected - connect AutoSteer module to run calibration."
                                FontSize="14"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"

--- a/Tests/AgValoniaGPS.Services.Tests/AutoMotorCalibrationGateTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoMotorCalibrationGateTests.cs
@@ -1,0 +1,155 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the auto motor calibration step's physical-switch gate. The
+/// host requires Tool.IsSteerSwitchEnabled + a live PGN 253 with
+/// SteerSwitchActive bit set before motor tests can run; the wizard
+/// has to reflect that, both so the operator can't fire the test
+/// without the safety toggle and so the operator can see *why* the
+/// Start button is greyed.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class AutoMotorCalibrationGateTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+    }
+
+    private static AutoMotorCalibrationStepViewModel CreateEnteredStep(
+        IConfigurationService configService,
+        IAutoSteerService? autoSteer)
+    {
+        var step = new AutoMotorCalibrationStepViewModel(configService, autoSteer);
+        // Force OnEntering via the public IsActive setter (reflection
+        // because the setter is internal).
+        var prop = typeof(WizardStepViewModel).GetProperty(nameof(WizardStepViewModel.IsActive));
+        prop!.SetValue(step, true);
+        return step;
+    }
+
+    [Test]
+    public void GateOpen_WhenSteerSwitchNotRequired()
+    {
+        // If the operator hasn't enabled the steer-switch requirement,
+        // the gate is irrelevant and the Start button must be enabled
+        // regardless of the physical switch state.
+        _store.Tool.IsSteerSwitchEnabled = false;
+
+        var autoSteer = Substitute.For<IAutoSteerService>();
+        autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false, PwmDisplay: 0));
+
+        var step = CreateEnteredStep(_configService, autoSteer);
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+        Assert.That(step.CanStartTest, Is.True);
+        Assert.That(step.PhysicalSwitchPromptText, Is.Empty);
+    }
+
+    [Test]
+    public void GateClosed_WhenSwitchRequiredButInactive()
+    {
+        // Operator wants the safety toggle (IsSteerSwitchEnabled = true)
+        // but the live PGN 253 says the physical switch is OFF. The gate
+        // must close so the operator can't fire the ramp.
+        _store.Tool.IsSteerSwitchEnabled = true;
+
+        var autoSteer = Substitute.For<IAutoSteerService>();
+        autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false, PwmDisplay: 0));
+
+        var step = CreateEnteredStep(_configService, autoSteer);
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.True);
+        Assert.That(step.CanStartTest, Is.False);
+        Assert.That(step.PhysicalSwitchPromptText, Does.Contain("Steer Switch"));
+    }
+
+    [Test]
+    public void GateOpens_WhenLastSteerDataSteerSwitchActiveFlipsTrue()
+    {
+        // The operator flips the physical switch ON. The wizard sees a
+        // new PGN 253 via StateUpdated, re-evaluates the gate, and
+        // unblocks the Start button. Matches lead spec
+        // 'AutoMotorCalibrationStep_GateFollowsLastSteerDataSteerSwitchActive'.
+        _store.Tool.IsSteerSwitchEnabled = true;
+
+        var autoSteer = Substitute.For<IAutoSteerService>();
+        var off = new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false, PwmDisplay: 0);
+        autoSteer.LastSteerData.Returns(off);
+
+        var step = CreateEnteredStep(_configService, autoSteer);
+        Assert.That(step.WaitingForPhysicalSwitch, Is.True, "starts closed");
+
+        // Flip the simulated PGN 253 to switch-ON, then raise the event
+        // the way AutoSteerService would after a fresh packet.
+        var on = new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: true,
+            RemoteButtonPressed: false, VwasFusionActive: false, PwmDisplay: 0);
+        autoSteer.LastSteerData.Returns(on);
+        autoSteer.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            autoSteer, new VehicleStateSnapshot());
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+        Assert.That(step.CanStartTest, Is.True);
+        Assert.That(step.PhysicalSwitchPromptText, Is.Empty);
+    }
+
+    [Test]
+    public void GateReacts_WhenOperatorTogglesIsSteerSwitchEnabledLive()
+    {
+        // Operator flips Tool.IsSteerSwitchEnabled in the config dialog
+        // while the wizard is on-screen. Without subscribing to Tool's
+        // PropertyChanged, the wizard would only re-evaluate the gate
+        // on the next PGN 253. Verify the immediate response.
+        _store.Tool.IsSteerSwitchEnabled = false;
+
+        var autoSteer = Substitute.For<IAutoSteerService>();
+        autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false, PwmDisplay: 0));
+
+        var step = CreateEnteredStep(_configService, autoSteer);
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+
+        // Operator turns the requirement on; gate must close immediately.
+        _store.Tool.IsSteerSwitchEnabled = true;
+        Assert.That(step.WaitingForPhysicalSwitch, Is.True);
+
+        // Operator turns it back off; gate reopens.
+        _store.Tool.IsSteerSwitchEnabled = false;
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/AutoSteerSteerSwitchChainTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoSteerSteerSwitchChainTests.cs
@@ -1,0 +1,156 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.AutoSteer;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.Services.Track;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the PGN 253 -> AutoSteerService -> StateUpdated chain so the
+/// wizard's physical-switch gate sees the operator console toggle the
+/// moment a fresh PGN 253 arrives, not after the next GPS packet.
+///
+/// Pre-fix bug surfaced on bench-test of #381: <c>ProcessSteerData</c>
+/// updated <c>_lastSteerData</c> and the switch mirrors but never fired
+/// <c>StateUpdated</c>, so the wizard's <c>OnStateUpdated</c> handler
+/// stayed asleep on switch-only changes.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class AutoSteerSteerSwitchChainTests
+{
+    private IUdpCommunicationService _udp = null!;
+    private AutoSteerService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+
+        _udp = Substitute.For<IUdpCommunicationService>();
+        var guidance = Substitute.For<ITrackGuidanceService>();
+        var gps = Substitute.For<IGpsService>();
+        var appState = new ApplicationState();
+        _service = new AutoSteerService(guidance, _udp, gps, appState);
+        _service.Start();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _service.Stop();
+    }
+
+    /// <summary>
+    /// Build a wire-valid PGN 253 packet (steer angle + switch + PWM)
+    /// matching the format the simulator's VirtualSteerModule emits. We
+    /// hand-construct rather than reuse a builder so the test stays
+    /// self-contained and the bit layout is documented inline.
+    ///
+    /// Format: [0x80, 0x81, Source(0x7F), 0xFD, 8, AngleLo, AngleHi,
+    ///          HeadingLo, HeadingHi, RollLo, RollHi, Switches, PWM, CRC]
+    /// </summary>
+    private static byte[] BuildPgn253(short angleX100, bool steerSwitch,
+        bool workSwitchActive, byte pwm)
+    {
+        var packet = new byte[14];
+        packet[0] = 0x80;
+        packet[1] = 0x81;
+        packet[2] = 0x7F;        // source = steer module
+        packet[3] = 0xFD;        // PGN 253
+        packet[4] = 8;           // payload length
+        packet[5] = (byte)(angleX100 & 0xFF);
+        packet[6] = (byte)((angleX100 >> 8) & 0xFF);
+        packet[7] = 0; packet[8] = 0;  // deprecated heading
+        packet[9] = 0; packet[10] = 0; // deprecated roll
+        // Switch byte: bit 0 work (INVERTED: 0=ON), bit 1 steer, bit 2 remote.
+        byte switches = 0;
+        if (!workSwitchActive) switches |= 0x01;  // inverted
+        if (steerSwitch) switches |= 0x02;
+        packet[11] = switches;
+        packet[12] = pwm;
+        // CRC: sum of bytes 2 through 12.
+        byte crc = 0;
+        for (int i = 2; i <= 12; i++) crc += packet[i];
+        packet[13] = crc;
+        return packet;
+    }
+
+    private void RaiseSteerDataPgn(byte[] packet)
+    {
+        _udp.DataReceived += Raise.Event<EventHandler<UdpDataReceivedEventArgs>>(
+            _udp,
+            new UdpDataReceivedEventArgs { Data = packet, PGN = 0xFD });
+    }
+
+    [Test]
+    public void Pgn253WithSteerSwitchBit_UpdatesLastSteerData()
+    {
+        // SteerSwitchActive on the parsed packet must flow into
+        // LastSteerData so the wizard's OnStateUpdated handler — which
+        // reads LastSteerData.SteerSwitchActive — can gate correctly.
+        RaiseSteerDataPgn(BuildPgn253(angleX100: 1000, steerSwitch: true,
+            workSwitchActive: false, pwm: 42));
+
+        Assert.That(_service.LastSteerData.SteerSwitchActive, Is.True);
+        Assert.That(_service.LastSteerData.PwmDisplay, Is.EqualTo(42));
+        Assert.That(_service.LastSteerData.ActualSteerAngle, Is.EqualTo(10.0).Within(0.01));
+    }
+
+    [Test]
+    public void Pgn253SwitchTransition_FiresStateUpdated()
+    {
+        // First packet establishes the baseline; the second flips the
+        // steer switch and must drive StateUpdated so wizard gates wake
+        // up without waiting for the next GPS packet.
+        RaiseSteerDataPgn(BuildPgn253(0, steerSwitch: false,
+            workSwitchActive: false, pwm: 0));
+
+        int callCount = 0;
+        _service.StateUpdated += (_, _) => callCount++;
+
+        RaiseSteerDataPgn(BuildPgn253(0, steerSwitch: true,
+            workSwitchActive: false, pwm: 0));
+
+        Assert.That(callCount, Is.EqualTo(1),
+            "StateUpdated must fire when the steer-switch bit changes");
+        Assert.That(_service.LastSteerData.SteerSwitchActive, Is.True);
+    }
+
+    [Test]
+    public void Pgn253SteadyState_DoesNotSpamStateUpdated()
+    {
+        // The PGN 253 stream runs at 10 Hz; if every packet fired
+        // StateUpdated, UI subscribers would re-render constantly even
+        // when nothing useful changed. Guard against future regression
+        // where someone moves the NotifyStateUpdated call out of the
+        // 'switchChanged' branch.
+        RaiseSteerDataPgn(BuildPgn253(0, steerSwitch: true,
+            workSwitchActive: false, pwm: 0));
+
+        int callCount = 0;
+        _service.StateUpdated += (_, _) => callCount++;
+
+        // Three identical packets — only the angle is changing, switches
+        // and remote stay the same.
+        RaiseSteerDataPgn(BuildPgn253(100, steerSwitch: true,
+            workSwitchActive: false, pwm: 50));
+        RaiseSteerDataPgn(BuildPgn253(200, steerSwitch: true,
+            workSwitchActive: false, pwm: 60));
+        RaiseSteerDataPgn(BuildPgn253(300, steerSwitch: true,
+            workSwitchActive: false, pwm: 70));
+
+        Assert.That(callCount, Is.EqualTo(0),
+            "Angle/PWM-only updates must not fire StateUpdated " +
+            "(GPS-receive path handles per-cycle notifications)");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/FreeDrivePgnEngagementTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/FreeDrivePgnEngagementTests.cs
@@ -1,0 +1,79 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services.AutoSteer;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the free-drive PGN 254 status byte so receivers — both the
+/// real firmware autosteer task and the simulator's
+/// <c>VirtualSteerModule</c> — engage their PID loops on the wizard's
+/// motor-calibration ramp commands.
+///
+/// Pre-fix bug: <see cref="PgnBuilder.BuildAutoSteerPgn"/> set the
+/// status byte to <c>0x01</c> (SteerSwitchActive) when
+/// <see cref="VehicleState.IsInFreeDriveMode"/> was true. The
+/// receiver's engagement gate, however, checks bit <c>0x04</c>
+/// (IsAutoSteerEngaged) — see <c>PgnProtocol.ParseAutoSteerCommand</c>
+/// in the simulator's PgnProtocol.cs. The PID therefore stayed in
+/// the "not engaged → pwm = 0" branch and the wheels never moved.
+/// </summary>
+[TestFixture]
+public class FreeDrivePgnEngagementTests
+{
+    /// <summary>
+    /// Build the wire-level PGN 254 for a free-drive command at the
+    /// given angle. Mirrors what <c>SendPgnsForControlTick</c> would
+    /// emit while the wizard's motor ramp is running.
+    /// </summary>
+    private static byte[] BuildFreeDrivePgn(double angleDeg)
+    {
+        var state = new VehicleState
+        {
+            IsInFreeDriveMode = true,
+            FreeDriveSteerAngle = angleDeg,
+        };
+        return (byte[])PgnBuilder.BuildAutoSteerPgn(ref state).Clone();
+    }
+
+    [Test]
+    public void FreeDrivePgn254_StatusByte_HasAutoSteerEngagedBit()
+    {
+        // 0x04 is the bit the receiver's parser inspects for "is engaged".
+        var packet = BuildFreeDrivePgn(angleDeg: 5.0);
+        byte status = packet[7];
+
+        Assert.That(status & 0x04, Is.Not.Zero,
+            "Free-drive PGN 254 must set the IsAutoSteerEngaged bit (0x04) " +
+            "so the firmware/simulator PID engages and drives toward the " +
+            "commanded angle. Without it the wizard's motor ramp is a no-op.");
+    }
+
+    [Test]
+    public void FreeDrivePgn254_AngleEncoding_IsLittleEndianX100()
+    {
+        // Sanity check: the angle goes out in the same scale the
+        // simulator's parser expects (signed int16, *100). 5.0° -> 500.
+        var packet = BuildFreeDrivePgn(angleDeg: 5.0);
+        short angleRaw = (short)(packet[8] | (packet[9] << 8));
+
+        Assert.That(angleRaw, Is.EqualTo(500));
+    }
+
+    [Test]
+    public void FreeDrivePgn254_SpeedField_IsEightKmhFakeValue()
+    {
+        // The firmware refuses to drive the motor below MinSpeed (default
+        // 1 km/h) to keep stationary turning from burning out the motor.
+        // Free-drive bypasses that by reporting a constant fake speed —
+        // verify it stays where the receiver expects (~8 km/h x10 = 80).
+        var packet = BuildFreeDrivePgn(angleDeg: 0);
+        ushort speedRaw = (ushort)(packet[5] | (packet[6] << 8));
+
+        Assert.That(speedRaw, Is.EqualTo(80));
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/RollCalibrationStepViewModelTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/RollCalibrationStepViewModelTests.cs
@@ -1,0 +1,115 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Windows.Input;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the Zero-Roll button semantics in the wizard's roll calibration
+/// step. <c>LiveRoll</c> is the post-calibration angle published by the
+/// NMEA parser (raw is already inverted if needed and the existing
+/// <c>RollZero</c> has already been subtracted). A second Zero-Roll
+/// press at a non-zero tilt must accumulate against the prior offset,
+/// not replace it — same shape as the WAS bug from PR #385 F/G.
+///
+/// Unlike WAS, the invert sign is already baked into LiveRoll upstream,
+/// so the Zero formula is plain addition rather than the WAS sign-aware
+/// accumulator.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class RollCalibrationStepViewModelTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+    }
+
+    [Test]
+    public void ZeroRoll_AppliedTwiceAtDifferentTilts_LandsAtZero()
+    {
+        // Press 1: raw=3°, IsRollInvert=false, RollZero=0.
+        // LiveRoll reads (3 - 0) = 3°. Press should set RollZero=3, so
+        // next LiveRoll would read (3 - 3) = 0°.
+        _store.Ahrs.IsRollInvert = false;
+        _store.Ahrs.RollZero = 0;
+        var step = new RollCalibrationStepViewModel(_configService);
+        step.LiveRoll = 3.0;
+
+        ((ICommand)step.ZeroRollCommand).Execute(null);
+
+        Assert.That(step.RollZero, Is.EqualTo(3.0));
+
+        // Simulate the host applying the new RollZero (live propagation
+        // writes RollZero into ConfigStore.Ahrs immediately in the
+        // production code path) and the operator tilting another 2°:
+        // raw=5°, parser publishes LiveRoll = (5 - 3) = 2°.
+        _store.Ahrs.RollZero = step.RollZero;
+        step.LiveRoll = 2.0;
+
+        ((ICommand)step.ZeroRollCommand).Execute(null);
+
+        // Accumulator: 3 + 2 = 5. The naive replacement would have left
+        // 2 here and the operator would still see a 3° drift on screen.
+        Assert.That(step.RollZero, Is.EqualTo(5.0),
+            "Second Zero-Roll press must accumulate against the prior offset");
+    }
+
+    [Test]
+    public void ZeroRoll_WithInvertOn_AppliedTwice_LandsAtZero()
+    {
+        // Confirms the invert sign is baked into LiveRoll upstream:
+        // ZeroRoll itself doesn't need a sign flip; it adds whatever
+        // LiveRoll says, and the parser's invert handling keeps the
+        // arithmetic correct.
+        _store.Ahrs.IsRollInvert = true;
+        _store.Ahrs.RollZero = 0;
+        var step = new RollCalibrationStepViewModel(_configService);
+        // Raw=-3° with invert -> live = (-(-3)) - 0 = 3°.
+        step.LiveRoll = 3.0;
+
+        ((ICommand)step.ZeroRollCommand).Execute(null);
+        Assert.That(step.RollZero, Is.EqualTo(3.0));
+
+        // Operator tilts further; parser publishes 2°.
+        _store.Ahrs.RollZero = step.RollZero;
+        step.LiveRoll = 2.0;
+
+        ((ICommand)step.ZeroRollCommand).Execute(null);
+
+        Assert.That(step.RollZero, Is.EqualTo(5.0),
+            "Invert is handled upstream — accumulator must still be plain addition");
+    }
+
+    [Test]
+    public void ZeroRoll_OnLevelGround_KeepsOffsetStable()
+    {
+        // Edge case: pressing Zero when already level (LiveRoll == 0)
+        // must preserve the existing calibration rather than wipe it.
+        _store.Ahrs.IsRollInvert = false;
+        _store.Ahrs.RollZero = 1.5;
+        var step = new RollCalibrationStepViewModel(_configService);
+        step.RollZero = 1.5;
+        step.LiveRoll = 0.0;
+
+        ((ICommand)step.ZeroRollCommand).Execute(null);
+
+        Assert.That(step.RollZero, Is.EqualTo(1.5),
+            "Zero-Roll at level must preserve the existing offset, not zero it");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/WasCalibrationStepViewModelTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/WasCalibrationStepViewModelTests.cs
@@ -1,0 +1,140 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Windows.Input;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the Zero-WAS button semantics in the wizard's WAS calibration
+/// step. <c>ActualSteerAngle</c> from PGN 253 is the *post-calibration*
+/// angle (raw counts have already had <c>WasOffset</c> subtracted and
+/// <c>InvertWas</c> applied), so a second Zero-WAS press must
+/// accumulate against the prior offset rather than replace it.
+///
+/// Pre-fix bugs (bench-test on top of #381):
+/// - F: <c>ZeroWas</c> wrote <c>(actualAngle * cpd)</c>, throwing away
+///   the prior calibration.
+/// - G: it ignored <c>InvertWas</c> entirely, so a second press in
+///   inverted mode drove the offset the wrong direction.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class WasCalibrationStepViewModelTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+    private IAutoSteerService _autoSteer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+
+        _autoSteer = Substitute.For<IAutoSteerService>();
+    }
+
+    /// <summary>
+    /// Stub <c>LastSteerData</c> to return a fresh
+    /// <see cref="SteerModuleData"/> with the given post-calibration
+    /// angle. <c>NSubstitute.Returns</c> requires us to redo this every
+    /// time the simulated angle changes between presses.
+    /// </summary>
+    private void GivenReportedAngle(double angleDeg)
+    {
+        _autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: angleDeg, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: false,
+            RemoteButtonPressed: false, VwasFusionActive: false,
+            PwmDisplay: 0));
+    }
+
+    [Test]
+    public void ZeroWas_AppliedTwiceAtDifferentAngles_LandsAtZero()
+    {
+        // Setup: no prior calibration, CPD=100, wheel at 5°.
+        _store.AutoSteer.CountsPerDegree = 100;
+        _store.AutoSteer.WasOffset = 0;
+        _store.AutoSteer.InvertWas = false;
+        GivenReportedAngle(5.0);
+
+        var step = new WasCalibrationStepViewModel(_configService, _autoSteer);
+        ((ICommand)step.ZeroWasCommand).Execute(null);
+
+        // Press 1: offset = 0 + 1 * 5 * 100 = 500.
+        Assert.That(step.WasOffset, Is.EqualTo(500),
+            "First Zero-WAS press should drive offset to raw-counts equivalent of the live angle");
+
+        // Simulate the host pushing the new offset to the module and the
+        // operator moving the wheel a further 5°. The module's next
+        // PGN 253 reports the new post-calibration angle of 5°.
+        _store.AutoSteer.WasOffset = step.WasOffset;
+        GivenReportedAngle(5.0);
+
+        ((ICommand)step.ZeroWasCommand).Execute(null);
+
+        // Press 2: offset = 500 + 1 * 5 * 100 = 1000.
+        Assert.That(step.WasOffset, Is.EqualTo(1000),
+            "Second Zero-WAS press must accumulate against the prior offset, not replace it");
+    }
+
+    [Test]
+    public void ZeroWas_WithInvertOn_AppliedTwice_LandsAtZero()
+    {
+        // With InvertWas=true the module reports negated angles. The
+        // accumulator must subtract instead of add so the second press
+        // still drives the displayed value to zero.
+        _store.AutoSteer.CountsPerDegree = 100;
+        _store.AutoSteer.WasOffset = 0;
+        _store.AutoSteer.InvertWas = true;
+        GivenReportedAngle(-5.0);
+
+        var step = new WasCalibrationStepViewModel(_configService, _autoSteer);
+        ((ICommand)step.ZeroWasCommand).Execute(null);
+
+        // Press 1: offset = 0 + (-1) * (-5 * 100) = 500.
+        Assert.That(step.WasOffset, Is.EqualTo(500));
+
+        // Module now reports -5° again (wheel moved 5° further in the
+        // physical direction the inversion treats as negative display).
+        _store.AutoSteer.WasOffset = step.WasOffset;
+        GivenReportedAngle(-5.0);
+
+        ((ICommand)step.ZeroWasCommand).Execute(null);
+
+        // Press 2: offset = 500 + (-1) * (-5 * 100) = 1000.
+        Assert.That(step.WasOffset, Is.EqualTo(1000),
+            "Inverted accumulator must move the offset in the same monotonic " +
+            "direction so the live reading lands at zero after each press");
+    }
+
+    [Test]
+    public void ZeroWas_NoInvert_NoMotion_KeepsOffsetStable()
+    {
+        // Edge case: if the operator is already at the zero angle (display
+        // = 0°), Zero-WAS must be a no-op. Past behaviour overwrote the
+        // offset to zero in this case, which would *undo* any prior
+        // calibration the operator was happy with.
+        _store.AutoSteer.CountsPerDegree = 100;
+        _store.AutoSteer.WasOffset = 700;
+        _store.AutoSteer.InvertWas = false;
+        GivenReportedAngle(0.0);
+
+        var step = new WasCalibrationStepViewModel(_configService, _autoSteer);
+        ((ICommand)step.ZeroWasCommand).Execute(null);
+
+        Assert.That(step.WasOffset, Is.EqualTo(700),
+            "Zero-WAS at zero angle must preserve the existing offset");
+    }
+}


### PR DESCRIPTION
Three independent bugs in the wizard's switch-state handling, surfaced by bench-test of the steer wizard against the Vehicle Simulator. Each commit is independently reviewable.

## Issue C — Physical-switch gate + AXAML prompt (`05233c22`)
The motor-cal step (#9) had no visible explanation when its Start button was greyed. Wizard VM had `WaitingForPhysicalSwitch` plumbing but the AXAML didn't bind it, and the gate itself was incomplete.

- `AutoMotorCalibrationStepViewModel`: scaffolded `WaitingForPhysicalSwitch`, `PhysicalSwitchPromptText`, `CanStartTest`. Subscribes to both `StateUpdated` (live PGN 253) and `Tool.PropertyChanged` (operator flipping `IsSteerSwitchEnabled` in the config dialog) so the gate reacts to either side.
- AXAML: Start button binds `IsEnabled` to `CanStartTest`; new TextBlock below binds `PhysicalSwitchPromptText` so the gate reason is visible.
- 4 tests in `AutoMotorCalibrationGateTests` covering all reachable states.

## Issue D — PGN 253 switch transitions fire `StateUpdated` (`0ff0251f`)
**Root cause:** `AutoSteerService.ProcessSteerData` updated `_lastSteerData` and the `_state` switch mirrors but **never called `NotifyStateUpdated`**. The wizard's `OnStateUpdated` stayed asleep on switch-only PGN 253 packets — operator's simulator-switch toggle never propagated to the host until the next GPS publish.

Fix narrowed to switch bits only: compare incoming Steer/Work/Remote against cached `_lastSteerData` and only fire `StateUpdated` on transitions. Steady-state PGN 253 (angle/PWM-only changes) stays silent so subscribers don't get 10 Hz noise. Diagnostic log line on transition for bench-test visibility.

3 tests in `AutoSteerSteerSwitchChainTests`.

## Issue E — Free-drive PGN 254 sets `AutoSteerEngaged` bit (`970a76d6`)
**Root cause:** `PgnBuilder.BuildAutoSteerPgn` set the free-drive status byte to `0x01` (`SteerSwitchActive` only), but the receiver's PID engages on bit `0x04` (`IsAutoSteerEngaged`). The wizard's motor ramp commands were silently dropped — the module saw `engaged=false`, branched to `pwm=0`, wheels never moved.

Fix: status = `0x01 | 0x04` in the free-drive branch.

3 tests in `FreeDrivePgnEngagementTests` pinning the bit, angle encoding, and fake-speed value.

## Counts
- Full Services suite: 856 pass, 1 fail (pre-existing Windows file-lock flake, unrelated), 2 skip.
- Build clean.

## Test plan
- [x] All new tests green.
- [ ] Bench: wizard step 9 with `Tool.IsSteerSwitchEnabled=true`. Start button is disabled with a visible hint "Flip the physical AutoSteer switch ON to continue." Toggle the simulator's Steer Switch ON — hint disappears, button enables.
- [ ] Bench: wizard step 9, switch ON. Press Start. Motor ramp now produces visible wheel movement in the simulator (the engaged-bit fix).