### PR TITLE
Fix #417: section width units + total-width math (+ smooth grid LOD)

### DIFF
--- a/Shared/AgValoniaGPS.Models/Base/UnitConversion.cs
+++ b/Shared/AgValoniaGPS.Models/Base/UnitConversion.cs
@@ -1,0 +1,33 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace AgValoniaGPS.Models.Base;
+
+/// <summary>
+/// Display-boundary length conversions. All lengths are stored internally in
+/// metric (cm for tool/section widths, meters for totals); these helpers
+/// convert only at the UI display/input boundary when the user selects
+/// Imperial units. Keep storage metric — convert here, never in the model.
+/// </summary>
+public static class UnitConversion
+{
+    public const double CmPerInch = 2.54;
+    public const double FeetPerMeter = 3.280839895;
+
+    public static double CmToInches(double cm) => cm / CmPerInch;
+    public static double InchesToCm(double inches) => inches * CmPerInch;
+    public static double MetersToFeet(double meters) => meters * FeetPerMeter;
+}

--- a/Shared/AgValoniaGPS.Models/Configuration/ConfigurationStore.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ConfigurationStore.cs
@@ -106,7 +106,23 @@ public class ConfigurationStore : ObservableObject
     public int NumSections
     {
         get => _numSections;
-        set => SetProperty(ref _numSections, Math.Clamp(value, 1, 16));
+        set
+        {
+            int clamped = Math.Clamp(value, 1, 16);
+            int previous = _numSections;
+            // Seed newly-activated sections with the current Default Section
+            // Width ("Width applied to new sections") BEFORE raising the
+            // NumSections change, so listeners that re-read section widths see
+            // the seeded values. Sections that already existed keep their
+            // individually-set widths. Profile load sets explicit per-section
+            // widths AFTER NumSections, so those overwrite this seed (#417).
+            if (clamped > previous)
+            {
+                for (int i = previous; i < clamped; i++)
+                    Tool.SetSectionWidth(i, Tool.DefaultSectionWidth);
+            }
+            SetProperty(ref _numSections, clamped);
+        }
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 
 using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
 using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Services.Interfaces;
 using CommunityToolkit.Mvvm.Input;
@@ -659,8 +660,54 @@ public partial class ConfigurationViewModel : ObservableObject
         }
     }
 
+    // ── Units (#417) ──────────────────────────────────────────────────
+    // Widths are stored in cm; totals in meters. When the user selects
+    // Imperial, section widths display/edit in inches and totals in feet.
+    // Conversion happens only here at the display/input boundary — the
+    // model stays metric. All of these are reactive: raised on IsMetric,
+    // NumSections, DefaultSectionWidth, and individual width edits.
+
+    /// <summary>Unit suffix for individual section widths ("cm" / "in").</summary>
+    public string SectionWidthUnit => Config.IsMetric ? "cm" : "in";
+
+    /// <summary>Numeric format for section widths (cm whole, inches 1 dp).</summary>
+    public string SectionWidthFormat => Config.IsMetric ? "F0" : "F1";
+
+    /// <summary>Footer caption under the section-width grid.</summary>
+    public string SectionWidthUnitLabel => Config.IsMetric ? "All widths in cm" : "All widths in inches";
+
+    /// <summary>Default section width in the current display unit (TwoWay).</summary>
+    public double DefaultSectionWidthDisplay
+    {
+        get => Config.IsMetric
+            ? Tool.DefaultSectionWidth
+            : UnitConversion.CmToInches(Tool.DefaultSectionWidth);
+        set
+        {
+            Tool.DefaultSectionWidth = Config.IsMetric ? value : UnitConversion.InchesToCm(value);
+        }
+    }
+
+    /// <summary>Formatted total tool width with unit ("16.00 m" / "52.49 ft").
+    /// Used by both the in-tab total and the dialog footer — replaces the
+    /// stale, non-notifying Config.ActualToolWidth binding (#417 math bug).</summary>
+    public string CalculatedTotalWidthText
+    {
+        get
+        {
+            double meters = CalculatedSectionTotal;
+            return Config.IsMetric
+                ? $"{meters:F2} m"
+                : $"{UnitConversion.MetersToFeet(meters):F2} ft";
+        }
+    }
+
+    private string FormatSectionWidth(double cm) => Config.IsMetric
+        ? cm.ToString("F0", CultureInfo.InvariantCulture)
+        : UnitConversion.CmToInches(cm).ToString("F1", CultureInfo.InvariantCulture);
+
     /// <summary>
