### PR TITLE
Wizard: split motor cal into two steps, seed CPD gate on entry, simulator wheel clamp

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
@@ -1,5 +1,5 @@
 // AgValoniaGPS
-// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,41 +26,34 @@ using CommunityToolkit.Mvvm.Input;
 namespace AgValoniaGPS.ViewModels.Wizards.SteerWizard;
 
 /// <summary>
-/// Calibration phases for the auto motor calibration step.
+/// Phase progression for the motor direction + MinPWM step. The legacy
+/// CalibrationPhase enum carried a Phase B branch for max steering
+/// angle; that lives in <see cref="MaxSteeringAngleStepViewModel"/>
+/// now, so this enum only tracks the discovery flow.
 /// </summary>
 public enum CalibrationPhase
 {
-    /// <summary>Phase A0: Waiting for user to start PWM ramp test.</summary>
+    /// <summary>Waiting for the operator to start the ramp.</summary>
     WaitingToStart,
 
-    /// <summary>Phase A1: Auto-ramping PWM, detecting motor direction and MinPWM.</summary>
+    /// <summary>Ramping the motor command, watching for first WAS motion.</summary>
     RampingPWM,
 
-    /// <summary>Phase A result: Shows detected motor direction and MinPWM.</summary>
-    RampResult,
-
-    /// <summary>Phase B0: Waiting for user to start max angle measurement.</summary>
-    WaitingForMaxAngle,
-
-    /// <summary>Phase B1: Driving full lock both ways to measure max angles.</summary>
-    MeasuringMaxAngle,
-
-    /// <summary>All calibration complete, showing final results.</summary>
-    Complete
+    /// <summary>Ramp result: motor direction + observed MinPWM.</summary>
+    RampResult
 }
 
 /// <summary>
-/// Combined auto motor calibration step that replaces the separate Motor Direction Test
-/// and PWM Calibration steps. Automatically detects motor direction, minimum PWM,
-/// and maximum steering angles.
-///
-/// Phase A: Auto-ramp PWM to detect motor direction + MinPWM
-/// Phase B: Drive full lock both ways to measure max steering angles
+/// Motor Direction + MinPWM auto-detection step. Sweeps a small motor
+/// command until the wheels respond, captures the firmware-reported
+/// PWM at first motion as MinPWM, and infers motor direction from the
+/// sign of WAS movement. The max-steering-angle measurement that used
+/// to live here has moved to <see cref="MaxSteeringAngleStepViewModel"/>
+/// so the two operations — quick discovery vs. full-lock stress test —
+/// can be presented to the operator as distinct, linear wizard pages.
 /// </summary>
-public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
+public class AutoMotorCalibrationStepViewModel : SwitchGatedWizardStep
 {
-    private readonly IConfigurationService _configService;
-    private readonly IAutoSteerService? _autoSteerService;
     private HardwareInstalledStepViewModel? _hardwareStep;
     private CancellationTokenSource? _cancellationTokenSource;
 
@@ -70,19 +63,29 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     internal Func<int, CancellationToken, Task> DelayFunc { get; set; } = Task.Delay;
 
     /// <summary>
-    /// Injectable function to read current WAS angle. Production reads from IAutoSteerService.
+    /// Injectable function to read current WAS angle. Production reads
+    /// from <see cref="IAutoSteerService.LastSteerData"/>.
     /// </summary>
     internal Func<double>? ReadWasAngle { get; set; }
 
-    public override string Title => "Auto Motor Calibration";
+    public override string Title => "Motor Direction + MinPWM";
 
     public override string Description =>
-        "Automatically detects motor direction, minimum PWM, and maximum steering angles. " +
-        "Keep hands clear of the steering wheel during testing.";
+        "Automatically detects motor direction and the minimum PWM duty " +
+        "needed to move the wheels. Keep hands clear of the steering wheel " +
+        "during testing.";
 
     public override bool ShouldSkip => _hardwareStep?.HardwareLevel == 0;
 
     public void SetHardwareStep(HardwareInstalledStepViewModel step) => _hardwareStep = step;
+
+    public AutoMotorCalibrationStepViewModel(IConfigurationService configService,
+        IAutoSteerService? autoSteerService = null)
+        : base(configService, autoSteerService)
+    {
+        StartTestCommand = new AsyncRelayCommand(RunPwmRampAsync);
+        RedoCommand = new AsyncRelayCommand(RedoRamp);
+    }
 
     // =========================================================================
     // State
@@ -99,9 +102,6 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
                 OnPropertyChanged(nameof(IsPhaseA0));
                 OnPropertyChanged(nameof(IsPhaseA1));
                 OnPropertyChanged(nameof(IsPhaseAResult));
-                OnPropertyChanged(nameof(IsPhaseB0));
-                OnPropertyChanged(nameof(IsPhaseB1));
-                OnPropertyChanged(nameof(IsComplete));
                 OnPropertyChanged(nameof(PhaseDescription));
             }
         }
@@ -110,30 +110,18 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     public bool IsPhaseA0 => Phase == CalibrationPhase.WaitingToStart;
     public bool IsPhaseA1 => Phase == CalibrationPhase.RampingPWM;
     public bool IsPhaseAResult => Phase == CalibrationPhase.RampResult;
-    public bool IsPhaseB0 => Phase == CalibrationPhase.WaitingForMaxAngle;
-    public bool IsPhaseB1 => Phase == CalibrationPhase.MeasuringMaxAngle;
-    public bool IsComplete => Phase == CalibrationPhase.Complete;
 
     public string PhaseDescription => Phase switch
     {
         CalibrationPhase.WaitingToStart =>
-            "This test will slowly increase motor power to detect the minimum PWM " +
-            "needed to move the wheels and which direction the motor drives.\n\n" +
+            "We'll command a small turn and gradually increase steering strength " +
+            "until the wheels respond. This finds the minimum drive level and " +
+            "the motor direction.\n\n" +
             "WARNING: Keep hands clear of the steering wheel.",
         CalibrationPhase.RampingPWM =>
             "Testing motor response... Keep hands clear.",
         CalibrationPhase.RampResult =>
             "Motor direction and minimum PWM detected.",
-        CalibrationPhase.WaitingForMaxAngle =>
-            "This test will briefly drive the wheels to full lock in both directions " +
-            "to measure the maximum steering angle.\n\n" +
-            "If your vehicle has power steering that resists stationary turning, " +
-            "drive slowly during this test.\n\n" +
-            "WARNING: Keep hands clear of the steering wheel.",
-        CalibrationPhase.MeasuringMaxAngle =>
-            "Measuring maximum steering angles... Keep hands clear.",
-        CalibrationPhase.Complete =>
-            "Calibration complete. Review the results below.",
         _ => ""
     };
 
@@ -169,31 +157,6 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         set => SetProperty(ref _detectedInvertMotor, value);
     }
 
-    private double _detectedMaxAngleRight;
-    public double DetectedMaxAngleRight
-    {
-        get => _detectedMaxAngleRight;
-        set => SetProperty(ref _detectedMaxAngleRight, value);
-    }
-
-    private double _detectedMaxAngleLeft;
-    public double DetectedMaxAngleLeft
-    {
-        get => _detectedMaxAngleLeft;
-        set => SetProperty(ref _detectedMaxAngleLeft, value);
-    }
-
-    private int _maxSteerAngle;
-    /// <summary>
-    /// Final max steer angle as raw WAS value (not degrees - CPD not calibrated yet).
-    /// Calculated as min(left, right) * 0.9.
-    /// </summary>
-    public int MaxSteerAngle
-    {
-        get => _maxSteerAngle;
-        set => SetProperty(ref _maxSteerAngle, value);
-    }
-
     private bool _noMovementDetected;
     public bool NoMovementDetected
     {
@@ -202,7 +165,7 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     }
 
     private bool _calibrationCompleted;
-    /// <summary>Whether a full calibration has been completed (both phases).</summary>
+    /// <summary>True once the ramp has produced a usable MinPWM result.</summary>
     public bool CalibrationCompleted
     {
         get => _calibrationCompleted;
@@ -227,29 +190,12 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         set => SetProperty(ref _currentPwm, value);
     }
 
-    /// <summary>True when hardware is connected and sending data.</summary>
-    public bool HasHardware => _autoSteerService != null;
-
     // =========================================================================
     // Commands
     // =========================================================================
 
     public ICommand StartTestCommand { get; }
