### PR TITLE
Fix #420: label boundary recording offset field, default to 100 cm

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2804,7 +2804,7 @@ public partial class MainViewModel : ObservableObject
         }
     }
 
-    private double _boundaryOffset;
+    private double _boundaryOffset = 100.0;
     public double BoundaryOffset
     {
         get => _boundaryOffset;

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryPlayerPanel.axaml
@@ -31,7 +31,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <StackPanel Spacing="4">
 
                 <!-- Offset Distance Input -->
-                <Grid ColumnDefinitions="Auto,*" Margin="8,4">
+                <TextBlock Text="Recording Offset" FontSize="14" FontWeight="Bold"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                           Margin="8,4,8,0"/>
+                <Grid ColumnDefinitions="Auto,*" Margin="8,0,8,4">
                     <Button Grid.Column="0" Background="AliceBlue" CornerRadius="4" Padding="8,4" MinWidth="100"
                             ClickMode="Press" Command="{Binding ShowBoundaryOffsetDialogCommand}" Cursor="Hand"
                             ToolTip.Tip="Click to enter offset distance">

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 0
+#define VERSION_PATCH 1
 
-#define VERSION "26.5.0"
+#define VERSION "26.5.1"
 #define VERSION_DATE "2026-05-23"


### PR DESCRIPTION
## Summary
Issue #420 reported boundary recording on the "incorrect side." As confirmed during investigation, the recording side and offset both work correctly — the screenshot showed coverage from the tractor center because the offset defaulted to **0 cm**. The real problem was discoverability: the numeric data field in the boundary recording panel had no label, so it wasn't clear it was the recording offset.

## Changes
- **Add a "Recording Offset" label** above the offset field in `BoundaryPlayerPanel.axaml` (the "cm" unit was already shown beside the value).
- **Default `BoundaryOffset` to 100 cm** (`MainViewModel.cs`) instead of 0, so new fields record an offset from center by default.
- Bump version 26.5.0 → 26.5.1.

## Testing
- Desktop build succeeds (pre-existing warnings only).
- Offset behavior itself was verified working by the reporter prior to this change.
<img width="649" height="586" alt="Screenshot 2026-05-23 at 8 20 32 PM" src="https://github.com/user-attachments/assets/65bc096d-fad2-45f6-a04b-a1abbbe36805" />

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)