### PR TITLE
PERF-05: Phase 1 subsystem instrumentation + Phase 2c display-tick fix (iPad +21 fps in S5)

### DIFF
--- a/Plans/perf_data/.gitignore
+++ b/Plans/perf_data/.gitignore
@@ -1,0 +1,2 @@
+# Raw capture logs are large and per-run; summarize findings in #403 instead.
+*.log

--- a/Plans/perf_data/.gitignore
+++ b/Plans/perf_data/.gitignore
@@ -1,2 +1,5 @@
 # Raw capture logs are large and per-run; summarize findings in #403 instead.
 *.log
+# Xcode Instruments trace bundles can be 100s of MB; analyze locally, summarize.
+*.trace
+instruments/

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -416,7 +416,91 @@ per-property cascade — 3× reduction on iPad sim, 0 cost on real
 - Tool/hitch position setters drive the map render path, not text;
   leave alone.
 
-## 10. Bugs filed during this audit
+## 10. Phase 2c results — unified 5 Hz status-display tick
+
+Two PRs landed:
+- **Phase 2c #1** (`91b6919`): decouple GPS-sourced display properties
+  from `ApplyGpsCycleResult`; sample from `State.Vehicle` at a 10 Hz
+  display tick.
+- **Phase 2c #2** (`d38eb00`): generalize to a single 5 Hz status tick
+  covering *every* MainViewModel property bound to the top status bar,
+  regardless of upstream source rate. Folded in `GpsToPgnLatencyMs`
+  (was written at 100 Hz from `OnAutoSteerStateUpdated`). Architectural
+  rule established: new status diagnostics use the cache → tick
+  pattern, no direct PropertyChanged firings at source rate.
+
+### Instruments confirmation (3 Time Profiler traces compared)
+
+Captured on iPad Pro 12.9" 2nd gen in S5 state (sim driving, sections
+off, panel closed), 30-second window each. Numbers below are %
+of main-thread samples.
+
+| Function | Phase 2b | Phase 2c#1 | Phase 2c#2 | Total Δ |
+|---|---|---|---|---|
+| **TextLayout.CreateTextLines** | 23% | 18.6% | **7.2%** | **−69%** |
+| TextLayout ctor | 23% | 18.6% | 7.2% | −69% |
+| BidiAlgorithm.Process | ~3% | 1.9% | 0.7% | −77% |
+| **set_GpsToPgnLatencyMs** | 5.6% | 5.9% | **0.5%** | **−91%** |
+| set_Latitude | 4.2% | 3.3% | 2.2% | −48% |
+| InpcPropertyAccessor.OnEvent | 8% | 7.7% | **3.9%** | −51% |
+| OnPropertyChanged | 16% | 15.1% | 12.9% | −19% |
+| WeakEvents dispatch | 15% | 15.1% | 12.0% | −20% |
+
+**Main-thread CPU**: 23.4% → 19% → **13%** (total: −44%).
+**Render-thread CPU**: ~93% → ~89% → **~82%** (total: −12%).
+
+The render thread benefits structurally: less binding work means less
+invalidation means fewer per-frame visual tree walks. Absolute Skia
+draw call counts:
+
+| Render-thread draw call | Phase 2b | Phase 2c#2 | Δ samples |
+|---|---|---|---|
+| `DrawRectangle` (panel/HUD bg) | 2,643 | 1,810 | −833 (~−31%) |
+| `DrawRoundRect` (panel borders) | 1,614 | 814 | −800 (~−50%) |
+
+The 3.2× reduction in TextLayout cost (23% → 7.2%) closely matches the
+trigger-rate ratio: GPS-sourced setters 30 Hz → 5 Hz (6×) and
+AutoSteer-sourced 100 Hz → 5 Hz (20×), weighted by their original
+contributions. The model predicted, the data confirmed.
+
+### S5 frame budget result (iPad)
+
+| Metric | Phase 2a baseline | **Phase 2c#2** | Δ |
+|---|---|---|---|
+| fps | 43 | **64** | +21 (+49%) |
+| frame time | 23.3 ms | 15.6 ms | −7.7 ms |
+| inside OnRender | 6.3 ms | 5.5 ms | −0.8 ms |
+| **outside OnRender** | **17.0 ms** | **10.1 ms** | **−6.9 ms** |
+| ApplyGpsCycle µs/cycle | 1,299 | 781 | −40% |
+| StateMirror µs/cycle | 185 | 135 | −27% |
+| Allocator throughput (UI thread) | ~770 KB/s | ~520 KB/s | ~−32% |
+
+Phase 1's *"+13 ms iPad outside cost when simulator runs"* mystery is
+now ~50% recovered (17 → 10 ms outside). The remaining ~3 ms is the
+unavoidable composition/Skia/Metal cost for the visual tree the
+compositor must still walk every frame — that's Phase 2c #6 territory
+(render-thread audit).
+
+### Android S5 (vsync-bound)
+
+Vsync ceiling at 61 fps hides the visible win, but `ApplyGpsCycle` CPU
+dropped 63% (1,517 → 557 µs/cycle). Battery / thermal benefit,
+indirect responsiveness gain (more slack for other UI work).
+
+### What Phase 2c #1+#2 actually shipped
+
+1. **A single architectural rule**: every status-bar-bound MainViewModel
+   property follows the cache → tick pattern. No future diagnostic
+   can re-introduce a 100-Hz PropertyChanged storm by accident.
+2. **`MainViewModel.cs` / `MainViewModel.GpsHandling.cs` /
+   `MainViewModel.Guidance.cs` / `MainViewModel.ApplyResults.cs`**:
+   `_statusTickTimer` (5 Hz), `OnStatusTick`, `_latestRollDegrees`,
+   `_latestGpsToPgnLatencyMs`. Setter calls removed from sources.
+3. **iPad recovers +21 fps in S5**, well above the 24 fps product floor.
+4. **Cross-platform**: Android benefits proportionally; ApplyGpsCycle
+   CPU dropped 63% there too.
+
+## 11. Bugs filed during this audit
 
 - **#404** — Android `AutoSteerService` not running (no PGN TX, breaks
   manual section painting)

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -142,10 +142,13 @@ In rough priority order (biggest iPad relief, smallest blast radius):
    not a fix, but the Phase-2 measurement that unblocks #C above. iPad
    +13 ms/frame outside is the biggest single recoverable cost in the
    whole audit.
-4. **Decouple `Coverage.AddCoveragePoint` cadence from
-   `AutoSteerTx`** — 1,616 paints/s is ~3× more than GPS-fix rate
-   requires. Painting at GPS rate (~30 Hz × 16 sections = 480/s) would
-   cut coverage CPU + churn ~3×.
+4. **Cut per-cycle allocation in `Coverage.AddCoveragePoint`** — at
+   1,616 cycles/s with 1.06 KB/cycle that's 1.7 MB/s of pure
+   allocator pressure. The cadence itself is intentional (AutoSteer
+   100 Hz tick is decoupled from GPS for accurate section control —
+   do not propose throttling it). Fix the *per-call* cost: pool the
+   intermediate quad/cell tuples, reuse rasterization buffers,
+   avoid `Dictionary` lookups that allocate boxed keys.
 5. **Cache `Track` instance upstream of `GpsCycleResult`** — the
    original #403 finding. Confirmed still present: 3.39 KB/cycle ×
    30 Hz = 102 KB/s of pure churn.

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -144,10 +144,14 @@ In rough priority order (biggest iPad relief, smallest blast radius):
    whole audit.
 4. **Cut per-cycle allocation in `Coverage.AddCoveragePoint`** — at
    1,616 cycles/s with 1.06 KB/cycle that's 1.7 MB/s of pure
-   allocator pressure. The cadence itself is intentional (AutoSteer
-   100 Hz tick is decoupled from GPS for accurate section control —
-   do not propose throttling it). Fix the *per-call* cost: pool the
-   intermediate quad/cell tuples, reuse rasterization buffers,
+   allocator pressure. The cadence itself is intentional: control
+   loop runs at 100 Hz (matches firmware `taskAutosteer`), steer
+   packet exchange at 50 Hz, GPS at 10 Hz, on-screen tractor position
+   dead-reckoned between fixes. See
+   `Plans/Completed/UNIFIED_CONTROL_LOOP_PLAN.md` and
+   `Plans/Completed/UNIFIED_PACKET_PROTOCOL.md` — do NOT propose
+   collapsing back to GPS rate. Fix the *per-call* cost instead: pool
+   the intermediate quad/cell tuples, reuse rasterization buffers,
    avoid `Dictionary` lookups that allocate boxed keys.
 5. **Cache `Track` instance upstream of `GpsCycleResult`** — the
    original #403 finding. Confirmed still present: 3.39 KB/cycle ×

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -234,7 +234,87 @@ Phase 2b — Xcode Instruments Time Profiler on iPad during S5 — should
 isolate this. Setup script:
 [`instruments-trace-ipad.sh`](instruments-trace-ipad.sh).
 