-    /// Gets the width of a specific section for display (1-based index).
+    /// Gets the width of a specific section for display (1-based index), in cm.
     /// </summary>
     public double GetSectionWidthForDisplay(int sectionNumber)
     {
@@ -669,24 +716,24 @@ public partial class ConfigurationViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Section width display properties for binding (1-based).
+    /// Section width display strings for binding (1-based), in current units.
     /// </summary>
-    public double Section1Width => Tool.GetSectionWidth(0);
-    public double Section2Width => Tool.GetSectionWidth(1);
-    public double Section3Width => Tool.GetSectionWidth(2);
-    public double Section4Width => Tool.GetSectionWidth(3);
-    public double Section5Width => Tool.GetSectionWidth(4);
-    public double Section6Width => Tool.GetSectionWidth(5);
-    public double Section7Width => Tool.GetSectionWidth(6);
-    public double Section8Width => Tool.GetSectionWidth(7);
-    public double Section9Width => Tool.GetSectionWidth(8);
-    public double Section10Width => Tool.GetSectionWidth(9);
-    public double Section11Width => Tool.GetSectionWidth(10);
-    public double Section12Width => Tool.GetSectionWidth(11);
-    public double Section13Width => Tool.GetSectionWidth(12);
-    public double Section14Width => Tool.GetSectionWidth(13);
-    public double Section15Width => Tool.GetSectionWidth(14);
-    public double Section16Width => Tool.GetSectionWidth(15);
+    public string Section1Width => FormatSectionWidth(Tool.GetSectionWidth(0));
+    public string Section2Width => FormatSectionWidth(Tool.GetSectionWidth(1));
+    public string Section3Width => FormatSectionWidth(Tool.GetSectionWidth(2));
+    public string Section4Width => FormatSectionWidth(Tool.GetSectionWidth(3));
+    public string Section5Width => FormatSectionWidth(Tool.GetSectionWidth(4));
+    public string Section6Width => FormatSectionWidth(Tool.GetSectionWidth(5));
+    public string Section7Width => FormatSectionWidth(Tool.GetSectionWidth(6));
+    public string Section8Width => FormatSectionWidth(Tool.GetSectionWidth(7));
+    public string Section9Width => FormatSectionWidth(Tool.GetSectionWidth(8));
+    public string Section10Width => FormatSectionWidth(Tool.GetSectionWidth(9));
+    public string Section11Width => FormatSectionWidth(Tool.GetSectionWidth(10));
+    public string Section12Width => FormatSectionWidth(Tool.GetSectionWidth(11));
+    public string Section13Width => FormatSectionWidth(Tool.GetSectionWidth(12));
+    public string Section14Width => FormatSectionWidth(Tool.GetSectionWidth(13));
+    public string Section15Width => FormatSectionWidth(Tool.GetSectionWidth(14));
+    public string Section16Width => FormatSectionWidth(Tool.GetSectionWidth(15));
 
     // Section color properties (for color preview display)
     public uint SectionColor1 => Tool.GetSectionColor(0);
@@ -733,6 +780,21 @@ public partial class ConfigurationViewModel : ObservableObject
         OnPropertyChanged(nameof(Section15Width));
         OnPropertyChanged(nameof(Section16Width));
         OnPropertyChanged(nameof(CalculatedSectionTotal));
+        OnPropertyChanged(nameof(CalculatedTotalWidthText));
+    }
+
+    /// <summary>
+    /// Re-raise every unit-dependent display property after a metric/imperial
+    /// switch so widths and totals re-render in the new unit (#417).
+    /// </summary>
+    private void RefreshUnitDependentProperties()
+    {
+        OnPropertyChanged(nameof(SectionWidthUnit));
+        OnPropertyChanged(nameof(SectionWidthFormat));
+        OnPropertyChanged(nameof(SectionWidthUnitLabel));
+        OnPropertyChanged(nameof(DefaultSectionWidthDisplay));
+        OnPropertyChanged(nameof(CalculatedTotalWidthText));
+        RefreshSectionWidthProperties();
     }
 
     // Zone end section properties (for binding in zone mode)
