### PR TITLE
Fix #430: grid keeps resizing past max zoom-out in 3D

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
@@ -935,9 +935,11 @@ public partial class SkiaMapControl : Control, ISharedMapControl
 
     private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
-        double zoomFactor = e.Delta.Y > 0 ? 1.1 : 0.9;
-        _zoom = Math.Clamp(_zoom * zoomFactor, MinZoom, MaxZoom);
-        SendStateToHandler();
+        // Route through Zoom() so the wheel honors the same 3D plateau bail as the
+        // zoom buttons. A raw clamp here let _zoom keep dropping past the 3D visual
+        // limit (camera pinned at the zoomScalar cap), which kept coarsening the
+        // grid spacing (200/_zoom) several more steps after max zoom-out (#430).
+        Zoom(e.Delta.Y > 0 ? 1.1 : 0.9);
         e.Handled = true;
     }
 

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 8
+#define VERSION_PATCH 9
 
-#define VERSION "26.5.8"
+#define VERSION "26.5.9"
 #define VERSION_DATE "2026-05-24"


### PR DESCRIPTION
## Summary
Closes #430. In 3D (tilted) mode, scrolling the wheel to zoom out kept coarsening the grid ~3 more times after the view had already hit its max zoom-out.

`OnPointerWheelChanged` did a raw `_zoom = Clamp(_zoom * factor, MinZoom, MaxZoom)` that skipped the **3D plateau bail** the zoom *buttons* already have in `Zoom(factor)`. So the perspective camera pinned at its `zoomScalar` cap (60) while `_zoom` kept dropping toward `MinZoom` (0.02). Grid spacing is derived from `viewSpan = 200/_zoom`, so it kept stepping on the 1-2-5 series even though the visual had stopped.

Fix: route the wheel through `Zoom(factor)`, which bails when the 3D scalar limit is reached — `_zoom` no longer drifts past the plateau and the grid holds steady. Also removes a duplicate clamp.

## Testing
Verified in 3D on desktop: at max zoom-out the grid stops changing and further scrolling is a no-op. 146 UI tests green. Version → 26.5.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)