### PR TITLE
Wizard: MaxSteer as invariant raw counts, MaxPWM = 2 × MinPWM default

### DIFF
--- a/Shared/AgValoniaGPS.Models/Configuration/AutoSteerConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/AutoSteerConfig.cs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
+
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AgValoniaGPS.Models.Configuration;
@@ -107,7 +109,17 @@ public class AutoSteerConfig : ObservableObject
     public double CountsPerDegree
     {
         get => _countsPerDegree;
-        set => SetProperty(ref _countsPerDegree, value);
+        set
+        {
+            if (SetProperty(ref _countsPerDegree, value))
+            {
+                // MaxSteerAngle is computed from MaxSteerRawCounts / CPD,
+                // so a CPD change re-meaning the degree view requires an
+                // explicit notification — bindings on the config dialog
+                // need to pick up the new degree number.
+                OnPropertyChanged(nameof(MaxSteerAngle));
+            }
+        }
     }
 
     private int _ackermann = 100;
@@ -122,15 +134,52 @@ public class AutoSteerConfig : ObservableObject
         set => SetProperty(ref _ackermann, value);
     }
 
-    private int _maxSteerAngle = 45;
+    // The mechanical-stop measurement is stored as raw WAS counts so it
+    // stays correct across CountsPerDegree changes. The wizard's
+    // Max Steering Angle step writes this directly; the legacy
+    // MaxSteerAngle (in degrees) is now a thin view computed from
+    // _maxSteerRawCounts at the current CPD. Before this change the
+    // operator had to run CPD calibration *before* max-steer or the
+    // saved degree value was scaled by the wrong ratio.
+    private int _maxSteerRawCounts = 45 * 100; // 45° at default CPD 100
+
     /// <summary>
-    /// Maximum physical steering angle (degrees).
-    /// Range: 10 - 90
+    /// Raw WAS counts at the mechanical steering stop (the measurement
+    /// captured by the max-steering-angle wizard step). Invariant under
+    /// CountsPerDegree changes — read <see cref="MaxSteerAngle"/> for
+    /// the degree-valued view.
+    /// </summary>
+    public int MaxSteerRawCounts
+    {
+        get => _maxSteerRawCounts;
+        set
+        {
+            if (SetProperty(ref _maxSteerRawCounts, value))
+                OnPropertyChanged(nameof(MaxSteerAngle));
+        }
+    }
+
+    /// <summary>
+    /// Maximum physical steering angle (degrees), computed from
+    /// <see cref="MaxSteerRawCounts"/> at the current
+    /// <see cref="CountsPerDegree"/>. Setting this value back-converts
+    /// using the current CPD so legacy callers (JSON profile load,
+    /// config dialog spinner) continue to work.
     /// </summary>
     public int MaxSteerAngle
     {
-        get => _maxSteerAngle;
-        set => SetProperty(ref _maxSteerAngle, value);
+        get
+        {
+            double cpd = _countsPerDegree;
+            if (cpd <= 0) return 0;
+            return (int)Math.Round(_maxSteerRawCounts / cpd);
+        }
+        set
+        {
+            double cpd = _countsPerDegree;
+            if (cpd <= 0) cpd = 100;
+            MaxSteerRawCounts = (int)Math.Round(value * cpd);
+        }
     }
 
     // ============================================

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
@@ -388,6 +388,21 @@ public class AutoMotorCalibrationStepViewModel : SwitchGatedWizardStep
                     {
                         DetectedMinPwm = module.PwmDisplay;
                         DetectedInvertMotor = autoSteerConfig.InvertMotor;
+
+                        // Persist the captured values immediately so the
+                        // operator's tuning survives any navigation path
+                        // out of the step (the previous OnLeaving-only
+                        // save was gated on a flag the ramp never set,
+                        // so results were lost on Next).
+                        //
+                        // MaxPwm defaults to 2 × MinPwm capped at 255 —
+                        // a sensible starting point. Operator can tune in
+                        // the AutoSteer config dialog afterwards.
+                        autoSteerConfig.MinPwm = DetectedMinPwm;
+                        autoSteerConfig.MaxPwm = Math.Min(2 * DetectedMinPwm, 255);
+                        autoSteerConfig.InvertMotor = DetectedInvertMotor;
+
+                        CalibrationCompleted = true;
                         detected = true;
                     }
                     else