@@ -974,10 +1036,17 @@ public partial class ConfigurationViewModel : ObservableObject
             {
                 OnPropertyChanged(nameof(HasUnsavedChanges));
             }
-            // Update calculated section total when NumSections changes
+            // Update calculated section total when NumSections changes.
+            // Also refresh the per-section displays so sections newly seeded
+            // with the Default Section Width render their seeded value (#417).
             if (e.PropertyName == nameof(ConfigurationStore.NumSections))
             {
-                OnPropertyChanged(nameof(CalculatedSectionTotal));
+                RefreshSectionWidthProperties();
+            }
+            // Re-render all widths/totals in the new unit on metric switch (#417)
+            if (e.PropertyName == nameof(ConfigurationStore.IsMetric))
+            {
+                RefreshUnitDependentProperties();
             }
         };
 
@@ -987,6 +1056,8 @@ public partial class ConfigurationViewModel : ObservableObject
             if (e.PropertyName == nameof(ToolConfig.DefaultSectionWidth))
             {
                 OnPropertyChanged(nameof(CalculatedSectionTotal));
+                OnPropertyChanged(nameof(CalculatedTotalWidthText));
+                OnPropertyChanged(nameof(DefaultSectionWidthDisplay));
             }
         };
 
@@ -1130,9 +1201,16 @@ public partial class ConfigurationViewModel : ObservableObject
                 "s", integerOnly: false, allowNegative: false, min: 0, max: 5));
 
         EditDefaultSectionWidthCommand = new RelayCommand(() =>
-            ShowNumericInput("Default Section Width", Tool.DefaultSectionWidth,
-                v => Tool.DefaultSectionWidth = v,
-                "cm", integerOnly: false, allowNegative: false, min: 10, max: 500));
+        {
+            bool metric = Config.IsMetric;
+            // Stored cm bounds 10..500 → inches 3.9..196.9
+            ShowNumericInput("Default Section Width",
+                metric ? Tool.DefaultSectionWidth : UnitConversion.CmToInches(Tool.DefaultSectionWidth),
+                v => Tool.DefaultSectionWidth = metric ? v : UnitConversion.InchesToCm(v),
+                metric ? "cm" : "in", integerOnly: false, allowNegative: false,
+                min: metric ? 10 : UnitConversion.CmToInches(10),
+                max: metric ? 500 : UnitConversion.CmToInches(500));
+        });
 
         EditMinCoverageCommand = new RelayCommand(() =>
             ShowNumericInput("Minimum Coverage", Tool.MinCoverage,
@@ -1190,14 +1268,19 @@ public partial class ConfigurationViewModel : ObservableObject
     private void EditSectionWidth(int sectionNumber)
     {
         int index = sectionNumber - 1;
-        double currentWidth = Tool.GetSectionWidth(index);
-        ShowNumericInput($"Section {sectionNumber} Width", currentWidth,
+        bool metric = Config.IsMetric;
+        double currentCm = Tool.GetSectionWidth(index);
+        // Stored cm bounds 1..500 → inches 0.4..196.9
+        ShowNumericInput($"Section {sectionNumber} Width",
+            metric ? currentCm : UnitConversion.CmToInches(currentCm),
             v =>
             {
-                Tool.SetSectionWidth(index, v);
+                Tool.SetSectionWidth(index, metric ? v : UnitConversion.InchesToCm(v));
                 RefreshSectionWidthProperties();
             },
-            "cm", integerOnly: false, allowNegative: false, min: 1, max: 500);
+            metric ? "cm" : "in", integerOnly: false, allowNegative: false,
+            min: metric ? 1 : UnitConversion.CmToInches(1),
+            max: metric ? 500 : UnitConversion.CmToInches(500));
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
@@ -95,8 +95,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Width applied to new sections (or all sections in zone mode)" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"/>
                     </StackPanel>
                     <controls:EditableNumericField Grid.Column="1"
-                        Value="{Binding Tool.DefaultSectionWidth, Mode=TwoWay}"
-                        Unit="cm" FormatString="F0"
+                        Value="{Binding DefaultSectionWidthDisplay, Mode=TwoWay}"
+                        Unit="{Binding SectionWidthUnit}" FormatString="{Binding SectionWidthFormat}"
                         EditCommand="{Binding EditDefaultSectionWidthCommand}"/>
                 </Grid>
             </Border>
@@ -116,56 +116,56 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="1" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section1Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section1Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection2WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="2" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section2Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section2Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection3WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=2}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="3" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section3Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section3Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection4WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=3}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="4" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section4Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section4Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection5WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=4}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="5" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section5Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section5Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection6WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=5}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="6" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section6Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section6Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection7WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=6}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="7" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section7Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section7Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection8WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=7}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="8" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section8Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section8Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
@@ -176,62 +176,62 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=8}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="9" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section9Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section9Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection10WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=9}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="10" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section10Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section10Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection11WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=10}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section11Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section11Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection12WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=11}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="12" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section12Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section12Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection13WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=12}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="13" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section13Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section13Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection14WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=13}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="14" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section14Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section14Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection15WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=14}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="15" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section15Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section15Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Classes="SectionWidthBtn" Command="{Binding EditSection16WidthCommand}"
                                     Margin="4" IsVisible="{Binding Config.NumSections, Converter={StaticResource GreaterThanConverter}, ConverterParameter=15}">
                                 <StackPanel HorizontalAlignment="Center">
                                     <TextBlock Text="16" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Section16Width, StringFormat='{}{0:F0}'}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Section16Width}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
                     </StackPanel>
 
