### PR TITLE
Fix blank coverage on cold-start Resume Last Job / session resume

### DIFF
--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -103,17 +103,7 @@ public partial class MainView : UserControl
             {
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                 {
-                    if (args.PixelsAlreadyLoaded)
-                    {
-                        _mapControl.MarkCoverageDirty();
-                    }
-                    else if (args.IsFullReload)
-                    {
-                        _mapControl.ClearCoveragePixels();
-                        _mapControl.MarkCoverageFullRebuildNeeded();
-                    }
-                    else
-                        _mapControl.MarkCoverageDirty();
+                    CoverageRefreshDispatcher.Apply(_mapControl, args.IsFullReload);
                     _viewModel?.RefreshCoverageStatistics();
                 });
             };

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -147,21 +147,7 @@ public partial class MainWindow : Window
             {
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                 {
-                    if (args.PixelsAlreadyLoaded)
-                    {
-                        MapControl.MarkCoverageDirty();
-                    }
-                    else if (args.IsFullReload)
-                    {
-                        // ClearCoveragePixels drops the existing SKBitmap paint
-                        // and re-composites the background; MarkCoverageFullRebuildNeeded
-                        // then repaints from whatever cells the service still has
-                        // (zero after ClearAll, populated after LoadFromFile).
-                        MapControl.ClearCoveragePixels();
-                        MapControl.MarkCoverageFullRebuildNeeded();
-                    }
-                    else
-                        MapControl.MarkCoverageDirty();
+                    CoverageRefreshDispatcher.Apply(MapControl, args.IsFullReload);
                     ViewModel?.RefreshCoverageStatistics();
                 });
             };

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -115,17 +115,7 @@ public partial class MainView : UserControl
             {
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                 {
-                    if (args.PixelsAlreadyLoaded)
-                    {
-                        _mapControl.MarkCoverageDirty();
-                    }
-                    else if (args.IsFullReload)
-                    {
-                        _mapControl.ClearCoveragePixels();
-                        _mapControl.MarkCoverageFullRebuildNeeded();
-                    }
-                    else
-                        _mapControl.MarkCoverageDirty();
+                    CoverageRefreshDispatcher.Apply(_mapControl, args.IsFullReload);
                     _viewModel?.RefreshCoverageStatistics();
                 });
             };

--- a/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Coverage/CoverageMapService.cs
@@ -1206,8 +1206,7 @@ public class CoverageMapService : ICoverageMapService
                 TotalArea = _totalWorkedArea,
                 PatchCount = (int)GetTotalCellCount(),
                 AreaAdded = 0,
-                IsFullReload = true,
-                PixelsAlreadyLoaded = hasSectionDisplay  // Only skip repaint if we loaded display data
+                IsFullReload = true
             });
         }
     }
@@ -1819,10 +1818,11 @@ public class CoverageMapService : ICoverageMapService
             Console.WriteLine($"[Coverage] Loaded section display: {nonZeroPixels:N0} covered pixels{(needsScaling ? " (scaled)" : "")}");
 
             // If the display file decoded to an empty canvas (no covered pixels) but the
