### PR TITLE
Support up to 64 sections with dynamic control-bar layout

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -247,16 +247,10 @@ public partial class MainView : UserControl
     {
         if (_mapControl != null && _viewModel != null)
         {
-            if (e.PropertyName?.StartsWith("Section") == true &&
-                     (e.PropertyName.EndsWith("Active") || e.PropertyName.EndsWith("ColorCode")))
-            {
-                _mapControl.SetSectionStates(
-                    _viewModel.GetSectionStates(),
-                    _viewModel.GetSectionWidths(),
-                    _viewModel.NumSections,
-                    _viewModel.GetSectionButtonStates());
-            }
-            else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
+            // Section state/layout is pushed to the map directly by the
+            // ViewModel (MainViewModel.UpdateSectionStates) and every GPS cycle
+            // by ApplyGpsCycleResult, so there is no per-property section bridge.
+            if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
             {
                 _mapControl.EnableClickSelection = _viewModel.EnableABClickSelection;
             }

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -476,20 +476,10 @@ public partial class MainWindow : Window
         // visible tool/hitch oscillation: SetVehiclePosition moves the camera
         // and triggers a render with stale tool state, then SetAllPositions
         // snaps the tool forward — once per GPS tick.
-        if (e.PropertyName?.StartsWith("Section") == true &&
-                 (e.PropertyName.EndsWith("Active") || e.PropertyName.EndsWith("ColorCode")))
-        {
-            // Section state or color code changed - update map control
-            if (ViewModel != null && MapControl != null)
-            {
-                MapControl.SetSectionStates(
-                    ViewModel.GetSectionStates(),
-                    ViewModel.GetSectionWidths(),
-                    ViewModel.NumSections,
-                    ViewModel.GetSectionButtonStates());
-            }
-        }
-        else if (e.PropertyName == nameof(MainViewModel.IsGridOn))
+        // Section state/layout is pushed to the map directly by the ViewModel
+        // (MainViewModel.UpdateSectionStates) and every GPS cycle by
+        // ApplyGpsCycleResult, so there is no per-property section bridge here.
+        if (e.PropertyName == nameof(MainViewModel.IsGridOn))
         {
             if (ViewModel != null && MapControl != null)
             {

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -284,16 +284,10 @@ public partial class MainView : UserControl
         // snaps the tool forward — once per GPS tick.
         if (_mapControl != null && _viewModel != null)
         {
-            if (e.PropertyName?.StartsWith("Section") == true &&
-                     (e.PropertyName.EndsWith("Active") || e.PropertyName.EndsWith("ColorCode")))
-            {
-                _mapControl.SetSectionStates(
-                    _viewModel.GetSectionStates(),
-                    _viewModel.GetSectionWidths(),
-                    _viewModel.NumSections,
-                    _viewModel.GetSectionButtonStates());
-            }
-            else if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
+            // Section state/layout is pushed to the map directly by the
+            // ViewModel (MainViewModel.UpdateSectionStates) and every GPS cycle
+            // by ApplyGpsCycleResult, so there is no per-property section bridge.
+            if (e.PropertyName == nameof(MainViewModel.EnableABClickSelection))
             {
                 _mapControl.EnableClickSelection = _viewModel.EnableABClickSelection;
             }

--- a/Shared/AgValoniaGPS.Models/Configuration/ConfigurationStore.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ConfigurationStore.cs
@@ -108,7 +108,7 @@ public class ConfigurationStore : ObservableObject
         get => _numSections;
         set
         {
-            int clamped = Math.Clamp(value, 1, 16);
+            int clamped = Math.Clamp(value, 1, ToolConfig.MaxSections);
             int previous = _numSections;
             // Seed newly-activated sections with the current Default Section
             // Width ("Width applied to new sections") BEFORE raising the
@@ -134,7 +134,7 @@ public class ConfigurationStore : ObservableObject
         get
         {
             double total = 0;
-            for (int i = 0; i < _numSections && i < 16; i++)
+            for (int i = 0; i < _numSections && i < ToolConfig.MaxSections; i++)
             {
                 total += Tool.GetSectionWidth(i) / 100.0; // cm to meters
             }
@@ -142,7 +142,7 @@ public class ConfigurationStore : ObservableObject
         }
     }
 
-    private double[] _sectionPositions = new double[17];
+    private double[] _sectionPositions = new double[ToolConfig.MaxSections + 1];
     public double[] SectionPositions
     {
         get => _sectionPositions;

--- a/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
@@ -24,6 +24,13 @@ namespace AgValoniaGPS.Models.Configuration;
 /// </summary>
 public class ToolConfig : ObservableObject
 {
+    /// <summary>
+    /// Maximum number of sections supported across the app. Section on/off
+    /// for sections 1–16 ships in PGN 239/254; sections 17–64 ship in the
+    /// 64-section PGN 229 (sent only when more than 16 sections are configured).
+    /// </summary>
+    public const int MaxSections = 64;
+
     // Tool dimensions
     private double _width = 6.0;
     public double Width
@@ -156,8 +163,9 @@ public class ToolConfig : ObservableObject
     }
 
     // Section colors (RGB values stored as 0xRRGGBB)
-    // Default colors match AgOpenGPS preset palette
-    private uint[] _sectionColors = new uint[16]
+    // Default colors match AgOpenGPS preset palette (16 hues, cycled across all
+    // MaxSections so sections 17–64 also get a sensible default color).
+    private static readonly uint[] DefaultSectionPalette =
     {
         0x00FF00, // Green
         0xFF0000, // Red
@@ -177,6 +185,16 @@ public class ToolConfig : ObservableObject
         0xFF80FF  // Light Magenta
     };
 
+    private uint[] _sectionColors = CreateDefaultSectionColors();
+
+    private static uint[] CreateDefaultSectionColors()
+    {
+        var colors = new uint[MaxSections];
+        for (int i = 0; i < MaxSections; i++)
+            colors[i] = DefaultSectionPalette[i % DefaultSectionPalette.Length];
+        return colors;
+    }
+
     /// <summary>
     /// Section colors as RGB values (0xRRGGBB format).
     /// </summary>
@@ -191,7 +209,7 @@ public class ToolConfig : ObservableObject
     /// </summary>
     public uint GetSectionColor(int index)
     {
-        if (index < 0 || index >= 16) return _sectionColors[0];
+        if (index < 0 || index >= MaxSections) return _sectionColors[0];
         return _sectionColors[index];
     }
 
@@ -200,7 +218,7 @@ public class ToolConfig : ObservableObject
     /// </summary>
     public void SetSectionColor(int index, uint color)
     {
-        if (index < 0 || index >= 16) return;
+        if (index < 0 || index >= MaxSections) return;
         _sectionColors[index] = color;
         OnPropertyChanged(nameof(SectionColors));
     }
@@ -274,12 +292,19 @@ public class ToolConfig : ObservableObject
     /// </summary>
     public double CoverageMarginMeters => _coverageMargin / 100.0;
 
-    // Individual section widths (cm) - up to 16 sections
-    private double[] _sectionWidths = new double[16] { 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100 };
+    // Individual section widths (cm) - up to MaxSections sections
+    private double[] _sectionWidths = CreateDefaultSectionWidths();
+
+    private static double[] CreateDefaultSectionWidths()
+    {
+        var widths = new double[MaxSections];
+        for (int i = 0; i < MaxSections; i++) widths[i] = 100;
+        return widths;
+    }
 
     /// <summary>
     /// Gets or sets individual section widths in centimeters.
-    /// Array of 16 values, one per section.
+    /// Array of MaxSections values, one per section.
     /// </summary>
     public double[] SectionWidths
     {
@@ -288,11 +313,11 @@ public class ToolConfig : ObservableObject
     }
 
     /// <summary>
-    /// Gets or sets a specific section width by index (0-15).
+    /// Gets or sets a specific section width by index (0..MaxSections-1).
     /// </summary>
     public double GetSectionWidth(int index)
     {
-        if (index < 0 || index >= 16) return DefaultSectionWidth;
+        if (index < 0 || index >= MaxSections) return DefaultSectionWidth;
         return _sectionWidths[index];
     }
 
@@ -301,7 +326,7 @@ public class ToolConfig : ObservableObject
     /// </summary>
     public void SetSectionWidth(int index, double value)
     {
-        if (index < 0 || index >= 16) return;
+        if (index < 0 || index >= MaxSections) return;
         _sectionWidths[index] = value;
         OnPropertyChanged(nameof(SectionWidths));
         OnPropertyChanged(nameof(TotalSectionWidth));
@@ -317,7 +342,7 @@ public class ToolConfig : ObservableObject
             double total = 0;
             // NumSections is in ConfigurationStore, so we use a simpler approach here
             // This will be calculated properly in the ViewModel
-            for (int i = 0; i < 16; i++)
+            for (int i = 0; i < MaxSections; i++)
                 total += _sectionWidths[i];
             return total / 100.0; // Convert cm to meters
         }

--- a/Shared/AgValoniaGPS.Models/State/SectionState.cs
+++ b/Shared/AgValoniaGPS.Models/State/SectionState.cs
@@ -24,7 +24,7 @@ namespace AgValoniaGPS.Models.State;
 /// </summary>
 public class SectionState : ObservableObject
 {
-    public const int MaxSections = 16;
+    public const int MaxSections = 64;
 
     // Section on/off states
     private readonly bool[] _sectionActive = new bool[MaxSections];
@@ -117,24 +117,24 @@ public class SectionState : ObservableObject
     /// <summary>
     /// Set all sections at once (from UDP message bitmask)
     /// </summary>
-    public void SetAllSections(ushort sectionBits)
+    public void SetAllSections(ulong sectionBits)
     {
         for (int i = 0; i < MaxSections; i++)
         {
-            SetSectionActive(i, (sectionBits & (1 << i)) != 0);
+            SetSectionActive(i, (sectionBits & (1UL << i)) != 0);
         }
     }
 
     /// <summary>
     /// Get all sections as a bitmask
     /// </summary>
-    public ushort GetAllSectionsAsBits()
+    public ulong GetAllSectionsAsBits()
     {
-        ushort bits = 0;
+        ulong bits = 0;
         for (int i = 0; i < MaxSections; i++)
         {
             if (_sectionActive[i])
-                bits |= (ushort)(1 << i);
+                bits |= 1UL << i;
         }
         return bits;
     }

--- a/Shared/AgValoniaGPS.Models/VehicleState.cs
+++ b/Shared/AgValoniaGPS.Models/VehicleState.cs
@@ -125,8 +125,12 @@ public struct VehicleState
     // Section Control (updated by section control logic)
     // ═══════════════════════════════════════════════════════════════════════
 
-    /// <summary>Section states as a bitmask (bit 0 = section 1, etc.)</summary>
-    public ushort SectionStates;
+    /// <summary>
+    /// Section states as a 64-bit bitmask (bit 0 = section 1, … bit 63 = section 64).
+    /// Low 16 bits ship in PGN 239/254; the full mask ships in PGN 229 when
+    /// more than 16 sections are configured.
+    /// </summary>
+    public ulong SectionStates;
 
     /// <summary>Master section switch state</summary>
     public bool MasterSectionOn;

--- a/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/AutoSteerService.cs
@@ -399,7 +399,7 @@ public class AutoSteerService : IAutoSteerService
         _udpService.SendToModules(pgn);
     }
 
-    public void SetMachineState(ushort sectionBits, bool isInUTurn, byte hydLiftState = 0)
+    public void SetMachineState(ulong sectionBits, bool isInUTurn, byte hydLiftState = 0)
     {
         _state.SectionStates = sectionBits;
         _state.IsInUTurn = isInUTurn;
@@ -613,6 +613,16 @@ public class AutoSteerService : IAutoSteerService
             tram: _state.TramState,
             geoStop: _state.GeoStopState);
         _udpService.SendToModules(machinePgn);
+
+        // Send PGN 229 (64-section on/off) alongside PGN 239 only when more
+        // than 16 sections are configured. PGN 239 still carries sections 1–16;
+        // the firmware reconciles the overlap. Below 17 sections, 239 is
+        // sufficient and 229 is skipped to keep the bus quiet.
+        if (ConfigurationStore.Instance.NumSections > 16)
+        {
+            var sections64Pgn = PgnBuilder.BuildSection64Pgn(ref _state);
+            _udpService.SendToModules(sections64Pgn);
+        }
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
@@ -38,6 +38,7 @@ public static class PgnBuilder
     // PGN identifiers (from PgnNumbers)
     public const byte PGN_AUTOSTEER = 0xFE;      // 254 - AutoSteer Data
     public const byte PGN_MACHINE = 0xEF;        // 239 - Machine Data
+    public const byte PGN_SECTIONS_64 = 0xE5;    // 229 - 64-section on/off + L/R speed
     public const byte PGN_STEER_SETTINGS = 0xFC; // 252 - Steer Settings
     public const byte PGN_STEER_CONFIG = 0xFB;   // 251 - Steer Config
     public const byte PGN_MACHINE_CONFIG = 0xEE;  // 238 - Machine Config
@@ -48,6 +49,7 @@ public static class PgnBuilder
     // Buffer sizes: header(2) + source(1) + pgn(1) + length(1) + data(N) + crc(1)
     public const int AUTOSTEER_PGN_SIZE = 14;       // 5 header + 8 data + 1 crc
     public const int MACHINE_PGN_SIZE = 14;         // 5 header + 8 data + 1 crc
+    public const int SECTIONS_64_PGN_SIZE = 16;     // 5 header + 10 data + 1 crc
     public const int STEER_SETTINGS_PGN_SIZE = 14;  // 5 header + 8 data + 1 crc
     public const int STEER_CONFIG_PGN_SIZE = 11;    // 5 header + 5 data + 1 crc
     public const int MACHINE_CONFIG_PGN_SIZE = 14;  // 5 header + 8 data + 1 crc
@@ -59,6 +61,9 @@ public static class PgnBuilder
 
     [ThreadStatic]
     private static byte[]? _machineBuffer;
+
+    [ThreadStatic]
+    private static byte[]? _sections64Buffer;
 
     [ThreadStatic]
     private static byte[]? _steerSettingsBuffer;
@@ -222,6 +227,52 @@ public static class PgnBuilder
 
         // CRC
         buf[13] = CalculateCrc(buf, 2, 11);
+
+        return buf;
+    }
+
+    /// <summary>
+    /// Build PGN 229 (0xE5) — 64-section on/off plus left/right speed.
+    /// Sent in addition to PGN 239 when more than 16 sections are configured;
+    /// the firmware reconciles the overlap on sections 1–16.
+    ///
+    /// Byte 5:  SC1to8   (sections 1–8 bitmask)
+    /// Byte 6:  SC9to16  (sections 9–16)
+    /// Byte 7:  SC17to24
+    /// Byte 8:  SC25to32
+    /// Byte 9:  SC33to40
+    /// Byte 10: SC41to48
+    /// Byte 11: SC49to56
+    /// Byte 12: SC57to64
+    /// Byte 13: Lspeed (speed * 10, clamped 0–255)
+    /// Byte 14: Rspeed (speed * 10, clamped 0–255)
+    /// Byte 15: CRC
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static byte[] BuildSection64Pgn(ref VehicleState state)
+    {
+        _sections64Buffer ??= new byte[SECTIONS_64_PGN_SIZE];
+        var buf = _sections64Buffer;
+
+        // Header
+        buf[0] = HEADER1;
+        buf[1] = HEADER2;
+        buf[2] = SOURCE;
+        buf[3] = PGN_SECTIONS_64;
+        buf[4] = 10;  // Data length
+
+        // 64 section bits, little-endian (section 1 = bit 0 of byte 5)
+        ulong sections = state.SectionStates;
+        for (int i = 0; i < 8; i++)
+            buf[5 + i] = (byte)((sections >> (8 * i)) & 0xFF);
+
+        // L/R speed mirror PGN 239's speed byte (speed * 10, clamped to a byte)
+        byte speed = (byte)Math.Clamp((int)(state.SpeedKmh * 10), 0, 255);
+        buf[13] = speed;
+        buf[14] = speed;
+
+        // CRC: sum of bytes 2 through 14 (source through last data byte)
+        buf[15] = CalculateCrc(buf, 2, 13);
 
         return buf;
     }

--- a/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IAutoSteerService.cs
@@ -150,10 +150,11 @@ public interface IAutoSteerService
     void SendMachinePinConfig();
 
     /// <summary>
-    /// Update machine control state sent via PGN 239.
+    /// Update machine control state sent via PGN 239 (low 16 sections) and,
+    /// when more than 16 sections are configured, PGN 229 (all 64 sections).
     /// Called by ViewModel after section control updates.
     /// </summary>
-    void SetMachineState(ushort sectionBits, bool isInUTurn, byte hydLiftState = 0);
+    void SetMachineState(ulong sectionBits, bool isInUTurn, byte hydLiftState = 0);
 
     // ═══════════════════════════════════════════════════════════════════════
     // Module Feedback (PGN 253, 250)
@@ -216,7 +217,7 @@ public readonly struct VehicleStateSnapshot
     public bool IsOnTrack { get; init; }
     public bool IsAutoSteerEngaged { get; init; }
 
-    public ushort SectionStates { get; init; }
+    public ulong SectionStates { get; init; }
     public bool MasterSectionOn { get; init; }
 
     public byte TramState { get; init; }

--- a/Shared/AgValoniaGPS.Services/Interfaces/ISectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/ISectionControlService.cs
@@ -101,6 +101,13 @@ public interface ISectionControlService
     ushort GetSectionBits();
 
     /// <summary>
+    /// Get section bits as a 64-bit mask (for PGN 229 when more than 16
+    /// sections are configured). Low 16 bits match <see cref="GetSectionBits"/>.
+    /// </summary>
+    /// <returns>Bitmask where bit N = section N state (0..63)</returns>
+    ulong GetSectionBits64();
+
+    /// <summary>
     /// Event fired when any section state changes
     /// </summary>
     event EventHandler<SectionStateChangedEventArgs>? SectionStateChanged;

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -949,7 +949,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
         // build in (9) reads them.
         byte hydLiftState = ComputeHydLiftState(toolPos, pos.Speed, headlandLine);
         _autoSteerService.SetMachineState(
-            _sectionControlService.GetSectionBits(),
+            _sectionControlService.GetSectionBits64(),
             isInYouTurn,
             hydLiftState);
 

--- a/Shared/AgValoniaGPS.Services/Profile/ProfileJsonServiceV1.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ProfileJsonServiceV1.cs
@@ -299,15 +299,23 @@ public static class ProfileJsonServiceV1
         store.Tool.IsWorkSwitchManualSections = dto.Tool?.IsWorkSwitchManualSections ?? false;
         store.Tool.IsSteerSwitchEnabled = dto.Tool?.IsSteerSwitchEnabled ?? false;
         store.Tool.IsSteerSwitchManualSections = dto.Tool?.IsSteerSwitchManualSections ?? false;
-        if (dto.Tool?.SectionColors != null && dto.Tool.SectionColors.Length == 16)
-            store.Tool.SectionColors = (uint[])dto.Tool.SectionColors.Clone();
+        // Overlay saved colors onto the full MaxSections-length array so older
+        // 16-color profiles keep palette defaults for sections 17–64.
+        if (dto.Tool?.SectionColors != null && dto.Tool.SectionColors.Length > 0)
+        {
+            var colors = (uint[])store.Tool.SectionColors.Clone();
+            Array.Copy(dto.Tool.SectionColors, colors,
+                Math.Min(dto.Tool.SectionColors.Length, colors.Length));
+            store.Tool.SectionColors = colors;
+        }
 
         // Section config — set NumSections first so width-derivation knows how
         // many sections to populate.
         store.NumSections = dto.Sections?.Count ?? 1;
-        var sectionPositions = new double[17];
+        var sectionPositions = new double[Models.Configuration.ToolConfig.MaxSections + 1];
         if (dto.Sections?.Positions != null)
-            Array.Copy(dto.Sections.Positions, sectionPositions, Math.Min(dto.Sections.Positions.Length, 17));
+            Array.Copy(dto.Sections.Positions, sectionPositions,
+                Math.Min(dto.Sections.Positions.Length, sectionPositions.Length));
         store.SectionPositions = sectionPositions;
 
         // Restore Tool.SectionWidths — the runtime source of truth that the

--- a/Shared/AgValoniaGPS.Services/Profile/ToolProfileJsonService.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ToolProfileJsonService.cs
@@ -167,14 +167,22 @@ public static class ToolProfileJsonService
         store.Tool.IsWorkSwitchManualSections = dto.Tool?.IsWorkSwitchManualSections ?? false;
         store.Tool.IsSteerSwitchEnabled = dto.Tool?.IsSteerSwitchEnabled ?? false;
         store.Tool.IsSteerSwitchManualSections = dto.Tool?.IsSteerSwitchManualSections ?? false;
-        if (dto.Tool?.SectionColors != null && dto.Tool.SectionColors.Length == 16)
-            store.Tool.SectionColors = (uint[])dto.Tool.SectionColors.Clone();
+        // Overlay saved colors onto the full MaxSections-length array so older
+        // 16-color profiles keep palette defaults for sections 17–64.
+        if (dto.Tool?.SectionColors != null && dto.Tool.SectionColors.Length > 0)
+        {
+            var colors = (uint[])store.Tool.SectionColors.Clone();
+            Array.Copy(dto.Tool.SectionColors, colors,
+                Math.Min(dto.Tool.SectionColors.Length, colors.Length));
+            store.Tool.SectionColors = colors;
+        }
 
         // Section count first so width derivation knows how many to populate.
         store.NumSections = dto.Sections?.Count ?? 1;
-        var sectionPositions = new double[17];
+        var sectionPositions = new double[Models.Configuration.ToolConfig.MaxSections + 1];
         if (dto.Sections?.Positions != null)
-            Array.Copy(dto.Sections.Positions, sectionPositions, Math.Min(dto.Sections.Positions.Length, 17));
+            Array.Copy(dto.Sections.Positions, sectionPositions,
+                Math.Min(dto.Sections.Positions.Length, sectionPositions.Length));
         store.SectionPositions = sectionPositions;
 
         int restoredNum = Math.Max(1, store.NumSections);

--- a/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
+++ b/Shared/AgValoniaGPS.Services/Section/SectionControlService.cs
@@ -171,8 +171,8 @@ public class SectionControlService : ISectionControlService
         _state = state;
 
         // Initialize section states
-        _sectionStates = new SectionControlState[16];
-        for (int i = 0; i < 16; i++)
+        _sectionStates = new SectionControlState[ToolConfig.MaxSections];
+        for (int i = 0; i < _sectionStates.Length; i++)
         {
             _sectionStates[i] = new SectionControlState { Index = i };
         }
@@ -938,7 +938,7 @@ public class SectionControlService : ISectionControlService
 
     public (Vec2 left, Vec2 right) GetSectionWorldPosition(int sectionIndex, Vec3 toolPosition, double toolHeading)
     {
-        if (sectionIndex < 0 || sectionIndex >= 16)
+        if (sectionIndex < 0 || sectionIndex >= _sectionStates.Length)
             return (new Vec2(0, 0), new Vec2(0, 0));
 
         var section = _sectionStates[sectionIndex];
@@ -961,7 +961,7 @@ public class SectionControlService : ISectionControlService
 
     public void SetSectionState(int sectionIndex, SectionButtonState state)
     {
-        if (sectionIndex < 0 || sectionIndex >= 16) return;
+        if (sectionIndex < 0 || sectionIndex >= _sectionStates.Length) return;
 
         _sectionStates[sectionIndex].ButtonState = state;
 
@@ -987,7 +987,7 @@ public class SectionControlService : ISectionControlService
 
     public void SetAllSections(SectionButtonState state)
     {
-        for (int i = 0; i < 16; i++)
+        for (int i = 0; i < _sectionStates.Length; i++)
         {
             _sectionStates[i].ButtonState = state;
 
@@ -1011,7 +1011,7 @@ public class SectionControlService : ISectionControlService
 
     public void TurnAllOff()
     {
-        for (int i = 0; i < 16; i++)
+        for (int i = 0; i < _sectionStates.Length; i++)
         {
             UpdateSectionOff(i);
         }
@@ -1065,7 +1065,7 @@ public class SectionControlService : ISectionControlService
         }
 
         // Clear positions for unused sections
-        for (int i = numSections; i < 16; i++)
+        for (int i = numSections; i < _sectionStates.Length; i++)
         {
             _sectionStates[i].PositionLeft = 0;
             _sectionStates[i].PositionRight = 0;
@@ -1080,6 +1080,25 @@ public class SectionControlService : ISectionControlService
             if (_sectionStates[i].IsOn)
             {
                 bits |= (ushort)(1 << i);
+            }
+        }
+        return bits;
+    }
+
+    /// <summary>
+    /// Section on/off as a 64-bit mask (sections 1–64 in bits 0–63). The low
+    /// 16 bits match <see cref="GetSectionBits"/>. Used to build PGN 229 when
+    /// more than 16 sections are configured.
+    /// </summary>
+    public ulong GetSectionBits64()
+    {
+        ulong bits = 0;
+        int count = Math.Min(_sectionStates.Length, ToolConfig.MaxSections);
+        for (int i = 0; i < count; i++)
+        {
+            if (_sectionStates[i].IsOn)
+            {
+                bits |= 1UL << i;
             }
         }
         return bits;

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -648,7 +648,7 @@ public partial class ConfigurationViewModel : ObservableObject
             {
                 // Individual sections mode - sum actual widths
                 double total = 0;
-                for (int i = 0; i < Config.NumSections && i < 16; i++)
+                for (int i = 0; i < Config.NumSections && i < Models.Configuration.ToolConfig.MaxSections; i++)
                     total += Tool.GetSectionWidth(i);
                 return total / 100.0; // cm to meters
             }
@@ -1183,7 +1183,8 @@ public partial class ConfigurationViewModel : ObservableObject
         EditNumSectionsCommand = new RelayCommand(() =>
             ShowNumericInput("Number of Sections", Config.NumSections,
                 v => Config.NumSections = (int)v,
-                "", integerOnly: true, allowNegative: false, min: 1, max: 16));
+                "", integerOnly: true, allowNegative: false, min: 1,
+                max: Models.Configuration.ToolConfig.MaxSections));
 
         EditLookAheadOnCommand = new RelayCommand(() =>
             ShowNumericInput("Look Ahead On", Tool.LookAheadOnSetting,

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -333,54 +333,12 @@ public partial class MainViewModel
 
     private void UpdateSectionPropertiesFromResult(bool[] states, int[]? colorCodes)
     {
-        int count = Math.Min(states.Length, 16);
+        // The section bar binds to per-button ColorCode. The pipeline supplies
+        // the authoritative 6-state codes each cycle; apply them to the stable
+        // button objects (sized to NumSections by RebuildSectionRows).
+        if (colorCodes == null) return;
+        int count = Math.Min(_sectionButtons.Count, colorCodes.Length);
         for (int i = 0; i < count; i++)
-        {
-            switch (i)
-            {
-                case 0: Section1Active = states[0]; break;
-                case 1: Section2Active = states[1]; break;
-                case 2: Section3Active = states[2]; break;
-                case 3: Section4Active = states[3]; break;
-                case 4: Section5Active = states[4]; break;
-                case 5: Section6Active = states[5]; break;
-                case 6: Section7Active = states[6]; break;
-                case 7: Section8Active = states[7]; break;
-                case 8: Section9Active = states[8]; break;
-                case 9: Section10Active = states[9]; break;
-                case 10: Section11Active = states[10]; break;
-                case 11: Section12Active = states[11]; break;
-                case 12: Section13Active = states[12]; break;
-                case 13: Section14Active = states[13]; break;
-                case 14: Section15Active = states[14]; break;
-                case 15: Section16Active = states[15]; break;
-            }
-        }
-
-        if (colorCodes != null)
-        {
-            for (int i = 0; i < Math.Min(colorCodes.Length, count); i++)
-            {
-                switch (i)
-                {
-                    case 0: Section1ColorCode = colorCodes[0]; break;
-                    case 1: Section2ColorCode = colorCodes[1]; break;
-                    case 2: Section3ColorCode = colorCodes[2]; break;
-                    case 3: Section4ColorCode = colorCodes[3]; break;
-                    case 4: Section5ColorCode = colorCodes[4]; break;
-                    case 5: Section6ColorCode = colorCodes[5]; break;
-                    case 6: Section7ColorCode = colorCodes[6]; break;
-                    case 7: Section8ColorCode = colorCodes[7]; break;
-                    case 8: Section9ColorCode = colorCodes[8]; break;
-                    case 9: Section10ColorCode = colorCodes[9]; break;
-                    case 10: Section11ColorCode = colorCodes[10]; break;
-                    case 11: Section12ColorCode = colorCodes[11]; break;
-                    case 12: Section13ColorCode = colorCodes[12]; break;
-                    case 13: Section14ColorCode = colorCodes[13]; break;
-                    case 14: Section15ColorCode = colorCodes[14]; break;
-                    case 15: Section16ColorCode = colorCodes[15]; break;
-                }
-            }
-        }
+            _sectionButtons[i].ColorCode = colorCodes[i];
     }
 }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.SectionControl.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.SectionControl.cs
@@ -15,260 +15,102 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
+using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Services.Interfaces;
-
-using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AgValoniaGPS.ViewModels;
 
 /// <summary>
 /// MainViewModel partial class containing Section Control state and event handling.
-/// Manages section on/off states, color codes, and synchronization with ISectionControlService.
+/// Manages the section control bar (one button per configured section, laid out
+/// into rows) and synchronization with ISectionControlService.
 /// </summary>
 public partial class MainViewModel
 {
-    #region Section State Fields
+    #region Section Bar State
 
-    // Section states (backing fields)
-    private bool _section1Active;
-    private bool _section2Active;
-    private bool _section3Active;
-    private bool _section4Active;
-    private bool _section5Active;
-    private bool _section6Active;
-    private bool _section7Active;
-    private bool _section8Active;
-    private bool _section9Active;
-    private bool _section10Active;
-    private bool _section11Active;
-    private bool _section12Active;
-    private bool _section13Active;
-    private bool _section14Active;
-    private bool _section15Active;
-    private bool _section16Active;
+    // Stable button objects keyed by section index. Reused across row rebuilds
+    // so only ColorCode changes as sections cycle Off → Auto → On.
+    private readonly List<SectionButtonViewModel> _sectionButtons = new();
 
-    // Section color codes (0=Red/Off, 1=Yellow/ManualOn, 2=Green/AutoOn, 3=Gray/AutoOff)
-    private int _section1ColorCode;
-    private int _section2ColorCode;
-    private int _section3ColorCode;
-    private int _section4ColorCode;
-    private int _section5ColorCode;
-    private int _section6ColorCode;
-    private int _section7ColorCode;
-    private int _section8ColorCode;
-    private int _section9ColorCode;
-    private int _section10ColorCode;
-    private int _section11ColorCode;
-    private int _section12ColorCode;
-    private int _section13ColorCode;
-    private int _section14ColorCode;
-    private int _section15ColorCode;
-    private int _section16ColorCode;
-
-    // Cached section count for binding
+    // Cached section count for binding/layout.
     private int _numSections;
 
-    #endregion
+    /// <summary>
+    /// Section buttons laid out into rows. One row for up to 16 sections; above
+    /// 16 the sections split into evenly-sized rows (ceil(N/16), max 4 rows,
+    /// max 16 buttons per row). When N doesn't divide evenly, earlier rows take
+    /// the extra so the top row holds the greater count.
+    /// </summary>
+    public ObservableCollection<SectionRowViewModel> SectionRows { get; } = new();
 
-    #region Section Active Properties
-
-    public bool Section1Active
+    /// <summary>
+    /// Number of configured sections (map rendering + bar layout).
+    /// </summary>
+    public int NumSections
     {
-        get => _section1Active;
-        set => SetProperty(ref _section1Active, value);
+        get => _numSections;
+        private set
+        {
+            if (SetProperty(ref _numSections, value))
+            {
+                RebuildSectionRows();
+                RefreshSectionButtonColors();
+                // The renderer picks up the new section count/layout on the
+                // next GPS cycle via ApplyGpsCycleResult (matching prior
+                // behavior); no direct push here, which can run before the
+                // map control is registered.
+            }
+        }
     }
 
-    public bool Section2Active
+    /// <summary>
+    /// The section control bar is shown only when a field is open AND at least
+    /// one master is engaged (Auto or Manual). With both masters off the bar is
+    /// hidden; the master toggles already force every section off in that case.
+    /// </summary>
+    public bool IsSectionBarVisible => IsFieldOpen && (IsManualSectionMode || IsSectionMasterOn);
+
+    /// <summary>
+    /// Build the initial section bar. Called once from the constructor because
+    /// the initial NumSections is seeded directly into the backing field.
+    /// </summary>
+    private void InitializeSectionBar()
     {
-        get => _section2Active;
-        set => SetProperty(ref _section2Active, value);
+        RebuildSectionRows();
+        RefreshSectionButtonColors();
     }
 
-    public bool Section3Active
+    private void RebuildSectionRows()
     {
-        get => _section3Active;
-        set => SetProperty(ref _section3Active, value);
-    }
+        int n = Math.Clamp(NumSections, 1, ToolConfig.MaxSections);
 
-    public bool Section4Active
-    {
-        get => _section4Active;
-        set => SetProperty(ref _section4Active, value);
-    }
+        // Ensure a stable button object exists for every visible section.
+        while (_sectionButtons.Count < n)
+        {
+            int index = _sectionButtons.Count;
+            _sectionButtons.Add(new SectionButtonViewModel(index, i => ToggleSectionCommand.Execute(i)));
+        }
 
-    public bool Section5Active
-    {
-        get => _section5Active;
-        set => SetProperty(ref _section5Active, value);
-    }
+        const int maxPerRow = 16;
+        int rows = (n + maxPerRow - 1) / maxPerRow;  // ceil(n / 16), 1..4
+        int baseCount = n / rows;
+        int remainder = n % rows;  // first `remainder` rows get one extra (top larger)
 
-    public bool Section6Active
-    {
-        get => _section6Active;
-        set => SetProperty(ref _section6Active, value);
-    }
-
-    public bool Section7Active
-    {
-        get => _section7Active;
-        set => SetProperty(ref _section7Active, value);
-    }
-
-    public bool Section8Active
-    {
-        get => _section8Active;
-        set => SetProperty(ref _section8Active, value);
-    }
-
-    public bool Section9Active
-    {
-        get => _section9Active;
-        set => SetProperty(ref _section9Active, value);
-    }
-
-    public bool Section10Active
-    {
-        get => _section10Active;
-        set => SetProperty(ref _section10Active, value);
-    }
-
-    public bool Section11Active
-    {
-        get => _section11Active;
-        set => SetProperty(ref _section11Active, value);
-    }
-
-    public bool Section12Active
-    {
-        get => _section12Active;
-        set => SetProperty(ref _section12Active, value);
-    }
-
-    public bool Section13Active
-    {
-        get => _section13Active;
-        set => SetProperty(ref _section13Active, value);
-    }
-
-    public bool Section14Active
-    {
-        get => _section14Active;
-        set => SetProperty(ref _section14Active, value);
-    }
-
-    public bool Section15Active
-    {
-        get => _section15Active;
-        set => SetProperty(ref _section15Active, value);
-    }
-
-    public bool Section16Active
-    {
-        get => _section16Active;
-        set => SetProperty(ref _section16Active, value);
-    }
-
-    #endregion
-
-    #region Section Color Code Properties
-
-    // Section color codes for panel buttons (0=Red/Off, 1=Yellow/ManualOn, 2=Green/AutoOn, 3=Gray/AutoOff)
-    public int Section1ColorCode
-    {
-        get => _section1ColorCode;
-        set => SetProperty(ref _section1ColorCode, value);
-    }
-
-    public int Section2ColorCode
-    {
-        get => _section2ColorCode;
-        set => SetProperty(ref _section2ColorCode, value);
-    }
-
-    public int Section3ColorCode
-    {
-        get => _section3ColorCode;
-        set => SetProperty(ref _section3ColorCode, value);
-    }
-
-    public int Section4ColorCode
-    {
-        get => _section4ColorCode;
-        set => SetProperty(ref _section4ColorCode, value);
-    }
-
-    public int Section5ColorCode
-    {
-        get => _section5ColorCode;
-        set => SetProperty(ref _section5ColorCode, value);
-    }
-
-    public int Section6ColorCode
-    {
-        get => _section6ColorCode;
-        set => SetProperty(ref _section6ColorCode, value);
-    }
-
-    public int Section7ColorCode
-    {
-        get => _section7ColorCode;
-        set => SetProperty(ref _section7ColorCode, value);
-    }
-
-    public int Section8ColorCode
-    {
-        get => _section8ColorCode;
-        set => SetProperty(ref _section8ColorCode, value);
-    }
-
-    public int Section9ColorCode
-    {
-        get => _section9ColorCode;
-        set => SetProperty(ref _section9ColorCode, value);
-    }
-
-    public int Section10ColorCode
-    {
-        get => _section10ColorCode;
-        set => SetProperty(ref _section10ColorCode, value);
-    }
-
-    public int Section11ColorCode
-    {
-        get => _section11ColorCode;
-        set => SetProperty(ref _section11ColorCode, value);
-    }
-
-    public int Section12ColorCode
-    {
-        get => _section12ColorCode;
-        set => SetProperty(ref _section12ColorCode, value);
-    }
-
-    public int Section13ColorCode
-    {
-        get => _section13ColorCode;
-        set => SetProperty(ref _section13ColorCode, value);
-    }
-
-    public int Section14ColorCode
-    {
-        get => _section14ColorCode;
-        set => SetProperty(ref _section14ColorCode, value);
-    }
-
-    public int Section15ColorCode
-    {
-        get => _section15ColorCode;
-        set => SetProperty(ref _section15ColorCode, value);
-    }
-
-    public int Section16ColorCode
-    {
-        get => _section16ColorCode;
-        set => SetProperty(ref _section16ColorCode, value);
+        SectionRows.Clear();
+        int idx = 0;
+        for (int r = 0; r < rows; r++)
+        {
+            int count = baseCount + (r < remainder ? 1 : 0);
+            var buttons = new List<SectionButtonViewModel>(count);
+            for (int k = 0; k < count; k++)
+                buttons.Add(_sectionButtons[idx++]);
+            SectionRows.Add(new SectionRowViewModel(buttons));
+        }
     }
 
     #endregion
@@ -276,58 +118,46 @@ public partial class MainViewModel
     #region Section Helper Methods
 
     /// <summary>
-    /// Get section on/off states for map rendering.
+    /// Get section on/off states for map rendering, sized to the configured
+    /// section count.
     /// </summary>
     public bool[] GetSectionStates()
     {
         var states = _sectionControlService.SectionStates;
-        var result = new bool[16];
-        for (int i = 0; i < Math.Min(states.Count, 16); i++)
-        {
+        int n = Math.Min(NumSections, ToolConfig.MaxSections);
+        var result = new bool[Math.Max(n, 0)];
+        for (int i = 0; i < result.Length && i < states.Count; i++)
             result[i] = states[i].IsOn;
-        }
         return result;
     }
 
     /// <summary>
     /// Get per-section color codes for renderer + control bar. Returns the
     /// pipeline's 6-state palette: 0=Off, 1=Manual On, 2=Auto On,
-    /// 3=Turning Off, 4=Turning On, 5=Auto Off. Method name is historical;
-    /// the renderer's section-bar switch and the SectionColorCodeToBackground
-    /// converter both consume these codes.
+    /// 3=Turning Off, 4=Turning On, 5=Auto Off.
     /// </summary>
     public int[] GetSectionButtonStates()
     {
         var states = _sectionControlService.SectionStates;
-        var result = new int[16];
-        for (int i = 0; i < Math.Min(states.Count, 16); i++)
-        {
+        int n = Math.Min(NumSections, ToolConfig.MaxSections);
+        var result = new int[Math.Max(n, 0)];
+        for (int i = 0; i < result.Length && i < states.Count; i++)
             result[i] = GetSectionColorCode(states[i]);
-        }
         return result;
     }
 
     /// <summary>
-    /// Get section widths in meters for map rendering.
+    /// Get section widths in meters for map rendering, sized to the configured
+    /// section count.
     /// </summary>
     public double[] GetSectionWidths()
     {
-        var config = Models.Configuration.ConfigurationStore.Instance;
-        var result = new double[16];
-        for (int i = 0; i < 16; i++)
-        {
+        var config = ConfigurationStore.Instance;
+        int n = Math.Min(NumSections, ToolConfig.MaxSections);
+        var result = new double[Math.Max(n, 0)];
+        for (int i = 0; i < result.Length; i++)
             result[i] = config.Tool.GetSectionWidth(i) / 100.0; // cm to meters
-        }
         return result;
-    }
-
-    /// <summary>
-    /// Number of configured sections for map rendering.
-    /// </summary>
-    public int NumSections
-    {
-        get => _numSections;
-        private set => SetProperty(ref _numSections, value);
     }
 
     #endregion
@@ -392,53 +222,44 @@ public partial class MainViewModel
         // Marshal to UI thread
         if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
         {
-            UpdateSectionActiveProperties();
+            UpdateSectionStates();
         }
         else
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(UpdateSectionActiveProperties);
+            Avalonia.Threading.Dispatcher.UIThread.Post(UpdateSectionStates);
         }
     }
 
-    private void UpdateSectionActiveProperties()
+    /// <summary>
+    /// Refresh each section button's color code from the service. Safe to call
+    /// before the map control is registered (no renderer push).
+    /// </summary>
+    private void RefreshSectionButtonColors()
     {
-        // Sync Section*Active properties with service state
         var states = _sectionControlService.SectionStates;
-        Section1Active = states.Count > 0 && states[0].IsOn;
-        Section2Active = states.Count > 1 && states[1].IsOn;
-        Section3Active = states.Count > 2 && states[2].IsOn;
-        Section4Active = states.Count > 3 && states[3].IsOn;
-        Section5Active = states.Count > 4 && states[4].IsOn;
-        Section6Active = states.Count > 5 && states[5].IsOn;
-        Section7Active = states.Count > 6 && states[6].IsOn;
-        Section8Active = states.Count > 7 && states[7].IsOn;
-        Section9Active = states.Count > 8 && states[8].IsOn;
-        Section10Active = states.Count > 9 && states[9].IsOn;
-        Section11Active = states.Count > 10 && states[10].IsOn;
-        Section12Active = states.Count > 11 && states[11].IsOn;
-        Section13Active = states.Count > 12 && states[12].IsOn;
-        Section14Active = states.Count > 13 && states[13].IsOn;
-        Section15Active = states.Count > 14 && states[14].IsOn;
-        Section16Active = states.Count > 15 && states[15].IsOn;
+        for (int i = 0; i < _sectionButtons.Count; i++)
+            _sectionButtons[i].ColorCode = i < states.Count ? GetSectionColorCode(states[i]) : 0;
+    }
 
-        // Update color codes for panel buttons (matching map rendering colors)
-        // 0=Red (Off), 1=Yellow (Manual On), 2=Green (Auto On), 3=Gray (Auto Off)
-        Section1ColorCode = states.Count > 0 ? GetSectionColorCode(states[0]) : 0;
-        Section2ColorCode = states.Count > 1 ? GetSectionColorCode(states[1]) : 0;
-        Section3ColorCode = states.Count > 2 ? GetSectionColorCode(states[2]) : 0;
-        Section4ColorCode = states.Count > 3 ? GetSectionColorCode(states[3]) : 0;
-        Section5ColorCode = states.Count > 4 ? GetSectionColorCode(states[4]) : 0;
-        Section6ColorCode = states.Count > 5 ? GetSectionColorCode(states[5]) : 0;
-        Section7ColorCode = states.Count > 6 ? GetSectionColorCode(states[6]) : 0;
-        Section8ColorCode = states.Count > 7 ? GetSectionColorCode(states[7]) : 0;
-        Section9ColorCode = states.Count > 8 ? GetSectionColorCode(states[8]) : 0;
-        Section10ColorCode = states.Count > 9 ? GetSectionColorCode(states[9]) : 0;
-        Section11ColorCode = states.Count > 10 ? GetSectionColorCode(states[10]) : 0;
-        Section12ColorCode = states.Count > 11 ? GetSectionColorCode(states[11]) : 0;
-        Section13ColorCode = states.Count > 12 ? GetSectionColorCode(states[12]) : 0;
-        Section14ColorCode = states.Count > 13 ? GetSectionColorCode(states[13]) : 0;
-        Section15ColorCode = states.Count > 14 ? GetSectionColorCode(states[14]) : 0;
-        Section16ColorCode = states.Count > 15 ? GetSectionColorCode(states[15]) : 0;
+    /// <summary>
+    /// Refresh button colors and push the layout/state to the renderer. The
+    /// push covers non-cycle changes (e.g. a manual toggle while GPS/sim isn't
+    /// running); the GPS pipeline also pushes every cycle from
+    /// ApplyGpsCycleResult. Called only from the runtime section-changed event,
+    /// after the map control has been registered.
+    /// </summary>
+    private void UpdateSectionStates()
+    {
+        RefreshSectionButtonColors();
+
+        if (NumSections > 0)
+        {
+            _mapService.SetSectionStates(
+                GetSectionStates(),
+                GetSectionWidths(),
+                NumSections,
+                GetSectionButtonStates());
+        }
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -369,6 +369,10 @@ public partial class MainViewModel : ObservableObject
         _sectionControlService.SectionStateChanged += OnSectionStateChanged;
         _coverageMapService.BoundsExpanded += OnCoverageBoundsExpanded;
 
+        // Build the initial section bar (rows + colors) from the seeded
+        // NumSections; subsequent NumSections changes rebuild it.
+        InitializeSectionBar();
+
         // Sync drift compensation to AutoSteerService when edited via TextBox
         State.Field.PropertyChanged += (s, e) =>
         {
@@ -928,13 +932,21 @@ public partial class MainViewModel : ObservableObject
     public bool IsManualSectionMode
     {
         get => _isManualAllOn;
-        set => SetProperty(ref _isManualAllOn, value);
+        set
+        {
+            if (SetProperty(ref _isManualAllOn, value))
+                OnPropertyChanged(nameof(IsSectionBarVisible));
+        }
     }
 
     public bool IsSectionMasterOn
     {
         get => _isAutoAllOn;
-        set => SetProperty(ref _isAutoAllOn, value);
+        set
+        {
+            if (SetProperty(ref _isAutoAllOn, value))
+                OnPropertyChanged(nameof(IsSectionBarVisible));
+        }
     }
 
     public bool IsAutoSteerAvailable
@@ -3311,6 +3323,7 @@ public partial class MainViewModel : ObservableObject
                 // Commands gated on having a field open need to refresh
                 // CanExecute when the field is opened or closed.
                 DeleteAppliedAreaCommand?.NotifyCanExecuteChanged();
+                OnPropertyChanged(nameof(IsSectionBarVisible));
             }
         }
     }

--- a/Shared/AgValoniaGPS.ViewModels/SectionBarViewModels.cs
+++ b/Shared/AgValoniaGPS.ViewModels/SectionBarViewModels.cs
@@ -1,0 +1,75 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// One section button in the section control bar. The button is a stable
+/// object keyed by <see cref="Index"/>; only <see cref="ColorCode"/> changes as
+/// the section cycles Off → Auto → On, so the bar repartitions into rows
+/// without recreating buttons.
+/// </summary>
+public sealed partial class SectionButtonViewModel : ObservableObject
+{
+    /// <summary>Zero-based section index (0 = section 1).</summary>
+    public int Index { get; }
+
+    /// <summary>One-based number shown on the button.</summary>
+    public int Number => Index + 1;
+
+    private int _colorCode;
+
+    /// <summary>
+    /// 6-state color code driving the button background, matching
+    /// SectionColorCodeToBackgroundConverter:
+    /// 0=Off, 1=Manual On, 2=Auto On, 3=Turning Off, 4=Turning On, 5=Auto Off.
+    /// </summary>
+    public int ColorCode
+    {
+        get => _colorCode;
+        set => SetProperty(ref _colorCode, value);
+    }
+
+    public IRelayCommand ToggleCommand { get; }
+
+    public SectionButtonViewModel(int index, Action<int> onToggle)
+    {
+        Index = index;
+        ToggleCommand = new RelayCommand(() => onToggle(index));
+    }
+}
+
+/// <summary>
+/// A single row of section buttons in the control bar. The bar shows one row
+/// for up to 16 sections; above 16 it splits into evenly-sized rows
+/// (ceil(N/16), max 4), with earlier rows taking the extra when N doesn't
+/// divide evenly so the top row holds the greater count.
+/// </summary>
+public sealed class SectionRowViewModel
+{
+    public IReadOnlyList<SectionButtonViewModel> Buttons { get; }
+
+    public SectionRowViewModel(IReadOnlyList<SectionButtonViewModel> buttons)
+    {
+        Buttons = buttons;
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SectionControlPanel.axaml
@@ -62,126 +62,52 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Button.SectionButton > TextBlock">
             <Setter Property="HorizontalAlignment" Value="Center"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <!-- Dark text reads well on every section color (yellow/cyan/orange
+                 etc.); the theme's white foreground washed out on yellow. -->
+            <Setter Property="Foreground" Value="#FF202020"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="FontSize" Value="12"/>
         </Style>
     </UserControl.Styles>
 
     <!-- Floating panel with section indicators.
-         Shown whenever a field is open (#419) — Auto works without a boundary,
-         driving section on/off off coverage. Hidden only when no field is open
-         (#347): sections can't paint with no field defined. -->
-    <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="0" Padding="12"
-            IsVisible="{Binding IsFieldOpen}">
-        <StackPanel Orientation="Horizontal" Spacing="8">
-            <!-- Section buttons - 2 rows of up to 8 each -->
-            <StackPanel Orientation="Vertical" Spacing="4">
-                <!-- Row 1: Sections 1-8 -->
-                <StackPanel Orientation="Horizontal" Spacing="3">
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section1ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="0"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=0}">
-                        <TextBlock Text="1"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section2ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="1"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=1}">
-                        <TextBlock Text="2"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section3ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="2"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=2}">
-                        <TextBlock Text="3"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section4ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="3"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=3}">
-                        <TextBlock Text="4"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section5ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="4"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=4}">
-                        <TextBlock Text="5"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section6ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="5"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=5}">
-                        <TextBlock Text="6"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section7ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="6"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=6}">
-                        <TextBlock Text="7"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section8ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="7"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=7}">
-                        <TextBlock Text="8"/>
-                    </Button>
-                </StackPanel>
+         Shown when a field is open (#419 — Auto works without a boundary,
+         driving section on/off off coverage) AND a master (Auto or Manual) is
+         engaged. With both masters off the bar hides and the masters force all
+         sections off; sections also can't paint with no field defined (#347).
 
-                <!-- Row 2: Sections 9-16 (only visible if > 8 sections) -->
-                <StackPanel Orientation="Horizontal" Spacing="3"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=8}">
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section9ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="8"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=8}">
-                        <TextBlock Text="9"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section10ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="9"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=9}">
-                        <TextBlock Text="10"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section11ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="10"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=10}">
-                        <TextBlock Text="11"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section12ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="11"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=11}">
-                        <TextBlock Text="12"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section13ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="12"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=12}">
-                        <TextBlock Text="13"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section14ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="13"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=13}">
-                        <TextBlock Text="14"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section15ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="14"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=14}">
-                        <TextBlock Text="15"/>
-                    </Button>
-                    <Button Classes="SectionButton"
-                            Background="{Binding Section16ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
-                            Command="{Binding ToggleSectionCommand}" CommandParameter="15"
-                            IsVisible="{Binding NumSections, Converter={x:Static converters:IntGreaterThanConverter.Instance}, ConverterParameter=15}">
-                        <TextBlock Text="16"/>
-                    </Button>
-                </StackPanel>
-            </StackPanel>
-        </StackPanel>
+         Layout: one row for up to 16 sections; above 16 the sections split into
+         evenly-sized rows (ceil(N/16), max 16 per row, max 4 rows) with the top
+         rows holding the greater count when N is odd. Rows/buttons come from the
+         SectionRows collection on the ViewModel. -->
+    <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="0" Padding="12"
+            IsVisible="{Binding IsSectionBarVisible}">
+        <ItemsControl ItemsSource="{Binding SectionRows}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Vertical" Spacing="4"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="vm:SectionRowViewModel">
+                    <ItemsControl ItemsSource="{Binding Buttons}" HorizontalAlignment="Center">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" Spacing="3"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="vm:SectionButtonViewModel">
+                                <Button Classes="SectionButton"
+                                        Background="{Binding ColorCode, Converter={StaticResource SectionColorCodeToBackground}}"
+                                        Command="{Binding ToggleCommand}">
+                                    <TextBlock Text="{Binding Number}"/>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
     </Border>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