-## 8. Bugs filed during this audit
+## 8. Phase 2b — Xcode Instruments Time Profiler on iPad during S5
+
+Captured 2026-05-20 12:04 via [`instruments-trace-ipad.sh`](instruments-trace-ipad.sh).
+Trace bundle at `instruments/2026-05-20_120411_time_profiler_s5.trace`
+(gitignored, 20 MB). 30-second window with S5 state held on iPad.
+
+### Where the main thread spends its time
+
+Main thread received **7,037 CPU samples** over 30 s = ~7.0 s of main-thread
+CPU = **~23% of one core constantly busy**. Top inclusive-time call sites
+(% of all main-thread samples; any frame in stack counts):
+
+| % main | Where | What |
+|---|---|---|
+| **22-23%** | `Avalonia.Media.TextFormatting.TextLayout` ctor / `CreateTextLines` / `FormatLine` / `ShapeTextRuns` / `FetchTextRuns` / `BidiAlgorithm` / `LineBreakEnumerator` | **Text layouts being re-created every GPS cycle** for TextBlock-bound properties |
+| 16% | `CommunityToolkit.Mvvm.ObservableObject.OnPropertyChanged` (×2) | `PropertyChanged` event firing |
+| 15% | `Avalonia.Utilities.WeakEvents...OnEvent` + `WeakEvent.Subscription.OnEvent` | Weak-event dispatch to binding subscribers |
+| 14.9% | `MainViewModel.ApplyGpsCycleResult` | Phase-2a-instrumented bracket (matches the 39 ms/s measured at 30 Hz) |
+| 8% | `Avalonia.Markup.Xaml.MarkupExtensions.CompiledBindings.InpcPropertyAccessor.OnEvent` / `SendCurrentValue` | INPC binding accessor |
+| 6.5% | `Avalonia.Data.Core.BindingExpression.OnNodeValueChanged` / `ConvertAndPublishValue` | Avalonia binding pipeline |
+| 6% | `Avalonia.Utilities.WeakHashList.GetAlive` | Binding subscriber list enumeration |
+| 5.6% | `MainViewModel.set_GpsToPgnLatencyMs(double)` | One specific text-bound property setter |
+| 4.2% | `MainViewModel.set_Latitude(double)` | Another text-bound property setter |
+
+### The actual call chain on iPad main thread
+
+```
+ApplyGpsCycleResult (15%)
+  → set_Latitude / set_Heading / set_GpsToPgnLatencyMs / … (each ~3-5%)
+    → ObservableObject.OnPropertyChanged (16% total)
+      → WeakEvent dispatch (15%)
+        → CompiledBindings.InpcPropertyAccessor.OnEvent (8%)
+          → BindingExpression.ConvertAndPublishValue (6.5%)
+            → TextBlock re-render
+              → TextLayout.CreateTextLines (23%)
+                → BidiAlgorithm, LineBreakEnumerator, ShapeTextRuns
+```
+
+### What this confirms / resolves
+
+The Phase 1 finding "iPad +13 ms/frame outside OnRender when simulator
+runs" is **TextLayout cost driven by TextBlocks bound to high-frequency
+properties**. At 43 fps the 23% text layout cost translates to
+**~5 ms/frame** — about a third of the +14 ms iPad-outside gap, just
+from text re-shaping. The remaining ~9 ms/frame is the rest of the
+binding cascade (WeakEvent dispatch, BindingExpression, INPC accessor
+chain), all of which scale with the trigger rate.
+
+This is "death by a thousand cuts" — no single function is more than
+~23% of main thread, but the cascade adds up to dominate. The fix lever
+is **reducing the trigger rate**, not chasing Avalonia internals.
+
+### Phase 2c fix candidates from this trace
+
+In priority order:
+
+1. **Throttle GPS-display text-bound properties to ~5 Hz.** Speed,
+   lat/lon, heading, latency — none of these need to update visually
+   at 30 Hz. A 200 ms throttle is invisible to the eye and would cut
+   text layout cost ~6×. Quick fix: add a small DispatcherTimer-driven
+   mirror that updates the display-bound copies of these properties.
+2. **Compare-and-skip identical values in `ApplyGpsCycleResult`
+   setters.** Several setters call `CommunityToolkit.Mvvm.SetProperty`
+   which short-circuits on reference-equal — but on `double` setters
+   this never short-circuits because every double bit-pattern differs
+   from the last. Add `Math.Abs(new - old) < epsilon` checks for
+   display-only properties.
+3. **Audit which TextBlocks bind to high-frequency properties** and
+   replace direct bindings with `Formatted` properties that update from
+   the throttled tick instead of the raw GPS tick. Pairs well with #1.
+4. **Pool snapshot DTOs in `ApplyGpsCycleResult`** — 9.4 KB/cycle is
+   real GC pressure (281 KB/s on iPad). Even if the cascade is cheaper
+   after #1, less garbage = fewer GC pauses contributing to "outside"
+   time.
+5. **The earlier-priority items still hold**: `DrawTrackSk` paint
+   caching (lift from spike branch), `DrawVehicleSk` paint caching,
+   cache `Track` instance upstream (#403 original finding). These are
+   per-frame allocation churn fixes, independent of the binding
+   cascade.
+
+## 9. Bugs filed during this audit
 
 - **#404** — Android `AutoSteerService` not running (no PGN TX, breaks
   manual section painting)

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -1,4 +1,13 @@
-# PERF-05 Phase 1 — Analysis (2026-05-20)
+# PERF-05 — Analysis (2026-05-20)
+
+> **Status: audit complete.** All three phases (1 instrumentation,
+> 2a-b investigation, 2c #1+#2 fix) closed. Headline result: **iPad
+> S5 43 → 64 fps (+49%)**, main-thread CPU −44%, render-thread CPU
+> −12%. Remaining `#403` candidates (`DrawTrackSk` paint caching,
+> `DrawVehicleSk` paint caching, `Track` instance pooling,
+> render-thread audit) are tracked there for future iteration.
+
+## Phase 1 — Instrumentation pass
 
 Captured: iPad Pro 12.9" 2nd gen + Samsung Android tablet R52TB090VAK.
 Branch: `perf-05/instrumentation`.

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -286,6 +286,44 @@ This is "death by a thousand cuts" — no single function is more than
 ~23% of main thread, but the cascade adds up to dominate. The fix lever
 is **reducing the trigger rate**, not chasing Avalonia internals.
 
+### Render-thread (tid_7803) is the real bottleneck — pegged at ~93% CPU
+
+The main thread analysis above shows ~23% CPU. But the **render thread**
+captured **27,822 samples = ~27.8 s of CPU in a 30-second window =
+~93% of one core constantly busy**. That's the actual ceiling we're
+hitting, not the main thread.
+
+Top inclusive time on tid_7803 (Avalonia compositor / Skia / Metal):
+
+| % render | Where | What |
+|---|---|---|
+| 40% | `NSRunLoop` / `CADisplayLink` + `ServerCompositor.RenderCore` overhead | Compositor framework — drives the render loop |
+| 27% | `ServerCompositionTarget.RenderRootToContextWithClip` | Walk the visual tree, render the root |
+| 26.5% | `ServerCompositionVisual.Render` (each visual) | Per-visual render; **scales with visual tree size** |
+| 12.9% | `ServerCompositionDrawListVisual.RenderCore` | Drawing the draw lists per visual |
+| **9.5%** | **`Avalonia.Skia.DrawingContextImpl.DrawRectangle`** | Rectangle draw — panel/HUD backgrounds |
+| 7.7% | `ServerCompositionCustomVisual.RenderCore` | Custom-visual host (our `DrawingContextMapControl`) |
+| **7.6%** | **`MapCompositionHandler.OnRender`** | Our map render (matches PERF logging) |
+| 7.2% | `SkiaMetalRenderSession.Dispose` | Skia render-session teardown |
+| **5.8%** | **`SKCanvas.DrawRoundRect`** | Rounded rectangles — panel borders, buttons |
+| 5.7% | `SKCanvas.Flush` / `GRContext.Flush` | Skia → Metal command submission |
+
+### What this reframes
+
+- **Our map render is only 7.6% of render-thread CPU.** Even if every
+  `DrawTrackSk` / `DrawVehicleSk` allocation churn fix landed at 100%
+  effectiveness, render thread would still be ~85% pegged.
+- **Panels / HUD render together are ~15% of render-thread CPU**
+  (rectangle 9.5% + rounded rectangle 5.8%). Dovetails with the
+  empirical "simulator panel open costs ~8 fps" finding — open panels
+  add visuals the compositor must walk every frame.
+- **`SkiaMetalRenderSession.Dispose` is 7.2%** — a per-frame Skia
+  resource session is being torn down. May be amortizable.
+- **The +14 ms iPad-outside gap has two layers**: ~5 ms from
+  main-thread TextLayout (PropertyChanged cascade → text reshape), and
+  the rest from render-thread work the main thread is implicitly
+  blocked on or that drives the next frame's wait.
+
 ### Phase 2c fix candidates from this trace
 
 In priority order:
@@ -313,6 +351,19 @@ In priority order:
    cache `Track` instance upstream (#403 original finding). These are
    per-frame allocation churn fixes, independent of the binding
    cascade.
+6. **Render-thread audit — biggest long-term lever.** With render
+   thread pegged at ~93% CPU and the map only 7.6% of that, the win
+   isn't in the map render code — it's in reducing what the
+   compositor has to walk every frame:
+   - Audit which panels are *always rendered* even when not visually
+     active (the +8 fps "simulator panel open" finding suggests open
+     panels carry real per-frame cost).
+   - Look at the rectangle / rounded-rectangle hot draws (15% combined
+     of render thread). Could nested `Border` + `Rectangle` panel
+     decorations be replaced with fewer composited visuals?
+   - Investigate the 7.2% `SkiaMetalRenderSession.Dispose` — should
+     the render session be amortized across frames instead of torn
+     down each one?
 
 ## 9. Bugs filed during this audit
 

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -365,7 +365,58 @@ In priority order:
      the render session be amortized across frames instead of torn
      down each one?
 
-## 9. Bugs filed during this audit
+## 9. Phase 2c #1 implementation plan — decouple display from GPS arrival
+
+The earlier framing of "throttle GPS-display setters to 10 Hz" was the
+wrong shape. **GPS is just another sensor feeding the position
+estimator at its own 10 Hz arrival rate** — see the cadence design in
+[`UNIFIED_CONTROL_LOOP_PLAN`](../../Completed/UNIFIED_CONTROL_LOOP_PLAN.md)
+and [`UNIFIED_PACKET_PROTOCOL`](../../Completed/UNIFIED_PACKET_PROTOCOL.md).
+Control runs at 100 Hz consuming dead-reckoned pose; nothing should be
+*gated on GPS sensor arrival*.
+
+The mistake we're correcting: `ApplyGpsCycleResult` directly sets
+`MainViewModel.Latitude / Longitude / Easting / Northing / Heading /
+_speed / RollDegrees / FixQuality` from each GPS cycle's `result`.
+Each setter fires `PropertyChanged` → Avalonia binding cascade →
+TextBlock re-render → TextLayout recompute (Phase 2b finding). At sim
+30 Hz iPad rate that's 30 cascades/s; at real 10 Hz it's 10/s. Either
+way the architecture couples display refresh rate to sensor arrival —
+the same coupling we removed for control logic.
+
+### Fix shape
+
+- **`State.Vehicle` is already the system of record** — it has
+  `Latitude`, `Longitude`, `Easting`, `Northing`, `Heading`, `Speed`,
+  `FixQuality`, `SatelliteCount` as `ObservableObject` properties,
+  written by `ApplyGpsCycleResult` via `State.Vehicle.UpdateFromGps`.
+- **Add a 10 Hz display tick** (separate `DispatcherTimer` independent
+  of any sensor or control-loop tick) that reads from `State.Vehicle`
+  (plus a small cache for fields not yet on `State.Vehicle`, e.g.
+  `RollDegrees`) and sets the MainViewModel display properties.
+- **Remove the direct display-property setters from
+  `ApplyGpsCycleResult`** — keep `State.Vehicle.UpdateFromGps(...)`
+  (that's the canonical state update; control loop and renderer need
+  it at sensor rate). Drop the redundant `MainViewModel.Latitude = …`
+  / `MainViewModel.Heading = …` etc. block.
+
+Net effect: MainViewModel display PropertyChanged fires at exactly
+10 Hz regardless of sensor or sim rate. Bindings unchanged.
+TextLayout cost drops from ~30 Hz × per-property cascade to 10 Hz ×
+per-property cascade — 3× reduction on iPad sim, 0 cost on real
+10 Hz GPS (matched rate).
+
+### Out of scope for this PR
+
+- `GpsToPgnLatencyMs` setter (5.6% main-thread CPU in Phase 2b trace)
+  is written from AutoSteer 100 Hz tick, not from GPS cycle. Same
+  disease, separate fix — follow-up.
+- `StatusMessage` updates from `ApplyGpsCycleResult` are
+  event-driven (not every cycle) and don't need throttling.
+- Tool/hitch position setters drive the map render path, not text;
+  leave alone.
+
+## 10. Bugs filed during this audit
 
 - **#404** — Android `AutoSteerService` not running (no PGN TX, breaks
   manual section painting)

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -170,7 +170,71 @@ In rough priority order (biggest iPad relief, smallest blast radius):
 - Avalonia composition / Skia → Metal handoff cost (Xcode Instruments
   territory, not pure logging)
 
-## 7. Bugs filed during this audit
+## 7. Phase 2a — `ApplyGpsCycleResult` instrumentation result
+
+Hypothesis going in: the iPad "+13 ms outside OnRender" at S5 from
+Phase 1 lives inside `ApplyGpsCycleResult` (UI-thread bridge from the
+background GPS cycle to State updates).
+
+Result: **partial confirmation.** `ApplyGpsCycle` is a real allocator
+contributor and the largest single UI-thread allocator subsystem, but
+its **direct** CPU cost only explains ~1 ms/frame of the iPad outside
+gap — not the full ~14 ms.
+
+### Clean S5 (panel closed, sim driving, sections off) on Phase 2a build
+
+| Bucket | µs/cycle | KB/cycle | Rate | CPU ms/s | KB/s | ms/frame |
+|---|---|---|---|---|---|---|
+| iPad RenderBudget inside | — | 5.4 | 43 fps | 270 | 232 | 6.3 |
+| **iPad `ApplyGpsCycle-PERF`** | **1,299** | **9.37** | **30** | **39** | **281** | **0.9** |
+| iPad StateMirror | 179 | 1.78 | 20 | 4 | 36 | 0.08 |
+| iPad GpsPipeline (bg) | 696 | 3.38 | 30 | 21 | 101 | — |
+| iPad AutoSteerTx | 393 | 1.02 | 100 | 39 | 102 | 0.9 |
+| iPad UdpTx | 178 | 0.50 | 210 | 37 | 105 | 0.9 |
+| **Android `ApplyGpsCycle-PERF`** | **1,517** | **8.87** | **19** | **30** | **177** | **0.5** |
+
+Frame-time accounting on iPad at S5 (Phase 2a):
+- frame budget: 1000/43 = **23.3 ms/frame**
+- inside `OnRender`: **6.3 ms**
+- `ApplyGpsCycle` (UI thread): **0.9 ms**
+- `StateMirror` + `UdpTx` + `AutoSteerTx` on UI thread: **~1.9 ms**
+- **unaccounted "outside": ~14 ms/frame** ← still missing
+
+### What we learned that IS actionable
+
+1. **`ApplyGpsCycleResult` allocates 9.37 KB/cycle × 30 Hz = 281 KB/s.**
+   Biggest single UI-thread allocator subsystem. Worth pooling the
+   snapshot/DTO objects it produces even though it's not the +13 ms
+   answer.
+2. **Android `ApplyGpsCycle` is *slower per cycle* than iPad**
+   (1,517 µs vs 1,299 µs) but lower CPU/s because Android runs at
+   19 Hz vs iPad 30 Hz. This **confirms the GpsPipeline rate
+   asymmetry from Phase 1 is real and propagates downstream** — same
+   asymmetry in `ApplyGpsCycle` cycle rate.
+3. **Per-cycle allocation is the same shape on both platforms**
+   (9.37 KB vs 8.87 KB). The churn is in the code, not the platform.
+
+### What's still missing (Phase 2b → Instruments)
+
+The remaining ~14 ms/frame iPad outside cost can't be attributed to
+any of the now-9 instrumented subsystems. Suspect bucket:
+
+- **Avalonia binding / composition response** to the `PropertyChanged`
+  cascade fired *inside* `ApplyGpsCycle`'s bracket — the property
+  setter call is synchronous (inside our timing), but the
+  binding's effect on layout/composition is scheduled and runs on
+  the next compositor frame (outside our timing).
+- **GC pauses** from accumulated allocator pressure on the UI thread:
+  ApplyGps 281 + AutoSteerTx 102 + UdpTx 105 + StateMirror 36 + render
+  frame allocs 232 = **~756 KB/s flowing through the UI thread alone.**
+- **Skia → Metal handoff** per present, which pure C# logging can't
+  see.
+
+Phase 2b — Xcode Instruments Time Profiler on iPad during S5 — should
+isolate this. Setup script:
+[`instruments-trace-ipad.sh`](instruments-trace-ipad.sh).
+
+## 8. Bugs filed during this audit
 
 - **#404** — Android `AutoSteerService` not running (no PGN TX, breaks
   manual section painting)

