### PR TITLE
Horizontal simulator bar (AgOpen-style) above the bottom bars

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -85,12 +85,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Button>
                 </StackPanel>
 
-                <!-- BOTTOM: Section control stacked above bottom navigation -->
+                <!-- BOTTOM: Simulator bar above section control above bottom navigation -->
                 <StackPanel ZIndex="10"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Bottom"
                             Margin="0,0,0,8"
                             Spacing="4">
+                    <panels:SimulatorPanel x:Name="SimulatorBarPanel"
+                                           HorizontalAlignment="Center"
+                                           DataContext="{Binding}"/>
                     <panels:SectionControlPanel x:Name="SectionControlPanel"
                                                 HorizontalAlignment="Center"
                                                 DataContext="{Binding}"/>

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -41,6 +41,7 @@ public partial class MainView : UserControl
         WireChartPanelDrag("SteerChartPanel");
         WireChartPanelDrag("HeadingChartPanel");
         WireChartPanelDrag("XTEChartPanel");
+        // SimulatorBarPanel is a fixed layout child of the bottom stack — no drag/positioning needed.
 
         this.PropertyChanged += MainView_PropertyChanged;
         this.Unloaded += MainView_Unloaded;

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -99,12 +99,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             </Button>
         </StackPanel>
 
-        <!-- BOTTOM: Section control stacked above bottom navigation -->
+        <!-- BOTTOM: Simulator bar above section control above bottom navigation -->
         <StackPanel ZIndex="10"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Bottom"
                     Margin="0,0,0,8"
                     Spacing="4">
+            <panels:SimulatorPanel x:Name="SimulatorBarPanel"
+                                   HorizontalAlignment="Center"
+                                   DataContext="{Binding}"/>
             <panels:SectionControlPanel x:Name="SectionControlPanel"
                                         HorizontalAlignment="Center"
                                         DataContext="{Binding}"/>

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -114,6 +114,7 @@ public partial class MainWindow : Window
             HeadingChartPanel.DragMoved += (_, delta) => MovePanel(HeadingChartPanel, delta);
         if (XTEChartPanel != null)
             XTEChartPanel.DragMoved += (_, delta) => MovePanel(XTEChartPanel, delta);
+        // SimulatorBarPanel is a fixed layout child of the bottom stack — no drag/positioning needed.
     }
 
     private void MovePanel(Control panel, Vector delta)
@@ -650,7 +651,7 @@ public partial class MainWindow : Window
         var position = e.GetPosition(this);
 
         // Check anchored panels using their actual rendered bounds
-        Control[] panels = { LeftNavPanel, RightNavPanel, SectionControlPanel, BottomNavPanel };
+        Control[] panels = { LeftNavPanel, RightNavPanel, SectionControlPanel, BottomNavPanel, SimulatorBarPanel };
         foreach (var panel in panels)
         {
             if (panel?.IsVisible == true && panel.Bounds.Width > 0)

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -85,12 +85,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Button>
                 </StackPanel>
 
-                <!-- BOTTOM: Section control stacked above bottom navigation -->
+                <!-- BOTTOM: Simulator bar above section control above bottom navigation -->
                 <StackPanel ZIndex="10"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Bottom"
                             Margin="0,0,0,8"
                             Spacing="4">
+                    <panels:SimulatorPanel x:Name="SimulatorBarPanel"
+                                           HorizontalAlignment="Center"
+                                           DataContext="{Binding}"/>
                     <panels:SectionControlPanel x:Name="SectionControlPanel"
                                                 HorizontalAlignment="Center"
                                                 DataContext="{Binding}"/>

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -52,6 +52,7 @@ public partial class MainView : UserControl
         WireChartPanelDrag("SteerChartPanel");
         WireChartPanelDrag("HeadingChartPanel");
         WireChartPanelDrag("XTEChartPanel");
+        // SimulatorBarPanel is a fixed layout child of the bottom stack — no drag/positioning needed.
 
         this.PropertyChanged += MainView_PropertyChanged;
         this.Unloaded += MainView_Unloaded;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
@@ -188,7 +188,7 @@ public partial class MainViewModel
         }
     }
 
-    public string SimulatorSteerAngleDisplay => $"Steer Angle: {_simulatorSteerAngle:F1}°";
+    public string SimulatorSteerAngleDisplay => $"{_simulatorSteerAngle:F1}°";
 
     /// <summary>
     /// Simulator speed in kph. Range: -10 to +25 kph (or -100 to +250 with 10x enabled).
