### PR TITLE
PERF-05 Phase 2c #6: remove cosmetic GPU costs (-5.4% render CPU, +6-8 FPS)

### DIFF
--- a/Plans/perf_data/2026-05-20/ANALYSIS.md
+++ b/Plans/perf_data/2026-05-20/ANALYSIS.md
@@ -509,7 +509,96 @@ indirect responsiveness gain (more slack for other UI work).
 4. **Cross-platform**: Android benefits proportionally; ApplyGpsCycle
    CPU dropped 63% there too.
 
-## 11. Bugs filed during this audit
+## 11. Phase 2c #6 results — render-thread audit (Tier 1/2/3)
+
+Starting from Phase 2c #2 (render thread at ~82% of one core, 11116 ms CPU
+in a 30 s window, FPS ~64 in S5), audited the render thread to find which
+specific work was paid every frame. Built three "tiers" of always-visible
+visual cuts and measured each with a fresh Time Profiler trace.
+
+### Three traces, four columns
+
+Each tier is cumulative on top of the previous one. Trace timestamps:
+baseline `134912`, Tier 1 `145157`, Tier 2 `151041`, Tier 3 `152648`. All
+captured iPad Pro 12.9" 2nd gen in S5 (sim driving, sections off, field +
+boundary loaded, panel closed), 30 s window.
+
+| Function (inclusive) | Base | T1 | T2 | T3 |
+|---|---:|---:|---:|---:|
+| `Avalonia_Skia_DrawingContextImpl` (all Skia) | 50.5% | 51.0% | **45.3%** | 45.5% |
+| `MapCompositionHandler_OnRender` | 23.2% | 23.3% | 23.9% | 24.5% |
+| `SkiaMetalRenderSession` | 18.8% | 18.9% | **16.2%** | 15.8% |
+| `BoxShadow` rendering path | 16.4% | 16.7% | **11.6%** | 11.5% |
+| `DrawingContextImpl_DrawRectangle` | 16.3% | 16.6% | **11.4%** | 11.4% |
+| `SKCanvas_Flush` (GPU submit) | 14.1% | 14.4% | **10.6%** | 10.3% |
+| `HandlePreGraphTransformClipOpacity` | 10.5% | 10.4% | 12.1% | 11.4% |
+| `SKCanvas_DrawRoundRect` | 7.3% | 8.0% | 4.4% | **0.2%** |
+| `SKCanvas_DrawRect` | 2.0% | 1.9% | 2.3% | **7.0%** |
+| `SKImageFilter` (blur filter path) | 0.9% | 0.9% | **0.0%** | 0.0% |
+| `Blur` | 0.6% | 0.6% | **0.0%** | 0.0% |
+
+**Render thread total CPU**: 11116 → 11156 → 10528 → **10520 ms** (−5.4%).
+**FPS in S5**: ~64 → 63-68 → 68-71 → **70-72**.
+**Per-frame render CPU** (total CPU / frames at FPS × 30s): 5.79 → 5.7 →
+5.1 → **4.94 ms (−14.7%)**.
+
+### What each tier did
+
+- **Tier 1: removed 14 decorative `<Rectangle Width="1">` separators and
+  `<Separator>` controls** in StatusBar (7), FieldStats (5), LeftNav (1),
+  BottomNav (1). Hypothesis: visual count = per-frame cost.
+- **Tier 2: removed `BoxShadow` from the shared `Border.FloatingPanel`
+  style and from `SectionControlPanel`'s outer Border** — 4 always-active
+  Gaussian-blur GPU passes per frame eliminated.
+- **Tier 3: squared all panel-button + outer-Border `CornerRadius`**
+  (`Border.FloatingPanel` 12 → 0; `LeftPanelButton/RightPanelButton/
+  BottomPanelButton/MenuButton` 8 → 0; `SectionButton` 4 → 0;
+  `ZoomButton` 8 → 0; camera-mode button 32 → 0).
+
+### Three structural learnings
+
+1. **Static visual count is NOT a reliable steady-state lever** on
+   Avalonia 12's compositor. Tier 1 removed 14 always-rendered visuals
+   and moved the render thread by +0.4% — pure noise. Best explanation:
+   the visuals were 1×16 px decorative dividers whose rasterization cost
+   was already below the per-sample noise floor.
+
+2. **Dynamic GPU effects like `BoxShadow` ARE the real lever for
+   steady-state cost.** Tier 2 cut 5.3% off render-thread CPU (−588 ms
+   in 30 s) and eliminated the entire `SKImageFilter` / `Blur` paths.
+   Drawing-list caching can't amortize blur passes because the blur is a
+   runtime Skia operation, not just static geometry replay.
+
+3. **Plain rect vs rounded rect of the same size costs about the same
+   on the GPU.** Tier 3 successfully converted `DrawRoundRect` calls
+   into `DrawRect` calls (−4.4 pp / +4.7 pp respectively) — proving
+   that static visuals DO render every frame, contrary to (1)'s naive
+   reading. But the work just transferred between Skia paths; total
+   per-frame cost only dropped marginally (~1-2 FPS, ~0.1% render CPU).
+   Static geometry is cheap; static *effects* are not.
+
+### The actual biggest remaining lever (next session)
+
+Empirically observed on the iPad during this audit: **when the tractor
+drives off the field-imagery PNG area, FPS jumps from ~70 to ~100 — a
++30 FPS / ~4-5 ms-per-frame swing.** That is 6× the impact of all three
+tiers above combined.
+
+`SKCanvas.DrawImage` shows only 4.4% inclusive on Time Profiler — Time
+Profiler is CPU-only and severely undercounts GPU-bound work like
+texture sampling, fragment shader cost, and bandwidth. The right tool
+for the imagery audit is **Metal System Trace** (already supported by
+`Plans/perf_data/2026-05-20/instruments-trace-ipad.sh` via
+`TEMPLATE='Metal System Trace' bash …`).
+
+Levers to investigate: texture resolution and tile size, mipmap
+presence, texture format (compressed ASTC/ETC2 vs raw RGBA),
+per-frame uploads vs cache, sampling mode (bilinear vs nearest), alpha
+blending mode (opaque vs semi-transparent).
+
+Memory pointer saved for next session: `project_imagery_render_cost`.
+
+## 12. Bugs filed during this audit
 
 - **#404** — Android `AutoSteerService` not running (no PGN TX, breaks
   manual section painting)

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -92,7 +92,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     Width="64" Height="64"
                     HorizontalAlignment="Center"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    CornerRadius="32" Background="#4A90D9"