-    public ICommand ContinueToMaxAngleCommand { get; }
-    public ICommand RedoPhaseACommand { get; }
-    public ICommand RedoPhaseBCommand { get; }
-
-    public AutoMotorCalibrationStepViewModel(IConfigurationService configService,
-        IAutoSteerService? autoSteerService = null)
-    {
-        _configService = configService;
-        _autoSteerService = autoSteerService;
-
-        StartTestCommand = new AsyncRelayCommand(RunPwmRampAsync);
-        ContinueToMaxAngleCommand = new AsyncRelayCommand(RunMaxAngleMeasurementAsync);
-        RedoPhaseACommand = new AsyncRelayCommand(RedoPhaseA);
-        RedoPhaseBCommand = new AsyncRelayCommand(RedoPhaseB);
-    }
+    public ICommand RedoCommand { get; }
 
     // =========================================================================
     // Phase A1: PWM Ramp
@@ -264,7 +210,7 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
 
         double startAngle = GetCurrentWasAngle();
 
-        _autoSteerService?.EnableFreeDrive();
+        AutoSteerService?.EnableFreeDrive();
 
         try
         {
@@ -273,7 +219,7 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
                 token.ThrowIfCancellationRequested();
 
                 double testAngle = pwm * 0.15;
-                _autoSteerService?.SetFreeDriveAngle(testAngle);
+                AutoSteerService?.SetFreeDriveAngle(testAngle);
                 await DelayFunc(200, token);
 
                 double currentAngle = GetCurrentWasAngle();
@@ -287,10 +233,11 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
                     DetectedInvertMotor = moved < 0;
                     DetectedMinPwm = (int)(pwm * 1.1);
 
-                    _autoSteerService?.SetFreeDriveAngle(0);
+                    AutoSteerService?.SetFreeDriveAngle(0);
                     await DelayFunc(500, token);
-                    _autoSteerService?.DisableFreeDrive();
+                    AutoSteerService?.DisableFreeDrive();
 
+                    CalibrationCompleted = true;
                     Phase = CalibrationPhase.RampResult;
                     PhaseResult = $"Motor direction: {(DetectedInvertMotor ? "Inverted" : "Normal")}\n" +
                                   $"Minimum PWM: {DetectedMinPwm}";
@@ -299,77 +246,20 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
             }
 
             // No movement detected at max PWM
-            _autoSteerService?.SetFreeDriveAngle(0);
-            _autoSteerService?.DisableFreeDrive();
+            AutoSteerService?.SetFreeDriveAngle(0);
+            AutoSteerService?.DisableFreeDrive();
             NoMovementDetected = true;
             Phase = CalibrationPhase.RampResult;
             PhaseResult = "Warning: No wheel movement detected. Check motor connection.";
         }
         catch (OperationCanceledException)
         {
-            _autoSteerService?.SetFreeDriveAngle(0);
-            _autoSteerService?.DisableFreeDrive();
+            AutoSteerService?.SetFreeDriveAngle(0);
+            AutoSteerService?.DisableFreeDrive();
         }
     }
 
-    // =========================================================================
-    // Phase B1: Max Angle Measurement
-    // =========================================================================
-
-    internal async Task RunMaxAngleMeasurementAsync()
-    {
-        Phase = CalibrationPhase.MeasuringMaxAngle;
-        _cancellationTokenSource = new CancellationTokenSource();
-        var token = _cancellationTokenSource.Token;
-
-        _autoSteerService?.EnableFreeDrive();
-
-        try
-        {
-            // Full right - brief hold, read angle
-            _autoSteerService?.SetFreeDriveAngle(45);
-            await DelayFunc(1500, token);
-            DetectedMaxAngleRight = Math.Abs(GetCurrentWasAngle());
-            Progress = 0.33;
-
-            // Return to center
-            _autoSteerService?.SetFreeDriveAngle(0);
-            await DelayFunc(800, token);
-            Progress = 0.5;
-
-            // Full left - brief hold, read angle
-            _autoSteerService?.SetFreeDriveAngle(-45);
-            await DelayFunc(1500, token);
-            DetectedMaxAngleLeft = Math.Abs(GetCurrentWasAngle());
-            Progress = 0.83;
-
-            // Return to center
-            _autoSteerService?.SetFreeDriveAngle(0);
-            await DelayFunc(500, token);
-            _autoSteerService?.DisableFreeDrive();
-            Progress = 1.0;
-
-            // Calculate max angle (conservative) - raw WAS value
-            MaxSteerAngle = (int)(Math.Min(DetectedMaxAngleRight, DetectedMaxAngleLeft) * 0.9);
-
-            CalibrationCompleted = true;
-            Phase = CalibrationPhase.Complete;
-            PhaseResult = $"Right max: {DetectedMaxAngleRight:F1}\n" +
-                          $"Left max: {DetectedMaxAngleLeft:F1}\n" +
-                          $"Max steer angle (raw WAS): {MaxSteerAngle}";
-        }
-        catch (OperationCanceledException)
-        {
-            _autoSteerService?.SetFreeDriveAngle(0);
-            _autoSteerService?.DisableFreeDrive();
-        }
-    }
-
-    // =========================================================================
-    // Redo commands
-    // =========================================================================
-
-    private Task RedoPhaseA()
+    private Task RedoRamp()
     {
         Phase = CalibrationPhase.WaitingToStart;
         PhaseResult = "";
@@ -382,17 +272,6 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         return Task.CompletedTask;
     }
 
-    private Task RedoPhaseB()
-    {
-        Phase = CalibrationPhase.WaitingForMaxAngle;
-        Progress = 0;
-        DetectedMaxAngleRight = 0;
-        DetectedMaxAngleLeft = 0;
-        MaxSteerAngle = 0;
-        CalibrationCompleted = false;
-        return Task.CompletedTask;
-    }
-
     // =========================================================================
     // Helpers
     // =========================================================================
@@ -401,7 +280,7 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
     {
         if (ReadWasAngle != null)
             return ReadWasAngle();
-        return _autoSteerService?.LastSteerData.ActualSteerAngle ?? 0;
+        return AutoSteerService?.LastSteerData.ActualSteerAngle ?? 0;
     }
 
     // =========================================================================
@@ -415,13 +294,14 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         Progress = 0;
         CalibrationCompleted = false;
 
-        var autoSteer = _configService.Store.AutoSteer;
+        var autoSteer = ConfigService.Store.AutoSteer;
         DetectedMinPwm = autoSteer.MinPwm;
         DetectedInvertMotor = autoSteer.InvertMotor;
-        MaxSteerAngle = autoSteer.MaxSteerAngle;
 
-        if (_autoSteerService != null)
-            _autoSteerService.StateUpdated += OnStateUpdated;
+        if (AutoSteerService != null)
+            AutoSteerService.StateUpdated += OnStateUpdated;
+
+        SubscribeToSwitchGate();
     }
 
     protected override void OnLeaving()
@@ -429,31 +309,33 @@ public class AutoMotorCalibrationStepViewModel : WizardStepViewModel
         // Cancel any running calibration
         _cancellationTokenSource?.Cancel();
 
-        if (_autoSteerService != null)
+        if (AutoSteerService != null)
         {
-            _autoSteerService.StateUpdated -= OnStateUpdated;
+            AutoSteerService.StateUpdated -= OnStateUpdated;
 
             // Ensure free drive is off
-            if (_autoSteerService.IsInFreeDriveMode)
+            if (AutoSteerService.IsInFreeDriveMode)
             {
-                _autoSteerService.SetFreeDriveAngle(0);
-                _autoSteerService.DisableFreeDrive();
+                AutoSteerService.SetFreeDriveAngle(0);
+                AutoSteerService.DisableFreeDrive();
             }
         }
+
+        UnsubscribeFromSwitchGate();
 
         // Save results if calibration was completed
         if (CalibrationCompleted)
         {
-            var autoSteer = _configService.Store.AutoSteer;
+            var autoSteer = ConfigService.Store.AutoSteer;
             autoSteer.InvertMotor = DetectedInvertMotor;
             autoSteer.MinPwm = DetectedMinPwm;
-            autoSteer.MaxSteerAngle = MaxSteerAngle;
         }
     }
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
-        LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
+        if (AutoSteerService != null)
+            LiveSteerAngle = Math.Round(AutoSteerService.LastSteerData.ActualSteerAngle, 1);
     }
 
     public override Task<bool> ValidateAsync()

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/CpdCircleTestStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/CpdCircleTestStepViewModel.cs
@@ -244,7 +244,19 @@ public class CpdCircleTestStepViewModel : WizardStepViewModel
         CountsPerDegree = _configService.Store.AutoSteer.CountsPerDegree;
 
         if (_autoSteerService != null)
