### PR TITLE
Vehicle Simulator: operator-adjustable wheelbase knob

### DIFF
--- a/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/ViewModels/MainWindowViewModel.cs
@@ -34,6 +34,10 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private double _heading; // degrees
     private double _latitude = 42.0308;
     private double _longitude = -93.6319;
+    // Bicycle-model axle length. Operator-adjustable so the host's wizard
+    // belief about wheelbase can be tested against a configurable truth, the
+    // same pattern as the virtual CPD / WAS offset knobs.
+    private double _wheelbase = 2.5; // meters; matches VehiclePhysicsModel default
 
     // Sensors
     private double _wasAngle; // degrees
@@ -91,6 +95,19 @@ public class MainWindowViewModel : INotifyPropertyChanged
     {
         get => _longitude;
         set { _longitude = value; OnPropertyChanged(); }
+    }
+
+    public double Wheelbase
+    {
+        get => _wheelbase;
+        set
+        {
+            _wheelbase = Math.Clamp(value, 1.0, 5.0);
+            OnPropertyChanged();
+            // Push live so changes affect the next kinematic step without
+            // requiring a Stop/Start cycle.
+            _vehicle.Wheelbase = _wheelbase;
+        }
     }
 
     public double WasAngle
@@ -317,6 +334,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
             _vehicle.HeadingDeg = Heading;
             _vehicle.SpeedKmh = Speed;
             _vehicle.SteerAngleDeg = WasAngle;
+            _vehicle.Wheelbase = Wheelbase;
 
             _hub = new VirtualModuleHub(hostReceivePort: 9999, moduleListenPort: 8888);
             _hub.Gps.Latitude = Latitude;

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -46,6 +46,16 @@
                     <Slider Minimum="0" Maximum="30" Value="{Binding Speed}"
                             TickFrequency="1" IsSnapToTickEnabled="False" />
 
+                    <!-- Bicycle-model axle length. The host's wizard has its own
+                         belief about wheelbase; the operator dials this slider
+                         to set the simulator's truth and verify the wizard /
+                         guidance reacts correctly to a mismatch. Range matches
+                         small ATVs up through large cab tractors. -->
+                    <TextBlock Text="{Binding Wheelbase, StringFormat='Wheelbase: {0:F2} m'}" />
+                    <Slider Minimum="1.0" Maximum="5.0" Value="{Binding Wheelbase}"
+                            TickFrequency="0.1" IsSnapToTickEnabled="False"
+                            ToolTip.Tip="Axle length used by the simulator's bicycle kinematic model. Operator-controlled truth — the host's wizard tries to discover this." />
+
                     <TextBlock Text="{Binding WasAngle, StringFormat='Wheel Angle: {0:F1} deg'}" />
                     <Slider Minimum="-45" Maximum="45" Value="{Binding WasAngle}"
                             TickFrequency="1" IsSnapToTickEnabled="False"
@@ -67,16 +77,6 @@
                     BorderThickness="1" CornerRadius="4">
                 <StackPanel Spacing="8">
                     <TextBlock Text="GPS" FontWeight="SemiBold" FontSize="14" />
-
-                    <!-- Bicycle-model axle length. The host's wizard has its own
-                         belief about wheelbase; the operator dials this slider
-                         to set the simulator's truth and verify the wizard /
-                         guidance reacts correctly to a mismatch. Range matches
-                         small ATVs up through large cab tractors. -->
-                    <TextBlock Text="{Binding Wheelbase, StringFormat='Wheelbase: {0:F2} m'}" />
-                    <Slider Minimum="1.0" Maximum="5.0" Value="{Binding Wheelbase}"
-                            TickFrequency="0.1" IsSnapToTickEnabled="False"
-                            ToolTip.Tip="Axle length used by the simulator's bicycle kinematic model. Operator-controlled truth — the host's wizard tries to discover this." />
 
                     <TextBlock Text="{Binding Latitude, StringFormat='Latitude: {0:F6}'}" />
                     <NumericUpDown Value="{Binding Latitude}" Increment="0.0001"

--- a/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
+++ b/Simulators/AgValoniaGPS.VehicleSimulator/Views/MainWindow.axaml
@@ -68,6 +68,16 @@
                 <StackPanel Spacing="8">
                     <TextBlock Text="GPS" FontWeight="SemiBold" FontSize="14" />
 
+                    <!-- Bicycle-model axle length. The host's wizard has its own
+                         belief about wheelbase; the operator dials this slider
+                         to set the simulator's truth and verify the wizard /
+                         guidance reacts correctly to a mismatch. Range matches
+                         small ATVs up through large cab tractors. -->
+                    <TextBlock Text="{Binding Wheelbase, StringFormat='Wheelbase: {0:F2} m'}" />
+                    <Slider Minimum="1.0" Maximum="5.0" Value="{Binding Wheelbase}"
+                            TickFrequency="0.1" IsSnapToTickEnabled="False"
+                            ToolTip.Tip="Axle length used by the simulator's bicycle kinematic model. Operator-controlled truth — the host's wizard tries to discover this." />
+
                     <TextBlock Text="{Binding Latitude, StringFormat='Latitude: {0:F6}'}" />
                     <NumericUpDown Value="{Binding Latitude}" Increment="0.0001"
                                    FormatString="F6" Minimum="-90" Maximum="90" />


### PR DESCRIPTION
Adds an operator-adjustable wheelbase parameter to the Vehicle Simulator's Bicycle Model column. `VehiclePhysicsModel` already had a `Wheelbase` property (default 2.5 m) but it was unsurfaced — this exposes it as a 1.0–5.0 m slider so the host's perception of wheelbase can be tested against a configurable "truth" value (same pattern as Virtual CPD / Off-center for WAS).

## Changes
- `MainWindowViewModel.Wheelbase` property with 1.0..5.0 m clamp. Setter writes through to `_vehicle.Wheelbase` live, so changes affect the next 10 Hz kinematic step without Stop/Start.
- `StartSimulation` seeds the field on the initial physics state.
- Slider placed in the **Bicycle Model** column (Column 0 in the post-#388 4-column layout) right under Speed.

## Test plan
- [x] Build clean.
- [ ] Bench: drag the wheelbase slider while the simulator is running — turn radius and heading rate respond to the new value within ~100 ms (one kinematic tick).