--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -1,0 +1,173 @@
+# PERF-05 Phase 1 — Analysis (2026-05-20)
+
+Captured: iPad Pro 12.9" 2nd gen + Samsung Android tablet R52TB090VAK.
+Branch: `perf-05/instrumentation`.
+Scenarios: S1 (app open, no field) · S2 (field loaded) · S3 (+AB line) ·
+S5 (simulator driving, sections off) · S6 (sim driving, sections on).
+S4, S7, S8 skipped this pass.
+
+## 1. Frame-budget summary (medians per scenario)
+
+| Scenario | iPad fps | iPad inside | iPad outside | Android fps | Android inside | Android outside |
+|---|---|---|---|---|---|---|
+| S1 app open | 117 | ~1.7 ms | **~6.8 ms** | 61 | ~1.5 ms | ~14.9 ms |
+| S2 field loaded | 101 | ~1.4 ms | **~8.5 ms** (+1.7 vs S1) | 61 | ~1.8 ms | ~14.6 ms (flat) |
+| S3 + AB line | 70 | 5.5 ms | ~8.8 ms | 61 | 4.9 ms | ~11.5 ms |
+| S5 sim driving | 36 | 5.7 ms | **~22.1 ms** (+13.3 vs S3) | 54 | 5.5 ms | ~13 ms (flat) |
+| S6 sim + sections on | 47 | 2.5 ms\* | ~18.7 ms | 59 | 2.3 ms\* | ~14.6 ms |
+
+\* S6 zoom dropped to 0.21 (camera-follow zoomed out during sim driving),
+which reduces visible geometry — trk drops from 4.2 ms to 0.4 ms. Not a
+real "track cost fix," just less geometry on screen.
+
+## 2. Three systematic asymmetries
+
+### A. Presentation model — iPad renders unbounded; Android locks to vsync
+
+- iPad at idle (S1) hits **117 fps**; Android caps at **61 fps**.
+- Android is vsync-locked at the display refresh; when inside+outside
+  fits inside 16.7 ms, the render thread sleeps the slack.
+- iPad presents as fast as the Avalonia + Metal pipeline allows. **Every
+  millisecond of cost shows up as fewer frames** rather than slack
+  absorbed into vsync wait.
+
+Implication: comparing platforms by raw FPS misleads. **iPad's FPS
+sensitivity to load is the consequence of unbounded presentation, not
+inherently slower rendering.** Adding 5 ms of work drops iPad 20+ fps;
+Android absorbs the same 5 ms into vsync slack until 16.7 ms is gone.
+
+This is the single biggest reason "Android beats iPad in FPS" looks
+worse than it is. iPad's absolute work-per-frame is competitive (often
+*better*) — it just doesn't get to coast.
+
+### B. AutoSteer pipeline is iPad-only — driving most of iPad's "extra" CPU and TX load
+
+Across **every** scenario:
+
+|  | iPad | Android |
+|---|---|---|
+| AutoSteerTx | 101 cycles/s × 487 µs × 1,017 B | **0 cycles/s** |
+| UdpTx | 212 sends/s × 226 µs × 500 B | 10 sends/s × 514 µs × 496 B |
+| AutoSteerRx | (not exercised — sim path) | 0 |
+| Coverage (S6) | 1,616 cycles/s × 34 µs × 1,058 B | **0** (section state never reached) |
+
+Filed as **#404** (Android AutoSteerService not running). The
+*correctness* downstream of this is that manual section painting is
+broken on Android. The *perf* downstream is that **iPad pays ~110 ms
+CPU/s + ~200 KB/s allocator churn for a pipeline Android isn't even
+running.** Until #404 lands the perf comparison is structurally
+asymmetric.
+
+### C. iPad "outside-OnRender" explodes when simulator runs — Android stays flat
+
+The interesting finding from this audit. Going from S3 (AB line idle)
+to S5 (simulator driving, sections off):
+
+|  | iPad | Android |
+|---|---|---|
+| Frame time | 14.3 → **27.8 ms** (+13.5) | 16.4 → 18.5 ms (+2.1) |
+| Inside OnRender | 5.5 → 5.7 ms (+0.2 — basically flat) | 4.9 → 5.5 ms (+0.6) |
+| **Outside OnRender** | 8.8 → **22.1 ms (+13.3)** | 11.5 → 13.0 ms (+1.5) |
+
+iPad pays **+13 ms/frame outside OnRender** the moment the simulator
+starts, while Android pays +1.5 ms. The new work the simulator
+introduces is:
+
+- `GpsPipeline.ProcessCycle` on a background thread — iPad **30 Hz** ×
+  566 µs = 17 ms/s CPU (off the UI thread)
+- A `Dispatcher.UIThread.Post(() => ApplyGpsCycleResult(result))` per
+  cycle — **NOT instrumented in Phase 1.**
+
+`ApplyGpsCycleResult` is the bridge between the background GPS cycle
+and the UI thread state mirror. It:
+- Mirrors `Track` references (#403's original finding)
+- Sets `State.Vehicle`, `State.Guidance`, `State.YouTurn`
+- Fires `PropertyChanged` cascade
+
+**Hypothesis**: PropertyChanged from `ApplyGpsCycleResult` triggers
+Avalonia binding evaluation that costs significantly more on iOS Metal
+than on Android. On iPad this drops 30 frames/s into composition wait;
+on Android it slides into vsync slack invisibly.
+
+This is the **#1 Phase 2 target** — instrument `ApplyGpsCycleResult` +
+Avalonia binding pipeline + Xcode Instruments Time Profiler during S5
+to see exactly where the +13 ms is going.
+
+## 3. GpsPipeline rate asymmetry — 30 Hz iPad vs 20 Hz Android
+
+Same simulator, same scenario, different cycle rate:
+
+|  | iPad | Android |
+|---|---|---|
+| GpsPipeline cycles/s (S5) | 30 | 20 |
+
+Worth investigating where the simulator's emission cadence diverges per
+platform. Could be a `DispatcherTimer` vs `Timer` choice, a different
+backing clock, or platform-specific throttling.
+
+Not a churn issue per se but explains why iPad takes a bigger hit from
+the simulator — it gets 50% more cycles to process.
+
+## 4. Churn candidates — ranked by iPad us/s × cycles/s (≈ CPU cost) + KB/s allocator
+
+Combined sources of CPU + allocator pressure under steady state (S6
+worst case, iPad). **Worst-offender first.**
+
+| Site | Rate | us/cycle | KB/cycle | CPU ms/s | KB/s | Notes |
+|---|---|---|---|---|---|---|
+| Vehicle marker render (all scenarios) | 47–117 fps | ~700 µs | 3.5 KB | 32–82 | 165–410 | Fires every frame regardless of state; biggest *quiet* churn |
+| `Coverage.AddCoveragePoint` (S6) | 1,616 | 34 µs | 1.06 KB | 55 | 1,709 | Rate driven by AutoSteer 100 Hz × 16 sections; not GPS rate |
+| `DrawTrackSk` SKPaint/PathEffect/Font churn (S3+) | 47–70 fps | 4.2 ms | 1.78 KB | 195–294 | 84–125 | Original iPad smoking gun |
+| `GpsPipeline.ProcessCycle` (sim on) | 30 | 566–890 µs | 3.39 KB | 17–27 | 102 | Track instance allocation churn (#403 original finding) |
+| `AutoSteerTx` (iPad only) | 101 | 487 µs | 1.02 KB | 49 | 103 | Platform-asymmetric (#404) |
+| `UdpTx` (iPad only at high rate) | 212 | 226 µs | 500 B | 48 | 106 | Driven by AutoSteer; collapses to 10 Hz on Android |
+| `StateMirror` (`OnRenderPullTick`) | 20 | 147–230 µs | ~2.0 KB | 3–5 | 38 | Throttled to 20 Hz both platforms |
+| Frame-level allocations (RenderBudget tot_alloc) | 47–117 fps | — | 3.7–5.7 KB | — | 175–660 | Includes vehicle + track + grid; subset of above |
+
+**iPad steady-state alloc churn at S6 ≈ ~2.3 MB/s.** That's enough to
+keep gen-0 GC running constantly; some of the "outside" cost on iPad
+is likely GC pause time.
+
+## 5. Concrete findings → fix candidates (for #403)
+
+In rough priority order (biggest iPad relief, smallest blast radius):
+
+1. **Cache `SKPaint`/`SKPathEffect`/`SKFont` in `DrawTrackSk`** — fixes
+   the iPad track regression confirmed in S3 (4.2 ms → expected ~1 ms).
+   Already drafted on the spike branch; can lift the diff over.
+2. **Cache `SKPaint` in `DrawVehicleSk`** — same anti-pattern, fires
+   every frame, costs ~3.5 KB/frame. ~165–410 KB/s avoided depending
+   on FPS.
+3. **Instrument `ApplyGpsCycleResult` + UI-thread binding cascade** —
+   not a fix, but the Phase-2 measurement that unblocks #C above. iPad
+   +13 ms/frame outside is the biggest single recoverable cost in the
+   whole audit.
+4. **Decouple `Coverage.AddCoveragePoint` cadence from
+   `AutoSteerTx`** — 1,616 paints/s is ~3× more than GPS-fix rate
+   requires. Painting at GPS rate (~30 Hz × 16 sections = 480/s) would
+   cut coverage CPU + churn ~3×.
+5. **Cache `Track` instance upstream of `GpsCycleResult`** — the
+   original #403 finding. Confirmed still present: 3.39 KB/cycle ×
+   30 Hz = 102 KB/s of pure churn.
+6. **Investigate `GpsPipeline` rate asymmetry** (iPad 30 vs Android
+   20). One platform is wrong relative to the other.
+
+## 6. What we did not measure but should (Phase 2 scope)
+
+- `ApplyGpsCycleResult` UI-thread work (the biggest gap)
+- S4 (curve track with ~500 points) — polyline cost scaling
+- S7 (headland turn) — YouTurnGuidance cost (didn't fire this run; need
+  a field with a headland)
+- S8 (real GPS) — `AutoSteerRx` zero-copy path; UDP RX at real-world
+  rate
+- Avalonia composition / Skia → Metal handoff cost (Xcode Instruments
+  territory, not pure logging)
+
+## 7. Bugs filed during this audit
+
+- **#404** — Android `AutoSteerService` not running (no PGN TX, breaks
+  manual section painting)
+- **#405** — `CoverageMapService.ClearAll()` wipes `_activeSections`,
+  requires section-toggle cycle to resume painting after Delete
+  Applied Area
+- **#403** — Umbrella churn issue (this analysis populates it)

--- a/Plans/perf_data/2026-05-20/NEXT_SESSION_PROMPT.md
+++ b/Plans/perf_data/2026-05-20/NEXT_SESSION_PROMPT.md
@@ -1,0 +1,89 @@
+# Next-session prompt — PERF-05 Phase 2c #6: render-thread audit
+
+Paste the section below into a new session.
+
+---
+
+## Goal
+
+Continue the PERF-05 perf audit on the AgValoniaGPS app. Phase 1 (instrumentation), Phase 2a-b (investigation), and Phase 2c #1+#2 (display-tick fix) shipped on branch `perf-05/instrumentation` and are awaiting review as PR #406. The **next item from the priority list on issue #403 is the render-thread audit** (Phase 2c #6) — measure where the render thread's remaining ~82% CPU goes, identify which fixes have meaningful impact, then implement them.
+
+## What we already know
+
+The Time Profiler trace from `Plans/perf_data/2026-05-20/instruments/2026-05-20_134912_time_profiler_s5.trace` (iPad S5, sim driving + sections off + field loaded + panel closed, post-fix Phase 2c #2 build) shows the render thread (`tid_7603`, the Avalonia compositor) at ~82% of one core. Top inclusive time on the render thread:
+
+| % render | Where |
+|---|---|
+| 30.2% | `ServerCompositionTarget.RenderRootToContextWithClip` |
+| 29.4% | `ServerCompositionVisual.Render` (per-visual; **scales with visual tree size**) |
+| 10.5% | `MapCompositionHandler.OnRender` (our map control) |
+| 10.4% | `ServerCompositionDrawListVisual.RenderCore` |
+| 8.5% | `Avalonia.Skia.Metal.SkiaMetalGpu.SkiaMetalRenderSession.Dispose` |
+| 7.3% | `Avalonia.Skia.DrawingContextImpl.DrawRectangle` (panel / HUD backgrounds) |
+| 3.3% | `SkiaSharp.SKCanvas.DrawRoundRect` (panel borders, buttons) |
+
+**Empirical signal** that supports the visual-tree-size hypothesis: in the Phase 1 capture run we accidentally left the simulator panel open during one S6 capture (`S6_panel_open.log`). That single panel cost ~8 FPS on iPad — confirming that open panels carry real per-frame render-thread cost from the compositor walking their visual subtree.
+
+## Suspect areas, in rough priority order
+
+1. **Panel decoration overhead** — `DrawRectangle` 7.3% + `DrawRoundRect` 3.3% = 10.6% of render thread for panel backgrounds/borders. The status bar alone has nested `Border` + `Rectangle` + `TextBlock` for each readout. Could nested decorations collapse into fewer composited visuals?
+2. **`SkiaMetalRenderSession.Dispose` at 8.5%** — looks like a per-frame Skia GPU resource session is being constructed and torn down each frame. May be amortizable.
+3. **Visual tree size** — `ServerCompositionVisual.Render` at 29.4% scales linearly with the number of visuals the compositor walks per frame. Likely small-element-heavy regions: status bar, button strip, simulator panel (when open), Section Control panel.
+4. **What our `MapCompositionHandler.OnRender` (10.5%) is doing** — `[RenderBudget]` shows track render `trk=` is the biggest item inside this when an AB line is active. The drafted `DrawTrackSk` paint-caching fix on the spike branch would help, but only by ~3-4% of render thread total. Lower priority than #1-#3.
+
+## How the audit pattern works (already in place)
+
+- **PERF-05 plan**: `Plans/PERF_05_SUBSYSTEM_CHURN_AUDIT.md`
+- **Layered tooling**: `Stopwatch` + `GC.GetAllocatedBytesForCurrentThread()` for cheap structural measurements (Phase 1 style); Xcode Instruments Time Profiler for focused attribution (Phase 2b style).
+- **DiagFlags markers**: file-presence flags in `Shared/AgValoniaGPS.Models/Diagnostics/DiagFlags.cs`. Each subsystem's instrumentation is off by default; turn on by pushing a marker file to the app's Documents folder.
+- **Marker push**: `Plans/perf_data/2026-05-20/push-markers.sh` (iPad via `xcrun devicectl device copy to --domain-type appDataContainer`; Android via `adb shell run-as <pkg> cp`).
+- **Instruments capture**: `Plans/perf_data/2026-05-20/instruments-trace-ipad.sh` — attaches Time Profiler by process name, 30 s window, saves to `instruments/<timestamp>_time_profiler_s5.trace`. Override template via `TEMPLATE='Allocations' bash …` or `TEMPLATE='Metal System Trace' bash …`.
+- **Scenario protocol**: `Plans/perf_data/2026-05-20/TESTING.md` — repeatable S1–S8 captures with marker windows.
+- **Analysis writeup**: `Plans/perf_data/2026-05-20/ANALYSIS.md` (the audit log so far — read §8 and §10 for the most recent state).
+
+## Suggested first moves for the render audit
+
+Per the user's anti-deferral pattern, don't assume — measure. In order:
+
+1. **Read the existing trace** before doing anything new. Pull the breakdown from `Plans/perf_data/2026-05-20/instruments/2026-05-20_134912_time_profiler_s5.trace` and look at the *callers* of `DrawRectangle` and `DrawRoundRect` on the render thread. Use the `python3` regex extraction pattern from the prior session (see ANALYSIS.md §10 — `inclusive` aggregation by frame-name prefix). Goal: find out *which* control/visual is invalidating + redrawing those rectangles every frame.
+2. **Then** decide whether the fix is (a) reducing visual count in a specific panel, (b) caching/amortizing `SkiaMetalRenderSession`, or (c) something else the trace points at. The user wants data-driven decisions — measure first.
+3. **For SkiaMetalRenderSession.Dispose** specifically — search the Avalonia source / `Avalonia.Skia.Metal` namespace for who owns and recycles the session. The 8.5% per-frame teardown is suspicious for a value that should be amortized.
+4. **Don't propose any "fast vs slow" framings** with a bypass option (memory `feedback_no_workaround_paths`). Don't propose throttling cadences (memory `project_autosteer_decoupled_from_gps` — control cadences are intentional). Don't propose "later" or "deferred" work (memory `feedback_no_later_deferred`).
+
+## Key constraints / memories to know
+
+- iOS testing is on a **physical iPad Pro 12.9" 2nd gen**, never the simulator. Build with `-r ios-arm64`. The user has corrected this repeatedly.
+- Control cadences (100 Hz machine, 50 Hz steer, 10 Hz GPS sensor, dead-reckoned display) are **architectural choices**, not perf bugs. Don't throttle them.
+- The user maintains the AiO firmware and is a senior systems thinker. Match the conversation level.
+- Multi-fix sessions go on a feature branch from the start (don't pollute develop).
+- Build to verify compile, wait for user to confirm fix works, then one commit + push (not per-iteration).
+- Honor user config without floors — built-in min/clamp values on user-visible settings are wrong.
+- When iterating on the iPad, the test scenario S5 = simulator driving + sections off + field loaded + simulator panel closed. The panel-open variant adds ~8 FPS of cost so always confirm it's closed before measuring.
+- Cycle pattern that worked well last session: user runs scenario for ~30 s, types `SN go` / `SN done` to mark window, then I slice the syslog/logcat stream into a per-scenario log file.
+
+## Test devices currently set up
+
+- **iPad**: UDID `d2fcb0323a90ad2954ab501f2603cd7573d99b2a`, bundle `com.agvaloniaagps.ios`. Phase 2c #2 build installed. Documents/AgValoniaGPS/ has all 8 PERF markers present.
+- **Android**: serial `R52TB090VAK`, package `com.agvaloniaagps.android`. Same build state.
+
+## Branch / PR state
+
+- `perf-05/instrumentation` — 18 commits ahead of develop, PR #406 open. Wait for review before merging.
+- For new render-audit work, **branch from `perf-05/instrumentation`** (so the instrumentation infrastructure is still in place — the audit needs it). Don't branch from develop until #406 merges.
+
+## What I'd start with concretely
+
+```bash
+# 1. New branch from PR head
+git checkout perf-05/instrumentation && git pull
+git checkout -b perf-05/render-thread-audit
+
+# 2. Re-aggregate the existing trace by *immediate caller* of DrawRectangle on render thread
+#    to figure out which visual is the source. Use the python3 pattern from
+#    ANALYSIS.md §10 but modify to walk one frame deeper.
+
+# 3. Capture an Allocations trace if Time Profiler points at "everywhere"
+TEMPLATE='Allocations' bash Plans/perf_data/2026-05-20/instruments-trace-ipad.sh
+```
+
+Then iterate: data → hypothesis → fix → re-measure, the same loop the rest of this audit ran on.

--- a/Plans/perf_data/2026-05-20/TESTING.md
+++ b/Plans/perf_data/2026-05-20/TESTING.md
@@ -1,0 +1,169 @@
+# PERF-05 Phase 1 Capture — Test Script (2026-05-20)
+
+Driven by **[../../PERF_05_SUBSYSTEM_CHURN_AUDIT.md](../../PERF_05_SUBSYSTEM_CHURN_AUDIT.md)**.
+Branch: `perf-05/instrumentation`.
+
+Devices:
+- **iPad Pro 12.9" 2nd gen** (UDID `d2fcb0323a90ad2954ab501f2603cd7573d99b2a`,
+  bundle `com.agvaloniaagps.ios`)
+- **Samsung Android tablet R52TB090VAK** (package
+  `com.agvaloniaagps.android`)
+
+Output: one log file per (platform, scenario) at
+`Plans/perf_data/2026-05-20/<platform>/<scenario>.log`. The whole `*.log` set
+is gitignored — summary goes on #403.
+
+---
+
+## Pre-flight (Claude drives)
+
+1. ✅ Build iOS + Android on `perf-05/instrumentation` (done — both green).
+2. Install fresh build on both devices.
+3. Push 7 marker files to both devices via
+   `Plans/perf_data/2026-05-20/push-markers.sh` (created alongside this doc).
+4. Launch the app on iPad and Android.
+5. Start syslog capture on both devices, filtered for `PERF` / `RenderBudget`,
+   written to:
+   - `Plans/perf_data/2026-05-20/ipad/_stream.log`
+   - `Plans/perf_data/2026-05-20/android/_stream.log`
+6. Verify the `[DiagFlags]` startup line appears in each stream — confirms
+   all 7 markers were read.
+
+After pre-flight Claude says **"ready — run S1 on both devices and tell me
+'S1 done'"**.
+
+---
+
+## Per-scenario protocol
+
+For every scenario:
+
+1. **Claude** says: *"Ready to start SN — go."*
+2. **You** put both devices into the SN state described below.
+3. **You** type `SN go` in chat to mark the window start.
+4. **You** hold the state, untouched, for **~30 seconds**.
+5. **You** type `SN done` in chat to mark the window end.
+6. **Claude** reads the stream logs, slices the window between your two
+   timestamps, writes the slice to `…/<platform>/<scenario>.log`, and reports
+   the per-subsystem numbers.
+
+A 30-second hold gives ~30 emissions per subsystem at 1 Hz — enough for
+stable averages.
+
+---
+
+## Scenarios
+
+### S1 — App open, no field
+- App freshly launched.
+- No field opened.
+- Do not interact. Phone-down both devices.
+
+Expected baseline: pure composition + render-vehicle-only cost. Nothing else
+should be active. Useful as the "everything else" floor.
+
+### S2 — Field loaded, idle
+- Open the **330 ha field**.
+- No track active, no AB / curve set.
+- Vehicle parked. No simulator.
+- Hold steady.
+
+Adds boundary + headland + coverage-bitmap-present (but no painting) to S1.
+
+### S3 — Active AB track
+- S2 state, plus: tap A, drive forward a few meters (sim off, so move manually
+  by drag if needed — just need an A and a B point set), tap B.
+- Active AB line visible on screen.
+- No simulator running.
+- Hold steady.
+
+Adds the `DrawTrackSk` path with per-frame `SKPaint` allocs — the leading
+suspect from the earlier iPad investigation.
+
+### S4 — Active curve track (~500 points)
+- S2 state, plus: start a curve recording, drive a short meandering loop in
+  the simulator (or drag) until ~500 points are recorded, then stop recording.
+- Curve becomes the active track.
+- Simulator stopped after recording.
+- Hold steady.
+
+Probes per-point polyline rendering cost vs. the AB-line 2-point case.
+
+### S5 — Simulator driving, sections off
+- S2 state, plus: enable simulator, set ~10 km/h, drive straight.
+- All sections OFF.
+- No coverage being painted.
+- Let it drive for the full 30 s window.
+
+Adds GPS pipeline + state mirror at simulator rate. No coverage write.
+
+### S6 — Simulator driving, sections on
+- S5 state, plus: turn all sections ON. Coverage paints behind the vehicle.
+- Continue driving.
+
+Adds `CoverageMapService.AddCoveragePoint` per-tick cost on top of S5.
+
+### S7 — Headland turn execution *(optional first pass)*
+- S6 state, plus: AutoSteer engaged on an AB line that aims into the
+  headland boundary. Let YouTurn fire.
+- Capture covers approach + the turn + first few meters of the new pass.
+
+YouTurn compute is on the UI thread (per `PERFORMANCE_STRATEGY.md` item #2);
+this is the only scenario where `[YouTurnGuidance-PERF]` should report
+non-zero cycles. May be hard to set up cleanly — skip on first pass if
+needed and treat as a follow-up run.
+
+### S8 — Real GPS attached, sections off *(optional first pass)*
+- Connect the AiO board over UDP. Real GPS streams in at ~10 Hz.
+- Simulator off.
+- Vehicle stationary or slow-moving.
+- No field load required (or use S2's 330 ha field).
+
+Probes the real UDP RX + `AutoSteerService.ProcessGpsBuffer` path. Needs the
+physical AiO hardware connected to the network the iPad/Android can reach;
+skip if not set up today.
+
+---
+
+## Post-flight
+
+1. Stop syslog captures.
+2. Confirm scenario log files exist:
+   ```
+   Plans/perf_data/2026-05-20/ipad/S1.log
+   Plans/perf_data/2026-05-20/ipad/S2.log
+   …
+   Plans/perf_data/2026-05-20/android/S1.log
+   …
+   ```
+3. Claude builds the analysis table, posts it as a comment on #403, and
+   appends an "iPad characterization" section to `PERFORMANCE_STRATEGY.md`
+   per the plan's Outputs section.
+4. Remove marker files from both devices so a stray production run won't
+   keep emitting `*-PERF` lines:
+   ```
+   Plans/perf_data/2026-05-20/clear-markers.sh
+   ```
+
+---
+
+## What the logs look like
+
+Per-subsystem 1-Hz emit format (same across all subsystems for analysis
+uniformity):
+
+```
+[RenderBudget]        frames=N ground=Xms/YB grid=Xms/YB cov=Xms/YB bnd=Xms/YB trk=Xms/YB veh=Xms/YB tot_alloc=…B/frame zoom=…
+[StateMirror-PERF]    cycles=N us/cycle=X alloc/cycle=YB total_us=… total_alloc=…B window=…s
+[GpsPipeline-PERF]    cycles=N us/cycle=X alloc/cycle=YB …
+[TrackGuidance-PERF]  cycles=N us/cycle=X alloc/cycle=YB …
+[YouTurnGuidance-PERF] cycles=N us/cycle=X alloc/cycle=YB …
+[Coverage-PERF]       cycles=N us/cycle=X alloc/cycle=YB …
+[UdpRx-PERF]          packets=N us/packet=X alloc/packet=YB …
+[UdpTx-PERF]          sends=N us/send=X alloc/send=YB …
+[AutoSteerRx-PERF]    cycles=N us/cycle=X alloc/cycle=YB …
+[AutoSteerTx-PERF]    cycles=N us/cycle=X alloc/cycle=YB …
+```
+
+Necessary-vs-churn judgement applied per the audit plan's "Analysis
+framework" section.

--- a/Plans/perf_data/2026-05-20/TESTING.md
+++ b/Plans/perf_data/2026-05-20/TESTING.md
@@ -71,8 +71,8 @@ should be active. Useful as the "everything else" floor.
 Adds boundary + headland + coverage-bitmap-present (but no painting) to S1.
 
 ### S3 — Active AB track
-- S2 state, plus: tap A, drive forward a few meters (sim off, so move manually
-  by drag if needed — just need an A and a B point set), tap B.
+- S2 state, plus: tap A somewhere on the map, then tap B somewhere else.
+  No driving required — AB creation is just two taps.
 - Active AB line visible on screen.
 - No simulator running.
 - Hold steady.

--- a/Plans/perf_data/2026-05-20/TESTING.md
+++ b/Plans/perf_data/2026-05-20/TESTING.md
@@ -125,6 +125,34 @@ skip if not set up today.
 
 ---
 
+## Phase 2 protocol (focused follow-up)
+
+Phase 2a added a `.perf_apply_gps_cycle` marker (the 8th subsystem,
+`ApplyGpsCycleResult`). Push it the same way as the other 7
+markers — `push-markers.sh` already includes it.
+
+### Phase 2b — Xcode Instruments Time Profiler on iPad during S5
+
+To chase the ~14 ms/frame iPad "outside-OnRender" cost that pure
+logging couldn't attribute (see ANALYSIS.md §7):
+
+1. Put iPad into the **S5 state** (sim driving, sections off, panel
+   closed) — same as the logging-side S5.
+2. Run [`instruments-trace-ipad.sh`](instruments-trace-ipad.sh). It
+   attaches Time Profiler to the running app and records for 30 s.
+3. Trace bundle lands in `instruments/<timestamp>_s5_time_profiler.trace`
+   (gitignored).
+4. Open in Instruments.app: `open instruments/<file>.trace`. Focus on
+   the main / UI thread inside the recording window. Look for big time
+   chunks in:
+   - Avalonia binding evaluation / `PropertyChanged` invocation
+   - Skia draw / Metal command submission
+   - GC pause samples (visible as time outside any frame)
+
+If Time Profiler points at allocations or PropertyChanged storms,
+swap the template for `Allocations` for stack-attributed allocation
+data, or `Metal System Trace` for GPU command timing.
+
 ## Post-flight
 
 1. Stop syslog captures.

--- a/Plans/perf_data/2026-05-20/clear-markers.sh
+++ b/Plans/perf_data/2026-05-20/clear-markers.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# PERF-05 Phase 1 marker cleanup — removes the 7 marker files from both
+# devices so the app stops emitting *-PERF lines. Run after the capture.
+#
+# Apple's devicectl doesn't have a direct "rm file" — instead we push an
+# empty marker over to overwrite, then the trick is that DiagFlags only
+# checks File.Exists, so we actually need to delete. easier route on iOS:
+# uninstall + reinstall the app. For now we instead leave the markers and
+# accept that subsequent launches will keep PERF emission on until the next
+# reinstall (cheap on iPad).
+#
+# Android we can delete directly via adb shell rm.
+
+set -euo pipefail
+
+IPAD_UDID="d2fcb0323a90ad2954ab501f2603cd7573d99b2a"
+IPAD_BUNDLE="com.agvaloniaagps.ios"
+ANDROID_SERIAL="R52TB090VAK"
+
+MARKERS=(
+  .log_render_timing
+  .perf_state_mirror
+  .perf_gps_pipeline
+  .perf_guidance
+  .perf_coverage
+  .perf_udp
+  .perf_autosteer
+)
+
+echo "Android — deleting marker files via adb shell rm"
+for m in "${MARKERS[@]}"; do
+  adb -s "$ANDROID_SERIAL" shell "rm -f /storage/emulated/0/Documents/AgValoniaGPS/$m" || true
+  echo "  rm $m"
+done
+
+echo
+echo "iPad — devicectl does not expose remote rm cleanly. To clear iPad markers:"
+echo "  1. Stop the app on the iPad."
+echo "  2. Reinstall: mlaunch --installdev … (overwrites the bundle but"
+echo "     not the data container)."
+echo "  3. Or fully uninstall + reinstall via the Home screen / Xcode if you"
+echo "     want a clean Documents/AgValoniaGPS."
+echo
+echo "Practical: leave iPad markers in place until the next reinstall — the"
+echo "perf logging is harmless when no analyst is reading it."

--- a/Plans/perf_data/2026-05-20/instruments-trace-ipad.sh
+++ b/Plans/perf_data/2026-05-20/instruments-trace-ipad.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# PERF-05 Phase 2b — capture an Xcode Instruments Time Profiler trace from
+# the iPad app while it's running. Use this to chase the ~14 ms/frame
+# iPad "outside-OnRender" cost that pure logging couldn't attribute.
+#
+# Prerequisites:
+#   - iPad connected, paired, developer-mode on.
+#   - AgValoniaGPS.iOS running on iPad, ideally already in the S5 state
+#     (sim driving, sections off, panel closed) before this script starts
+#     the recording window.
+#   - xctrace available (ships with Xcode command-line tools).
+#
+# Usage:
+#   1. Manually put the iPad into the S5 state and hold it.
+#   2. Run this script. It records for 30 s, then saves a .trace bundle.
+#   3. Open the saved .trace in Instruments.app to inspect.
+#
+# Notes on reading the trace:
+#   - Focus on the main / UI thread during the recording window.
+#   - Look for big chunks of time in Avalonia binding evaluation,
+#     PropertyChanged invocation, Skia draw, or Metal command submission.
+#   - Symbols from Mono/.NET will be partly mangled — function names like
+#     `wrapper_managed_to_native_…` are common. The C# method name is
+#     usually embedded in the mangled name; ignore the wrapper prefix.
+#   - For allocation tracking, swap "Time Profiler" for "Allocations" below.
+
+set -euo pipefail
+
+IPAD_UDID="d2fcb0323a90ad2954ab501f2603cd7573d99b2a"
+PROCESS="AgValoniaGPS.iOS"   # xctrace --attach matches by process name
+TEMPLATE="${TEMPLATE:-Time Profiler}"
+DURATION="${DURATION:-30s}"
+
+OUT_DIR="$(cd "$(dirname "$0")" && pwd)/instruments"
+mkdir -p "$OUT_DIR"
+SAFE_TEMPLATE="$(echo "$TEMPLATE" | tr ' ' '_' | tr '[:upper:]' '[:lower:]')"
+TRACE="$OUT_DIR/$(date +%Y-%m-%d_%H%M%S)_${SAFE_TEMPLATE}_s5.trace"
+
+echo "Recording template:  $TEMPLATE"
+echo "Recording duration:  $DURATION"
+echo "Attaching to process: $PROCESS on iPad $IPAD_UDID"
+echo "Trace will be saved:  $TRACE"
+echo "  (the app must already be running on the iPad — start with S5 state held)"
+echo
+
+xcrun xctrace record \
+  --template "$TEMPLATE" \
+  --device "$IPAD_UDID" \
+  --attach "$PROCESS" \
+  --output "$TRACE" \
+  --time-limit "$DURATION" \
+  --no-prompt
+
+echo
+echo "Done. Open in Instruments:"
+echo "  open \"$TRACE\""
+echo
+echo "Alternate templates worth trying once Time Profiler points at a suspect:"
+echo "  --template 'Allocations'    (per-allocation stacks, ~2-3x slowdown)"
+echo "  --template 'Metal System Trace' (GPU command timing)"

--- a/Plans/perf_data/2026-05-20/push-markers.sh
+++ b/Plans/perf_data/2026-05-20/push-markers.sh
@@ -17,6 +17,7 @@ MARKERS=(
   .perf_coverage          # subsystem 5
   .perf_udp               # subsystem 6 (UdpRx + UdpTx)
   .perf_autosteer         # subsystem 7 (AutoSteerRx + AutoSteerTx)
+  .perf_apply_gps_cycle   # Phase 2a — UI-thread ApplyGpsCycleResult
 )
 
 STAGE=$(mktemp -d)

--- a/Plans/perf_data/2026-05-20/push-markers.sh
+++ b/Plans/perf_data/2026-05-20/push-markers.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# PERF-05 Phase 1 marker push — drops all 7 marker files into the app's
+# Documents/AgValoniaGPS directory on both devices. Restart the app after
+# (DiagFlags reads markers once at startup).
+
+set -euo pipefail
+
+IPAD_UDID="d2fcb0323a90ad2954ab501f2603cd7573d99b2a"
+IPAD_BUNDLE="com.agvaloniaagps.ios"
+ANDROID_SERIAL="R52TB090VAK"
+
+MARKERS=(
+  .log_render_timing      # subsystem 1 (existing flag, drives DrawingContextMapControl)
+  .perf_state_mirror      # subsystem 2
+  .perf_gps_pipeline      # subsystem 3
+  .perf_guidance          # subsystem 4 (TrackGuidance + YouTurnGuidance)
+  .perf_coverage          # subsystem 5
+  .perf_udp               # subsystem 6 (UdpRx + UdpTx)
+  .perf_autosteer         # subsystem 7 (AutoSteerRx + AutoSteerTx)
+)
+
+STAGE=$(mktemp -d)
+trap "rm -rf $STAGE" EXIT
+for m in "${MARKERS[@]}"; do touch "$STAGE/$m"; done
+
+echo "iPad → $IPAD_BUNDLE Documents/AgValoniaGPS/"
+for m in "${MARKERS[@]}"; do
+  xcrun devicectl device copy to \
+    --device "$IPAD_UDID" \
+    --domain-type appDataContainer \
+    --domain-identifier "$IPAD_BUNDLE" \
+    --source "$STAGE/$m" \
+    --destination "Documents/AgValoniaGPS/$m" \
+    --quiet
+  echo "  pushed $m"
+done
+
+echo
+echo "Android → shared MyDocuments at /storage/emulated/0/Documents/AgValoniaGPS/"
+adb -s "$ANDROID_SERIAL" shell "mkdir -p /storage/emulated/0/Documents/AgValoniaGPS" >/dev/null
+for m in "${MARKERS[@]}"; do
+  adb -s "$ANDROID_SERIAL" push "$STAGE/$m" "/storage/emulated/0/Documents/AgValoniaGPS/$m" >/dev/null
+  echo "  pushed $m"
+done
+
+echo
+echo "Done. Restart the app on both devices so DiagFlags picks them up."
+echo "Look for the [DiagFlags] line in each stream to confirm all 7 are true."

--- a/Shared/AgValoniaGPS.Models/Diagnostics/DiagFlags.cs
+++ b/Shared/AgValoniaGPS.Models/Diagnostics/DiagFlags.cs
@@ -40,6 +40,17 @@ public static class DiagFlags
     public static readonly bool LogSendStateFrequency;
     public static readonly bool LogRenderTiming;
 
+    // PERF-05 subsystem markers — each enables [<Subsystem>-PERF] emission
+    // (time + GC.GetAllocatedBytesForCurrentThread deltas at 1 Hz). See
+    // Plans/PERF_05_SUBSYSTEM_CHURN_AUDIT.md. Subsystem 1 (2D render path)
+    // reuses LogRenderTiming above.
+    public static readonly bool PerfStateMirror;
+    public static readonly bool PerfGpsPipeline;
+    public static readonly bool PerfGuidance;
+    public static readonly bool PerfCoverage;
+    public static readonly bool PerfUdp;
+    public static readonly bool PerfAutoSteer;
+
     // Test-harness flags
     public static readonly bool AutoResumeField;
 
@@ -59,6 +70,12 @@ public static class DiagFlags
         DisableAnimationFrameUpdate = MarkerPresent(".disable_animation_frame_update");
         LogSendStateFrequency      = MarkerPresent(".log_send_state_frequency");
         LogRenderTiming            = MarkerPresent(".log_render_timing");
+        PerfStateMirror            = MarkerPresent(".perf_state_mirror");
+        PerfGpsPipeline            = MarkerPresent(".perf_gps_pipeline");
+        PerfGuidance               = MarkerPresent(".perf_guidance");
+        PerfCoverage               = MarkerPresent(".perf_coverage");
+        PerfUdp                    = MarkerPresent(".perf_udp");
+        PerfAutoSteer              = MarkerPresent(".perf_autosteer");
         AutoResumeField            = MarkerPresent(".auto_resume_field");
 
         AnySet = SkipCoverageDraw || SkipBoundaryDraw || SkipTracks
@@ -66,7 +83,10 @@ public static class DiagFlags
                || ShowVehicleDebug
                || PanelsOpaque || HideAllPanels
                || DisableAnimationFrameUpdate || LogSendStateFrequency
-               || LogRenderTiming || AutoResumeField;
+               || LogRenderTiming
+               || PerfStateMirror || PerfGpsPipeline || PerfGuidance
+               || PerfCoverage || PerfUdp || PerfAutoSteer
+               || AutoResumeField;
     }
 
     /// <summary>
@@ -89,6 +109,12 @@ public static class DiagFlags
             + $" disableAnimFrame={DisableAnimationFrameUpdate}"
             + $" logSendState={LogSendStateFrequency}"
             + $" logRenderTiming={LogRenderTiming}"
+            + $" perfStateMirror={PerfStateMirror}"
+            + $" perfGpsPipeline={PerfGpsPipeline}"
+            + $" perfGuidance={PerfGuidance}"
+            + $" perfCoverage={PerfCoverage}"
+            + $" perfUdp={PerfUdp}"
+            + $" perfAutoSteer={PerfAutoSteer}"
             + $" autoResumeField={AutoResumeField}");
     }
 

--- a/Shared/AgValoniaGPS.Models/Diagnostics/DiagFlags.cs
+++ b/Shared/AgValoniaGPS.Models/Diagnostics/DiagFlags.cs
@@ -50,6 +50,10 @@ public static class DiagFlags
     public static readonly bool PerfCoverage;
     public static readonly bool PerfUdp;
     public static readonly bool PerfAutoSteer;
+    // Phase 2a: UI-thread bridge from background GPS cycle to State updates.
+    // Suspected dominant source of the iPad "+13 ms outside OnRender" cost
+    // observed at S5 in Phase 1.
+    public static readonly bool PerfApplyGpsCycle;
 
     // Test-harness flags
     public static readonly bool AutoResumeField;
@@ -76,6 +80,7 @@ public static class DiagFlags
         PerfCoverage               = MarkerPresent(".perf_coverage");
         PerfUdp                    = MarkerPresent(".perf_udp");
         PerfAutoSteer              = MarkerPresent(".perf_autosteer");
+        PerfApplyGpsCycle          = MarkerPresent(".perf_apply_gps_cycle");
         AutoResumeField            = MarkerPresent(".auto_resume_field");
 
         AnySet = SkipCoverageDraw || SkipBoundaryDraw || SkipTracks
@@ -86,6 +91,7 @@ public static class DiagFlags
                || LogRenderTiming
                || PerfStateMirror || PerfGpsPipeline || PerfGuidance
                || PerfCoverage || PerfUdp || PerfAutoSteer
+               || PerfApplyGpsCycle
                || AutoResumeField;
     }
 
@@ -115,6 +121,7 @@ public static class DiagFlags
             + $" perfCoverage={PerfCoverage}"
             + $" perfUdp={PerfUdp}"
             + $" perfAutoSteer={PerfAutoSteer}"
+            + $" perfApplyGpsCycle={PerfApplyGpsCycle}"
             + $" autoResumeField={AutoResumeField}");
     }
 

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -438,19 +438,37 @@ public class AutoSteerService : IAutoSteerService
     {
         if (!_isEnabled) return;
 
-        // Parse directly into VehicleState (zero-copy). ParseIntoState marks
-        // its own parse-timing fields; no BeginNewCycle here because the
-        // cycle owns timing now.
-        ReadOnlySpan<byte> data = buffer.AsSpan(0, length);
-        if (!NmeaParserServiceFast.ParseIntoState(data, ref _state))
+        // PERF-05 #7 (autosteer-RX). Cycle = one GPS buffer parsed.
+        // Marker .perf_autosteer shared with TX. Emits [AutoSteerRx-PERF].
+        bool perf = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfAutoSteer;
+        long perfT0 = perf ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+        long perfA0 = perf ? GC.GetAllocatedBytesForCurrentThread() : 0;
+        try
         {
-            _parseFailures++;
-            return;
-        }
+            // Parse directly into VehicleState (zero-copy). ParseIntoState marks
+            // its own parse-timing fields; no BeginNewCycle here because the
+            // cycle owns timing now.
+            ReadOnlySpan<byte> data = buffer.AsSpan(0, length);
+            if (!NmeaParserServiceFast.ParseIntoState(data, ref _state))
+            {
+                _parseFailures++;
+                return;
+            }
 
-        // Publish the parsed fix to GpsService. This is the sole event the
-        // cycle worker listens to; everything else runs there.
-        PublishGpsData();
+            // Publish the parsed fix to GpsService. This is the sole event the
+            // cycle worker listens to; everything else runs there.
+            PublishGpsData();
+        }
+        finally
+        {
+            if (perf)
+            {
+                _perfRxTicks += System.Diagnostics.Stopwatch.GetTimestamp() - perfT0;
+                _perfRxAllocs += GC.GetAllocatedBytesForCurrentThread() - perfA0;
+                _perfRxCount++;
+                EmitAutoSteerRxIfWindowElapsed();
+            }
+        }
     }
 
     /// <summary>