+        {
             _autoSteerService.StateUpdated += OnStateUpdated;
+
+            // Seed the gate inputs from the cached latest snapshot so the
+            // Record button reflects the current GPS state immediately on
+            // entry, instead of staying greyed for up to ~100 ms while
+            // waiting for the next StateUpdated publish. Without this the
+            // operator sees a disabled button on entry even when RTK fix
+            // and speed already meet the gate conditions.
+            var cached = _autoSteerService.LatestSnapshot;
+            if (cached.HasValue)
+                ApplySnapshot(cached.Value);
+        }
     }
 
     protected override void OnLeaving()
@@ -263,14 +275,25 @@ public class CpdCircleTestStepViewModel : WizardStepViewModel
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
     {
-        IsRtkFixed = snapshot.FixQuality >= 4;
-        Speed = Math.Round(snapshot.SpeedKmh, 1);
-        LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
+        ApplySnapshot(snapshot);
 
         if (IsRecording)
         {
             ProcessGpsUpdate(snapshot.Easting, snapshot.Northing);
         }
+    }
+
+    /// <summary>
+    /// Copy the gate-relevant fields out of a snapshot. Pulled out of
+    /// <see cref="OnStateUpdated"/> so <see cref="OnEntering"/> can
+    /// seed from <see cref="IAutoSteerService.LatestSnapshot"/> without
+    /// triggering the recording branch.
+    /// </summary>
+    private void ApplySnapshot(VehicleStateSnapshot snapshot)
+    {
+        IsRtkFixed = snapshot.FixQuality >= 4;
+        Speed = Math.Round(snapshot.SpeedKmh, 1);
+        LiveSteerAngle = Math.Round(_autoSteerService!.LastSteerData.ActualSteerAngle, 1);
     }
 
     public override Task<bool> ValidateAsync()

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/MaxSteeringAngleStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/MaxSteeringAngleStepViewModel.cs
@@ -1,0 +1,346 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+using AgValoniaGPS.Services.Interfaces;
+
+using CommunityToolkit.Mvvm.Input;
+
+namespace AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+
+/// <summary>
+/// Phase progression for the max-steering-angle measurement step.
+/// </summary>
+public enum MaxSteeringAnglePhase
+{
+    /// <summary>Waiting for the operator to start the test.</summary>
+    WaitingToStart,
+
+    /// <summary>Driving the wheels to full right lock and reading the plateau.</summary>
+    MeasuringRight,
+
+    /// <summary>Driving the wheels to full left lock and reading the plateau.</summary>
+    MeasuringLeft,
+
+    /// <summary>Final results captured, awaiting operator confirmation.</summary>
+    Complete
+}
+
+/// <summary>
+/// Drives the steering to full lock both directions and captures the
+/// natural plateau angle from the WAS feedback. Split out from the
+/// motor-direction step so the operator gets a distinct page for the
+/// stress-style test — full lock pulses the hydraulics harder than
+/// the small Phase A discovery sweep and deserves its own warnings.
+///
+/// The plateau detector watches WAS deltas between samples; once the
+/// magnitude of change drops below <see cref="PlateauThresholdDeg"/>
+/// for <see cref="PlateauStableSamples"/> consecutive samples, we
+/// snapshot the angle. This works with both real-world steering
+/// (which plateaus on hydraulic stops) and the simulator (which clamps
+/// the simulated wheel angle at a configurable max — see Issue L).
+/// </summary>
+public class MaxSteeringAngleStepViewModel : SwitchGatedWizardStep
+{
+    private const double CommandedFullLockDeg = 60.0;
+    private const double PlateauThresholdDeg = 0.2;
+    private const int PlateauStableSamples = 5;
+    private const int PollIntervalMs = 100;
+    private const int PlateauTimeoutMs = 6000;
+    private const int CenterReturnSettleMs = 800;
+
+    private HardwareInstalledStepViewModel? _hardwareStep;
+    private CancellationTokenSource? _cancellationTokenSource;
+
+    /// <summary>
+    /// Injectable delay function for testing.
+    /// </summary>
+    internal Func<int, CancellationToken, Task> DelayFunc { get; set; } = Task.Delay;
+
+    /// <summary>
+    /// Injectable WAS reader. Production reads from
+    /// <see cref="IAutoSteerService.LastSteerData"/>.
+    /// </summary>
+    internal Func<double>? ReadWasAngle { get; set; }
+
+    public override string Title => "Maximum Steering Angle";
+
+    public override string Description =>
+        "Find the physical limits of the steering by briefly driving the " +
+        "wheels to full lock in both directions. If your vehicle has " +
+        "power steering that resists stationary turning, do this on level " +
+        "ground at idle. Keep hands clear of the steering wheel.";
+
+    public override bool ShouldSkip => _hardwareStep?.HardwareLevel == 0;
+
+    public void SetHardwareStep(HardwareInstalledStepViewModel step) => _hardwareStep = step;
+
+    public MaxSteeringAngleStepViewModel(IConfigurationService configService,
+        IAutoSteerService? autoSteerService = null)
+        : base(configService, autoSteerService)
+    {
+        StartTestCommand = new AsyncRelayCommand(RunMaxAngleMeasurementAsync);
+        RedoCommand = new AsyncRelayCommand(Redo);
+    }
+
+    private MaxSteeringAnglePhase _phase = MaxSteeringAnglePhase.WaitingToStart;
+    public MaxSteeringAnglePhase Phase
+    {
+        get => _phase;
+        set
+        {
+            if (SetProperty(ref _phase, value))
+            {
+                OnPropertyChanged(nameof(IsWaiting));
+                OnPropertyChanged(nameof(IsMeasuring));
+                OnPropertyChanged(nameof(IsComplete));
+                OnPropertyChanged(nameof(PhaseDescription));
+            }
+        }
+    }
+
+    public bool IsWaiting => Phase == MaxSteeringAnglePhase.WaitingToStart;
+    public bool IsMeasuring => Phase == MaxSteeringAnglePhase.MeasuringRight
+                            || Phase == MaxSteeringAnglePhase.MeasuringLeft;
+    public bool IsComplete => Phase == MaxSteeringAnglePhase.Complete;
+
+    public string PhaseDescription => Phase switch
+    {
+        MaxSteeringAnglePhase.WaitingToStart =>
+            "When you press Start, the wheels will turn fully right then " +
+            "fully left. Each direction holds for a moment so the angle " +
+            "can settle, then we capture the steady-state reading.",
+        MaxSteeringAnglePhase.MeasuringRight =>
+            "Measuring right lock... Keep hands clear.",
+        MaxSteeringAnglePhase.MeasuringLeft =>
+            "Measuring left lock... Keep hands clear.",
+        MaxSteeringAnglePhase.Complete =>
+            "Maximum steering angle captured.",
+        _ => ""
+    };
+
+    private double _progress;
+    public double Progress
+    {
+        get => _progress;
+        set => SetProperty(ref _progress, value);
+    }
+
+    private string _phaseResult = "";
+    public string PhaseResult
+    {
+        get => _phaseResult;
+        set => SetProperty(ref _phaseResult, value);
+    }
+
+    private double _detectedMaxAngleRight;
+    public double DetectedMaxAngleRight
+    {
+        get => _detectedMaxAngleRight;
+        set => SetProperty(ref _detectedMaxAngleRight, value);
+    }
+
+    private double _detectedMaxAngleLeft;
+    public double DetectedMaxAngleLeft
+    {
+        get => _detectedMaxAngleLeft;
+        set => SetProperty(ref _detectedMaxAngleLeft, value);
+    }
+
+    private int _maxSteerAngle;
+    /// <summary>
+    /// Final max steer angle as a raw WAS value. Conservative:
+    /// <c>min(left, right) * 0.9</c>.
+    /// </summary>
+    public int MaxSteerAngle
+    {
+        get => _maxSteerAngle;
+        set => SetProperty(ref _maxSteerAngle, value);
+    }
+
+    private bool _calibrationCompleted;
+    public bool CalibrationCompleted
+    {
+        get => _calibrationCompleted;
+        set => SetProperty(ref _calibrationCompleted, value);
+    }
+
+    private double _liveSteerAngle;
+    public double LiveSteerAngle
+    {
+        get => _liveSteerAngle;
+        set => SetProperty(ref _liveSteerAngle, value);
+    }
+
+    public ICommand StartTestCommand { get; }
+    public ICommand RedoCommand { get; }
+
+    /// <summary>
+    /// Run a full-lock pulse in both directions, capturing each side's
+    /// natural plateau. Restores center and disables free-drive on
+    /// every exit path.
+    /// </summary>
+    internal async Task RunMaxAngleMeasurementAsync()
+    {
+        _cancellationTokenSource = new CancellationTokenSource();
+        var token = _cancellationTokenSource.Token;
+
+        AutoSteerService?.EnableFreeDrive();
+        Progress = 0;
+
+        try
+        {
+            Phase = MaxSteeringAnglePhase.MeasuringRight;
+            DetectedMaxAngleRight = Math.Abs(await DriveToPlateauAsync(+CommandedFullLockDeg, token));
+            Progress = 0.5;
+
+            // Return through center with a short settle so the next
+            // direction starts from a stable anchor.
+            AutoSteerService?.SetFreeDriveAngle(0);
+            await DelayFunc(CenterReturnSettleMs, token);
+
+            Phase = MaxSteeringAnglePhase.MeasuringLeft;
+            DetectedMaxAngleLeft = Math.Abs(await DriveToPlateauAsync(-CommandedFullLockDeg, token));
+            Progress = 1.0;
+
+            AutoSteerService?.SetFreeDriveAngle(0);
+            await DelayFunc(CenterReturnSettleMs, token);
+
+            // Conservative: 90 % of the smaller side. Treating asymmetric
+            // mechanical limits as if they were symmetric would push past
+            // the tighter stop on every guidance correction.
+            MaxSteerAngle = (int)(Math.Min(DetectedMaxAngleRight, DetectedMaxAngleLeft) * 0.9);
+
+            CalibrationCompleted = true;
+            Phase = MaxSteeringAnglePhase.Complete;
+            PhaseResult =
+                $"Right max: {DetectedMaxAngleRight:F1}\n" +
+                $"Left max: {DetectedMaxAngleLeft:F1}\n" +
+                $"Max steer angle (raw WAS): {MaxSteerAngle}";
+        }
+        catch (OperationCanceledException)
+        {
+            // finally restores free-drive state.
+        }
+        finally
+        {
+            AutoSteerService?.SetFreeDriveAngle(0);
+            AutoSteerService?.DisableFreeDrive();
+        }
+    }
+
+    /// <summary>
+    /// Command full lock in the requested direction and poll the WAS
+    /// at <see cref="PollIntervalMs"/> until the angle change between
+    /// successive samples stays below <see cref="PlateauThresholdDeg"/>
+    /// for <see cref="PlateauStableSamples"/> consecutive samples. If
+    /// no plateau materialises within <see cref="PlateauTimeoutMs"/>
+    /// the last sample is returned — partial information beats no
+    /// information.
+    /// </summary>
+    private async Task<double> DriveToPlateauAsync(double commandedAngleDeg, CancellationToken token)
+    {
+        AutoSteerService?.SetFreeDriveAngle(commandedAngleDeg);
+
+        double previous = GetCurrentWasAngle();
+        int stableCount = 0;
+        int elapsed = 0;
+
+        while (elapsed < PlateauTimeoutMs)
+        {
+            token.ThrowIfCancellationRequested();
+            await DelayFunc(PollIntervalMs, token);
+            elapsed += PollIntervalMs;
+
+            double sample = GetCurrentWasAngle();
+            LiveSteerAngle = Math.Round(sample, 1);
+
+            if (Math.Abs(sample - previous) < PlateauThresholdDeg)
+            {
+                if (++stableCount >= PlateauStableSamples)
+                    return sample;
+            }
+            else
+            {
+                stableCount = 0;
+            }
+            previous = sample;
+        }
+
+        return previous;
+    }
+
+    private Task Redo()
+    {
+        Phase = MaxSteeringAnglePhase.WaitingToStart;
+        Progress = 0;
+        DetectedMaxAngleRight = 0;
+        DetectedMaxAngleLeft = 0;
+        MaxSteerAngle = 0;
+        PhaseResult = "";
+        CalibrationCompleted = false;
+        return Task.CompletedTask;
+    }
+
+    private double GetCurrentWasAngle()
+    {
+        if (ReadWasAngle != null)
+            return ReadWasAngle();
+        return AutoSteerService?.LastSteerData.ActualSteerAngle ?? 0;
+    }
+
+    protected override void OnEntering()
+    {
+        Phase = MaxSteeringAnglePhase.WaitingToStart;
+        Progress = 0;
+        PhaseResult = "";
+        CalibrationCompleted = false;
+
+        var autoSteer = ConfigService.Store.AutoSteer;
+        MaxSteerAngle = autoSteer.MaxSteerAngle;
+
+        if (AutoSteerService != null)
+            AutoSteerService.StateUpdated += OnStateUpdated;
+
+        SubscribeToSwitchGate();
+    }
+
+    protected override void OnLeaving()
+    {
+        _cancellationTokenSource?.Cancel();
+
+        if (AutoSteerService != null)
+        {
+            AutoSteerService.StateUpdated -= OnStateUpdated;
+
+            if (AutoSteerService.IsInFreeDriveMode)
+            {
+                AutoSteerService.SetFreeDriveAngle(0);
+                AutoSteerService.DisableFreeDrive();
+            }
+        }
+
+        UnsubscribeFromSwitchGate();
+
+        if (CalibrationCompleted)
+            ConfigService.Store.AutoSteer.MaxSteerAngle = MaxSteerAngle;
+    }
+
+    private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)
+    {
+        if (AutoSteerService != null)
+            LiveSteerAngle = Math.Round(AutoSteerService.LastSteerData.ActualSteerAngle, 1);
+    }
+
+    public override Task<bool> ValidateAsync()
+    {
+        ClearValidation();
+        return Task.FromResult(true);
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SteerWizardViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SteerWizardViewModel.cs
@@ -73,6 +73,13 @@ public class SteerWizardViewModel : WizardViewModel
         autoCal.SetHardwareStep(hardwareStep);
         AddStep(autoCal);
 
+        // Step 10: Maximum Steering Angle (split out of the old combined
+        // motor cal step so the stress-style full-lock test gets its own
+        // operator-facing page with distinct warnings).
+        var maxSteer = new MaxSteeringAngleStepViewModel(configService, autoSteerService);
+        maxSteer.SetHardwareStep(hardwareStep);
+        AddStep(maxSteer);
+
         var cpdCircle = new CpdCircleTestStepViewModel(configService, autoSteerService);
         cpdCircle.SetHardwareStep(hardwareStep);
         AddStep(cpdCircle);

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SwitchGatedWizardStep.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SwitchGatedWizardStep.cs
@@ -1,0 +1,171 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.ComponentModel;
+
+using AgValoniaGPS.Services.Interfaces;
+
+using Avalonia.Threading;
+
+namespace AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+
+/// <summary>
+/// Base for steer-wizard calibration steps that must respect the
+/// physical Steer-Switch safety gate. When the operator has
+/// <c>Tool.IsSteerSwitchEnabled = true</c>, the step is held off until
+/// the live PGN 253 reports the switch active; when that flag is
+/// false, the gate is bypassed entirely so operators without a wired
+/// switch can still calibrate.
+///
+/// Subclasses get <see cref="WaitingForPhysicalSwitch"/>,
+/// <see cref="PhysicalSwitchPromptText"/>, <see cref="HasHardware"/>
+/// and <see cref="CanStartTest"/> for free. They must:
+///   1. Call <see cref="SubscribeToSwitchGate"/> in their
+///      <c>OnEntering</c> override and
+///      <see cref="UnsubscribeFromSwitchGate"/> in <c>OnLeaving</c>.
+///   2. Bind the Start button's <c>IsEnabled</c> to
+///      <see cref="CanStartTest"/> in AXAML.
+///   3. Display <see cref="PhysicalSwitchPromptText"/> when
+///      <see cref="WaitingForPhysicalSwitch"/> is true.
+///
+/// The gate recomputes on PGN 253 transitions
+/// (<see cref="IAutoSteerService.StateUpdated"/>) and on
+/// <c>Tool.IsSteerSwitchEnabled</c> changes via
+/// <c>INotifyPropertyChanged</c>. All updates are marshalled to the
+/// UI thread (<see cref="Dispatcher.UIThread"/>) so Avalonia bindings
+/// refresh correctly even when the events fire on the UDP receive
+/// thread.
+/// </summary>
+public abstract class SwitchGatedWizardStep : WizardStepViewModel
+{
+    protected IConfigurationService ConfigService { get; }
+    protected IAutoSteerService? AutoSteerService { get; }
+
+    private bool _gateSubscribed;
+
+    protected SwitchGatedWizardStep(IConfigurationService configService,
+        IAutoSteerService? autoSteerService)
+    {
+        ConfigService = configService;
+        AutoSteerService = autoSteerService;
+    }
+
+    /// <summary>True when hardware is connected and sending data.</summary>
+    public bool HasHardware => AutoSteerService != null;
+
+    private bool _waitingForPhysicalSwitch;
+    /// <summary>
+    /// True when <c>Tool.IsSteerSwitchEnabled</c> is set but the live
+    /// PGN 253 reports the physical switch is OFF. While true, the
+    /// Start button must stay disabled and the prompt visible.
+    /// </summary>
+    public bool WaitingForPhysicalSwitch
+    {
+        get => _waitingForPhysicalSwitch;
+        private set
+        {
+            if (SetProperty(ref _waitingForPhysicalSwitch, value))
+            {
+                OnPropertyChanged(nameof(PhysicalSwitchPromptText));
+                OnPropertyChanged(nameof(CanStartTest));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Operator-facing prompt explaining why <see cref="CanStartTest"/>
+    /// is false. Empty when the gate is open so AXAML can drive
+    /// visibility off <c>StringConverters.IsNotNullOrEmpty</c>.
+    /// </summary>
+    public virtual string PhysicalSwitchPromptText => WaitingForPhysicalSwitch
+        ? "Turn the Steer Switch ON to start. The host is configured to require the physical switch."
+        : string.Empty;
+
+    /// <summary>
+    /// Composite gate for the Start button. Subclasses should bind the
+    /// button's <c>IsEnabled</c> to this so the button is greyed when
+    /// either hardware is missing or the switch is currently off.
+    /// </summary>
+    public bool CanStartTest => HasHardware && !WaitingForPhysicalSwitch;
+
+    /// <summary>
+    /// Hook into AutoSteerService + ConfigStore.Tool so the gate keeps
+    /// pace with both the live module feedback and the operator's
+    /// config-dialog edits. Idempotent — safe to call from OnEntering
+    /// without a "first time" guard.
+    /// </summary>
+    protected void SubscribeToSwitchGate()
+    {
+        if (_gateSubscribed)
+            return;
+        _gateSubscribed = true;
+
+        if (AutoSteerService != null)
+            AutoSteerService.StateUpdated += OnSwitchGateStateUpdated;
+        ConfigService.Store.Tool.PropertyChanged += OnSwitchGateToolPropertyChanged;
+
+        UpdatePhysicalSwitchGate();
+    }
+
+    /// <summary>
+    /// Mirror of <see cref="SubscribeToSwitchGate"/>. Subclasses must
+    /// call this from <c>OnLeaving</c> so the wizard step doesn't leak
+    /// handlers onto the singletons it observes.
+    /// </summary>
+    protected void UnsubscribeFromSwitchGate()
+    {
+        if (!_gateSubscribed)
+            return;
+        _gateSubscribed = false;
+
+        if (AutoSteerService != null)
+            AutoSteerService.StateUpdated -= OnSwitchGateStateUpdated;
+        ConfigService.Store.Tool.PropertyChanged -= OnSwitchGateToolPropertyChanged;
+    }
+
+    private void OnSwitchGateStateUpdated(object? sender, VehicleStateSnapshot snapshot)
+    {
+        // StateUpdated may fire from the UDP receive thread (PGN 253
+        // path). Avalonia bindings — including the Start button's
+        // IsEnabled gate — won't refresh on off-thread PropertyChanged,
+        // so marshal to the UI thread. CheckAccess keeps test code
+        // (which fires StateUpdated synchronously via NSubstitute
+        // Raise.Event) running inline.
+        DispatchToUI(UpdatePhysicalSwitchGate);
+    }
+
+    private void OnSwitchGateToolPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(ConfigService.Store.Tool.IsSteerSwitchEnabled))
+            return;
+
+        // Operator-driven changes typically come in on the UI thread,
+        // but defensive marshalling future-proofs against a config
+        // writer that fires PropertyChanged from a worker.
+        DispatchToUI(UpdatePhysicalSwitchGate);
+    }
+
+    /// <summary>
+    /// Recompute <see cref="WaitingForPhysicalSwitch"/> from the
+    /// current config + live module feedback. Public so subclasses
+    /// can re-seed after manual state changes (e.g. snapshot priming
+    /// in OnEntering).
+    /// </summary>
+    protected void UpdatePhysicalSwitchGate()
+    {
+        bool requireSwitch = ConfigService.Store.Tool.IsSteerSwitchEnabled;
+        bool switchActive = AutoSteerService?.LastSteerData.SteerSwitchActive ?? false;
+        WaitingForPhysicalSwitch = requireSwitch && !switchActive;
+    }
+
+    private static void DispatchToUI(Action action)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            action();
+        else
+            Dispatcher.UIThread.Post(action);
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/MaxSteeringAngleStepView.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/MaxSteeringAngleStepView.axaml
@@ -21,8 +21,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:steer="clr-namespace:AgValoniaGPS.ViewModels.Wizards.SteerWizard;assembly=AgValoniaGPS.ViewModels"
              mc:Ignorable="d" d:DesignWidth="450" d:DesignHeight="650"
-             x:Class="AgValoniaGPS.Views.Controls.Wizards.SteerWizard.AutoMotorCalibrationStepView"
-             x:DataType="steer:AutoMotorCalibrationStepViewModel">
+             x:Class="AgValoniaGPS.Views.Controls.Wizards.SteerWizard.MaxSteeringAngleStepView"
+             x:DataType="steer:MaxSteeringAngleStepViewModel">
 
     <Grid RowDefinitions="Auto,Auto,*,Auto">
         <TextBlock Grid.Row="0"
@@ -43,7 +43,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <ScrollViewer Grid.Row="2">
             <StackPanel Spacing="16">
 
-                <!-- Live WAS angle -->
                 <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                         CornerRadius="12"
                         Padding="20"
@@ -61,10 +60,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
                 </Border>
 
-                <!-- ===== Phase A0: Start + gate hints ===== -->
-                <StackPanel IsVisible="{Binding IsPhaseA0}" Spacing="12">
+                <!-- ===== Waiting + gate hints ===== -->
+                <StackPanel IsVisible="{Binding IsWaiting}" Spacing="12">
                     <Button Command="{Binding StartTestCommand}"
-                            Content="Start Motor Test"
+                            Content="Start Max Angle Test"
                             HorizontalAlignment="Center"
                             Padding="24,12"
                             FontSize="18"
@@ -83,7 +82,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                TextWrapping="Wrap"
                                IsVisible="{Binding WaitingForPhysicalSwitch}"/>
 
-                    <TextBlock Text="No hardware connected - connect AutoSteer module to run calibration."
+                    <TextBlock Text="No hardware connected - connect AutoSteer module to run this test."
                                FontSize="14"
                                Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                HorizontalAlignment="Center"
@@ -91,38 +90,66 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                IsVisible="{Binding !HasHardware}"/>
                 </StackPanel>
 
-                <!-- ===== Phase A1: Progress ===== -->
-                <StackPanel IsVisible="{Binding IsPhaseA1}" Spacing="12">
+                <!-- ===== Measuring ===== -->
+                <StackPanel IsVisible="{Binding IsMeasuring}" Spacing="12">
                     <ProgressBar Value="{Binding Progress}"
                                  Minimum="0" Maximum="1"
                                  Height="8"
                                  CornerRadius="4"
                                  Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="20">
-                        <StackPanel>
-                            <TextBlock Text="Current PWM"
-                                       FontSize="12"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                                       HorizontalAlignment="Center"/>
-                            <TextBlock Text="{Binding CurrentPwm}"
-                                       FontSize="24"
-                                       FontWeight="Bold"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                       HorizontalAlignment="Center"/>
-                        </StackPanel>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="16">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SteerLeft.png"
+                               Width="40" Height="40" Stretch="Uniform"/>
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SteerRight.png"
+                               Width="40" Height="40" Stretch="Uniform"/>
                     </StackPanel>
                 </StackPanel>
 
-                <!-- ===== Phase A Result ===== -->
-                <StackPanel IsVisible="{Binding IsPhaseAResult}" Spacing="16">
+                <!-- ===== Complete ===== -->
+                <StackPanel IsVisible="{Binding IsComplete}" Spacing="16">
                     <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
                             CornerRadius="8" Padding="16">
-                        <TextBlock Text="{Binding PhaseResult}"
-                                   FontSize="16"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                   TextWrapping="Wrap"/>
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="Results"
+                                       FontSize="18"
+                                       FontWeight="Bold"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Text="Right Max Angle"
+                                           FontSize="14"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding DetectedMaxAngleRight, StringFormat='{}{0:F1}'}"
+                                           FontSize="14"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                            </Grid>
+
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Text="Left Max Angle"
+                                           FontSize="14"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding DetectedMaxAngleLeft, StringFormat='{}{0:F1}'}"
+                                           FontSize="14"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                            </Grid>
+
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Text="Max Steer Angle (raw WAS)"
+                                           FontSize="14"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding MaxSteerAngle}"
+                                           FontSize="14"
+                                           FontWeight="Bold"
+                                           Foreground="{DynamicResource SystemControlHighlightAccentBrush}"/>
+                            </Grid>
+                        </StackPanel>
                     </Border>