-                    <TextBlock Text="All widths in cm" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                    <TextBlock Text="{Binding SectionWidthUnitLabel}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="10" HorizontalAlignment="Center" Margin="0,8,0,0"/>
                 </StackPanel>
             </Border>
 
@@ -340,7 +340,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <TextBlock Text="Calculated Total Width" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Text="(sum of active section widths)" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="11"/>
                     </StackPanel>
-                    <TextBlock Grid.Column="1" Text="{Binding CalculatedSectionTotal, StringFormat='{}{0:F2} m'}"
+                    <TextBlock Grid.Column="1" Text="{Binding CalculatedTotalWidthText}"
                                Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16" VerticalAlignment="Center"/>
                 </Grid>
             </Border>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -513,7 +513,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <!-- Width display (actual = sum of section widths) -->
                         <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="8" Margin="0,0,24,0">
                             <TextBlock Text="{loc:Localize Width}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding Config.ActualToolWidth, StringFormat='{}{0:F2} m'}"
+                            <TextBlock Text="{Binding CalculatedTotalWidthText}"
                                        Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" VerticalAlignment="Center"/>
                         </StackPanel>
 

--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
@@ -1610,16 +1610,38 @@ public partial class SkiaMapControl : Control, ISharedMapControl
 
         // ----------------- Grid -----------------
 