@@ -609,7 +627,62 @@ public class AutoSteerService : IAutoSteerService
     public void SendPgnsForControlTick()
     {
         if (!_isEnabled) return;
-        SendPgns();
+        // PERF-05 #7 (autosteer-TX). Cycle = one PGN-send tick (outbound
+        // steering / config / hello). Emits [AutoSteerTx-PERF].
+        bool perf = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfAutoSteer;
+        long perfT0 = perf ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+        long perfA0 = perf ? GC.GetAllocatedBytesForCurrentThread() : 0;
+        try { SendPgns(); }
+        finally
+        {
+            if (perf)
+            {
+                _perfTxTicks += System.Diagnostics.Stopwatch.GetTimestamp() - perfT0;
+                _perfTxAllocs += GC.GetAllocatedBytesForCurrentThread() - perfA0;
+                _perfTxCount++;
+                EmitAutoSteerTxIfWindowElapsed();
+            }
+        }
+    }
+
+    // PERF-05 #7 accumulators (gated by DiagFlags.PerfAutoSteer).
+    private long _perfRxTicks, _perfRxAllocs;
+    private int _perfRxCount;
+    private DateTime _perfRxWindowStart = DateTime.UtcNow;
+    private long _perfTxTicks, _perfTxAllocs;
+    private int _perfTxCount;
+    private DateTime _perfTxWindowStart = DateTime.UtcNow;
+
+    private void EmitAutoSteerRxIfWindowElapsed()
+    {
+        var elapsed = (DateTime.UtcNow - _perfRxWindowStart).TotalSeconds;
+        if (elapsed < 1.0 || _perfRxCount == 0) return;
+        double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+        Console.WriteLine(
+            $"[AutoSteerRx-PERF] cycles={_perfRxCount}"
+            + $" us/cycle={(_perfRxTicks / ticksPerUs / _perfRxCount):F1}"
+            + $" alloc/cycle={(_perfRxAllocs / _perfRxCount)}B"
+            + $" total_us={(long)(_perfRxTicks / ticksPerUs)}"
+            + $" total_alloc={_perfRxAllocs}B"
+            + $" window={elapsed:F2}s");
+        _perfRxTicks = 0; _perfRxAllocs = 0; _perfRxCount = 0;
+        _perfRxWindowStart = DateTime.UtcNow;
+    }
+
+    private void EmitAutoSteerTxIfWindowElapsed()
+    {
+        var elapsed = (DateTime.UtcNow - _perfTxWindowStart).TotalSeconds;
+        if (elapsed < 1.0 || _perfTxCount == 0) return;
+        double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+        Console.WriteLine(
+            $"[AutoSteerTx-PERF] cycles={_perfTxCount}"
+            + $" us/cycle={(_perfTxTicks / ticksPerUs / _perfTxCount):F1}"
+            + $" alloc/cycle={(_perfTxAllocs / _perfTxCount)}B"
+            + $" total_us={(long)(_perfTxTicks / ticksPerUs)}"
+            + $" total_alloc={_perfTxAllocs}B"
+            + $" window={elapsed:F2}s");
+        _perfTxTicks = 0; _perfTxAllocs = 0; _perfTxCount = 0;
+        _perfTxWindowStart = DateTime.UtcNow;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
@@ -165,9 +165,59 @@ public class CoverageMapService : ICoverageMapService
     {
         lock (_coverageLock)
         {
-        if (!_activeSections.Contains(zoneIndex))
-            return;
+            if (!_activeSections.Contains(zoneIndex))
+                return;
 
+            // PERF-05 #5. Cycle = one AddCoveragePoint that gets past the
+            // activeSections gate (so unmapped sections don't pollute counts).
+            // Marker: .perf_coverage. Wraps rasterization + pixel paint +
+            // bounds expand. Up to N_sections × GPS_Hz calls/sec.
+            if (!AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfCoverage)
+            {
+                AddCoveragePointCore(zoneIndex, leftEdge, rightEdge);
+                return;
+            }
+            long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
+            long a0 = GC.GetAllocatedBytesForCurrentThread();
+            try { AddCoveragePointCore(zoneIndex, leftEdge, rightEdge); }
+            finally
+            {
+                _perfCovTicks += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                _perfCovAllocs += GC.GetAllocatedBytesForCurrentThread() - a0;
+                _perfCovCount++;
+                var elapsed = (DateTime.UtcNow - _perfCovWindowStart).TotalSeconds;
+                if (elapsed >= 1.0 && _perfCovCount > 0)
+                {
+                    double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+                    Console.WriteLine(
+                        $"[Coverage-PERF] cycles={_perfCovCount}"
+                        + $" us/cycle={(_perfCovTicks / ticksPerUs / _perfCovCount):F1}"
+                        + $" alloc/cycle={(_perfCovAllocs / _perfCovCount)}B"
+                        + $" total_us={(long)(_perfCovTicks / ticksPerUs)}"
+                        + $" total_alloc={_perfCovAllocs}B"
+                        + $" window={elapsed:F2}s");
+                    _perfCovTicks = 0;
+                    _perfCovAllocs = 0;
+                    _perfCovCount = 0;
+                    _perfCovWindowStart = DateTime.UtcNow;
+                }
+            }
+        } // lock
+    }
+
+    // PERF-05 #5 accumulators. Gated by DiagFlags.PerfCoverage. Mutated under
+    // _coverageLock (same lock as AddCoveragePoint body).
+    private long _perfCovTicks;
+    private long _perfCovAllocs;
+    private int _perfCovCount;
+    private DateTime _perfCovWindowStart = DateTime.UtcNow;
+
+    /// <summary>
+    /// Core body of AddCoveragePoint. Caller holds _coverageLock and has
+    /// already verified the section is active.
+    /// </summary>
+    private void AddCoveragePointCore(int zoneIndex, Vec2 leftEdge, Vec2 rightEdge)
+    {
         // Check if we need to expand bounds (auto-initialized, vehicle near edge)
         if (_fieldBoundsSet)
         {
@@ -202,7 +252,6 @@ public class CoverageMapService : ICoverageMapService
         _lastEdgesPerSection[zoneIndex] = (
             (leftEdge.Easting, leftEdge.Northing),
             (rightEdge.Easting, rightEdge.Northing));
-        } // lock
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -369,6 +369,15 @@ public sealed class GpsPipelineService : IGpsPipelineService
     private void ProcessCycle(GpsData data)
     {
         _cycleCounter++;
+
+        // PERF-05 #3: GPS pipeline cycle = one full ProcessCycle invocation
+        // (background thread, fires per GPS fix). Captures everything from
+        // intent drain through the CycleCompleted event raise — guidance,
+        // youturn, snapshot build, etc. Marker: .perf_gps_pipeline.
+        bool perfGps = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfGpsPipeline;
+        long perfT0 = perfGps ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+        long perfA0 = perfGps ? GC.GetAllocatedBytesForCurrentThread() : 0;
+
         var config = ConfigurationStore.Instance;
 
         // Stage 1: Drain intents — see Plans/threading_model.svg cycle worker lane.
@@ -1032,7 +1041,36 @@ public sealed class GpsPipelineService : IGpsPipelineService
         };
 
         CycleCompleted?.Invoke(result);
+
+        if (perfGps)
+        {
+            _perfGpsCycleTicks += System.Diagnostics.Stopwatch.GetTimestamp() - perfT0;
+            _perfGpsCycleAllocs += GC.GetAllocatedBytesForCurrentThread() - perfA0;
+            _perfGpsCycleCount++;
+            var elapsed = (DateTime.UtcNow - _perfGpsWindowStart).TotalSeconds;
+            if (elapsed >= 1.0 && _perfGpsCycleCount > 0)
+            {
+                double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+                Console.WriteLine(
+                    $"[GpsPipeline-PERF] cycles={_perfGpsCycleCount}"
+                    + $" us/cycle={(_perfGpsCycleTicks / ticksPerUs / _perfGpsCycleCount):F1}"
+                    + $" alloc/cycle={(_perfGpsCycleAllocs / _perfGpsCycleCount)}B"
+                    + $" total_us={(long)(_perfGpsCycleTicks / ticksPerUs)}"
+                    + $" total_alloc={_perfGpsCycleAllocs}B"
+                    + $" window={elapsed:F2}s");
+                _perfGpsCycleTicks = 0;
+                _perfGpsCycleAllocs = 0;
+                _perfGpsCycleCount = 0;
+                _perfGpsWindowStart = DateTime.UtcNow;
+            }
+        }
     }
+
+    // PERF-05 #3: GPS pipeline accumulators. Gated by DiagFlags.PerfGpsPipeline.
+    private long _perfGpsCycleTicks;
+    private long _perfGpsCycleAllocs;
+    private int _perfGpsCycleCount;
+    private DateTime _perfGpsWindowStart = DateTime.UtcNow;
 
     private static YouTurnSnapshot BuildYouTurnSnapshot(YouTurnWorkingState src, bool justCompleted) => new()
     {

--- a/Shared/AgValoniaGPS.Services/Track/TrackGuidanceService.cs
+++ b/Shared/AgValoniaGPS.Services/Track/TrackGuidanceService.cs
@@ -42,6 +42,46 @@ public class TrackGuidanceService : ITrackGuidanceService
     /// <returns>Guidance output with steering angle and state</returns>
     public TrackGuidanceOutput CalculateGuidance(TrackGuidanceInput input)
     {
+        // PERF-05 #4 (track-side). Cycle = one CalculateGuidance call from
+        // GpsPipelineService.ProcessCycle. Marker: .perf_guidance (shared with
+        // YouTurnGuidanceService). Emits [TrackGuidance-PERF] at 1 Hz.
+        bool perf = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfGuidance;
+        if (!perf) return CalculateGuidanceCore(input);
+        long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
+        try { return CalculateGuidanceCore(input); }
+        finally
+        {
+            _perfCycleTicks += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+            _perfCycleAllocs += GC.GetAllocatedBytesForCurrentThread() - a0;
+            _perfCycleCount++;
+            var elapsed = (DateTime.UtcNow - _perfWindowStart).TotalSeconds;
+            if (elapsed >= 1.0 && _perfCycleCount > 0)
+            {
+                double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+                Console.WriteLine(
+                    $"[TrackGuidance-PERF] cycles={_perfCycleCount}"
+                    + $" us/cycle={(_perfCycleTicks / ticksPerUs / _perfCycleCount):F1}"
+                    + $" alloc/cycle={(_perfCycleAllocs / _perfCycleCount)}B"
+                    + $" total_us={(long)(_perfCycleTicks / ticksPerUs)}"
+                    + $" total_alloc={_perfCycleAllocs}B"
+                    + $" window={elapsed:F2}s");
+                _perfCycleTicks = 0;
+                _perfCycleAllocs = 0;
+                _perfCycleCount = 0;
+                _perfWindowStart = DateTime.UtcNow;
+            }
+        }
+    }
+
+    // PERF-05 #4 accumulators (gated by DiagFlags.PerfGuidance).
+    private long _perfCycleTicks;
+    private long _perfCycleAllocs;
+    private int _perfCycleCount;
+    private DateTime _perfWindowStart = DateTime.UtcNow;
+
+    private TrackGuidanceOutput CalculateGuidanceCore(TrackGuidanceInput input)
+    {
         var output = new TrackGuidanceOutput
         {
             GoalPoint = new Vec2(),

--- a/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
+++ b/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
@@ -161,6 +161,13 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     {
         if (!IsConnected || _udpSocket == null) return;
 
+        // PERF-05 #6 (UDP TX). Cycle = one SendToModules invocation that
+        // passed the connected check. Marker .perf_udp shared with RX path;
+        // emit line is [UdpTx-PERF].
+        bool perf = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfUdp;
+        long perfT0 = perf ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+        long perfA0 = perf ? GC.GetAllocatedBytesForCurrentThread() : 0;
+
         // Refresh discovery endpoints periodically
         if ((DateTime.UtcNow - _lastDiscoveryRefresh).TotalSeconds > DiscoveryRefreshSeconds)
         {
@@ -186,6 +193,14 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
             // Discovery: broadcast on all interfaces
             foreach (var ep in _discoveryEndpoints)
                 SendPacket(data, ep);
+        }
+
+        if (perf)
+        {
+            _perfTxTicks += System.Diagnostics.Stopwatch.GetTimestamp() - perfT0;
+            _perfTxAllocs += GC.GetAllocatedBytesForCurrentThread() - perfA0;
+            _perfTxCount++;
+            EmitTxIfWindowElapsed();
         }
     }
 
@@ -308,38 +323,104 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
 
     private void ProcessReceivedData(byte[] data, IPEndPoint remoteEndPoint)
     {
-        // Check if this is a binary PGN message or text NMEA sentence
-        if (data.Length >= 2 && data[0] == PgnMessage.HEADER1 && data[1] == PgnMessage.HEADER2)
+        // PERF-05 #6 (UDP RX). Cycle = one inbound packet processed.
+        // Captures DataReceived subscriber cost (NMEA parse, GpsData alloc,
+        // PGN handler dispatch). Marker .perf_udp shared with TX.
+        bool perf = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfUdp;
+        long perfT0 = perf ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+        long perfA0 = perf ? GC.GetAllocatedBytesForCurrentThread() : 0;
+        try
         {
-            // Binary PGN message
-            if (data.Length < 6) return;
-
-            byte pgn = data[3];
-
-            // Track module connections based on hello messages
-            UpdateModuleConnection(pgn, remoteEndPoint);
-
-            // Fire event
-            DataReceived?.Invoke(this, new UdpDataReceivedEventArgs
+            // Check if this is a binary PGN message or text NMEA sentence
+            if (data.Length >= 2 && data[0] == PgnMessage.HEADER1 && data[1] == PgnMessage.HEADER2)
             {
-                Data = data,
-                RemoteEndPoint = remoteEndPoint,
-                PGN = pgn,
-                Timestamp = DateTime.Now
-            });
+                // Binary PGN message
+                if (data.Length < 6) return;
+
+                byte pgn = data[3];
+
+                // Track module connections based on hello messages
+                UpdateModuleConnection(pgn, remoteEndPoint);
+
+                // Fire event
+                DataReceived?.Invoke(this, new UdpDataReceivedEventArgs
+                {
+                    Data = data,
+                    RemoteEndPoint = remoteEndPoint,
+                    PGN = pgn,
+                    Timestamp = DateTime.Now
+                });
+            }
+            else if (data.Length > 0 && data[0] == (byte)'$')
+            {
+                // Text NMEA sentence (starts with $)
+                // Fire event with PGN 0 to indicate NMEA text
+                DataReceived?.Invoke(this, new UdpDataReceivedEventArgs
+                {
+                    Data = data,
+                    RemoteEndPoint = remoteEndPoint,
+                    PGN = 0, // Special PGN for NMEA text
+                    Timestamp = DateTime.Now
+                });
+            }
         }
-        else if (data.Length > 0 && data[0] == (byte)'$')
+        finally
         {
-            // Text NMEA sentence (starts with $)
-            // Fire event with PGN 0 to indicate NMEA text
-            DataReceived?.Invoke(this, new UdpDataReceivedEventArgs
+            if (perf)
             {
-                Data = data,
-                RemoteEndPoint = remoteEndPoint,
-                PGN = 0, // Special PGN for NMEA text
-                Timestamp = DateTime.Now
-            });
+                _perfRxTicks += System.Diagnostics.Stopwatch.GetTimestamp() - perfT0;
+                _perfRxAllocs += GC.GetAllocatedBytesForCurrentThread() - perfA0;
+                _perfRxCount++;
+                EmitRxIfWindowElapsed();
+            }
         }
+    }
+
+    // PERF-05 #6 accumulators (gated by DiagFlags.PerfUdp). RX runs on the
+    // socket receive thread; TX runs on whichever thread fires SendToModules
+    // (autosteer pipeline / UI). No lock — last writer wins on the counters
+    // is acceptable for diagnostic data.
+    private long _perfRxTicks, _perfRxAllocs;
+    private int _perfRxCount;
+    private DateTime _perfRxWindowStart = DateTime.UtcNow;
+    private long _perfTxTicks, _perfTxAllocs;
+    private int _perfTxCount;
+    private DateTime _perfTxWindowStart = DateTime.UtcNow;
+
+    private void EmitRxIfWindowElapsed()
+    {
+        var elapsed = (DateTime.UtcNow - _perfRxWindowStart).TotalSeconds;
+        if (elapsed < 1.0 || _perfRxCount == 0) return;
+        double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+        Console.WriteLine(
+            $"[UdpRx-PERF] packets={_perfRxCount}"
+            + $" us/packet={(_perfRxTicks / ticksPerUs / _perfRxCount):F1}"
+            + $" alloc/packet={(_perfRxAllocs / _perfRxCount)}B"
+            + $" total_us={(long)(_perfRxTicks / ticksPerUs)}"
+            + $" total_alloc={_perfRxAllocs}B"
+            + $" window={elapsed:F2}s");
+        _perfRxTicks = 0;
+        _perfRxAllocs = 0;
+        _perfRxCount = 0;
+        _perfRxWindowStart = DateTime.UtcNow;
+    }
+
+    private void EmitTxIfWindowElapsed()
+    {
+        var elapsed = (DateTime.UtcNow - _perfTxWindowStart).TotalSeconds;
+        if (elapsed < 1.0 || _perfTxCount == 0) return;
+        double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+        Console.WriteLine(
+            $"[UdpTx-PERF] sends={_perfTxCount}"
+            + $" us/send={(_perfTxTicks / ticksPerUs / _perfTxCount):F1}"
+            + $" alloc/send={(_perfTxAllocs / _perfTxCount)}B"
+            + $" total_us={(long)(_perfTxTicks / ticksPerUs)}"
+            + $" total_alloc={_perfTxAllocs}B"
+            + $" window={elapsed:F2}s");
+        _perfTxTicks = 0;
+        _perfTxAllocs = 0;
+        _perfTxCount = 0;
+        _perfTxWindowStart = DateTime.UtcNow;
     }
 
     private void UpdateModuleConnection(byte pgn, IPEndPoint remoteEndPoint)

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnGuidanceService.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnGuidanceService.cs
@@ -33,6 +33,45 @@ namespace AgValoniaGPS.Services.YouTurn
         /// </summary>
         public YouTurnGuidanceOutput CalculateGuidance(YouTurnGuidanceInput input)
         {
+            // PERF-05 #4 (youturn-side). Shares .perf_guidance marker with
+            // TrackGuidanceService; emits as a separate [YouTurnGuidance-PERF]
+            // line so we can read them independently. Active only during U-turns.
+            bool perf = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfGuidance;
+            if (!perf) return CalculateGuidanceCore(input);
+            long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
+            long a0 = GC.GetAllocatedBytesForCurrentThread();
+            try { return CalculateGuidanceCore(input); }
+            finally
+            {
+                _perfCycleTicks += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                _perfCycleAllocs += GC.GetAllocatedBytesForCurrentThread() - a0;
+                _perfCycleCount++;
+                var elapsed = (DateTime.UtcNow - _perfWindowStart).TotalSeconds;
+                if (elapsed >= 1.0 && _perfCycleCount > 0)
+                {
+                    double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+                    Console.WriteLine(
+                        $"[YouTurnGuidance-PERF] cycles={_perfCycleCount}"
+                        + $" us/cycle={(_perfCycleTicks / ticksPerUs / _perfCycleCount):F1}"
+                        + $" alloc/cycle={(_perfCycleAllocs / _perfCycleCount)}B"
+                        + $" total_us={(long)(_perfCycleTicks / ticksPerUs)}"
+                        + $" total_alloc={_perfCycleAllocs}B"
+                        + $" window={elapsed:F2}s");
+                    _perfCycleTicks = 0;
+                    _perfCycleAllocs = 0;
+                    _perfCycleCount = 0;
+                    _perfWindowStart = DateTime.UtcNow;
+                }
+            }
+        }
+
+        private long _perfCycleTicks;
+        private long _perfCycleAllocs;
+        private int _perfCycleCount;
+        private DateTime _perfWindowStart = DateTime.UtcNow;
+
+        private YouTurnGuidanceOutput CalculateGuidanceCore(YouTurnGuidanceInput input)
+        {
             var output = new YouTurnGuidanceOutput();
 
             int ptCount = input.TurnPath.Count;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -43,15 +43,14 @@ public partial class MainViewModel
         if (result.GpsValid)
             _gpsService.MarkGpsReceived();
 
-        // GPS position
-        Latitude = result.Latitude;
-        Longitude = result.Longitude;
-        Easting = result.Easting;
-        Northing = result.Northing;
-        Heading = result.Heading;
-        _speed = result.Speed;
-        OnPropertyChanged(nameof(SpeedKmh));
-        RollDegrees = result.RollDegrees;
+        // PERF-05 Phase 2c #1: stop driving display-property PropertyChanged
+        // from sensor arrival. The MainViewModel.{Latitude, Longitude, Easting,
+        // Northing, Heading, _speed/SpeedKmh, RollDegrees, FixQuality} setters
+        // that used to live here have moved to OnDisplayTick (10 Hz, decoupled
+        // from sensor arrival). The cycle still writes State.Vehicle below —
+        // that's the canonical system of record the display tick samples from.
+        // For values not yet on State.Vehicle (RollDegrees), cache here.
+        _latestRollDegrees = result.RollDegrees;
 
         // Sole writer to State.Vehicle — Phase B completion. Was previously
         // also written from MainViewModel.HandleGpsUiUpdates on the
@@ -71,7 +70,6 @@ public partial class MainViewModel
             result.SatelliteCount,
             result.Hdop,
             result.DifferentialAge);
-        FixQuality = GetFixQualityString(result.FixQuality);
 
         // Tool position — set ToolEasting LAST to trigger map update
         ToolNorthing = result.ToolNorthing;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -26,6 +26,16 @@ public partial class MainViewModel
     /// </summary>
     public void ApplyGpsCycleResult(GpsCycleResult result)
     {
+        // PERF-05 Phase 2a. Cycle = one ApplyGpsCycleResult invocation on
+        // the UI thread (one per GpsCycleCompleted dispatch from the
+        // background pipeline). Captures everything from GpsDataRecorder
+        // through the final SetVehicleSteerAngle — all of the UI-thread
+        // state mirror + property change + binding-triggering work.
+        // Suspected source of the iPad "+13 ms outside OnRender" cost.
+        bool perfAgc = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfApplyGpsCycle;
+        long perfAgcT0 = perfAgc ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+        long perfAgcA0 = perfAgc ? GC.GetAllocatedBytesForCurrentThread() : 0;
+
         // Record for debug dump (ring buffer, last 60 seconds at 10Hz)
         AgValoniaGPS.Services.Logging.GpsDataRecorder.Instance.Record(result);
 
@@ -285,7 +295,36 @@ public partial class MainViewModel
             ? _simulatorService.SteerAngle
             : _autoSteerService.LastSteerData.ActualSteerAngle;
         _mapService.SetVehicleSteerAngle(steerDeg * Math.PI / 180.0);
+
+        if (perfAgc)
+        {
+            _perfAgcTicks += System.Diagnostics.Stopwatch.GetTimestamp() - perfAgcT0;
+            _perfAgcAllocs += GC.GetAllocatedBytesForCurrentThread() - perfAgcA0;
+            _perfAgcCount++;
+            var elapsed = (DateTime.UtcNow - _perfAgcWindowStart).TotalSeconds;
+            if (elapsed >= 1.0 && _perfAgcCount > 0)
+            {
+                double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+                Console.WriteLine(
+                    $"[ApplyGpsCycle-PERF] cycles={_perfAgcCount}"
+                    + $" us/cycle={(_perfAgcTicks / ticksPerUs / _perfAgcCount):F1}"
+                    + $" alloc/cycle={(_perfAgcAllocs / _perfAgcCount)}B"
+                    + $" total_us={(long)(_perfAgcTicks / ticksPerUs)}"
+                    + $" total_alloc={_perfAgcAllocs}B"
+                    + $" window={elapsed:F2}s");
+                _perfAgcTicks = 0;
+                _perfAgcAllocs = 0;
+                _perfAgcCount = 0;
+                _perfAgcWindowStart = DateTime.UtcNow;
+            }
+        }
     }
+
+    // PERF-05 Phase 2a accumulators (gated by DiagFlags.PerfApplyGpsCycle).
+    private long _perfAgcTicks;
+    private long _perfAgcAllocs;
+    private int _perfAgcCount;
+    private DateTime _perfAgcWindowStart = DateTime.UtcNow;
 
     private void UpdateSectionPropertiesFromResult(bool[] states, int[]? colorCodes)
     {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -43,12 +43,14 @@ public partial class MainViewModel
     private double _heading;
     private double _rollDegrees;
 
-    // PERF-05 Phase 2c #1: latest snapshot values for fields not on
-    // State.Vehicle. Written by ApplyGpsCycleResult at sensor arrival
-    // (10-30 Hz) and read by OnDisplayTick at the fixed 10 Hz display
+    // PERF-05 Phase 2c #1/#2: latest snapshot values for status-display
+    // properties that aren't on State.Vehicle. Each is written by its
+    // upstream source at full source rate (GPS 10 Hz, control loop 100 Hz,
+    // AutoSteer 100 Hz) and read by OnStatusTick at the unified 5 Hz status
     // cadence. Single-double writes/reads are atomic on x86/ARM; no lock
-    // needed for diagnostic display.
+    // needed for diagnostic display values.
     private double _latestRollDegrees;
+    private double _latestGpsToPgnLatencyMs;
 
     #endregion
 
@@ -398,30 +400,37 @@ public partial class MainViewModel
 
     #endregion
 
-    #region Display Tick (PERF-05 Phase 2c #1)
+    #region Status Display Tick (PERF-05 Phase 2c #1/#2)
 
     /// <summary>
-    /// 10 Hz display sampler. Decouples MainViewModel display properties from
-    /// GPS sensor arrival — instead of being set inside ApplyGpsCycleResult
-    /// (at 10-30 Hz, the sensor rate), they're sampled from State.Vehicle
-    /// here at a fixed display rate. Matches the cadence architecture:
-    /// sensor arrival drives the state of record + control loop; display
-    /// refresh is independent and tuned for human readability.
+    /// Unified 5 Hz status-display sampler. The single tick that publishes
+    /// every MainViewModel property bound to the top status bar, regardless
+    /// of upstream source rate. Matches the cadence architecture:
+    /// each subsystem runs at its own appropriate rate (GPS 10 Hz, control
+    /// loop 100 Hz, AutoSteer 100 Hz) and updates State / caches; display
+    /// refresh is independent of all of them and tuned for human readability.
     ///
-    /// State.Vehicle is the system of record (already updated by
-    /// ApplyGpsCycleResult via State.Vehicle.UpdateFromGps). Fields not on
-    /// State.Vehicle (currently just RollDegrees) are cached by
-    /// ApplyGpsCycleResult into _latestRollDegrees and read here.
+    /// Sources:
+    /// - <c>State.Vehicle</c> — system of record, updated by
+    ///   ApplyGpsCycleResult via State.Vehicle.UpdateFromGps (GPS rate).
+    /// - <c>_latestRollDegrees</c> — cached by ApplyGpsCycleResult.
+    /// - <c>_latestGpsToPgnLatencyMs</c> — cached by OnAutoSteerStateUpdated
+    ///   at the AutoSteer 100 Hz tick rate.
     ///
-    /// SetProperty is a no-op when the new value equals the old via the
-    /// ref-comparer, so static or slow-changing values (FixQuality int once
-    /// quality is stable, etc.) won't fire PropertyChanged unnecessarily.
-    /// For double fields the comparer is reference-not-applicable; we don't
-    /// add per-property epsilon checks here because the 10 Hz cadence cap
-    /// is the primary lever — text re-format at 10 Hz is below the
-    /// human-readability threshold but still cheap.
+    /// 5 Hz (200 ms) is below the human perception threshold for numeric
+    /// text on a status bar and consolidates every status PropertyChanged
+    /// cascade to the same predictable rate — no future diagnostic readout
+    /// can accidentally re-introduce a 100-Hz PropertyChanged storm by
+    /// setting its MainViewModel property from its source event handler.
+    /// New status values just add a <c>_latest…</c> field and one line to
+    /// this method.
+    ///
+    /// SetProperty short-circuits when the new value equals the old (ref
+    /// comparison for strings, value comparison for primitives via the
+    /// CommunityToolkit equality helper), so unchanged values don't fire
+    /// PropertyChanged — no per-property epsilon check needed.
     /// </summary>
-    private void OnDisplayTick(object? sender, EventArgs e)
+    private void OnStatusTick(object? sender, EventArgs e)
     {
         var v = State.Vehicle;
         Latitude = v.Latitude;
@@ -432,6 +441,7 @@ public partial class MainViewModel
         Speed = v.Speed;
         RollDegrees = _latestRollDegrees;
         FixQuality = GetFixQualityString(v.FixQuality);
+        GpsToPgnLatencyMs = _latestGpsToPgnLatencyMs;
     }
 
     #endregion

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -43,6 +43,13 @@ public partial class MainViewModel
     private double _heading;
     private double _rollDegrees;
 
+    // PERF-05 Phase 2c #1: latest snapshot values for fields not on
+    // State.Vehicle. Written by ApplyGpsCycleResult at sensor arrival
+    // (10-30 Hz) and read by OnDisplayTick at the fixed 10 Hz display
+    // cadence. Single-double writes/reads are atomic on x86/ARM; no lock
+    // needed for diagnostic display.
+    private double _latestRollDegrees;
+
     #endregion
 
     #region GPS Properties
@@ -387,6 +394,44 @@ public partial class MainViewModel
         _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled);
         _gpsPipelineService.SetYouTurnConfig(
             UTurnSkipRows, IsSkipWorkedMode, HeadlandCalculatedWidth, HeadlandDistance);
+    }
+
+    #endregion
+
+    #region Display Tick (PERF-05 Phase 2c #1)
+
+    /// <summary>
+    /// 10 Hz display sampler. Decouples MainViewModel display properties from
+    /// GPS sensor arrival — instead of being set inside ApplyGpsCycleResult
+    /// (at 10-30 Hz, the sensor rate), they're sampled from State.Vehicle
+    /// here at a fixed display rate. Matches the cadence architecture:
+    /// sensor arrival drives the state of record + control loop; display
+    /// refresh is independent and tuned for human readability.
+    ///
+    /// State.Vehicle is the system of record (already updated by
+    /// ApplyGpsCycleResult via State.Vehicle.UpdateFromGps). Fields not on
+    /// State.Vehicle (currently just RollDegrees) are cached by
+    /// ApplyGpsCycleResult into _latestRollDegrees and read here.
+    ///
+    /// SetProperty is a no-op when the new value equals the old via the
+    /// ref-comparer, so static or slow-changing values (FixQuality int once
+    /// quality is stable, etc.) won't fire PropertyChanged unnecessarily.
+    /// For double fields the comparer is reference-not-applicable; we don't
+    /// add per-property epsilon checks here because the 10 Hz cadence cap
+    /// is the primary lever — text re-format at 10 Hz is below the
+    /// human-readability threshold but still cheap.
+    /// </summary>
+    private void OnDisplayTick(object? sender, EventArgs e)
+    {
+        var v = State.Vehicle;
+        Latitude = v.Latitude;
+        Longitude = v.Longitude;
+        Easting = v.Easting;
+        Northing = v.Northing;
+        Heading = v.Heading;
+        Speed = v.Speed;
+        RollDegrees = _latestRollDegrees;
+        FixQuality = GetFixQualityString(v.FixQuality);
     }
 
     #endregion

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Guidance.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Guidance.cs
@@ -38,11 +38,20 @@ public partial class MainViewModel
 
     private void OnAutoSteerStateUpdated(object? sender, VehicleStateSnapshot state)
     {
-        // Update latency display and tram state from AutoSteer pipeline
-        // This fires at 10Hz from the GPS receive path
+        // AutoSteer fires StateUpdated at the unified control-loop rate
+        // (100 Hz, decoupled from GPS — see Plans/Completed/
+        // UNIFIED_CONTROL_LOOP_PLAN.md). Latency display can't sit on this
+        // path — at 100 Hz the PropertyChanged → TextLayout cascade for
+        // the status-bar "Lat: 0.00ms" readout was 5.9% main-thread CPU
+        // (Phase 2b trace). We cache the latest value here and let
+        // OnStatusTick publish it at 5 Hz.
+        //
+        // TramControlByte → map service is structural (not display) and
+        // stays on the source rate. Single-double / single-byte writes are
+        // atomic on x86/ARM — no lock needed.
+        _latestGpsToPgnLatencyMs = state.TotalLatencyMs;
         if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
         {
-            GpsToPgnLatencyMs = state.TotalLatencyMs;
             TramControlByte = state.TramState;
             _mapService.SetTramControlByte(state.TramState);
         }
@@ -50,7 +59,6 @@ public partial class MainViewModel
         {
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
-                GpsToPgnLatencyMs = state.TotalLatencyMs;
                 TramControlByte = state.TramState;
                 _mapService.SetTramControlByte(state.TramState);
             });

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -93,6 +93,8 @@ public partial class MainViewModel : ObservableObject
     private readonly ApplicationState _appState;
     private readonly Avalonia.Threading.DispatcherTimer _simulatorTimer;
     private Avalonia.Threading.DispatcherTimer? _renderPullTimer;
+    // PERF-05 Phase 2c #1: 10 Hz display tick, decoupled from sensor arrival.
+    private Avalonia.Threading.DispatcherTimer? _displayTickTimer;
 
     /// <summary>
     /// Centralized application state - single source of truth for all runtime state.
@@ -333,6 +335,23 @@ public partial class MainViewModel : ObservableObject
             _renderPullTimer.Tick += OnRenderPullTick;
             _renderPullTimer.Start();
         }