+
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12">
                         <Button Command="{Binding RedoCommand}"
                                 Content="Redo"

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/MaxSteeringAngleStepView.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/SteerWizard/MaxSteeringAngleStepView.axaml.cs
@@ -1,0 +1,16 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Wizards.SteerWizard;
+
+public partial class MaxSteeringAngleStepView : UserControl
+{
+    public MaxSteeringAngleStepView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardHost.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Wizards/WizardHost.axaml.cs
@@ -96,10 +96,15 @@ public partial class WizardHost : UserControl
             // Step 8: WAS Calibration
             WasCalibrationStepViewModel => new WasCalibrationStepView(),
 
-            // Step 9: Auto Motor Calibration
+            // Step 9: Motor Direction + MinPWM (split out of the
+            // legacy combined motor cal step).
             AutoMotorCalibrationStepViewModel => new AutoMotorCalibrationStepView(),
 
-            // Step 10: CPD Circle Test
+            // Step 10: Maximum Steering Angle (full-lock stress test
+            // separated from Phase A discovery; see Issue K).
+            MaxSteeringAngleStepViewModel => new MaxSteeringAngleStepView(),
+
+            // Step 11: CPD Circle Test
             CpdCircleTestStepViewModel => new CpdCircleTestStepView(),
 
             // Step 10: Ackermann Calibration

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Modules/VirtualSteerModule.cs
@@ -66,6 +66,16 @@ public class VirtualSteerModule : IDisposable
     /// <summary>Below this absolute error, drive pwm to zero so the wheel can rest.</summary>
     public double AngleDeadbandDeg { get; set; } = 0.05;
 
+    /// <summary>
+    /// Physical limit of the simulated wheel angle. The PID can command
+    /// any setpoint; the simulator clamps the integrated WAS so the
+    /// reported angle plateaus at this value (matching a real tractor's
+    /// hydraulic stops). Operator-adjustable in the simulator UI so the
+    /// wizard's max-steering-angle test sees a natural plateau. Default
+    /// ±35° approximates a typical agricultural front-axle range.
+    /// </summary>
+    public double MaxPhysicalWheelAngleDeg { get; set; } = 35.0;
+
     // Counters
     public long ReceivedCommandCount { get; private set; }
     public long SentFeedbackCount { get; private set; }
@@ -383,6 +393,17 @@ public class VirtualSteerModule : IDisposable
             double dAngle = pwm * PwmToDegPerSec * dt;
             if (Math.Abs(dAngle) > Math.Abs(error)) dAngle = error;
             ActualSteerAngleDeg += dAngle;
+
+            // Clamp to the simulated mechanical stops. Without this the
+            // PID can drive the integrated WAS angle indefinitely if the
+            // setpoint is past the physical max — the wizard's max-angle
+            // test then never sees a plateau and can't capture a stable
+            // reading. Real steering systems plateau on hydraulic stops
+            // and this models that behaviour.
+            if (ActualSteerAngleDeg > MaxPhysicalWheelAngleDeg)
+                ActualSteerAngleDeg = MaxPhysicalWheelAngleDeg;
+            else if (ActualSteerAngleDeg < -MaxPhysicalWheelAngleDeg)
+                ActualSteerAngleDeg = -MaxPhysicalWheelAngleDeg;
         }
     }
 

