### PR TITLE
Fix #421: no U-turns on a closed (polygon) track

### DIFF
--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -840,6 +840,14 @@ public partial class MainViewModel
 
         ToggleYouTurnCommand = new RelayCommand(() =>
         {
+            // No U-turns on a closed/polygon track — there's no field end to turn at (#421).
+            if (IsActiveTrackClosed)
+            {
+                IsYouTurnEnabled = false;
+                StatusMessage = "U-turns aren't available on a closed (polygon) track";
+                return;
+            }
+
             IsYouTurnEnabled = !IsYouTurnEnabled;
             SyncGuidanceStateToPipeline();
             StatusMessage = IsYouTurnEnabled ? "YouTurn enabled" : "YouTurn disabled";

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -394,7 +394,8 @@ public partial class MainViewModel
         _gpsPipelineService.SetBoundary(CurrentBoundary);
         _gpsPipelineService.SetHeadlandLine(_currentHeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
-        _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled);
+        // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
+        _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled && !IsActiveTrackClosed);
         _gpsPipelineService.SetYouTurnConfig(
             UTurnSkipRows, IsSkipWorkedMode, HeadlandCalculatedWidth, HeadlandDistance);
     }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -361,10 +361,18 @@ public partial class MainViewModel
     #region ConfigurationStore Display Forwarding
 
     /// <summary>
-    /// UTurn button visible when track available AND config allows it.
+    /// UTurn button visible when track available AND config allows it AND the
+    /// active track isn't a closed loop (no U-turns on polygon tracks, #421).
     /// </summary>
     public bool IsUTurnButtonVisible =>
-        IsAutoSteerAvailable && ConfigurationStore.Instance.Display.UTurnButtonVisible;
+        IsAutoSteerAvailable && ConfigurationStore.Instance.Display.UTurnButtonVisible
+        && !IsActiveTrackClosed;
+
+    /// <summary>
+    /// Manual U-turn left/right buttons: visible only while steering AND not on a
+    /// closed (polygon) track (#421).
+    /// </summary>
+    public bool IsManualUTurnVisible => IsAutoSteerEngaged && !IsActiveTrackClosed;
 
     /// <summary>
     /// Notify IsUTurnButtonVisible when IsAutoSteerAvailable changes.

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.YouTurn.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.YouTurn.cs
@@ -42,6 +42,14 @@ public partial class MainViewModel
         set => SetProperty(ref _isYouTurnEnabled, value);
     }
 
+    /// <summary>
+    /// True when the active track is a closed loop (polygon / boundary curve /
+    /// water pivot). U-turns make no sense on a closed track — there's no field
+    /// end to turn at, you just drive the loop continuously — so they're disabled
+    /// and the U-turn button is hidden in that case (#421).
+    /// </summary>
+    public bool IsActiveTrackClosed => SelectedTrack?.IsClosed == true;
+
     private int _uTurnSkipRows;
     /// <summary>Number of rows to skip during U-turn (0–9).</summary>
     public int UTurnSkipRows
@@ -153,9 +161,17 @@ public partial class MainViewModel
     /// <summary>Clear all U-turn state — called on field close or track deselect.</summary>
     public void ClearYouTurnState() => _intents.RequestClearYouTurn();
 
-    public void TriggerManualYouTurnLeft() => _intents.RequestManualYouTurn(turnLeft: true);
+    public void TriggerManualYouTurnLeft()
+    {
+        if (IsActiveTrackClosed) { StatusMessage = "U-turns aren't available on a closed (polygon) track"; return; }
+        _intents.RequestManualYouTurn(turnLeft: true);
+    }
 
-    public void TriggerManualYouTurnRight() => _intents.RequestManualYouTurn(turnLeft: false);
+    public void TriggerManualYouTurnRight()
+    {
+        if (IsActiveTrackClosed) { StatusMessage = "U-turns aren't available on a closed (polygon) track"; return; }
+        _intents.RequestManualYouTurn(turnLeft: false);
+    }
 
     /// <summary>
     /// Toggle the U-turn direction. Mirrors legacy <c>FormGPS.SwapDirection</c>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -962,7 +962,11 @@ public partial class MainViewModel : ObservableObject
     public bool IsAutoSteerEngaged
     {
         get => _isAutoSteerEngaged;
-        set => SetProperty(ref _isAutoSteerEngaged, value);
+        set
+        {
+            if (SetProperty(ref _isAutoSteerEngaged, value))
+                OnPropertyChanged(nameof(IsManualUTurnVisible));
+        }
     }
 
     // IsYouTurnEnabled is now in MainViewModel.YouTurn.cs
@@ -2041,6 +2045,14 @@ public partial class MainViewModel : ObservableObject
                 // Update guidance availability
                 HasActiveTrack = value != null;
                 IsAutoSteerAvailable = value != null;