-            // caller also has detection bits to draw from, return false so LoadFromFile's
-            // CoverageUpdated event reports PixelsAlreadyLoaded=false and the UI rebuilds
-            // the display from detection bits. Otherwise a truncated / stale / header-only
-            // disp file silently wins over valid detection data and the field opens blank.
+            // caller also has detection bits to draw from, return false so LoadFromFile
+            // still reports hasDetectionBits and fires CoverageUpdated, letting the UI
+            // rebuild the display from detection bits. Otherwise a truncated / stale /
+            // header-only disp file silently wins over valid detection data and the
+            // field opens blank.
             if (nonZeroPixels == 0)
             {
                 Console.WriteLine("[Coverage] Section display is empty — treating as no-display so detection bits can rebuild the map");

--- a/Shared/AgValoniaGPS.Services/Interfaces/ICoverageMapService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/ICoverageMapService.cs
@@ -307,14 +307,10 @@ public class CoverageUpdatedEventArgs : EventArgs
     public double AreaAdded { get; init; }
 
     /// <summary>
-    /// True if this is a full reload (e.g., from file), requiring full bitmap rebuild
+    /// True if this is a full reload (field load from file, or clear on close),
+    /// requiring the map control to drop and fully rebuild its coverage bitmap.
     /// </summary>
     public bool IsFullReload { get; init; }
-
-    /// <summary>
-    /// True if bitmap pixels were loaded directly from file - skip repainting
-    /// </summary>
-    public bool PixelsAlreadyLoaded { get; init; }
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Views/Controls/CoverageRefreshDispatcher.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/CoverageRefreshDispatcher.cs
@@ -1,0 +1,47 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+namespace AgValoniaGPS.Views.Controls;
+
+/// <summary>
+/// Single source of truth for translating a <c>CoverageUpdated</c> notification
+/// into the map control's bitmap-refresh calls.
+///
+/// This lives in shared code (rather than inline in each platform's
+/// CoverageUpdated handler) so the Desktop / iOS / Android copies cannot drift —
+/// which is exactly how the cold-start "Resume Last Job shows blank coverage"
+/// bug arose: a full reload was being short-circuited to an incremental update.
+/// </summary>
+public static class CoverageRefreshDispatcher
+{
+    /// <summary>
+    /// Apply a coverage-changed notification to <paramref name="map"/>.
+    ///
+    /// A <b>full reload</b> (field load via <c>LoadFromFile</c>, or <c>ClearAll</c>
+    /// on field close) <b>always</b> forces a full rebuild. On a cold field open
+    /// the coverage bitmap is created blank by
+    /// <c>InitializeCoverageBitmapWithBounds</c> (which clears the full-rebuild
+    /// flag) <i>before</i> the cells are loaded, and the loaded cells are not
+    /// tracked as "new", so an incremental update would paint nothing — the field
+    /// would open with blank coverage until a close+reopen happened to inherit a
+    /// stale full-rebuild flag. Steady-state paints (<paramref name="isFullReload"/>
+    /// = <c>false</c>) stay incremental for performance.
+    /// </summary>
+    public static void Apply(ISharedMapControl map, bool isFullReload)
+    {
+        if (isFullReload)
+        {
+            // Drop the existing SKBitmap paint + re-composite the background, then
+            // repaint from every cell the service currently holds (zero after
+            // ClearAll, the full loaded set after LoadFromFile).
+            map.ClearCoveragePixels();
+            map.MarkCoverageFullRebuildNeeded();
+        }
+        else
+        {
+            map.MarkCoverageDirty();
+        }
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 12
+#define VERSION_PATCH 13
 
-#define VERSION "26.5.12"
-#define VERSION_DATE "2026-05-25"
+#define VERSION "26.5.13"
+#define VERSION_DATE "2026-05-26"


### PR DESCRIPTION
## Problem

Opening a field with saved coverage (**Resume Last Job**, or resume via the **session dialog**) right after an app restart rendered the map blank. The coverage data loaded fine — nothing painted until a field **close + reopen**.

Originally reported as part of a cluster of "develop regressions" (sections not painting, U-turn offset/blow-through). A full `git bisect` proved those three were a **bad persisted field/config state**, not code — the bisect converged on a commit whose only net diff was an unrelated UI layout file. Once the on-disk state was healthy, this cold-resume coverage bug was the one real, reproducible issue left.

## Root cause

Ordering between bitmap init and coverage load:

1. On field open, `SetCurrentBoundary` → `InitializeCoverageBitmapWithBounds` creates a **blank** coverage bitmap and clears `_bitmapNeedsFullRebuild`.
2. `LoadFromFile` then loads the cells and fires `CoverageUpdated`. With section-display data present it set `PixelsAlreadyLoaded=true`, and the platform handlers short-circuited that to `MarkCoverageDirty()` (**incremental**).
3. The incremental path only paints cells tracked as "new" — freshly-loaded cells aren't, so it painted **nothing**.

Close + reopen only "worked" by accident: `ClearAll` on close left a stale full-rebuild flag that `InitializeCoverageBitmapWithBounds` preserves on the unchanged-bounds reopen, so the post-load update happened to do a full rebuild.

## Fix

- A full reload (`LoadFromFile` / `ClearAll`) **always** forces a full rebuild — loaded cells are never incremental. Drop the buggy `PixelsAlreadyLoaded` shortcut and key purely on `IsFullReload`. The full rebuild reads detection bits via `GetCoverageBitmapCells`, exactly as the working close+reopen path did, so cold resume now matches it byte-for-byte.
- Decision logic — previously duplicated byte-identically across the three platform `CoverageUpdated` handlers (Desktop / iOS / Android), where it could drift — now lives in one shared `CoverageRefreshDispatcher`.
- Removed the now-dead `PixelsAlreadyLoaded` property from `CoverageUpdatedEventArgs`.
- Version → 26.5.13.

## Testing

Confirmed by maintainer on **Desktop, 2D + 3D**:
- Resume Last Job renders previous coverage immediately on cold start (no close+reopen needed) ✅
- Session-dialog resume likewise ✅
- New coverage still paints while driving (incremental path unchanged) ✅

iOS/Android received the identical shared fix but have **not** been device-tested yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)