### PR TITLE
fix: V-flip Android imagery layer to correct N/S inversion (#439)

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.Coverage.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.Coverage.cs
@@ -92,6 +92,14 @@ public partial class SkiaMapControl
     private static readonly bool UseSeparateImageryLayer =
         !OperatingSystem.IsIOS() && !OperatingSystem.IsMacOS();
 
+    // #439: only the Android Skia build decodes the separate-layer imagery
+    // SKImage with the opposite row order, so its raw blit renders N↔S
+    // inverted. Coverage (our own row-0-is-south bitmap) is correct on every
+    // platform, so this is isolated to the decoded PNG on Android. The draw in
+    // DrawCoverageBitmap applies a vertical flip only when this is set.
+    private static readonly bool ImageryNeedsVerticalFlip =
+        OperatingSystem.IsAndroid();
+
     // ------------------------------------------------------------------
     // ISharedMapControl coverage entry points
     // ------------------------------------------------------------------

--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
@@ -1869,7 +1869,26 @@ public partial class SkiaMapControl : Control, ISharedMapControl
                     var bgDst = new SKRect(
                         (float)s.BgMinX, (float)s.BgMinY,
                         (float)s.BgMaxX, (float)s.BgMaxY);
-                    canvas.DrawImage(_backgroundSkImage, bgDst, _imageryMipmappedSampling);
+                    // Android (#439): the GL/Adreno Skia build decodes this PNG
+                    // SKImage with the opposite row order from the Desktop build,
+                    // so the raw blit lands N↔S inverted. Coverage is unaffected
+                    // (it's our own bitmap, row 0 = south, and paints correctly
+                    // under the vehicle), so the flip is specific to the decoded
+                    // imagery SKImage on this one platform. V-flip the draw about
+                    // the rect's vertical midpoint to cancel it. Desktop/Apple are
+                    // correct already and must not be flipped.
+                    if (ImageryNeedsVerticalFlip)
+                    {
+                        float bgMidY = (float)((s.BgMinY + s.BgMaxY) * 0.5);
+                        canvas.Save();
+                        canvas.Scale(1f, -1f, 0f, bgMidY);
+                        canvas.DrawImage(_backgroundSkImage, bgDst, _imageryMipmappedSampling);
+                        canvas.Restore();
+                    }
+                    else
+                    {
+                        canvas.DrawImage(_backgroundSkImage, bgDst, _imageryMipmappedSampling);
+                    }
                 }
             }
 

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 17
+#define VERSION_PATCH 18
 
-#define VERSION "26.5.17"
+#define VERSION "26.5.18"
 #define VERSION_DATE "2026-05-27"


### PR DESCRIPTION
Closes #439.

## Problem
Field background/satellite imagery rendered N/S inverted on **Android only**. Desktop (Win/macOS/Linux) and iPad were correct with the same field and the same code path.

## Root cause
Coverage and imagery are drawn by the **same** `canvas.DrawImage` call in `DrawCoverageBitmap`, on the same canvas, under the same transform. Yet on Android only imagery flipped:

- Coverage (our own bitmap, row 0 = south per `CoverageMapService.PaintDisplayPixel`) **paints correctly under the vehicle on Android** — confirmed on-device. That rules out a global GPU-backend Y-origin flip, since such a flip would hit coverage and imagery identically.
- The only remaining variable is the **decoded pixel data**: the Android Skia build decodes the separate-layer imagery `SKImage` (`SKCodec` → `FromPixelCopy`) with the opposite row order from the Desktop build, so the raw blit lands V-inverted.

## Fix
Vertically flip the imagery blit about the rect's vertical midpoint, gated by `ImageryNeedsVerticalFlip = OperatingSystem.IsAndroid()`. Coverage and the Desktop/Apple composite paths are untouched.

## Testing
- Desktop build: compiles clean, imagery unchanged (flag false).
- Android: built + sideloaded to Samsung R52TB090VAK (the repro device); imagery now reads north-up, matching Desktop/iPad. Confirmed by reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)