+                    CornerRadius="0" Background="#4A90D9"
                     ToolTip.Tip="Camera mode: North-Up / Heading-Up / Free">
                 <TextBlock Text="{Binding CameraModeLabel}" FontSize="20" FontWeight="Bold"
                            Foreground="White" HorizontalAlignment="Center"/>

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -79,7 +79,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Width="64" Height="64"
                             HorizontalAlignment="Center"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            CornerRadius="32" Background="#4A90D9">
+                            CornerRadius="0" Background="#4A90D9">
                         <TextBlock Text="{Binding CameraModeLabel}" FontSize="20" FontWeight="Bold"
                                    Foreground="White" HorizontalAlignment="Center"/>
                     </Button>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Floating Panel Style -->
         <Style Selector="Border.FloatingPanel">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Padding" Value="6"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
@@ -46,7 +46,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Bottom Panel Button Style -->
         <Style Selector="Button.BottomPanelButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
             <Setter Property="Padding" Value="8"/>
@@ -71,7 +71,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Menu Button (opens flyout) -->
         <Style Selector="Button.MenuButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
-            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
             <Setter Property="Padding" Value="8"/>
@@ -88,18 +88,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Flyout Panel Style -->
         <Style Selector="Border.FlyoutPanel">
             <Setter Property="Background" Value="#EE1E2A38"/>
-            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>
 
-        <!-- Panel Separator -->
-        <Style Selector="Separator.BottomPanelSeparator">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="Width" Value="2"/>
-            <Setter Property="Margin" Value="4,8"/>
-        </Style>
     </UserControl.Styles>
 
     <!-- Main container: Panel for proper layout measurement, Canvas overlay for flyouts.