@@ -401,7 +416,8 @@ public class AutoMotorCalibrationStepViewModel : SwitchGatedWizardStep
                 {
                     PhaseResult =
                         $"Motor direction: {(DetectedInvertMotor ? "Inverted" : "Normal")}\n" +
-                        $"Minimum PWM: {DetectedMinPwm}";
+                        $"Minimum PWM: {DetectedMinPwm}\n" +
+                        $"Maximum PWM (default): {autoSteerConfig.MaxPwm}";
                     Phase = CalibrationPhase.RampResult;
                     return;
                 }
@@ -588,14 +604,12 @@ public class AutoMotorCalibrationStepViewModel : SwitchGatedWizardStep
             }
         }
 
-        // Save results if calibration was completed
-        if (CalibrationCompleted)
-        {
-            var autoSteer = _configService.Store.AutoSteer;
-            autoSteer.InvertMotor = DetectedInvertMotor;
-            autoSteer.MinPwm = DetectedMinPwm;
-            autoSteer.MaxSteerAngle = MaxSteerAngle;
-        }
+        // Phase A persists MinPwm/MaxPwm/InvertMotor inline at success —
+        // see RunKpRampAsync. The old OnLeaving save block also tried to
+        // write a vestigial MaxSteerAngle field that's not produced by
+        // this step (it lives in MaxSteeringAngleStepViewModel now), so
+        // dropping it avoids clobbering the operator's real max-steer
+        // calibration with a stale zero on every step exit.
     }
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/MaxSteeringAngleStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/MaxSteeringAngleStepViewModel.cs
@@ -155,13 +155,28 @@ public class MaxSteeringAngleStepViewModel : SwitchGatedWizardStep
 
     private int _maxSteerAngle;
     /// <summary>
-    /// Final max steer angle as a raw WAS value. Conservative:
-    /// <c>min(left, right) * 0.9</c>.
+    /// Final max steer angle in degrees. Derived from the captured
+    /// raw counts at the current CountsPerDegree so the UI shows the
+    /// same value the config dialog will read back after persistence.
     /// </summary>
     public int MaxSteerAngle
     {
         get => _maxSteerAngle;
         set => SetProperty(ref _maxSteerAngle, value);
+    }
+
+    private int _maxSteerRawCounts;
+    /// <summary>
+    /// Final max steer measurement as raw WAS counts — what gets
+    /// persisted to <see cref="AutoSteerConfig.MaxSteerRawCounts"/>.
+    /// Invariant under CountsPerDegree changes, so the operator can
+    /// run CPD calibration before or after this step and the saved
+    /// limit stays correct.
+    /// </summary>
+    public int MaxSteerRawCounts
+    {
+        get => _maxSteerRawCounts;
+        set => SetProperty(ref _maxSteerRawCounts, value);
     }
 
     private bool _calibrationCompleted;
@@ -215,14 +230,23 @@ public class MaxSteeringAngleStepViewModel : SwitchGatedWizardStep
             // Conservative: 90 % of the smaller side. Treating asymmetric
             // mechanical limits as if they were symmetric would push past
             // the tighter stop on every guidance correction.