+
+        // PERF-05 Phase 2c #1. Display values (Latitude, Heading, Speed, etc.)
+        // are decoupled from GPS sensor arrival and instead sampled at a fixed
+        // 10 Hz from State.Vehicle (the system of record, updated by
+        // ApplyGpsCycleResult). This matches the cadence design:
+        // sensor arrival drives State.Vehicle and the control loop, NOT the
+        // display refresh — the same pattern that decouples control from GPS.
+        // 10 Hz is sufficient for human readability of numeric text and cuts
+        // the PropertyChanged → Avalonia binding → TextLayout cascade from
+        // ~30 Hz (iPad sim) down to 10 Hz. See Plans/perf_data/2026-05-20/
+        // ANALYSIS.md §9.
+        _displayTickTimer = new Avalonia.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(100),
+        };
+        _displayTickTimer.Tick += OnDisplayTick;
+        _displayTickTimer.Start();
         _udpService.ModuleConnectionChanged += OnModuleConnectionChanged;
         _ntripService.ConnectionStatusChanged += OnNtripConnectionChanged;
         _ntripService.RtcmDataReceived += OnRtcmDataReceived;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -490,6 +490,13 @@ public partial class MainViewModel : ObservableObject
     {
         if (_positionEstimator?.GetLatestSnapshot() is null)
             return;
+
+        // PERF-05 #2: state-mirror cycle = one OnRenderPullTick after the
+        // early-return. Captures GetPose + SetAllPositions + SendStateToHandler.
+        bool sm = AgValoniaGPS.Models.Diagnostics.DiagFlags.PerfStateMirror;
+        long smT0 = sm ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+        long smA0 = sm ? GC.GetAllocatedBytesForCurrentThread() : 0;
+
         var p = _positionEstimator.GetPose(Clock.Current.GetTimestamp());
 
         var tool = ConfigStore.Tool;
@@ -533,7 +540,36 @@ public partial class MainViewModel : ObservableObject
             toolE, toolN, toolHeading,
             ConfigStore.ActualToolWidth, hitchE, hitchN,
             _toolPositionService.IsToolPositionReady);
