### PR TITLE
Fix #408: snap to next track replans armed u-turn instead of jumping to exit

### DIFF
--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -412,6 +412,20 @@ public sealed class GpsPipelineService : IGpsPipelineService
             _guidanceWorking.HowManyPathsAway += delta;
             _guidanceWorking.NudgeOffset = 0;
             _trackGuidanceState = null;
+
+            // #408. If a u-turn is plotted but not yet executing, drop it
+            // so the state machine re-arms for the new pass direction on
+            // the next tick. Without this the tractor enters the already-
+            // armed arc and lands on the *old* NextTrack (the original
+            // exit pass) instead of replanning for the just-snapped pass.
+            // Mirrors the direction-override re-arm in YouTurnStateMachine.
+            // Mid-arc snaps are unsafe and stay no-op.
+            if (_youTurn.TurnPath != null && !_youTurn.IsExecuting)
+            {
+                _youTurn.TurnPath = null;
+                _youTurn.NextTrack = null;
+                _youTurn.IsTriggered = false;
+            }
         }
         // Phase D D5. Nudge accumulates (multiple clicks between drains sum).
         // Heading-same-way flips the sign so "left" always means left from the

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 4
-#define VERSION_PATCH 128
+#define VERSION_PATCH 129
 
-#define VERSION "26.4.128"
+#define VERSION "26.4.129"
 #define VERSION_DATE "2026-05-20"


### PR DESCRIPTION
Closes #408.

## Symptom

When approaching a plotted u-turn, pressing **Snap to Left Track** or
**Snap to Right Track** caused the tractor to enter the already-armed
arc and land on the original \`NextTrack\` (the *exit* of the old turn),
rather than discarding the plotted turn and replanning for the new
pass direction.

## Root cause

The snap intent handler in \`GpsPipelineService.ProcessCycle\` advanced
\`HowManyPathsAway\` and reset \`NudgeOffset\`, but left the
\`YouTurnWorkingState\` untouched. \`TurnPath\` and \`NextTrack\` stayed
pointing at the original computed turn, so the state machine kept
executing the original plan on entry to the headland zone.

## Fix

In the snap handler, drop \`TurnPath\` / \`NextTrack\` / \`IsTriggered\`
when a turn is armed but not yet executing. This mirrors the existing
direction-override re-arm in \`YouTurnStateMachine\` lines 192-203.
The state machine then re-arms with the new pass direction on the
next tick — same behavior the swap-direction button produces.

Mid-arc snaps (\`IsExecuting\`) stay no-op so the tractor never
suddenly loses its path while actively following an arc.

## Test plan

- [x] \`dotnet build\` — clean, 0 errors
- [x] \`dotnet test\` — 1,366 pass / 0 fail
- [x] Desktop visual: drive simulator toward armed u-turn, snap left/right → plotted cyan path disappears, new turn replans for the new pass, tractor follows the new arc
- [x] No regression for snap with no turn armed (just shifts passes as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)