--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -37,6 +37,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
 
     // Sensors
     private double _wasAngle; // degrees
+    private double _maxPhysicalWheelAngle = 35.0; // degrees, ± clamp
     private double _rollAngle; // degrees
     private int _fixQuality = 4; // RTK Fixed
     private int _satelliteCount = 12;
@@ -89,6 +90,31 @@ public class MainWindowViewModel : INotifyPropertyChanged
     {
         get => _wasAngle;
         set { _wasAngle = Math.Clamp(value, -45, 45); OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Maximum physical wheel angle (±degrees) the simulated tractor
+    /// can reach. The internal steer module clamps its integrated WAS
+    /// at this value so the wizard's max-steering-angle test sees a
+    /// real plateau rather than a slowly-converging PID output. Default
+    /// 35° approximates a typical agricultural front axle; operator can
+    /// dial it up or down to test the wizard against different limits.
+    /// </summary>
+    public double MaxPhysicalWheelAngle
+    {
+        get => _maxPhysicalWheelAngle;
+        set
+        {
+            // Allow 5..60° to cover everything from articulated tractors
+            // (very tight) to forklift-style steering (very wide).
+            double clamped = Math.Clamp(value, 5.0, 60.0);
+            if (_maxPhysicalWheelAngle != clamped)
+            {
+                _maxPhysicalWheelAngle = clamped;
+                _hub.Steer.MaxPhysicalWheelAngleDeg = clamped;
+                OnPropertyChanged();
+            }
+        }
     }
 
     public double RollAngle
@@ -264,6 +290,10 @@ public class MainWindowViewModel : INotifyPropertyChanged
             _hub.Gps.Satellites = SatelliteCount;
             _hub.Gps.RollDegrees = RollAngle;
             _hub.Steer.ActualSteerAngleDeg = WasAngle;
+            // Push the operator's mechanical-limit setting before Start
+            // so the synthetic PWM loop clamps the simulated wheel angle
+            // at the configured maximum from the first tick.
+            _hub.Steer.MaxPhysicalWheelAngleDeg = MaxPhysicalWheelAngle;
             // The module's synthetic PWM tick loop drives WAS when autosteer
             // is engaged; the legacy on-receive WAS-follow stays off.
             _hub.Steer.SimulateSteerResponse = false;

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -66,6 +66,14 @@
                     <Slider Minimum="-45" Maximum="45" Value="{Binding WasAngle}"
                             TickFrequency="1" IsSnapToTickEnabled="False" />
 
+                    <!-- Mechanical-limit clamp for the synthetic PWM loop. The
+                         wizard's Max Steering Angle test needs the simulator
+                         to plateau at a real-world maximum or its plateau
+                         detector never fires. -->
+                    <TextBlock Text="{Binding MaxPhysicalWheelAngle, StringFormat='Max Physical Wheel Angle: ±{0:F0} deg'}" />
+                    <Slider Minimum="5" Maximum="60" Value="{Binding MaxPhysicalWheelAngle}"
+                            TickFrequency="1" IsSnapToTickEnabled="True" />
+
                     <TextBlock Text="{Binding RollAngle, StringFormat='Roll: {0:F1} deg'}" />
                     <Slider Minimum="-15" Maximum="15" Value="{Binding RollAngle}"
                             TickFrequency="0.5" IsSnapToTickEnabled="False" />

--- a/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
+++ b/Tests/AgValoniaGPS.IntegrationTests/VirtualModules/VirtualSteerModule.cs
@@ -66,6 +66,14 @@ public class VirtualSteerModule : IDisposable
     /// <summary>Below this absolute error, drive pwm to zero so the wheel can rest.</summary>
     public double AngleDeadbandDeg { get; set; } = 0.05;
 
+    /// <summary>
+    /// Physical limit of the simulated wheel angle. Clamps the
+    /// integrated WAS so the reported angle plateaus on the simulated
+    /// mechanical stops rather than drifting toward any commanded
+    /// setpoint indefinitely. Default ±35°.
+    /// </summary>
+    public double MaxPhysicalWheelAngleDeg { get; set; } = 35.0;
+
     // Counters
     public long ReceivedCommandCount { get; private set; }
     public long SentFeedbackCount { get; private set; }
@@ -383,6 +391,11 @@ public class VirtualSteerModule : IDisposable
             double dAngle = pwm * PwmToDegPerSec * dt;
             if (Math.Abs(dAngle) > Math.Abs(error)) dAngle = error;
             ActualSteerAngleDeg += dAngle;
+
+            if (ActualSteerAngleDeg > MaxPhysicalWheelAngleDeg)
+                ActualSteerAngleDeg = MaxPhysicalWheelAngleDeg;
+            else if (ActualSteerAngleDeg < -MaxPhysicalWheelAngleDeg)
+                ActualSteerAngleDeg = -MaxPhysicalWheelAngleDeg;
         }
     }
 