+
+        if (sm)
+        {
+            _smCycleTicks += System.Diagnostics.Stopwatch.GetTimestamp() - smT0;
+            _smCycleAllocs += GC.GetAllocatedBytesForCurrentThread() - smA0;
+            _smCycleCount++;
+            var elapsed = (DateTime.UtcNow - _smWindowStart).TotalSeconds;
+            if (elapsed >= 1.0 && _smCycleCount > 0)
+            {
+                double ticksPerUs = System.Diagnostics.Stopwatch.Frequency / 1_000_000.0;
+                Console.WriteLine(
+                    $"[StateMirror-PERF] cycles={_smCycleCount}"
+                    + $" us/cycle={(_smCycleTicks / ticksPerUs / _smCycleCount):F1}"
+                    + $" alloc/cycle={(_smCycleAllocs / _smCycleCount)}B"
+                    + $" total_us={(long)(_smCycleTicks / ticksPerUs)}"
+                    + $" total_alloc={_smCycleAllocs}B"
+                    + $" window={elapsed:F2}s");
+                _smCycleTicks = 0;
+                _smCycleAllocs = 0;
+                _smCycleCount = 0;
+                _smWindowStart = DateTime.UtcNow;
+            }
+        }
     }
+
+    // PERF-05 #2: state-mirror accumulators. Gated by DiagFlags.PerfStateMirror.
+    private long _smCycleTicks;
+    private long _smCycleAllocs;
+    private int _smCycleCount;
+    private DateTime _smWindowStart = DateTime.UtcNow;
 
     private void RestoreSettings()
     {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -93,8 +93,10 @@ public partial class MainViewModel : ObservableObject
     private readonly ApplicationState _appState;
     private readonly Avalonia.Threading.DispatcherTimer _simulatorTimer;
     private Avalonia.Threading.DispatcherTimer? _renderPullTimer;
-    // PERF-05 Phase 2c #1: 10 Hz display tick, decoupled from sensor arrival.
-    private Avalonia.Threading.DispatcherTimer? _displayTickTimer;
+    // PERF-05 Phase 2c #2: unified 5 Hz status-display tick, decoupled from
+    // every data source (GPS 10 Hz, control loop 100 Hz, AutoSteer 100 Hz).
+    // Drives every MainViewModel property bound to the top status bar.
+    private Avalonia.Threading.DispatcherTimer? _statusTickTimer;
 
     /// <summary>
     /// Centralized application state - single source of truth for all runtime state.
@@ -336,22 +338,24 @@ public partial class MainViewModel : ObservableObject
             _renderPullTimer.Start();
         }
 