@@ -210,8 +204,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         IsVisible="{Binding IsFieldOpen}">
                     <Image Source="{Binding TramDisplayIcon, Converter={x:Static converters:StringToImageConverter.Instance}}" Stretch="Uniform"/>
                 </Button>
-
-                <Separator Classes="BottomPanelSeparator"/>
 
                 <!-- AB Line Menu Button (opens flyout) - always visible -->
                 <Button x:Name="ABLineMenuButton" Classes="MenuButton" ToolTip.Tip="AB Line Options">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldStatsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldStatsPanel.axaml
@@ -25,26 +25,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding HasActiveField}">
 
-    <StackPanel Orientation="Horizontal" Spacing="12">
+    <StackPanel Orientation="Horizontal" Spacing="18">
         <TextBlock Text="{Binding CurrentFieldAndJobLabel}" Foreground="#3498DB" FontSize="13" FontWeight="Bold"
-                   IsVisible="{Binding CurrentFieldName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-        <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}"
                    IsVisible="{Binding CurrentFieldName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
             <TextBlock Text="Field:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
             <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13" FontWeight="Bold"/>
         </StackPanel>
-        <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
             <TextBlock Text="Done:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
             <TextBlock Text="{Binding WorkedAreaDisplay}" Foreground="#2ECC71" FontSize="13" FontWeight="Bold"/>
         </StackPanel>
-        <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
             <TextBlock Text="Left:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
             <TextBlock Text="{Binding RemainingPercent, StringFormat='{}{0:F1}%'}" Foreground="#F39C12" FontSize="13" FontWeight="Bold"/>
         </StackPanel>
-        <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         <StackPanel Orientation="Horizontal" Spacing="4">
             <TextBlock Text="Rate:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
             <TextBlock Text="{Binding WorkRateDisplay}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="13" FontWeight="Bold"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Floating Panel Style -->
         <Style Selector="Border.FloatingPanel">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
@@ -41,7 +41,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Left Panel Button Style -->
         <Style Selector="Button.LeftPanelButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
             <Setter Property="Padding" Value="8"/>
@@ -55,12 +55,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
         </Style>
 
-        <!-- Left Panel Separator -->
-        <Style Selector="Separator.LeftPanelSeparator">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="Height" Value="2"/>
-            <Setter Property="Margin" Value="8,4"/>
-        </Style>
     </UserControl.Styles>
 
     <!-- Panel for proper layout measurement; Canvas overlay for sub-panels -->
@@ -74,8 +68,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ToggleFileMenuPanelCommand}">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/fileMenu.png" Stretch="Uniform"/>
                 </Button>
-
-                <Separator Classes="LeftPanelSeparator"/>
 
                 <!-- 2. View Settings -->
                 <Button Classes="LeftPanelButton" ToolTip.Tip="View Settings"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
@@ -37,7 +37,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Floating Panel Style -->
         <Style Selector="Border.FloatingPanel">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
-            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
@@ -46,7 +46,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Right Panel Button Style -->
         <Style Selector="Button.RightPanelButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Width" Value="64"/>
             <Setter Property="Height" Value="64"/>
             <Setter Property="Padding" Value="8"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Custom Button template that preserves bound Background on all states -->
         <Style Selector="Button.SectionButton">
-            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="CornerRadius" Value="0"/>
             <Setter Property="Height" Value="40"/>
             <Setter Property="Width" Value="48"/>
             <Setter Property="Cursor" Value="Hand"/>
