### PR TITLE
Fix 2D grid line flicker by anti-aliasing the grid paints

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
@@ -1655,14 +1655,12 @@ public partial class SkiaMapControl : Control, ISharedMapControl
 
             EnsureGridPaintsSk(s.IsDayMode, minorThickness, majorThickness, axisThickness);
 
-            // Anti-alias grid in 3D — sub-pixel camera shifts under perspective
-            // make unaliased far lines flicker. Costs ~17 FPS on iPad; the
-            // post-Phase-3 perf audit ([[task #16]]) will look at recovering this.
-            bool perspective = s.Is3DMode && s.CameraPitch > TopDownEpsilon;
-            _gridMinorPaintSk!.IsAntialias = perspective;
-            _gridMajorPaintSk!.IsAntialias = perspective;
-            _gridAxisXPaintSk!.IsAntialias = perspective;
-            _gridAxisYPaintSk!.IsAntialias = perspective;
+            // Grid paints are anti-aliased (set in EnsureGridPaintsSk). AA matters in
+            // both modes: in 3D, sub-pixel camera shifts under perspective make far
+            // lines flicker; in 2D north-up, axis-aligned lines perpendicular to travel
+            // scroll across pixel rows/cols and flicker as the vehicle drives. The 2D
+            // grid is one batched DrawPath, so AA is cheap there (the ~17 FPS iPad cost
+            // was the 3D per-line path). No per-frame IsAntialias override here.
 
             double minX = Math.Max(s.CameraX - viewWidth, -gridSize);
             double maxX = Math.Min(s.CameraX + viewWidth, gridSize);
@@ -1765,10 +1763,14 @@ public partial class SkiaMapControl : Control, ISharedMapControl
                 majorColor = new SKColor(200, 200, 200, 120);
             }
 
-            _gridMinorPaintSk = new SKPaint { Color = minorColor, Style = SKPaintStyle.Stroke, StrokeWidth = (float)minorThickness, IsAntialias = false };
-            _gridMajorPaintSk = new SKPaint { Color = majorColor, Style = SKPaintStyle.Stroke, StrokeWidth = (float)majorThickness, IsAntialias = false };
-            _gridAxisXPaintSk = new SKPaint { Color = new SKColor(204, 51, 51, 70), Style = SKPaintStyle.Stroke, StrokeWidth = (float)axisThickness, IsAntialias = false };
-            _gridAxisYPaintSk = new SKPaint { Color = new SKColor(51, 204, 51, 70), Style = SKPaintStyle.Stroke, StrokeWidth = (float)axisThickness, IsAntialias = false };
+            // Anti-aliased: axis-aligned grid lines in 2D north-up flicker badly as the
+            // camera pans when AA is off (a 1px line snaps between pixel rows/cols each
+            // frame). AA lets them move sub-pixel-smoothly. Became obvious once the grid
+            // LOD went finer (0dc1b13); the 3D skew hid it because the lines aren't axis-aligned.
+            _gridMinorPaintSk = new SKPaint { Color = minorColor, Style = SKPaintStyle.Stroke, StrokeWidth = (float)minorThickness, IsAntialias = true };
+            _gridMajorPaintSk = new SKPaint { Color = majorColor, Style = SKPaintStyle.Stroke, StrokeWidth = (float)majorThickness, IsAntialias = true };
+            _gridAxisXPaintSk = new SKPaint { Color = new SKColor(204, 51, 51, 70), Style = SKPaintStyle.Stroke, StrokeWidth = (float)axisThickness, IsAntialias = true };
+            _gridAxisYPaintSk = new SKPaint { Color = new SKColor(51, 204, 51, 70), Style = SKPaintStyle.Stroke, StrokeWidth = (float)axisThickness, IsAntialias = true };
 
             _gridPaintIsDayMode = isDayMode;
             _gridPaintMinorThickness = minorThickness;

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 10
+#define VERSION_PATCH 11
 
-#define VERSION "26.5.10"
-#define VERSION_DATE "2026-05-24"
+#define VERSION "26.5.11"
+#define VERSION_DATE "2026-05-25"


### PR DESCRIPTION
## Problem
The 2D map grid flickered badly while driving — specifically the lines perpendicular to travel (e.g. horizontal lines when heading north). Surfaced on `develop` after the grid LOD was made finer (`0dc1b13`); the denser grid made a long-standing AA-off issue obvious.

## Cause
`DrawGridSk` re-forced `IsAntialias = false` on all grid paints **every frame** in 2D (AA was only turned on under 3D perspective). In 2D north-up the grid lines are axis-aligned, so as the camera pans the unaliased lines snap between pixel rows/cols → flicker. The 3D view hid it because perspective skews the lines off-axis.

## Fix
Remove the per-frame 2D `IsAntialias` override and create the grid paints anti-aliased. The 2D grid is a single batched `DrawPath`, so AA is cheap there (the ~17 FPS iPad cost noted in the old comment was the 3D *per-line* path, which is unchanged).

## Verification
Flicker gone, FPS holding on all platforms:
- Desktop ✅
- Android ✅ 60 FPS
- iPad (physical, ios-arm64) ✅ 59 FPS — well above the 24 floor

Version → 26.5.11.