-        // PERF-05 Phase 2c #1. Display values (Latitude, Heading, Speed, etc.)
-        // are decoupled from GPS sensor arrival and instead sampled at a fixed
-        // 10 Hz from State.Vehicle (the system of record, updated by
-        // ApplyGpsCycleResult). This matches the cadence design:
-        // sensor arrival drives State.Vehicle and the control loop, NOT the
-        // display refresh — the same pattern that decouples control from GPS.
-        // 10 Hz is sufficient for human readability of numeric text and cuts
-        // the PropertyChanged → Avalonia binding → TextLayout cascade from
-        // ~30 Hz (iPad sim) down to 10 Hz. See Plans/perf_data/2026-05-20/
-        // ANALYSIS.md §9.
-        _displayTickTimer = new Avalonia.Threading.DispatcherTimer
+        // PERF-05 Phase 2c #2. Unified 5 Hz status-display tick — the single
+        // cadence for every top-status-bar bound MainViewModel property,
+        // decoupled from every upstream source rate (GPS 10 Hz, control loop
+        // 100 Hz, AutoSteer 100 Hz). 5 Hz (200 ms) is below the human
+        // perception threshold for numeric text on a status bar and cuts the
+        // PropertyChanged → Avalonia binding → TextLayout cascade for every
+        // status value to the same predictable rate.
+        //
+        // Replaces Phase 2c #1's 10 Hz "display tick" — same architecture,
+        // half the rate, and now also includes diagnostics like
+        // GpsToPgnLatencyMs that AutoSteer was writing at 100 Hz.
+        // See Plans/perf_data/2026-05-20/ANALYSIS.md.
+        _statusTickTimer = new Avalonia.Threading.DispatcherTimer
         {
-            Interval = TimeSpan.FromMilliseconds(100),
+            Interval = TimeSpan.FromMilliseconds(200),
         };
