### PR TITLE
Fix #419: enable Auto section control with a field open but no boundary

### DIFF
--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -889,13 +889,21 @@ public class SectionControlService : ISectionControlService
     {
         var boundary = _state.Field.CurrentBoundary;
         if (boundary == null || !boundary.IsValid)
-            // No field open → treat every section as fully outside.
-            // shouldBeOn requires lookOnInBoundary, so this gates Auto sections off.
-            // The strict isInBoundary check (>= 95 %) also fails, so the early
-            // UpdateSectionOff in UpdateAutoSection fires and forces IsOn=false.
-            // Issue #347: spraying outside a defined field is never the
-            // intended operation; the firmware on AiO already enforces this.
-            return BoundaryResult.FullyOutside;
+        {
+            // No usable boundary. Two cases:
+            //  • A field IS open but has no boundary yet (#419): Auto must
+            //    still work — coverage drives on/off so sections turn off
+            //    when crossing previously-applied area while free driving.
+            //    Treat every section as fully inside so the boundary gate is
+            //    a no-op and the coverage check is the only authority.
+            //  • No field open at all (#347): spraying with no field defined
+            //    is never intended (AiO firmware enforces the same), so treat
+            //    every section as fully outside, which gates Auto off and
+            //    forces IsOn=false via the strict isInBoundary check.
+            return _state.Field.HasActiveField
+                ? BoundaryResult.FullyInside
+                : BoundaryResult.FullyOutside;
+        }
 
         return boundary.GetSegmentBoundaryStatus(sectionCenter, heading, halfWidth);
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
@@ -108,12 +108,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Button>
 
             <!-- 3. Section Master Toggle - All sections Auto/Off -->
-            <!-- Requires a boundary: auto-section logic only has meaningful
-                 input (coverage / boundary intersect) once a boundary exists.
-                 Operators in the no-boundary workflow use Manual Mode (#2). -->
+            <!-- Available as soon as a field is open (#419). Auto section
+                 control is valid with no boundary: coverage alone drives
+                 on/off, so sections turn off when crossing previously-applied
+                 area while free driving. A boundary just adds boundary/headland
+                 gating on top when one exists. -->
             <Button Classes="RightPanelButton" ToolTip.Tip="All Sections Auto/Off"
                     Command="{Binding ToggleSectionMasterCommand}"
-                    IsVisible="{Binding HasBoundary}">
+                    IsVisible="{Binding IsFieldOpen}">
                 <Panel>
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/SectionMasterOn.png" Stretch="Uniform"
                            IsVisible="{Binding IsSectionMasterOn}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
@@ -69,9 +69,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <!-- Floating panel with section indicators.
-         Hidden when no field open (#347): sections can't paint with no boundary. -->
+         Shown whenever a field is open (#419) — Auto works without a boundary,
+         driving section on/off off coverage. Hidden only when no field is open
+         (#347): sections can't paint with no field defined. -->
     <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="0" Padding="12"
-            IsVisible="{Binding HasBoundary}">
+            IsVisible="{Binding IsFieldOpen}">
         <StackPanel Orientation="Horizontal" Spacing="8">
             <!-- Section buttons - 2 rows of up to 8 each -->
             <StackPanel Orientation="Vertical" Spacing="4">

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 1
+#define VERSION_PATCH 2
 
-#define VERSION "26.5.1"
+#define VERSION "26.5.2"
 #define VERSION_DATE "2026-05-23"


### PR DESCRIPTION
## Summary
Issue #419: with a field open but no boundary, only the **Manual** section button appeared — there was no **Auto** button. Auto section control should work without a boundary, turning sections off when crossing previously-applied (covered) area while free driving.

Root cause: the **Section Master (Auto)** button was gated on `HasBoundary`, while the **Manual** button was gated on `IsFieldOpen`. The two buttons used different gates, so a boundary-less field showed only Manual. The section service also treated "no boundary" identically to "no field" (returning `FullyOutside`), which would have gated Auto off even if the button were shown.

## Changes
- **`RightNavigationPanel.axaml`** — Section Master (Auto) button now shows on `IsFieldOpen` (matching the Manual button).
- **`SectionControlPanel.axaml`** — section-indicator panel shows on `IsFieldOpen` instead of `HasBoundary`.
- **`SectionControlService.GetSegmentBoundaryStatus`** — when there's no usable boundary:
  - **field open** → return `FullyInside`, so the boundary gate is a no-op and coverage alone drives section on/off (sections turn off over already-applied area).
  - **no field open** → still return `FullyOutside`, preserving #347 (sections locked off, no painting with no field defined).

## Behavior matrix
| State | Auto button | Auto behavior |
|-------|-------------|---------------|
| No field open | hidden | n/a (sections off — #347) |
| Field open, no boundary | **shown** | coverage-driven on/off (#419) |
| Field open, with boundary | shown | coverage + boundary + headland gating |

## Testing
- Desktop build succeeds, 0 errors.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)