@@ -240,12 +240,14 @@ public partial class MainViewModel
     {
         get
         {
+            // No "(10x)" suffix — the 10x toggle sits beside this readout and the
+            // value already reflects the multiplier, so the readout stays compact
+            // enough to hug the speed arrows while fitting a 3-digit speed.
             double speed = _isSimulatorSpeed10x ? _simulatorSpeedKph * 10 : _simulatorSpeedKph;
-            string suffix = _isSimulatorSpeed10x ? " (10x)" : "";
             if (ConfigStore.IsMetric)
-                return $"Speed: {speed:F1} kph{suffix}";
+                return $"{speed:F1} kph";
             else
-                return $"Speed: {speed * 0.621371:F1} mph{suffix}";
+                return $"{speed * 0.621371:F1} mph";
         }
     }
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
@@ -145,11 +145,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                   ZIndex="15"
                                   DataContext="{Binding}"/>
 
-        <!-- Simulator Panel -->
-        <controls:SimulatorPanel x:Name="SimulatorPanelControl"
-                                 Canvas.Left="90" Canvas.Top="150"
-                                 ZIndex="15"
-                                 DataContext="{Binding}"/>
+        <!-- Simulator Panel moved to the window-level floating canvas (bottom-center home) -->
 
         <!-- Boundary Recording Panel -->
         <controls:BoundaryRecordingPanel x:Name="BoundaryRecordingPanelControl"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
@@ -27,7 +27,7 @@ public partial class LeftNavigationPanel : UserControl
         InitializeComponent();
 
         // Wire up sub-panel drag events
-        WireUpSubPanelDrag<SimulatorPanel>("SimulatorPanelControl");
+        // SimulatorPanel moved to the window-level floating canvas (see platform views)
         WireUpSubPanelDrag<ViewSettingsPanel>("ViewSettingsPanelControl");
         WireUpSubPanelDrag<FileMenuPanel>("FileMenuPanelControl");
         WireUpSubPanelDrag<ToolsPanel>("ToolsPanelControl");

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml
@@ -19,128 +19,157 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
-             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Panels.SimulatorPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding IsSimulatorPanelVisible}"
              IsHitTestVisible="{Binding IsSimulatorPanelVisible}">
 
-    <controls:FloatingPanel x:Name="FP"
-                            MinWidth="320"
-                            Title="{loc:Localize GpsSimulator}"
-                            CloseCommand="{Binding ToggleSimulatorPanelCommand}">
-        <controls:FloatingPanel.PanelContent>
-            <StackPanel Spacing="8" Margin="12">
+    <UserControl.Styles>
+        <Style Selector="Button.SimButton">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Height" Value="40"/>
+            <Setter Property="MinWidth" Value="40"/>
+            <Setter Property="Padding" Value="8,4"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+        </Style>
+        <Style Selector="Button.SimButton:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+        </Style>
+        <Style Selector="Button.SimButton:pressed">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
+        </Style>
+    </UserControl.Styles>
 
-                <!-- Enable/Disable -->
-                <CheckBox Content="{loc:Localize SimulatorEnabled}"
-                          IsChecked="{Binding IsSimulatorEnabled}"
-                          FontWeight="Bold" FontSize="13"
-                          Margin="0,0,0,4"/>
+    <!-- Single-row horizontal simulator bar; sits above the bottom nav/section bars, close via the × -->
+    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+            CornerRadius="12" Padding="6"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="1">
+        <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
 