-            MaxSteerAngle = (int)(Math.Min(DetectedMaxAngleRight, DetectedMaxAngleLeft) * 0.9);
+            double chosenDeg = Math.Min(DetectedMaxAngleRight, DetectedMaxAngleLeft) * 0.9;
+
+            // Store the measurement as raw WAS counts so it stays correct
+            // even if the operator re-runs the CPD calibration after this
+            // step. Degrees are derived from rawCounts / currentCpd, both
+            // here for the UI and in AutoSteerConfig for persistence.
+            double cpd = ConfigService.Store.AutoSteer.CountsPerDegree;
+            if (cpd <= 0) cpd = 100;
+            MaxSteerRawCounts = (int)Math.Round(chosenDeg * cpd);
+            MaxSteerAngle = (int)Math.Round(chosenDeg);
 
             CalibrationCompleted = true;
             Phase = MaxSteeringAnglePhase.Complete;
             PhaseResult =
                 $"Right max: {DetectedMaxAngleRight:F1}\n" +
                 $"Left max: {DetectedMaxAngleLeft:F1}\n" +
-                $"Max steer angle (raw WAS): {MaxSteerAngle}";
+                $"Max steer angle: {MaxSteerAngle}° ({MaxSteerRawCounts} counts)";
         }
         catch (OperationCanceledException)
         {
@@ -283,6 +307,7 @@ public class MaxSteeringAngleStepViewModel : SwitchGatedWizardStep
         DetectedMaxAngleRight = 0;
         DetectedMaxAngleLeft = 0;
         MaxSteerAngle = 0;
+        MaxSteerRawCounts = 0;
         PhaseResult = "";
         CalibrationCompleted = false;
         return Task.CompletedTask;
@@ -303,6 +328,9 @@ public class MaxSteeringAngleStepViewModel : SwitchGatedWizardStep
         CalibrationCompleted = false;
 
         var autoSteer = ConfigService.Store.AutoSteer;
+        // Restore the persisted raw-counts measurement; MaxSteerAngle is
+        // derived from it for the UI display.
+        MaxSteerRawCounts = autoSteer.MaxSteerRawCounts;
         MaxSteerAngle = autoSteer.MaxSteerAngle;
 
         if (AutoSteerService != null)
@@ -329,7 +357,14 @@ public class MaxSteeringAngleStepViewModel : SwitchGatedWizardStep
         UnsubscribeFromSwitchGate();
 
         if (CalibrationCompleted)
-            ConfigService.Store.AutoSteer.MaxSteerAngle = MaxSteerAngle;
+        {
+            // Persist as raw counts. MaxSteerAngle (degrees) on the
+            // config is now a computed view of MaxSteerRawCounts at the
+            // current CountsPerDegree, so writing rawCounts is the
+            // single source of truth — and re-running CPD later
+            // automatically updates the displayed degree value.
+            ConfigService.Store.AutoSteer.MaxSteerRawCounts = MaxSteerRawCounts;
+        }
     }
 
     private void OnStateUpdated(object? sender, VehicleStateSnapshot snapshot)