-        _displayTickTimer.Tick += OnDisplayTick;
-        _displayTickTimer.Start();
+        _statusTickTimer.Tick += OnStatusTick;
+        _statusTickTimer.Start();
         _udpService.ModuleConnectionChanged += OnModuleConnectionChanged;
         _ntripService.ConnectionStatusChanged += OnNtripConnectionChanged;
         _ntripService.RtcmDataReceived += OnRtcmDataReceived;

--- a/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs
@@ -3239,6 +3239,12 @@ public class DrawingContextMapControl : Control, ISharedMapControl
 
         // Per-category render timing (only accumulates when DiagFlags.LogRenderTiming is true)
         private long _rtGround, _rtGrid, _rtCoverage, _rtBoundary, _rtTracks, _rtVehicle;
+        // Parallel allocation buckets — track bytes allocated per section via
+        // GC.GetAllocatedBytesForCurrentThread() so we can distinguish necessary
+        // compute (CPU time grows with input) from per-frame allocation churn
+        // (bytes/frame grows with frequency, not input). Same gate as the time
+        // buckets above. PERF-05.
+        private long _raGround, _raGrid, _raCoverage, _raBoundary, _raTracks, _raVehicle;
         private int _rtFrameCount;
         private DateTime _rtWindowStart = DateTime.UtcNow;
 
@@ -3484,6 +3490,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                 using var cameraScope = drawingContext.PushPreTransform(cameraMatrix);
 
                 t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+                long a0 = rt ? GC.GetAllocatedBytesForCurrentThread() : 0;
                 // Ground texture
                 if (s.GroundTexture != null && s.FieldTextureVisible && !DiagFlags.SkipGroundTexture)
                 {
@@ -3496,7 +3503,11 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                 {
                     DrawBackgroundImage(drawingContext, s);
                 }
-                if (rt) _rtGround += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                if (rt)
+                {
+                    _rtGround += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                    _raGround += GC.GetAllocatedBytesForCurrentThread() - a0;
+                }
 
                 // Grid drawing moved into SKCanvas block below so all line segments
                 // batch into 2-3 DrawPath calls instead of hundreds of DrawLine calls.
@@ -3522,20 +3533,31 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                         // Grid (batched SKPath — was dominating zoom-out perf with
                         // hundreds of per-line DrawLine calls on ImmediateDrawingContext)
                         t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+                        a0 = rt ? GC.GetAllocatedBytesForCurrentThread() : 0;
                         if (s.IsGridVisible && !DiagFlags.SkipGrid)
                             DrawGridSk(canvas, s, viewWidth, viewHeight);
-                        if (rt) _rtGrid += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                        if (rt)
+                        {
+                            _rtGrid += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                            _raGrid += GC.GetAllocatedBytesForCurrentThread() - a0;
+                        }
 
                         // Coverage bitmap
                         t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+                        a0 = rt ? GC.GetAllocatedBytesForCurrentThread() : 0;
                         if (s.CoverageSkBitmap != null && (s.BitmapHasContent || s.BitmapExplicitlyInitialized)
                             && s.BitmapWidth > 0 && s.BitmapHeight > 0
                             && !DiagFlags.SkipCoverageDraw)
                             DrawCoverageBitmap(drawingContext, canvas, s);
-                        if (rt) _rtCoverage += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                        if (rt)
+                        {
+                            _rtCoverage += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                            _raCoverage += GC.GetAllocatedBytesForCurrentThread() - a0;
+                        }
 
                         // Boundary, headland, paths
                         t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+                        a0 = rt ? GC.GetAllocatedBytesForCurrentThread() : 0;
                         if (!DiagFlags.SkipBoundaryDraw)
                         {
                             if (s.Boundary != null)
@@ -3551,10 +3573,15 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                             DrawClipLineSk(canvas, s);
                         if (s.YouTurnPath != null && s.YouTurnPath.Count > 1)
                             DrawYouTurnPathSk(canvas, s);
-                        if (rt) _rtBoundary += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                        if (rt)
+                        {
+                            _rtBoundary += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                            _raBoundary += GC.GetAllocatedBytesForCurrentThread() - a0;
+                        }
 
                         // Tram lines + Tracks
                         t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+                        a0 = rt ? GC.GetAllocatedBytesForCurrentThread() : 0;
                         if (s.TramDisplayMode != AgValoniaGPS.Models.Configuration.TramDisplayMode.Off
                             && !DiagFlags.SkipTracks)
                             DrawTramLinesSk(canvas, s);
@@ -3563,7 +3590,11 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                             || s.RecordedPaths.Count > 0 || s.ContourStrips.Count > 0)
                             && !DiagFlags.SkipTracks)
                             DrawTrackSk(canvas, s);
-                        if (rt) _rtTracks += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                        if (rt)
+                        {
+                            _rtTracks += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                            _raTracks += GC.GetAllocatedBytesForCurrentThread() - a0;
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -3572,6 +3603,7 @@ public class DrawingContextMapControl : Control, ISharedMapControl
 
                     // Vehicle/tool always draws even if above fails
                     t0 = rt ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+                    a0 = rt ? GC.GetAllocatedBytesForCurrentThread() : 0;
                     if (s.ExtraGuidelines && s.ActiveTrack != null && s.ActiveTrack.Points.Count >= 2
                         && !DiagFlags.SkipTracks)
                         DrawExtraGuidelinesSk(canvas, s);
@@ -3592,7 +3624,11 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                         DrawSelectionMarkersSk(canvas, s);
                     if (s.ShowBoundaryOffsetIndicator)
                         DrawBoundaryOffsetIndicatorSk(canvas, s);
-                    if (rt) _rtVehicle += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                    if (rt)
+                    {
+                        _rtVehicle += System.Diagnostics.Stopwatch.GetTimestamp() - t0;
+                        _raVehicle += GC.GetAllocatedBytesForCurrentThread() - a0;
+                    }
                 }
 
                 if (rt)
@@ -3603,16 +3639,25 @@ public class DrawingContextMapControl : Control, ISharedMapControl
                     {
                         double toMsPerFrame(long t) =>
                             t * 1000.0 / System.Diagnostics.Stopwatch.Frequency / _rtFrameCount;
+                        long toBytesPerFrame(long b) => b / _rtFrameCount;
+                        // Per-section format: <name>=<ms>/<bytes>. The bytes
+                        // figure is per-frame average. A section where bytes
+                        // grow per cycle without input change is churn (PERF-05
+                        // umbrella: GH #403).
+                        long totalAlloc = _raGround + _raGrid + _raCoverage
+                                        + _raBoundary + _raTracks + _raVehicle;
                         Console.WriteLine(
                             $"[RenderBudget] frames={_rtFrameCount}"
-                            + $" ground={toMsPerFrame(_rtGround):F2}ms"
-                            + $" grid={toMsPerFrame(_rtGrid):F2}ms"
-                            + $" cov={toMsPerFrame(_rtCoverage):F2}ms"
-                            + $" bnd={toMsPerFrame(_rtBoundary):F2}ms"
-                            + $" trk={toMsPerFrame(_rtTracks):F2}ms"
-                            + $" veh={toMsPerFrame(_rtVehicle):F2}ms"
+                            + $" ground={toMsPerFrame(_rtGround):F2}ms/{toBytesPerFrame(_raGround)}B"
+                            + $" grid={toMsPerFrame(_rtGrid):F2}ms/{toBytesPerFrame(_raGrid)}B"
+                            + $" cov={toMsPerFrame(_rtCoverage):F2}ms/{toBytesPerFrame(_raCoverage)}B"
+                            + $" bnd={toMsPerFrame(_rtBoundary):F2}ms/{toBytesPerFrame(_raBoundary)}B"
+                            + $" trk={toMsPerFrame(_rtTracks):F2}ms/{toBytesPerFrame(_raTracks)}B"
+                            + $" veh={toMsPerFrame(_rtVehicle):F2}ms/{toBytesPerFrame(_raVehicle)}B"
+                            + $" tot_alloc={toBytesPerFrame(totalAlloc)}B/frame"
                             + $" zoom={s.Zoom:F2}");
                         _rtGround = _rtGrid = _rtCoverage = _rtBoundary = _rtTracks = _rtVehicle = 0;
+                        _raGround = _raGrid = _raCoverage = _raBoundary = _raTracks = _raVehicle = 0;
                         _rtFrameCount = 0;
                         _rtWindowStart = now;
                     }


### PR DESCRIPTION
## Summary

End-to-end perf audit, plus the first round of fixes it surfaced. Body of work spans three phases on the `perf-05/instrumentation` branch:

- **Phase 1**: instrument 7 subsystems with `Stopwatch` + `GC.GetAllocatedBytesForCurrentThread()` brackets, gated behind DiagFlags markers. Captured S1/S2/S3/S5/S6 on iPad Pro 12.9" 2nd gen and Samsung Android tablet. Analyzed and ranked churn candidates.
- **Phase 2 (a + b)**: instrument the remaining UI-thread bridge (`ApplyGpsCycleResult`), then take Xcode Instruments traces to attribute the residual "+13 ms iPad outside OnRender" gap.
- **Phase 2c (#1 + #2)**: ship the structural fix the audit surfaced — decouple status-bar display from sensor arrival, route everything through a unified 5 Hz tick.

### Headline (iPad Pro 12.9" 2nd gen, S5: simulator driving + sections off + field loaded)

| Metric | Before (Phase 2a) | **After (Phase 2c #2)** | Δ |
|---|---|---|---|
| **fps** | 43 | **64** | **+21 (+49%)** |
| frame time | 23.3 ms | 15.6 ms | −7.7 ms |
| outside OnRender | 17.0 ms | 10.1 ms | −6.9 ms |
| Main-thread CPU | 23.4% | 13% | −44% |
| Render-thread CPU | ~93% | ~82% | −12% |
| TextLayout.CreateTextLines (% main) | 23% | 7.2% | −69% |
| set_GpsToPgnLatencyMs (% main) | 5.6% | 0.5% | **−91%** |

Android (vsync-bound at 61 fps; visible win hidden by vsync cap): `ApplyGpsCycle` CPU **−63%** (1,517 → 557 µs/cycle).

### What the fix actually is

`MainViewModel` display properties bound to the top status bar (`Latitude`, `Longitude`, `Heading`, `Speed`, `RollDegrees`, `FixQuality`, `GpsToPgnLatencyMs`) used to be set directly from their source events (`ApplyGpsCycleResult` at GPS-cycle rate, `OnAutoSteerStateUpdated` at 100 Hz). Every set fired `PropertyChanged` → Avalonia binding cascade → TextBlock re-render → `TextLayout.CreateTextLines`. On iPad sim that was a 30 Hz cascade for GPS-sourced values plus a 100 Hz cascade for the latency display.

Now: a single 5 Hz `DispatcherTimer` (`_statusTickTimer`) drives `OnStatusTick`, which samples `State.Vehicle` (the system of record, still updated at sensor rate so the control loop sees fresh data) plus a few `_latest<X>` cache fields for values not on `State.Vehicle`. Sources just write the cache; the tick publishes. Pattern is uniform — any future top-bar diagnostic plugs into the cache → tick rule without re-introducing the cascade.

Matches the cadence architecture established in `Plans/Completed/UNIFIED_CONTROL_LOOP_PLAN.md` and `UNIFIED_PACKET_PROTOCOL.md`: each subsystem at its appropriate rate (machine 100 Hz, steer packet 50 Hz, GPS sensor 10 Hz, dead-reckoned screen position), and now also **display refresh at 5 Hz independent of all sources**.

### What's NOT in this PR (intentionally)

- Other fix candidates from the audit (`DrawTrackSk` / `DrawVehicleSk` paint caching, `Track` instance pooling, render-thread audit) — tracked on the umbrella churn issue #403 for separate follow-up PRs.
- Two functional bugs surfaced by the audit but unrelated to perf: #404 (Android AutoSteer not running) and #405 (`CoverageMapService.ClearAll()` wipes `_activeSections`).
- The instrumentation itself ships behind file-presence DiagFlags markers (off by default). It costs ~0 when disabled, doesn't need ripping out before merge, and stays available for future audit runs.

### Files

**Instrumentation (Phase 1 + 2a — gated behind DiagFlags markers, off in production):**
- `Shared/AgValoniaGPS.Models/Diagnostics/DiagFlags.cs` — 7 new marker fields (`PerfStateMirror`, `PerfGpsPipeline`, `PerfGuidance`, `PerfCoverage`, `PerfUdp`, `PerfAutoSteer`, `PerfApplyGpsCycle`)
- `Shared/AgValoniaGPS.Views/Controls/DrawingContextMapControl.cs` — alloc tracking on existing `[RenderBudget]` per-section timings
- `Shared/AgValoniaGPS.ViewModels/MainViewModel.cs` — `OnRenderPullTick` (state mirror)
- `Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs` — `ApplyGpsCycleResult` (UI-thread mirror)
- `Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs` — `ProcessCycle` (background pipeline)
- `Shared/AgValoniaGPS.Services/Track/TrackGuidanceService.cs` + `YouTurn/YouTurnGuidanceService.cs` — `CalculateGuidance`
- `Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs` — `AddCoveragePoint`
- `Shared/AgValoniaGPS.Services/UdpCommunicationService.cs` — RX + TX
- `Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs` — RX + TX

**Fix (Phase 2c #1 + #2):**
- `MainViewModel.cs` — `_statusTickTimer` at 200 ms (5 Hz)
- `MainViewModel.GpsHandling.cs` — `OnStatusTick` + `_latestRollDegrees` / `_latestGpsToPgnLatencyMs` cache fields
- `MainViewModel.ApplyResults.cs` — removes direct display-setter block (keeps `State.Vehicle.UpdateFromGps` as canonical write)
- `MainViewModel.Guidance.cs` — `OnAutoSteerStateUpdated` writes the latency cache instead of the property

**Plans + scripts:**
- `Plans/PERF_05_SUBSYSTEM_CHURN_AUDIT.md` — the audit plan (drafted at audit start)
- `Plans/PERFORMANCE_STRATEGY.md` — linked PERF_05 into the umbrella strategy doc
- `Plans/perf_data/2026-05-20/ANALYSIS.md` — full audit writeup, 11 sections, marked complete
- `Plans/perf_data/2026-05-20/TESTING.md` — repeatable scenario protocol
- `Plans/perf_data/2026-05-20/push-markers.sh` / `clear-markers.sh` — DiagFlags marker helpers (iPad via `devicectl`, Android via `adb run-as`)
- `Plans/perf_data/2026-05-20/instruments-trace-ipad.sh` — Xcode Instruments Time Profiler capture helper
- `Plans/perf_data/.gitignore` — excludes `*.log` capture data + `*.trace` / `instruments/` bundles

## Test plan

- [x] All seven subsystem PERF emissions verified on both iPad and Android with their markers set (Phase 1 captures)
- [x] Phase 2c #1 + #2 fix verified end-to-end:
  - [x] Build compiles clean on iOS + Android
  - [x] User-confirmed display refresh feels fine on iPad at 5 Hz (lat/lon, speed, heading, latency)
  - [x] FPS-logging shows iPad S5: 43 → 64 fps (+21)
  - [x] Time Profiler trace confirms `TextLayout.CreateTextLines` dropped from 23% → 7.2% main thread
  - [x] `set_GpsToPgnLatencyMs` dropped from 5.6% → 0.5% main thread
- [ ] Verify status bar still reads correct values on Desktop / Linux (not platform-specific code, but a quick sanity check before merge)
- [ ] (Optional) re-run capture suite from `TESTING.md` after merge to ensure develop baseline matches branch numbers

## Related

- Umbrella churn issue: #403 (updated with full ranked fix list + Phase 2c results)
- Surfaced during audit: #404 (Android AutoSteer not running), #405 (`ClearAll` wipes `_activeSections`)
- Strategy doc: `Plans/PERFORMANCE_STRATEGY.md` (links to `PERF_05` plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)