+
+                // No U-turns on a closed/polygon track — turn the toggle off and
+                // refresh the dependent UI (button visibility) (#421).
+                if (IsActiveTrackClosed && IsYouTurnEnabled)
+                    IsYouTurnEnabled = false;
+                OnPropertyChanged(nameof(IsActiveTrackClosed));
+                OnPropertyChanged(nameof(IsManualUTurnVisible));
+                RaiseUTurnButtonVisibleChanged();
 
                 // Sync to pipeline so guidance computes on background thread
                 SyncGuidanceStateToPipeline();

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
@@ -181,8 +181,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Grid>
             </Button>
 
-            <!-- 4b. Manual U-Turn Left/Right buttons (only visible when autosteer engaged) -->
-            <Grid ColumnDefinitions="*,*" IsVisible="{Binding IsAutoSteerEngaged}">
+            <!-- 4b. Manual U-Turn Left/Right buttons (visible when steering, hidden on polygon tracks #421) -->
+            <Grid ColumnDefinitions="*,*" IsVisible="{Binding IsManualUTurnVisible}">
                 <Button Grid.Column="0" Classes="RightPanelButton" Width="30" Height="32"
                         ToolTip.Tip="Manual U-Turn Left"
                         Command="{Binding ManualYouTurnLeftCommand}"

--- a/Tests/AgValoniaGPS.ViewModels.Tests/YouTurnTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/YouTurnTests.cs
@@ -270,4 +270,55 @@ public class YouTurnTests
             Assert.That(vm.State.Guidance.IsHeadingSameWay, Is.True);
         });
     }
+
+    // ---- #421: no U-turns on a closed (polygon) track ----
+
+    private static Track ClosedCurve() => new()
+    {
+        Name = "Polygon",
+        Type = TrackType.Curve,
+        IsClosed = true,
+        Points = new List<Vec3>
+        {
+            new(0, 0, 0), new(100, 0, GeometryMath.PIBy2),
+            new(100, 100, Math.PI), new(0, 100, Math.PI + GeometryMath.PIBy2),
+            new(0, 0, 0)
+        }
+    };
+
+    [Test]
+    public void ClosedTrack_HidesUTurnButton_AndFlagsClosed()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.SelectedTrack = ClosedCurve();
+
+        Assert.That(vm.IsActiveTrackClosed, Is.True);
+        Assert.That(vm.IsUTurnButtonVisible, Is.False, "U-turn button must be hidden on a polygon track");
+    }
+
+    [Test]
+    public void ToggleYouTurn_OnClosedTrack_StaysDisabled()
+    {
+        var vm = new MainViewModelBuilder().Build();
+        vm.SelectedTrack = ClosedCurve();
+
+        vm.ToggleYouTurnCommand!.Execute(null);
+
+        Assert.That(vm.IsYouTurnEnabled, Is.False, "toggling must not enable U-turns on a polygon track");
+        Assert.That(vm.StatusMessage, Does.Contain("polygon"));
+    }
+
+    [Test]
+    public void SelectingClosedTrack_DisablesActiveYouTurn()
+    {
+        var vm = new MainViewModelBuilder().Build();
+
+        // Enable on an open AB line, then switch to a closed track.
+        vm.SelectedTrack = new Track { Name = "AB", Points = new List<Vec3> { new(0, 0, 0), new(0, 100, 0) } };
+        vm.IsYouTurnEnabled = true;
+
+        vm.SelectedTrack = ClosedCurve();
+
+        Assert.That(vm.IsYouTurnEnabled, Is.False, "selecting a polygon track must turn U-turns off");
+    }
 }

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 7
+#define VERSION_PATCH 8
 
-#define VERSION "26.5.7"
+#define VERSION "26.5.8"
 #define VERSION_DATE "2026-05-24"


### PR DESCRIPTION
## Summary
Closes #421. A closed-loop track (polygon / boundary curve) has no field end to turn at — you drive the loop continuously — so U-turns shouldn't be offered. They were being armed and the U-turn controls shown.

A single signal, `IsActiveTrackClosed` (`SelectedTrack.IsClosed`), gates U-turns at every level:

- **Pipeline safety gate:** `SetYouTurnEnabled(IsYouTurnEnabled && !IsActiveTrackClosed)` — a closed track never arms a U-turn even if the toggle was left enabled.
- **Auto U-turn button** hidden (`IsUTurnButtonVisible`); `ToggleYouTurnCommand` and the manual L/R triggers refuse with a status message.
- **Manual U-turn L/R buttons** hidden via new `IsManualUTurnVisible` (`IsAutoSteerEngaged && !IsActiveTrackClosed`) — previously gated only on engagement, so they stayed visible (and no-op'd) on a polygon track.
- **On selection:** switching to a closed track turns the toggle off and refreshes the dependent UI.

Builds on #422's `IsClosed` flag (including the load-time migration of existing curve tracks), so current boundary-curve fields are covered without recreation.

## Testing
Verified on the Res Test polygon track: both the auto and manual U-turn buttons disappear; switching to an open AB line brings them back. +3 unit tests; 221 ViewModels tests green. Version → 26.5.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)