@@ -70,8 +70,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <!-- Floating panel with section indicators.
          Hidden when no field open (#347): sections can't paint with no boundary. -->
-    <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="12"
-            BoxShadow="0 4 16 2 #40000000"
+    <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="0" Padding="12"
             IsVisible="{Binding HasBoundary}">
         <StackPanel Orientation="Horizontal" Spacing="8">
             <!-- Section buttons - 2 rows of up to 8 each -->

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
@@ -48,18 +48,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <StackPanel Spacing="6">
         <!-- Line 1: existing readouts on the left, G/I/A/M indicators on the right. -->
         <Grid ColumnDefinitions="*,Auto">
-            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="10">
+            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="20">
                 <!-- Widths fixed so values don't reflow the bar as digits change (#277). -->
                 <Ellipse Width="12" Height="12"
                          Fill="{Binding State.Vehicle.FixQualityText, Converter={StaticResource FixQualityToColorConverter}}"/>
                 <TextBlock Width="75" Text="{Binding State.Vehicle.FixQualityText}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" FontWeight="Bold"/>
-                <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="5,0"/>
                 <TextBlock Width="100" Text="{Binding SpeedKmh, StringFormat='{}{0:F1} km/h'}" Foreground="#E67E22" FontSize="14" FontWeight="Bold"/>
-                <Rectangle Width="1" Height="16" Fill="#555" Margin="5,0"/>
                 <TextBlock Width="70" Text="{Binding Heading, StringFormat='{}{0:F0}deg'}" Foreground="#E91E90" FontSize="14" FontWeight="Bold"/>
-                <Rectangle Width="1" Height="16" Fill="#555" Margin="5,0"/>
                 <TextBlock Width="95" Text="{Binding RollDegrees, StringFormat='Roll {0:F1}'}" Foreground="#9B59B6" FontSize="14" FontWeight="Bold"/>
-                <Rectangle Width="1" Height="16" Fill="#555" Margin="5,0"/>
                 <TextBlock Width="80" Text="{Binding CurrentTime}" Foreground="#95A5A6" FontSize="14"/>
             </StackPanel>
 
@@ -125,13 +121,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,2"/>
 
-        <StackPanel Orientation="Horizontal" Spacing="10">
+        <StackPanel Orientation="Horizontal" Spacing="20">
             <TextBlock Width="85"  Text="{Binding CurrentFps, StringFormat='FPS: {0:F0}'}" Foreground="#2ECC71" FontSize="14" FontWeight="Bold"/>
-            <Rectangle Width="1" Height="16" Fill="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="5,0"/>
             <TextBlock Width="110" Text="{Binding GpsToPgnLatencyMs, StringFormat='Lat: {0:F2}ms'}" Foreground="#F39C12" FontSize="14" FontWeight="Bold"/>
-            <Rectangle Width="1" Height="16" Fill="#555" Margin="5,0"/>
             <TextBlock Width="160" Text="{Binding Latitude, StringFormat='Lat: {0:F8}'}" Foreground="#3498DB" FontSize="14" FontWeight="Bold"/>
-            <Rectangle Width="1" Height="16" Fill="#555" Margin="5,0"/>
             <TextBlock Width="170" Text="{Binding Longitude, StringFormat='Lon: {0:F8}'}" Foreground="#3498DB" FontSize="14" FontWeight="Bold"/>
         </StackPanel>
     </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
@@ -26,9 +26,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Floating Panel Style -->
     <Style Selector="Border.FloatingPanel">
         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
-        <Setter Property="CornerRadius" Value="12"/>
+        <Setter Property="CornerRadius" Value="0"/>
         <Setter Property="Padding" Value="15"/>
-        <Setter Property="BoxShadow" Value="0 4 16 2 #40000000"/>
     </Style>
 
     <!-- Modern Button Style -->
@@ -77,7 +76,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Left Panel Button Style (for image-based icons) -->
     <Style Selector="Button.LeftPanelButton">
         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="CornerRadius" Value="0"/>
         <Setter Property="Width" Value="64"/>
         <Setter Property="Height" Value="64"/>
         <Setter Property="Padding" Value="8"/>
@@ -89,13 +88,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </Style>
     <Style Selector="Button.LeftPanelButton:pressed">
         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
-    </Style>
-
-    <!-- Left Panel Separator -->
-    <Style Selector="Separator.LeftPanelSeparator">
-        <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-        <Setter Property="Height" Value="2"/>
-        <Setter Property="Margin" Value="8,4"/>
     </Style>
 
     <!-- Status Indicator Style -->
@@ -137,7 +129,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="CornerRadius" Value="0"/>
         <Setter Property="BorderThickness" Value="0"/>
     </Style>
     <Style Selector="Button.ZoomButton:pointerover">

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 122
+#define VERSION_PATCH 125
 
-#define VERSION "26.4.122"
-#define VERSION_DATE "2026-05-17"
+#define VERSION "26.4.125"
+#define VERSION_DATE "2026-05-20"


### PR DESCRIPTION
## Summary

Render-thread audit on iPad Pro 12.9" 2nd gen (Phase 2c #6 of PERF-05). Three cumulative tiers of always-visible visual cuts, each measured against a fresh Time Profiler trace in S5.

- **Tier 1** — removed 14 decorative `<Rectangle>` / `<Separator>` dividers (StatusBar 7, FieldStats 5, LeftNav 1, BottomNav 1). Render CPU +0.4% (noise). **Static visuals below the noise floor are not the lever.**
- **Tier 2** — removed `BoxShadow` from the shared `Border.FloatingPanel` style (LeftNav, RightNav, BottomNav, RecordedPath) and from `SectionControlPanel`. 4 always-active Gaussian-blur GPU passes eliminated. Render CPU **−5.3%**, FPS 64 → 68-71. `SKImageFilter` and `Blur` paths fall to 0.0%.
- **Tier 3** — squared `CornerRadius` on all always-visible panel buttons and outer Borders (8/12/4/32 → 0). `DrawRoundRect` 4.4% → 0.2%; `DrawRect` 2.3% → 7.0%. Work transferred between Skia buckets. Net +2 FPS.

**Cumulative**: render thread CPU 11116 → 10520 ms (−5.4%); per-frame render cost 5.79 → 4.94 ms (−14.7%); S5 FPS ~64 → 70-72.

| Function | Base | Tier 2 | Tier 3 |
|---|---:|---:|---:|
| All Skia work | 50.5% | **45.3%** | 45.5% |
| `SkiaMetalRenderSession` | 18.8% | **16.2%** | 15.8% |
| `BoxShadow` rendering path | 16.4% | **11.6%** | 11.5% |
| `SKCanvas.Flush` | 14.1% | **10.6%** | 10.3% |
| `SKCanvas.DrawRoundRect` | 7.3% | 4.4% | **0.2%** |
| `SKImageFilter` (blur) | 0.9% | **0.0%** | 0.0% |

### Structural learnings

1. **Static visual count is NOT a steady-state lever** on Avalonia 12's compositor when the visuals are small (1×16 px dividers). Their per-frame cost is below the noise floor.
2. **Runtime GPU effects ARE the lever.** `BoxShadow` runs a Gaussian-blur pass every frame regardless of drawing-list caching, because the blur is a runtime Skia operation, not just geometry replay.
3. **Plain vs rounded rect costs about the same** on GPU for the same size — the work just moves between Skia paths. Static geometry is cheap; static *effects* are not.

### Next target (flagged for next session)

Empirically observed during this audit: when the tractor drives off the field-imagery PNG area, **iPad FPS jumps from ~70 to ~100** — a +30 FPS / 4-5 ms-per-frame swing. That's 6× the impact of all three tiers in this PR combined. Time Profiler showed only 4.4% inclusive on `SKCanvas.DrawImage` because GPU texture sampling and fragment shader work are invisible to CPU profiling. Next audit should use **Metal System Trace** (the trace script already supports `TEMPLATE='Metal System Trace'`). Memory pointer: `project_imagery_render_cost`.

Full writeup in `Plans/perf_data/2026-05-20/ANALYSIS.md` §11.

Builds on #406.

## Test plan

- [x] Desktop build clean (only pre-existing `Watermark` warnings)
- [x] iPad build clean (`-r ios-arm64`), installed and launched on UDID `d2fcb0323a90ad2954ab501f2603cd7573d99b2a`
- [x] Visual check on iPad: separators absent, shadows gone, square buttons — confirmed acceptable by user
- [x] FPS in S5 measured at each tier: 64 → 63-68 → 68-71 → 70-72
- [x] Time Profiler trace captured at each tier (4 total in `Plans/perf_data/2026-05-20/instruments/`, gitignored)
- [ ] Cross-platform parity: Desktop camera button also squared (was circle, kept iOS/Desktop in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)