--- a/Tests/AgValoniaGPS.Services.Tests/CpdCircleTestEntrySeedTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/CpdCircleTestEntrySeedTests.cs
@@ -1,0 +1,87 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins that the CPD circle-test step seeds its gate inputs from the
+/// AutoSteerService cached <c>LatestSnapshot</c> on entry, so the
+/// Record button reflects the current GPS state immediately rather
+/// than staying greyed until the next <c>StateUpdated</c> publish.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class CpdCircleTestEntrySeedTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+    private IAutoSteerService _autoSteer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+
+        _autoSteer = Substitute.For<IAutoSteerService>();
+        _autoSteer.LastSteerData.Returns(SteerModuleData.Empty);
+    }
+
+    private static void EnterStep(WizardStepViewModel step)
+    {
+        // IsActive setter is internal; flip via reflection so OnEntering fires.
+        var prop = typeof(WizardStepViewModel).GetProperty(nameof(WizardStepViewModel.IsActive));
+        prop!.SetValue(step, true);
+    }
+
+    [Test]
+    public void OnEntering_WithCachedRtkFixedSnapshot_EnablesRecordImmediately()
+    {
+        // Service cache reports RTK Fixed + ~5 km/h *before* the step is
+        // entered. Without the seed, the Record button stays disabled
+        // until the next StateUpdated publish ticks the gate inputs.
+        _autoSteer.LatestSnapshot.Returns(new VehicleStateSnapshot
+        {
+            FixQuality = 4,
+            Speed = 5.0 / 3.6,  // m/s -> SpeedKmh = 5
+        });
+
+        var step = new CpdCircleTestStepViewModel(_configService, _autoSteer);
+        EnterStep(step);
+
+        Assert.That(step.IsRtkFixed, Is.True,
+            "IsRtkFixed must be seeded from LatestSnapshot.FixQuality");
+        Assert.That(step.Speed, Is.EqualTo(5.0).Within(0.01),
+            "Speed must be seeded (SpeedKmh from LatestSnapshot)");
+        Assert.That(step.CanRecord, Is.True,
+            "Record gate (RTK + speed>0.5 + !IsRecording) must open immediately on entry");
+    }
+
+    [Test]
+    public void OnEntering_WithoutCachedSnapshot_LeavesGateClosed()
+    {
+        // No cached snapshot — the service is freshly started. The gate
+        // should stay closed; the next StateUpdated publishes will
+        // populate the inputs.
+        _autoSteer.LatestSnapshot.Returns((VehicleStateSnapshot?)null);
+
+        var step = new CpdCircleTestStepViewModel(_configService, _autoSteer);
+        EnterStep(step);
+
+        Assert.That(step.IsRtkFixed, Is.False);
+        Assert.That(step.Speed, Is.EqualTo(0.0));
+        Assert.That(step.CanRecord, Is.False);
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/MaxSteeringAngleStepTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/MaxSteeringAngleStepTests.cs
@@ -1,0 +1,129 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Threading.Tasks;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the new max-steering-angle wizard step. The split-out step
+/// must:
+///   1. Detect a WAS plateau (consecutive samples within
+///      PlateauThresholdDeg) and capture that angle, rather than read
+///      a fixed-time snapshot mid-motion.
+///   2. Capture both sides of the lock and persist
+///      <c>min(left, right) * 0.9</c> as MaxSteerAngle on completion.
+///   3. Honour cooperative cancellation by exiting the loop and
+///      restoring free-drive state.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class MaxSteeringAngleStepTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+    private IAutoSteerService _autoSteer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+
+        _autoSteer = Substitute.For<IAutoSteerService>();
+        _autoSteer.LastSteerData.Returns(SteerModuleData.Empty);
+    }
+
+    [Test]
+    public async Task PlateauDetector_FiresOnStableSamples_AndPersistsMaxAngle()
+    {
+        // Simulator-style WAS: ramp up to ±35° then plateau. The
+        // detector should fire once it sees PlateauStableSamples
+        // consecutive samples within PlateauThresholdDeg of each other.
+        var step = new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        step.DelayFunc = (_, _) => Task.CompletedTask;
+
+        // Right-lock sequence: 10, 20, 30, 35, 35, 35, 35, 35, 35, 35
+        // then center, then left: -10, -25, -30, -30, -30, -30, -30, -30
+        var rightSequence = new[] { 10.0, 20.0, 30.0, 35.0, 35.0, 35.0, 35.0, 35.0, 35.0, 35.0 };
+        var leftSequence = new[] { -10.0, -25.0, -30.0, -30.0, -30.0, -30.0, -30.0, -30.0 };
+
+        int call = 0;
+        bool measuringLeft = false;
+        step.ReadWasAngle = () =>
+        {
+            // Transition to "left" sequence the first time we hit
+            // Phase.MeasuringLeft. (See the SetFreeDriveAngle stub below.)
+            if (measuringLeft)
+            {
+                var v = leftSequence[System.Math.Min(call - rightSequence.Length, leftSequence.Length - 1)];
+                call++;
+                return v;
+            }
+            else
+            {
+                var v = rightSequence[System.Math.Min(call, rightSequence.Length - 1)];
+                call++;
+                if (call >= rightSequence.Length)
+                {
+                    // Reset call counter for the left-side polling.
+                    measuringLeft = true;
+                    call = rightSequence.Length;
+                }
+                return v;
+            }
+        };
+
+        await step.RunMaxAngleMeasurementAsync();
+
+        Assert.That(step.DetectedMaxAngleRight, Is.EqualTo(35.0).Within(0.5));
+        Assert.That(step.DetectedMaxAngleLeft, Is.EqualTo(30.0).Within(0.5));
+        // min(35, 30) * 0.9 = 27 (truncated).
+        Assert.That(step.MaxSteerAngle, Is.EqualTo(27));
+        Assert.That(step.CalibrationCompleted, Is.True);
+        Assert.That(step.Phase, Is.EqualTo(MaxSteeringAnglePhase.Complete));
+    }
+
+    [Test]
+    public async Task NoPlateau_FallsBackToLastSample_WithoutHanging()
+    {
+        // If the WAS never settles (e.g. simulator with no clamp, runaway
+        // hydraulics), the detector must time out and return the last
+        // sample rather than hang forever. The wizard caps the poll loop
+        // at PlateauTimeoutMs internally.
+        var step = new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        step.DelayFunc = (_, _) => Task.CompletedTask;
+
+        double angle = 0;
+        bool right = true;
+        step.ReadWasAngle = () =>
+        {
+            angle += right ? 0.5 : -0.5;  // never plateaus, just drifts
+            if (System.Math.Abs(angle) > 50)
+            {
+                right = !right;
+                angle = right ? 0 : 0;
+            }
+            return angle;
+        };
+
+        await step.RunMaxAngleMeasurementAsync();
+
+        // We don't assert exact values — the timeout-fallback path is
+        // operational, not metric. The point: it returned without
+        // hanging, and CalibrationCompleted is true so OnLeaving will
+        // still persist *something*.
+        Assert.That(step.Phase, Is.EqualTo(MaxSteeringAnglePhase.Complete));
+        Assert.That(step.CalibrationCompleted, Is.True);
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/MotorCalAndMaxSteerGateTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/MotorCalAndMaxSteerGateTests.cs
@@ -1,0 +1,173 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Both calibration steps (Motor Direction + MinPWM, and Maximum
+/// Steering Angle) carry the physical-switch safety gate. When the
+/// operator has <c>Tool.IsSteerSwitchEnabled</c> set but the live
+/// PGN 253 reports the physical switch is OFF, the Start button must
+/// stay disabled and the operator must see a prompt. When the gate
+/// flag is false, the gate is bypassed entirely.
+///
+/// One fixture exercises both VMs with parameterised type so future
+/// gate-bearing steps can be added without duplicating the suite.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class MotorCalAndMaxSteerGateTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+    private IAutoSteerService _autoSteer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+
+        _autoSteer = Substitute.For<IAutoSteerService>();
+        _autoSteer.LastSteerData.Returns(SteerModuleData.Empty);
+    }
+
+    private void GivenSwitch(bool active)
+    {
+        _autoSteer.LastSteerData.Returns(new SteerModuleData(
+            ActualSteerAngle: 0, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: active,
+            RemoteButtonPressed: false, VwasFusionActive: false,
+            PwmDisplay: 0));
+    }
+
+    private static void EnterStep(WizardStepViewModel step)
+    {
+        var prop = typeof(WizardStepViewModel).GetProperty(nameof(WizardStepViewModel.IsActive));
+        prop!.SetValue(step, true);
+    }
+
+    private SwitchGatedWizardStep CreateStep<T>() where T : SwitchGatedWizardStep
+    {
+        if (typeof(T) == typeof(AutoMotorCalibrationStepViewModel))
+            return new AutoMotorCalibrationStepViewModel(_configService, _autoSteer);
+        if (typeof(T) == typeof(MaxSteeringAngleStepViewModel))
+            return new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        throw new InvalidOperationException("Unknown step type for fixture");
+    }
+
+    [TestCase(typeof(AutoMotorCalibrationStepViewModel))]
+    [TestCase(typeof(MaxSteeringAngleStepViewModel))]
+    public void Gate_SwitchDisabled_AlwaysAllowsStart(Type stepType)
+    {
+        // No operator-console switch configured -> gate bypassed.
+        _store.Tool.IsSteerSwitchEnabled = false;
+        GivenSwitch(active: false);
+
+        SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
+            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        EnterStep(step);
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+        Assert.That(step.CanStartTest, Is.True);
+        Assert.That(step.PhysicalSwitchPromptText, Is.Empty);
+    }
+
+    [TestCase(typeof(AutoMotorCalibrationStepViewModel))]
+    [TestCase(typeof(MaxSteeringAngleStepViewModel))]
+    public void Gate_SwitchEnabledAndPgn253SwitchOff_BlocksStart(Type stepType)
+    {
+        _store.Tool.IsSteerSwitchEnabled = true;
+        GivenSwitch(active: false);
+
+        SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
+            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        EnterStep(step);
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.True);
+        Assert.That(step.CanStartTest, Is.False);
+        Assert.That(step.PhysicalSwitchPromptText, Does.Contain("Steer Switch"));
+    }
+
+    [TestCase(typeof(AutoMotorCalibrationStepViewModel))]
+    [TestCase(typeof(MaxSteeringAngleStepViewModel))]
+    public void Gate_SwitchEnabledAndPgn253SwitchOn_AllowsStart(Type stepType)
+    {
+        _store.Tool.IsSteerSwitchEnabled = true;
+        GivenSwitch(active: true);
+
+        SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
+            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        EnterStep(step);
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+        Assert.That(step.CanStartTest, Is.True);
+    }
+
+    [TestCase(typeof(AutoMotorCalibrationStepViewModel))]
+    [TestCase(typeof(MaxSteeringAngleStepViewModel))]
+    public void Gate_TransitionFromOffToOn_RefreshesImmediately(Type stepType)
+    {
+        // Operator enters with switch off, then flips it on at the
+        // console. The live PGN 253 transition must unblock the Start
+        // button immediately, not after a step navigation away/back.
+        _store.Tool.IsSteerSwitchEnabled = true;
+        GivenSwitch(active: false);
+
+        SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
+            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        EnterStep(step);
+        Assert.That(step.CanStartTest, Is.False);
+
+        // Flip switch on; fire StateUpdated like AutoSteerService would.
+        GivenSwitch(active: true);
+        _autoSteer.StateUpdated += Raise.Event<EventHandler<VehicleStateSnapshot>>(
+            _autoSteer, new VehicleStateSnapshot());
+
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+        Assert.That(step.CanStartTest, Is.True);
+    }
+
+    [TestCase(typeof(AutoMotorCalibrationStepViewModel))]
+    [TestCase(typeof(MaxSteeringAngleStepViewModel))]
+    public void Gate_OperatorTogglesIsSteerSwitchEnabledLive_Refreshes(Type stepType)
+    {
+        // Symmetric path: operator flips the requirement on/off in the
+        // config dialog while the step is on-screen. Tool's
+        // PropertyChanged must wake the gate without needing a fresh
+        // PGN 253.
+        _store.Tool.IsSteerSwitchEnabled = false;
+        GivenSwitch(active: false);
+
+        SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
+            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        EnterStep(step);
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False);
+
+        _store.Tool.IsSteerSwitchEnabled = true;
+        Assert.That(step.WaitingForPhysicalSwitch, Is.True,
+            "Toggling IsSteerSwitchEnabled on must close the gate immediately");
+
+        _store.Tool.IsSteerSwitchEnabled = false;
+        Assert.That(step.WaitingForPhysicalSwitch, Is.False,
+            "Toggling IsSteerSwitchEnabled off must reopen the gate");
+    }
+}


