### PR TITLE
Lay AB-line flyout sections in rows so it fits the Android tablet

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
@@ -219,62 +219,68 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 Canvas.Left="500" Canvas.Top="-350"
                 IsVisible="False">
             <StackPanel Spacing="6">
-                <!-- AB Tracks Dialog (manage saved tracks) -->
-                <Button Classes="BottomPanelButton" ToolTip.Tip="Tracks - Manage AB Lines"
-                        Command="{Binding ShowTracksDialogCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png" Stretch="Uniform"/>
-                </Button>
+                <!-- Track creation & selection — laid out in rows (3 wide) so
+                     the flyout stays short enough for the Android tablet. -->
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <!-- AB Tracks Dialog (manage saved tracks) -->
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Tracks - Manage AB Lines"
+                            Command="{Binding ShowTracksDialogCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png" Stretch="Uniform"/>
+                    </Button>
 
-                <!-- Auto Track toggle (green=on, dim=off) -->
-                <Button Classes="BottomPanelButton"
-                        ToolTip.Tip="Auto Track Select (closest track)"
-                        Command="{Binding ToggleAutoTrackCommand}"
-                        Classes.Active="{Binding IsAutoTrackEnabled}">
-                    <TextBlock Text="AT" FontSize="14" FontWeight="Bold"
-                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                </Button>
+                    <!-- Auto Track toggle (green=on, dim=off) -->
+                    <Button Classes="BottomPanelButton"
+                            ToolTip.Tip="Auto Track Select (closest track)"
+                            Command="{Binding ToggleAutoTrackCommand}"
+                            Classes.Active="{Binding IsAutoTrackEnabled}">
+                        <TextBlock Text="AT" FontSize="14" FontWeight="Bold"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Button>
 
-                <!-- Quick AB (mode selector for drive-in creation) -->
-                <Button Classes="BottomPanelButton" ToolTip.Tip="Quick AB Line Creator"
-                        Command="{Binding ShowQuickABSelectorCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAPlus.png" Stretch="Uniform"/>
-                </Button>
+                    <!-- Quick AB (mode selector for drive-in creation) -->
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Quick AB Line Creator"
+                            Command="{Binding ShowQuickABSelectorCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTrackAPlus.png" Stretch="Uniform"/>
+                    </Button>
+                </StackPanel>
 
-                <!-- Create AB from Boundary Edge -->
-                <Button Classes="BottomPanelButton" ToolTip.Tip="Create AB Line from Boundary Edge"
-                        Command="{Binding CreateTrackFromBoundaryCommand}">
-                    <TextBlock Text="BE" FontSize="14" FontWeight="Bold"
-                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                </Button>
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <!-- Create AB from Boundary Edge -->
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Create AB Line from Boundary Edge"
+                            Command="{Binding CreateTrackFromBoundaryCommand}">
+                        <TextBlock Text="BE" FontSize="14" FontWeight="Bold"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Button>
 
-                <!-- Draw AB (tap on map to place points) -->
-                <Button Classes="BottomPanelButton" ToolTip.Tip="Draw AB Line on Map"
-                        Command="{Binding ShowDrawABDialogCommand}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABDraw.png" Stretch="Uniform"/>
-                </Button>
+                    <!-- Draw AB (tap on map to place points) -->
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Draw AB Line on Map"
+                            Command="{Binding ShowDrawABDialogCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABDraw.png" Stretch="Uniform"/>
+                    </Button>
+                </StackPanel>
 
                 <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="2" Margin="4" IsVisible="{Binding HasActiveTrack}"/>
 
-                <!-- Cycle Lines -->
-                <Button Classes="BottomPanelButton" ToolTip.Tip="Cycle AB Lines"
-                        Command="{Binding CycleABLinesCommand}"
-                        IsVisible="{Binding HasActiveTrack}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png" Stretch="Uniform"/>
-                </Button>
+                <!-- Active track operations — one row (Cycle / Smooth / Delete). -->
+                <StackPanel Orientation="Horizontal" Spacing="4" IsVisible="{Binding HasActiveTrack}">
+                    <!-- Cycle Lines -->
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Cycle AB Lines"
+                            Command="{Binding CycleABLinesCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABLineCycle.png" Stretch="Uniform"/>
+                    </Button>
 
-                <!-- Smooth -->
-                <Button Classes="BottomPanelButton" ToolTip.Tip="Smooth AB Curve"
-                        Command="{Binding SmoothABLineCommand}"
-                        IsVisible="{Binding HasActiveTrack}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABSmooth.png" Stretch="Uniform"/>
-                </Button>
+                    <!-- Smooth -->
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Smooth AB Curve"
+                            Command="{Binding SmoothABLineCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABSmooth.png" Stretch="Uniform"/>
+                    </Button>
 
-                <!-- Delete Contours -->
-                <Button Classes="BottomPanelButton" ToolTip.Tip="Delete Contours"
-                        Command="{Binding DeleteContoursCommand}"
-                        IsVisible="{Binding HasActiveTrack}">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TrashContourRef.png" Stretch="Uniform"/>
-                </Button>
+                    <!-- Delete Contours -->
+                    <Button Classes="BottomPanelButton" ToolTip.Tip="Delete Contours"
+                            Command="{Binding DeleteContoursCommand}">
+                        <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/TrashContourRef.png" Stretch="Uniform"/>
+                    </Button>
+                </StackPanel>
 
                 <Separator Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Height="2" Margin="4" IsVisible="{Binding HasActiveTrack}"/>
 


### PR DESCRIPTION
## Summary
The track-line (AB-line) flyout menu was too tall for the Android tablet — its top section (5 buttons) and middle section (3 buttons) were stacked vertically, pushing the menu off-screen.

Lay both sections out in **horizontal rows (3 wide)** to match the existing nudge section:
- **Top:** 3 + 2 (Tracks / AT / Quick-AB, then Boundary-Edge / Draw)
- **Middle:** one row of 3 (Cycle / Smooth / Delete Contours)
- **Nudge section:** unchanged (already horizontal rows)

This roughly halves the flyout height. The runtime positioner (`ShowFlyoutAboveButton`) measures the flyout's actual height and anchors its bottom 10px above the bar, so the shorter menu re-anchors with no gap and no code-behind change.

`HasActiveTrack` visibility moved from the individual Cycle/Smooth/Delete buttons onto their row container.

## Testing
- Desktop builds clean.
- Built, installed, and verified on a physical Galaxy tablet — the flyout now fits on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)