@@ -109,11 +109,12 @@ public partial class SkiaMapControl : Control, ISharedMapControl
     private double _toolX, _toolY, _toolHeading, _toolWidth, _hitchX, _hitchY;
     private bool _toolPositionReady;
 
-    private bool[] _sectionOn = new bool[16];
-    private int[] _sectionButtonState = new int[16];
-    private double[] _sectionWidths = new double[16];
-    private double[] _sectionLeft = new double[16];
-    private double[] _sectionRight = new double[16];
+    private const int MaxSections = AgValoniaGPS.Models.Configuration.ToolConfig.MaxSections;
+    private bool[] _sectionOn = new bool[MaxSections];
+    private int[] _sectionButtonState = new int[MaxSections];
+    private double[] _sectionWidths = new double[MaxSections];
+    private double[] _sectionLeft = new double[MaxSections];
+    private double[] _sectionRight = new double[MaxSections];
     private int _numSections;
 
     // ------------------------------------------------------------------
@@ -699,7 +700,7 @@ public partial class SkiaMapControl : Control, ISharedMapControl
     public void SetSectionStates(bool[] sectionOn, double[] sectionWidths, int numSections,
         int[]? buttonStates = null)
     {
-        _numSections = Math.Min(numSections, 16);
+        _numSections = Math.Min(numSections, MaxSections);
         for (int i = 0; i < _numSections; i++)
         {
             _sectionOn[i] = i < sectionOn.Length && sectionOn[i];

--- a/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceV1Tests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ProfileJsonServiceV1Tests.cs
@@ -193,8 +193,8 @@ public class ProfileJsonServiceV1Tests
         _store.Tool.IsWorkSwitchManualSections = true;
         _store.Tool.IsSteerSwitchEnabled = true;
         _store.Tool.IsSteerSwitchManualSections = true;
-        var customColors = new uint[16];
-        for (int i = 0; i < 16; i++) customColors[i] = 0x010203 + (uint)i;
+        var customColors = new uint[AgValoniaGPS.Models.Configuration.ToolConfig.MaxSections];
+        for (int i = 0; i < customColors.Length; i++) customColors[i] = 0x010203 + (uint)i;
         _store.Tool.SectionColors = customColors;
 
         ProfileJsonServiceV1.Save(_tempDir, "ToolFields", _store);

--- a/Tests/AgValoniaGPS.ViewModels.Tests/SectionControlTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/SectionControlTests.cs
@@ -1,3 +1,7 @@
+using System.Linq;
+
+using AgValoniaGPS.Models.Configuration;
+
 namespace AgValoniaGPS.ViewModels.Tests;
 
 [TestFixture]
@@ -26,18 +30,47 @@ public class SectionControlTests
     }
 
     [Test]
-    public void SectionActiveProperties_AreAccessible()
+    public void SectionRows_ButtonsMatchSectionCount()
     {
         var vm = new MainViewModelBuilder().Build();
 
-        // All section active properties should be false by default
-        Assert.That(vm.Section1Active, Is.False);
-        Assert.That(vm.Section2Active, Is.False);
-        Assert.That(vm.Section3Active, Is.False);
-        Assert.That(vm.Section4Active, Is.False);
+        // Whatever NumSections is, the rows together hold exactly that many
+        // buttons, numbered 1..N in order.
+        var buttons = vm.SectionRows.SelectMany(r => r.Buttons).ToList();
+        Assert.That(buttons.Count, Is.EqualTo(vm.NumSections));
+        for (int i = 0; i < buttons.Count; i++)
+            Assert.That(buttons[i].Number, Is.EqualTo(i + 1));
+    }
 
-        // Can set them
-        vm.Section1Active = true;
-        Assert.That(vm.Section1Active, Is.True);
+    [Test]
+    public void SectionRows_SplitIntoEvenRows_TopRowLargerWhenOdd()
+    {
+        var store = ConfigurationStore.Instance;
+        int original = store.NumSections;
+        try
+        {
+            var vm = new MainViewModelBuilder().Build();
+
+            // ≤16 sections: a single row.
+            store.NumSections = 16;
+            Assert.That(vm.NumSections, Is.EqualTo(16));
+            Assert.That(vm.SectionRows.Count, Is.EqualTo(1));
+            Assert.That(vm.SectionRows[0].Buttons.Count, Is.EqualTo(16));
+
+            // 17 sections: two rows, top row holds the greater count (9 + 8).
+            store.NumSections = 17;
+            Assert.That(vm.SectionRows.Count, Is.EqualTo(2));
+            Assert.That(vm.SectionRows[0].Buttons.Count, Is.EqualTo(9));
+            Assert.That(vm.SectionRows[1].Buttons.Count, Is.EqualTo(8));
+
+            // 64 sections: four even rows of 16, never more than 16 per row.
+            store.NumSections = 64;
+            Assert.That(vm.SectionRows.Count, Is.EqualTo(4));
+            Assert.That(vm.SectionRows.All(r => r.Buttons.Count == 16), Is.True);
+        }
+        finally
+        {
+            store.NumSections = original;
+        }
     }
 }

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 4
+#define VERSION_PATCH 5
 