--- a/Tests/AgValoniaGPS.Services.Tests/MaxSteerRawCountsAndMaxPwmTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/MaxSteerRawCountsAndMaxPwmTests.cs
@@ -1,0 +1,201 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System.Threading.Tasks;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
+using AgValoniaGPS.ViewModels.Wizards.SteerWizard;
+using NSubstitute;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Pins the M / N redesign of the steer-wizard calibration outputs:
+///
+/// M. The max-steering-angle measurement is stored as raw WAS counts
+///    on <see cref="AutoSteerConfig"/> so it stays correct even if
+///    the operator runs the CPD circle test before or after the
+///    max-steer step. <see cref="AutoSteerConfig.MaxSteerAngle"/>
+///    becomes a computed view of <c>MaxSteerRawCounts / CountsPerDegree</c>.
+///
+/// N. After the motor-cal Kp ramp captures MinPwm, the step also
+///    seeds <see cref="AutoSteerConfig.MaxPwm"/> to
+///    <c>min(2 × MinPwm, 255)</c> — a sensible default the operator
+///    can tune in the AutoSteer config dialog.
+/// </summary>
+[TestFixture]
+[NonParallelizable] // ConfigurationStore singleton.
+public class MaxSteerRawCountsAndMaxPwmTests
+{
+    private IConfigurationService _configService = null!;
+    private ConfigurationStore _store = null!;
+    private IAutoSteerService _autoSteer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _store = new ConfigurationStore();
+        ConfigurationStore.SetInstance(_store);
+
+        _configService = Substitute.For<IConfigurationService>();
+        _configService.Store.Returns(_store);
+
+        _autoSteer = Substitute.For<IAutoSteerService>();
+        _autoSteer.LastSteerData.Returns(SteerModuleData.Empty);
+    }
+
+    private static SteerModuleData ModuleAt(double angleDeg, byte pwm) =>
+        new SteerModuleData(
+            ActualSteerAngle: angleDeg, ImuHeading: 0, ImuRoll: 0,
+            WorkSwitchActive: false, SteerSwitchActive: true,
+            RemoteButtonPressed: false, VwasFusionActive: false,
+            PwmDisplay: pwm);
+
+    // =====================================================================
+    // Issue M — MaxSteerAngle is CPD-invariant when stored as raw counts.
+    // =====================================================================
+
+    [Test]
+    public void MaxSteer_RawCountsInvariantUnderCpdChange()
+    {
+        // Operator measures at default CPD=100. Capture 35° -> 3500 raw counts.
+        _store.AutoSteer.CountsPerDegree = 100;
+        _store.AutoSteer.MaxSteerRawCounts = 3500;
+        Assert.That(_store.AutoSteer.MaxSteerAngle, Is.EqualTo(35),
+            "At CPD=100, 3500 raw counts must show as 35°");
+
+        // CPD calibration drops it to 85. The stored measurement is the
+        // same physical limit; only the degree view should adjust.
+        _store.AutoSteer.CountsPerDegree = 85;
+        Assert.That(_store.AutoSteer.MaxSteerAngle, Is.EqualTo(41),
+            "At CPD=85, 3500 raw counts must show as ~41° (rounded from 41.18)");
+
+        // CPD up to 120 in a different setup; same raw counts.
+        _store.AutoSteer.CountsPerDegree = 120;
+        Assert.That(_store.AutoSteer.MaxSteerAngle, Is.EqualTo(29),
+            "At CPD=120, 3500 raw counts must show as ~29° (rounded from 29.17)");
+
+        Assert.That(_store.AutoSteer.MaxSteerRawCounts, Is.EqualTo(3500),
+            "Raw counts are the source of truth; CPD changes never touch them");
+    }
+
+    [Test]
+    public void MaxSteer_SetByDegrees_BackConvertsToRawCounts()
+    {
+        // Legacy callers (JSON profile load, config dialog spinner) set
+        // MaxSteerAngle in degrees. The setter must back-convert using
+        // the current CPD so subsequent CPD changes still re-meaning the
+        // value correctly.
+        _store.AutoSteer.CountsPerDegree = 100;
+        _store.AutoSteer.MaxSteerAngle = 45;
+        Assert.That(_store.AutoSteer.MaxSteerRawCounts, Is.EqualTo(4500));
+
+        _store.AutoSteer.CountsPerDegree = 90;
+        // 4500 raw / 90 cpd = 50°.
+        Assert.That(_store.AutoSteer.MaxSteerAngle, Is.EqualTo(50));
+    }
+
+    [Test]
+    public async Task MaxSteer_CapturesPlateauAsRawCounts()
+    {
+        // The wizard step measures degrees from PGN 253 and persists
+        // raw counts. Drive a simulated WAS that ramps to ±35° and
+        // plateaus; verify the captured rawCounts equals
+        // chosenDeg × currentCPD.
+        _store.AutoSteer.CountsPerDegree = 80;
+        var step = new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        step.DelayFunc = (_, _) => Task.CompletedTask;
+
+        // Symmetric plateau at ±35°. min(35,35) * 0.9 = 31.5 -> rounds to 32.
+        // rawCounts = 32 × 80 = 2520.
+        double[] plateau = { 10, 20, 30, 35, 35, 35, 35, 35, 35, 35 };
+        int call = 0;
+        bool flipped = false;
+        step.ReadWasAngle = () =>
+        {
+            // First pass: ramp up to +35. Switch to negative after.
+            double v = plateau[System.Math.Min(call, plateau.Length - 1)];
+            call++;
+            if (call == plateau.Length && !flipped)
+            {
+                flipped = true;
+                call = 0;
+            }
+            return flipped ? -v : v;
+        };
+
+        // Enter the step BEFORE running the measurement so OnEntering's
+        // state reset doesn't trample the captured values; then run the
+        // measurement; then leave so OnLeaving persists.
+        var prop = typeof(AgValoniaGPS.ViewModels.Wizards.WizardStepViewModel)
+            .GetProperty(nameof(AgValoniaGPS.ViewModels.Wizards.WizardStepViewModel.IsActive));
+        prop!.SetValue(step, true);
+        await step.RunMaxAngleMeasurementAsync();
+        prop!.SetValue(step, false);
+
+        // chosenDeg = min(35, 35) * 0.9 = 31.5 -> Math.Round -> 32 -> ×80 = 2560.
+        Assert.That(_store.AutoSteer.MaxSteerRawCounts, Is.EqualTo(2520).Within(50),
+            "Persisted raw counts must equal chosenDeg × currentCPD at capture time");
+        Assert.That(step.CalibrationCompleted, Is.True);
+    }
+
+    // =====================================================================
+    // Issue N — Motor cal seeds MaxPwm = min(2 × MinPwm, 255) at capture.
+    // =====================================================================
+
+    [Test]
+    public async Task MotorCal_AfterCapture_SetsMaxPwmToDoubleMinPwm()
+    {
+        // Captured MinPwm = 35 from PGN 253 byte 7 at first motion.
+        // Wizard must also write MaxPwm = 70 (2 × 35, well under 255).
+        _store.AutoSteer.ProportionalGain = 10;
+        var step = new AutoMotorCalibrationStepViewModel(_configService, _autoSteer);
+        step.DelayFunc = (_, _) => Task.CompletedTask;
+        step.ReadModuleData = () =>
+        {
+            int kp = _store.AutoSteer.ProportionalGain;
+            // Below Kp=40, no motion. At Kp >= 40, the wheel has moved 2°
+            // and the firmware reports PWM=35 — the threshold duty cycle.
+            return kp < 40
+                ? ModuleAt(0.0, (byte)System.Math.Min(kp, 30))
+                : ModuleAt(2.0, 35);
+        };
+
+        await step.RunKpRampAsync();
+
+        Assert.That(step.DetectedMinPwm, Is.EqualTo(35),
+            "DetectedMinPwm must mirror PGN 253 PwmDisplay at the moment of motion");
+        Assert.That(_store.AutoSteer.MinPwm, Is.EqualTo(35),
+            "ConfigStore MinPwm is the captured firmware duty cycle");
+        Assert.That(_store.AutoSteer.MaxPwm, Is.EqualTo(70),
+            "MaxPwm seeded to 2 × MinPwm right after capture");
+        Assert.That(step.CalibrationCompleted, Is.True);
+    }
+
+    [Test]
+    public async Task MotorCal_AfterCapture_CapsMaxPwmAt255()
+    {
+        // Edge case: a high-friction setup pushes MinPwm into the
+        // 130+ range where 2 × MinPwm would exceed 255. The default
+        // must clamp at the byte ceiling.
+        _store.AutoSteer.ProportionalGain = 10;
+        var step = new AutoMotorCalibrationStepViewModel(_configService, _autoSteer);
+        step.DelayFunc = (_, _) => Task.CompletedTask;
+        step.ReadModuleData = () =>
+        {
+            int kp = _store.AutoSteer.ProportionalGain;
+            return kp < 80
+                ? ModuleAt(0.0, 0)
+                : ModuleAt(2.0, 200);
+        };
+
+        await step.RunKpRampAsync();
+
+        Assert.That(step.DetectedMinPwm, Is.EqualTo(200));
+        Assert.That(_store.AutoSteer.MaxPwm, Is.EqualTo(255),
+            "MaxPwm must clamp at 255 when 2 × MinPwm would overflow the byte");
+    }
+}