-                <!-- Enter Coords -->
-                <Button ClickMode="Press" HorizontalAlignment="Stretch"
-                        Command="{Binding ShowSimCoordsDialogCommand}"
-                        IsEnabled="{Binding !IsSimulatorEnabled}"
-                        ToolTip.Tip="Enter starting GPS coordinates (disable simulator first)">
-                    <TextBlock Text="{loc:Localize EnterSimCoords}" FontSize="12" IsHitTestVisible="False"/>
+            <!-- Simulator On/Off -->
+            <CheckBox IsChecked="{Binding IsSimulatorEnabled}"
+                      VerticalAlignment="Center" Margin="4,0"
+                      ToolTip.Tip="{loc:Localize SimulatorEnabled}">
+                <TextBlock Text="SIM" FontSize="11" FontWeight="Bold"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            </CheckBox>
+
+            <Separator Width="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="2,4"/>
+
+            <!-- Enter Sim Coords (only when simulator is disabled) -->
+            <Button Classes="SimButton" ClickMode="Press"
+                    Command="{Binding ShowSimCoordsDialogCommand}"
+                    IsEnabled="{Binding !IsSimulatorEnabled}"
+                    ToolTip.Tip="{loc:Localize EnterSimCoords}">
+                <TextBlock Text="GPS" FontSize="11" IsHitTestVisible="False"/>
+            </Button>
+
+            <!-- Reset Position -->
+            <Button Classes="SimButton" ClickMode="Press"
+                    Command="{Binding ResetSimulatorCommand}"
+                    ToolTip.Tip="{loc:Localize Reset}">
+                <TextBlock Text="RST" FontSize="11" IsHitTestVisible="False"/>
+            </Button>
+
+            <Separator Width="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="2,4"/>
+
+            <!-- Steer Left 0.5 -->
+            <Button Classes="SimButton" Width="36" ClickMode="Press"
+                    Command="{Binding SimulatorSteerLeftCommand}"
+                    ToolTip.Tip="Steer left 0.5°">
+                <TextBlock Text="L" FontSize="14" IsHitTestVisible="False"/>
+            </Button>
+
+            <!-- Steering Slider (0.5° steps) -->
+            <Slider Minimum="-40" Maximum="40" Width="160"
+                    Value="{Binding SimulatorSteerAngle, Mode=TwoWay}"
+                    TickFrequency="0.5" IsSnapToTickEnabled="True"
+                    VerticalAlignment="Center"
+                    ToolTip.Tip="Steering angle (0.5° steps)"/>
+
+            <!-- Steer Right 0.5 -->
+            <Button Classes="SimButton" Width="36" ClickMode="Press"
+                    Command="{Binding SimulatorSteerRightCommand}"
+                    ToolTip.Tip="Steer right 0.5°">
+                <TextBlock Text="R" FontSize="14" IsHitTestVisible="False"/>
+            </Button>
+
+            <!-- Steer Angle Display (fixed width so per-frame text changes don't resize the bar) -->
+            <TextBlock Text="{Binding SimulatorSteerAngleDisplay, Mode=OneWay}"
+                       VerticalAlignment="Center" FontSize="11" Width="48"
+                       TextAlignment="Center"
+                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+
+            <!-- Reset Steering -->
+            <Button Classes="SimButton" ClickMode="Press"
+                    Command="{Binding ResetSteerAngleCommand}"
+                    ToolTip.Tip="Reset steering to 0">
+                <TextBlock Text="&gt;0&lt;" FontSize="13" IsHitTestVisible="False"/>
+            </Button>
+
+            <Separator Width="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="2,4"/>
+
+            <!-- Speed −/readout/+ grouped tightly; readout fixed width fits a 3-digit
+                 speed (e.g. "250.0 kph") so per-frame value changes don't resize the bar -->
+            <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+                <Button Classes="SimButton" Width="36" ClickMode="Press"
+                        Command="{Binding SimulatorSpeedDownCommand}"
+                        ToolTip.Tip="Decrease speed 0.5 kph (min -10)">
+                    <TextBlock Text="&#x25BC;" FontSize="14" IsHitTestVisible="False"/>
                 </Button>
-
-                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
-
-                <!-- Reset / Reset Steering -->
-                <Grid ColumnDefinitions="*,*">
-                    <Button Grid.Column="0" Margin="0,0,4,0" ClickMode="Press"
-                            Command="{Binding ResetSimulatorCommand}"
-                            ToolTip.Tip="Reset to starting position">
-                        <TextBlock Text="{loc:Localize Reset}" FontSize="12" IsHitTestVisible="False"/>
-                    </Button>
-                    <Button Grid.Column="1" Margin="4,0,0,0" ClickMode="Press"
-                            Command="{Binding ResetSteerAngleCommand}"
-                            ToolTip.Tip="Reset steering to 0 (straight ahead)">
-                        <TextBlock Text="&gt;0&lt;" FontSize="14" FontWeight="Bold" IsHitTestVisible="False"/>
-                    </Button>
-                </Grid>
-
-                <!-- Steering L / Slider / R — tap L/R for one 0.5° increment -->
-                <Grid ColumnDefinitions="Auto,*,Auto">
-                    <Button Grid.Column="0" Width="40" Margin="0,0,8,0" ClickMode="Press"
-                            Command="{Binding SimulatorSteerLeftCommand}"
-                            ToolTip.Tip="Steer left 0.5°">
-                        <TextBlock Text="L" FontSize="16" IsHitTestVisible="False"/>
-                    </Button>
-                    <Slider Grid.Column="1"
-                            Minimum="-40" Maximum="40"
-                            Value="{Binding SimulatorSteerAngle, Mode=TwoWay}"
-                            TickFrequency="0.5" IsSnapToTickEnabled="True"
-                            ToolTip.Tip="Steering angle (0.5° steps)"/>
-                    <Button Grid.Column="2" Width="40" Margin="8,0,0,0" ClickMode="Press"
-                            Command="{Binding SimulatorSteerRightCommand}"
-                            ToolTip.Tip="Steer right 0.5°">
-                        <TextBlock Text="R" FontSize="16" IsHitTestVisible="False"/>
-                    </Button>
-                </Grid>
-
-                <!-- Steer Angle Display -->
-                <TextBlock Text="{Binding SimulatorSteerAngleDisplay, Mode=OneWay}"
-                           HorizontalAlignment="Center" FontSize="12"
-                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-
-                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
-
-                <!-- Speed label + 10x toggle -->
-                <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Grid.Column="0" Text="{loc:Localize Speed}"
-                               Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                               FontSize="11" HorizontalAlignment="Center" Margin="0,4,0,0"/>
-                    <CheckBox Grid.Column="1" Content="10x"
-                              IsChecked="{Binding IsSimulatorSpeed10x}"
-                              FontSize="10"
-                              Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                              ToolTip.Tip="10x speed multiplier for large fields"/>
-                </Grid>
-
-                <!-- Speed − / Slider / + — tap − or + for one 0.5 kph increment -->
-                <Grid ColumnDefinitions="Auto,*,Auto">
-                    <Button Grid.Column="0" Width="40" Margin="0,0,8,0" ClickMode="Press"
-                            Command="{Binding SimulatorSpeedDownCommand}"
-                            ToolTip.Tip="Decrease speed 0.5 kph (min -10)">
-                        <TextBlock Text="−" FontSize="16" IsHitTestVisible="False"/>
-                    </Button>
-                    <Slider Grid.Column="1"
-                            Minimum="-10" Maximum="25"
-                            Value="{Binding SimulatorSpeedKph, Mode=TwoWay}"
-                            TickFrequency="0.5" IsSnapToTickEnabled="True"
-                            ToolTip.Tip="Speed in kph (0.5 kph steps, -10 reverse to +25 forward)"/>
-                    <Button Grid.Column="2" Width="40" Margin="8,0,0,0" ClickMode="Press"
-                            Command="{Binding SimulatorSpeedUpCommand}"
-                            ToolTip.Tip="Increase speed 0.5 kph (max +25)">
-                        <TextBlock Text="+" FontSize="16" IsHitTestVisible="False"/>
-                    </Button>
-                </Grid>
-
-                <!-- Speed Display -->
                 <TextBlock Text="{Binding SimulatorSpeedDisplay, Mode=OneWay}"
-                           HorizontalAlignment="Center" FontSize="12"
-                           Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-
-                <!-- Stop -->
-                <Button ClickMode="Press"
-                        Command="{Binding SimulatorStopCommand}"
-                        ToolTip.Tip="Stop (set speed to 0)"
-                        HorizontalAlignment="Center" Width="80">
-                    <TextBlock Text="STOP" FontSize="14" FontWeight="Bold" IsHitTestVisible="False"/>
+                           VerticalAlignment="Center" FontSize="12" FontWeight="Bold"
+                           Width="84" TextAlignment="Center"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                <Button Classes="SimButton" Width="36" ClickMode="Press"
+                        Command="{Binding SimulatorSpeedUpCommand}"
+                        ToolTip.Tip="Increase speed 0.5 kph (max +25)">
+                    <TextBlock Text="&#x25B2;" FontSize="14" IsHitTestVisible="False"/>
                 </Button>
-
-                <!-- Reverse Direction -->
-                <Button ClickMode="Press"
-                        Command="{Binding SimulatorReverseDirectionCommand}"
-                        ToolTip.Tip="Reverse direction (180 turn)">
-                    <TextBlock Text="{loc:Localize ReverseDirection}" FontSize="12" IsHitTestVisible="False"/>
-                </Button>
-
             </StackPanel>
-        </controls:FloatingPanel.PanelContent>
-    </controls:FloatingPanel>
+
+            <!-- STOP -->
+            <Button Classes="SimButton" ClickMode="Press"
+                    Command="{Binding SimulatorStopCommand}"
+                    ToolTip.Tip="Stop (set speed to 0)"
+                    Background="#44E74C3C">
+                <TextBlock Text="STOP" FontSize="12" FontWeight="Bold" IsHitTestVisible="False"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            </Button>
+
+            <!-- 10x Speed Toggle -->
+            <CheckBox IsChecked="{Binding IsSimulatorSpeed10x}"
+                      VerticalAlignment="Center" Margin="2,0"
+                      ToolTip.Tip="10x speed multiplier for large fields">
+                <TextBlock Text="10x" FontSize="10"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+            </CheckBox>
+
+            <Separator Width="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="2,4"/>
+
+            <!-- Reverse Direction (flips vehicle heading 180°) -->
+            <Button Classes="SimButton" ClickMode="Press"
+                    Command="{Binding SimulatorReverseDirectionCommand}"
+                    ToolTip.Tip="{loc:Localize ReverseDirection}">
+                <TextBlock Text="&#x21C5;" FontSize="16" IsHitTestVisible="False"/>
+            </Button>
+
+            <!-- Close -->
+            <Button Classes="SimButton" Width="32" ClickMode="Press"
+                    Command="{Binding ToggleSimulatorPanelCommand}"
+                    Background="Transparent"
+                    ToolTip.Tip="Close">
+                <TextBlock Text="&#x2715;" FontSize="13" IsHitTestVisible="False"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+            </Button>
+
+        </StackPanel>
+    </Border>
 
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SimulatorPanel.axaml.cs
@@ -14,20 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-using Avalonia;
 using Avalonia.Controls;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
+// Fixed horizontal bar hosted in the bottom stack (above the section/nav bars).
 public partial class SimulatorPanel : UserControl
 {
-    public event EventHandler<Vector>? DragMoved;
-
     public SimulatorPanel()
     {
         InitializeComponent();
-        var fp = this.FindControl<FloatingPanel>("FP");
-        if (fp != null)
-            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 11
+#define VERSION_PATCH 12
 
-#define VERSION "26.5.11"
+#define VERSION "26.5.12"
 #define VERSION_DATE "2026-05-25"


### PR DESCRIPTION
## What
Replaces the vertical floating `SimulatorPanel` (a draggable sub-panel in `LeftNavigationPanel`) with a compact single-row **horizontal bar**, matching AgOpen's layout.

The bar is a fixed layout child at the top of the bottom-center stack, so it rides up naturally as the section-control and bottom-nav bars appear/grow — no Canvas, no drag/positioning code, no per-frame work.

## Layout
`SIM · | · GPS · RST · | · L · «steer slider» · R · 0.0° · >0< · | · ▼ «12.5 kph» ▲ · STOP · 10x · | · ⇅ · ✕`

- **SIM** – enable/disable the simulator
- **GPS** – enter starting coordinates (enabled only when the sim is off)
- **RST** – reset to start position
- **L / slider / R / >0<** – steering (0.5° steps), with the live steer-angle readout
- **▼ / readout / ▲** – speed (0.5 kph steps), readout sized for a 3-digit speed
- **STOP**, **10x** speed multiplier
- **⇅** – reverse driving direction (180° heading flip)
- **✕** – close (also toggled from the left nav)

## Notes
- Localized labels/tooltips and the 0.5°/0.5 kph increments are preserved from the previous panel.
- Readouts use fixed widths so per-frame value changes don't relayout the bar.
- Speed readout drops the old `(10x)` suffix — the 10x toggle sits beside it and the value already reflects the multiplier.
- Cross-platform: all UI in `Shared/`; the three platform views just host the panel in their bottom stack.

## Verification
- Desktop, Android, and iPad (physical, `ios-arm64`) ✅
- 146/146 UI tests green
- Version → 26.5.12

Builds on the grid anti-aliasing fix (#435), already merged to `develop`.