### PR DESCRIPTION
Three follow-ups from bench-test of the steer wizard, each independently reviewable.

## Issue J — CPD step (#10) seeds gate on entry (`40d257a8`)
`CpdCircleTestStepViewModel` only updated `IsRtkFixed`/`Speed` when a new `StateUpdated` snapshot arrived, so operators entering the step right after a navigation saw the Record button greyed for the full ~100 ms gap until the next GPS publish.

Fix: `OnEntering` now reads `IAutoSteerService.LatestSnapshot` and applies it through a new `ApplySnapshot` helper (extracted from `OnStateUpdated`). The recording branch stays in `OnStateUpdated` so the seed path doesn't accidentally start a measurement.

Tests: cached-RTK-Fixed-on-entry opens the gate; no-cached-snapshot leaves it closed.

## Issue K — Split step 9 + shared `SwitchGatedWizardStep` base (`e8c95b2a`)
Step 9 (Motor Direction + MinPWM via Kp-ramp) and the full-lock max-angle measurement were bundled into one step with two phases. They have different risk profiles (Kp-ramp is brief discovery; full-lock stresses the steering mechanism) and operators couldn't cleanly mark "MinPWM done" between them.

- New abstract base `SwitchGatedWizardStep` owns `WaitingForPhysicalSwitch`, `PhysicalSwitchPromptText`, `HasHardware`, `CanStartTest`, plus subscribe/unsubscribe helpers. Subscribes to both `IAutoSteerService.StateUpdated` AND `ConfigStore.Tool.PropertyChanged` so the gate reacts to both live PGN 253 and operator config edits. All recomputes dispatch to the UI thread (sync on the test thread via `CheckAccess`).
- `AutoMotorCalibrationStepViewModel` slimmed to Phase A only. `CalibrationPhase` enum drops the Phase B values; redo collapses to a single command. Inherits the gate from the base.
- New `MaxSteeringAngleStepViewModel` hosts the full-lock measurement. Plateau detector: poll WAS at 100 ms intervals, capture when `PlateauStableSamples=5` consecutive samples stay within `PlateauThresholdDeg=0.2°`. Times out to the last sample after 6 s.
- AXAML: motor-cal view trimmed; new `MaxSteeringAngleStepView`. Both bind `Start.IsEnabled` to `CanStartTest` and surface `PhysicalSwitchPromptText` when waiting.
- `SteerWizardViewModel` inserts the new step right after the motor cal step.