+        /// <summary>
+        /// Rounds up to the next value in the 1-2-5 × 10ⁿ series
+        /// (1, 2, 5, 10, 20, 50, …), with a floor of 1. Gives a grid level-of-
+        /// detail whose steps are at most ~2.5× apart, so spacing changes as
+        /// the view zooms feel gradual rather than snapping.
+        /// </summary>
+        private static double NiceStep125(double x)
+        {
+            if (x <= 1.0) return 1.0;
+            double pow = Math.Pow(10, Math.Floor(Math.Log10(x)));
+            double f = x / pow; // [1, 10)
+            double niceF = f <= 2.0 ? 2.0 : f <= 5.0 ? 5.0 : 10.0;
+            return niceF * pow;
+        }
+
         private void DrawGridSk(SKCanvas canvas, MapRenderState s, double viewWidth, double viewHeight)
         {
             const double gridSize = 2000.0;
             double toolW = s.ToolWidth > 0.5 ? s.ToolWidth : 6.0;
             double viewSpan = Math.Max(viewWidth, viewHeight);
 
-            double spacing, majorEvery;
-            if (viewSpan < toolW * 30) { spacing = toolW; majorEvery = toolW * 10; }
-            else if (viewSpan < toolW * 100) { spacing = toolW * 5; majorEvery = toolW * 50; }
-            else { spacing = toolW * 10; majorEvery = toolW * 100; }
+            // Grid spacing is a multiple of the tool width (each square ≈ one
+            // swath). Pick the multiplier on a smooth 1-2-5 series keyed off
+            // how many tool widths span the view, so zooming out steps the
+            // spacing gently (≤2.5×) instead of the old hard 1×→5× jump that
+            // made the grid snap dramatically. Clamped to ≥1 so the grid never
+            // subdivides below a single tool width — the zoomed-in look where
+            // each square is one swath stays correct (#417).
+            const double targetDivisions = 30.0;
+            double mult = NiceStep125(viewSpan / (toolW * targetDivisions));
+            double spacing = toolW * mult;
+            double majorEvery = spacing * 10;
 
             double screenHeight = s.BoundsHeight > 0 ? s.BoundsHeight : 600;
             double worldPerPixel = viewHeight / screenHeight;

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 3
+#define VERSION_PATCH 4
 
-#define VERSION "26.5.3"
+#define VERSION "26.5.4"
 #define VERSION_DATE "2026-05-23"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 1
+#define VERSION_PATCH 3
 
-#define VERSION "26.5.1"
+#define VERSION "26.5.3"
 #define VERSION_DATE "2026-05-23"


### PR DESCRIPTION
## Summary
Issue #417 ("Section math and units incorrect"): on the Tool/Implement Configuration → Sections tab, widths displayed in cm/m even with Units = Imperial, and the footer total **Width showed 1.00 m** for 16×100 cm sections.

### Root causes
- **Math (stale total):** the footer bound `Config.ActualToolWidth`, a computed model getter that never raises change notification. At dialog open `NumSections` defaults to 1, so it latched 1.00 m and never refreshed when the count changed.
- **Units:** section widths, default width, and totals were hard-coded metric; the Imperial toggle never affected them.
- **Default not applied (found in testing):** new sections ignored the Default Section Width — the `_sectionWidths` array is pre-filled with 100 cm, so raising the count just revealed stale 100 cm values.

## Changes
**Commit 1 — units + math + seeding (#417)**
- New `Models/Base/UnitConversion.cs` (cm↔in, m→ft) — conversions only at the display/input boundary; storage stays metric.
- `ConfigurationViewModel`: unit-aware reactive props — section widths in inches when Imperial, default width, and a formatted total (`CalculatedTotalWidthText`, feet when Imperial). Edit dialogs convert to/from inches with converted min/max. Re-raised on metric switch, NumSections, DefaultSectionWidth, per-section edits.
- `ToolSectionsSubTab.axaml` + `ConfigurationDialog.axaml`: bind the unit-aware props; footer Width is now reactive (fixes the stale 1.00 m).
- `ConfigurationStore.NumSections`: seed newly-added sections with the current Default Section Width ("applied to new sections"), before raising the change so listeners read seeded values. Profile load sets explicit per-section widths after NumSections, so it still overrides.

**Commit 2 — smooth grid LOD**
- `SkiaMapControl.DrawGridSk`: the tool-width-based grid spacing snapped 1×→5× in one step on zoom-out (the grid "jumped"). Replaced the hard thresholds with a 1‑2‑5 series keyed off how many tool widths span the view — steps are now ≤2.5× and gradual; floored at 1 so the zoomed-in "grid = one swath" look is unchanged. Surfaced while testing #417.

## Behavior
| | Metric | Imperial |
|---|---|---|
| Section width 100 cm | `100 cm` | `39.4 in` |
| Default 80 cm | `80 cm` | `31.5 in` |
| Total (16×100 cm) | `16.00 m` | `52.49 ft` |

New sections now adopt the current Default Section Width; existing sections keep their set widths.

## Testing
- Desktop build clean (0 errors).
- All 1149 tests pass (104 models / 899 services / 146 UI).
- Units, total math, default-seeding, and grid smoothing verified interactively by the reporter.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)