-#define VERSION "26.5.4"
-#define VERSION_DATE "2026-05-23"
+#define VERSION "26.5.5"
+#define VERSION_DATE "2026-05-24"


### PR DESCRIPTION
## Summary
Raises the section cap from 16 to **64** and reworks the section control bar to lay sections out across multiple rows. Full-stack change: UI, section state, wire protocol (PGN 229), and profile persistence.

## Section control bar
- Dynamic `SectionRows` collection replaces the 16 hard-coded buttons.
- **1 row for up to 16 sections.** Above 16, sections split into evenly-sized rows: `ceil(N/16)` rows (max 4), max 16 buttons/row. When N is odd the **top rows hold the greater count** (17 → 9+8, 40 → 14+13+13, 64 → 16×4).
- Bar shows **only when a field is open AND a master (Auto or Manual) is engaged**; hidden otherwise. The master toggles already force all sections off in that state, and they live in the right nav panel so they stay reachable.
- Section numbers are dark (`#202020`) so they read on yellow/cyan/orange.

## Capacity 16 → 64
`ConfigurationStore` clamp, `ToolConfig` width/color arrays + accessors, `SectionControlService` state array and per-section guards, `ConfigurationViewModel` max, `SkiaMapControl` overlay arrays, and the legacy `SectionState`.

## Wire protocol — PGN 229
- `VehicleState.SectionStates` widened to `ulong`; new `PgnBuilder.BuildSection64Pgn` (8 section bytes + L/R speed mirroring PGN 239's speed byte).
- `AutoSteerService` sends **both PGN 239 and 229 only when >16 sections** are configured (239 alone otherwise). Firmware reconciles the overlap on sections 1–16. Byte layout per `Docs/PGN.md`.

## Profile persistence
JSON load restores up to 64 section positions/colors, overlaying saved colors onto palette defaults so older 16-color profiles keep sensible colors for sections 17–64.

## Testing
- Desktop builds clean.
- **1367 tests pass** (ViewModels 218, Services 899, Models 104, UI 146), including new row-split tests (16→1 row, 17→9+8, 64→16×4).
- Version bumped to `26.5.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)