Tests: `MotorCalAndMaxSteerGateTests` parameterises both step types over the four gate states + the operator-toggle path (10 tests). `MaxSteeringAngleStepTests` pins plateau capture + no-plateau timeout fallback.

## Issue L — Simulator wheel-angle clamp (`617a5666`)
`VirtualSteerModule`'s synthetic PWM loop integrated WAS continuously with no physical stop. Sending `SetFreeDriveAngle(40°)` drove the wheel toward 40° forever — the wizard's plateau detector never triggered because the angle never settled.

- New `MaxPhysicalWheelAngleDeg` on `VirtualSteerModule` (default ±35°). PID-driven WAS clamps to that range, reaching natural plateau at the limit.
- Applied to both copies of `VirtualSteerModule` (sim app + integration-tests embedded copy).
- Simulator `MainWindowViewModel` exposes the clamp via a 5..60° slider in the Sensors panel; value pushed to the hub before `Start()` so the first tick respects the operator's setting.

## Counts
- Full Services suite: 861 pass, 1 fail (pre-existing Windows file-lock flake, unrelated), 2 skip.
- 14 new tests across the three commits, all green.
- Build clean.

## Merge-order caveats
- Branch is off `origin/develop@7e7053ea` (so #386 isn't included). When #385 lands, conflict will surface in `AutoMotorCalibrationStepViewModel`/View — resolve toward the gate work here (already reproduces #385's pattern via the shared base).
- When #386 (Kp-ramp) lands, same file conflict — keep the slim Phase A shape from this PR and re-port the Kp-ramp algorithm on top.
- The new `SwitchGatedWizardStep` base is the natural home for #385's inline gate code after its merge; worth a short follow-up consolidation PR.

## Test plan
- [x] All 14 new tests green.
- [x] Build clean.
- [ ] Bench: step 9 motor cal — physical switch gate visible, Kp-ramp completes after #386 re-port.
- [ ] Bench: new step 10 max steering angle — drive to full lock both ways, wizard captures the simulator's clamped angle (~35°).
- [ ] Bench: step 11 CPD circle — Record button enables immediately on entry when RTK Fixed.