### PR DESCRIPTION
Two related calibration refinements from bench-test of the wizard.

## Issue M — MaxSteer stored as raw counts, degrees computed from current CPD (\`ca6fea45\`)
The wizard's Max Steering Angle step read \`ActualSteerAngle\` (post-CPD-conversion degrees) and saved it as \`MaxSteerAngle\` (also degrees). If CPD circle test ran *after* max-steer (or didn't run at all), the stored max-angle was wrong by the ratio \`actualCPD / defaultCPD\` — operator's wizard order shouldn't matter that way.

- \`AutoSteerConfig.MaxSteerRawCounts\` is the new storage primitive (int counts).
- \`AutoSteerConfig.MaxSteerAngle\` becomes a computed view: \`MaxSteerRawCounts / CountsPerDegree\` on get; back-converts on set. CPD's PropertyChanged raises \`MaxSteerAngle\` PropertyChanged so config dialog bindings refresh when the operator finishes the CPD circle test.
- \`MaxSteeringAngleStepViewModel\` captures plateau, computes \`chosenDeg = min(left, right) × 0.9\`, multiplies by current CPD → raw counts. Persists only the raw count.

Net: operator can run CPD circle BEFORE or AFTER max-steer — final \`MaxSteerAngle\` is correct either way, because the raw-counts capture is CPD-invariant.

## Issue N — MaxPwm default = 2 × MinPwm after motor cal (\`0404bacc\`)
After the Kp-ramp captures MinPwm, also write \`MaxPwm = Math.Min(2 × MinPwm, 255)\`. Sensible default; operator can tune in the AutoSteer config dialog if needed.

While in that area, found and fixed two real bugs:
- \`RunKpRampAsync\` never set \`CalibrationCompleted=true\` on success. Result: \`OnLeaving\`'s save block (gated on the flag) silently dropped operator's MinPwm/InvertMotor. Now sets the flag inline at the success branch.
- Vestigial \`autoSteer.MaxSteerAngle = MaxSteerAngle\` write in \`OnLeaving\` referenced a dead \`_maxSteerAngle\` field (default 0). Any future success would clobber the real max-steer calibration with 0. Removed — max-steer persistence lives entirely in the new step now.

The result panel now correctly shows both MinPwm and the seeded MaxPwm.

## Tests
5 new in \`MaxSteerRawCountsAndMaxPwmTests\`:
- \`MaxSteer_RawCountsInvariantUnderCpdChange\`
- \`MaxSteer_SetByDegrees_BackConvertsToRawCounts\`
- \`MaxSteer_CapturesPlateauAsRawCounts\`
- \`MotorCal_AfterCapture_SetsMaxPwmToDoubleMinPwm\`
- \`MotorCal_AfterCapture_CapsMaxPwmAt255\`

Full Services suite: 903 pass, 1 fail (pre-existing Windows file-lock flake, unrelated), 2 skip.

## Non-spec note
The develop motor-cal VM still carries dead Phase B fields (\`MaxSteerAngle\` property, \`MeasuringMaxAngle\`/\`Complete\` enum values, \`IsPhaseB0/B1\`, \`IsComplete\`) that aren't wired to AXAML anymore. Harmless but visible. Worth a small follow-up to delete the carcass; left alone here to keep the diff focused on M+N.

## Test plan
- [x] All 5 new tests + existing wizard suite green.
- [x] Build clean.
- [ ] Bench: run wizard motor cal first (captures MinPwm, seeds MaxPwm). Then CPD circle test → CPD updates. Then max-steer → captures raw counts. Verify the persisted MaxSteerAngle in the config dialog reflects \`rawCounts / cpd\` correctly.
- [ ] Bench: reverse the order — max-steer before CPD circle. Final degree value should still be correct after CPD calibration.