### PR TITLE
feat: warn before discarding coverage worked with no open job (#443)

### DIFF
--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -329,6 +329,20 @@ public partial class MainWindow : Window
         if (ViewModel?.HasActiveField == true)
         {
             e.Cancel = true;
+
+            // Warn before quitting drops coverage painted with no active job
+            // (same loss vector as the in-app Close Field command). If the guard
+            // shows its prompt, the quit resumes from the Save/Discard button;
+            // Cancel leaves the window open.
+            if (ViewModel.TryShowUnsavedCoverageGuard(() =>
+                {
+                    _closeSaveInProgress = true;
+                    _ = SaveAndCloseAsync();
+                }))
+            {
+                return;
+            }
+
             _closeSaveInProgress = true;
             _ = SaveAndCloseAsync();
             return;

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -77,6 +77,7 @@ public class UIState : ObservableObject
                 OnPropertyChanged(nameof(IsSmartWasDialogVisible));
                 OnPropertyChanged(nameof(IsLoadVehicleToolDialogVisible));
                 OnPropertyChanged(nameof(IsAppSettingsDialogVisible));
+                OnPropertyChanged(nameof(IsUnsavedCoverageDialogVisible));
 
                 DialogChanged?.Invoke(this, new DialogChangedEventArgs(previous, value));
             }
@@ -124,6 +125,7 @@ public class UIState : ObservableObject
     public bool IsSmartWasDialogVisible => ActiveDialog == DialogType.SmartWas;
     public bool IsLoadVehicleToolDialogVisible => ActiveDialog == DialogType.LoadVehicleTool;
     public bool IsAppSettingsDialogVisible => ActiveDialog == DialogType.AppSettings;
+    public bool IsUnsavedCoverageDialogVisible => ActiveDialog == DialogType.UnsavedCoverage;
 
     // Panel visibility (non-modal, can have multiple open)
     private bool _isSimulatorPanelVisible;
@@ -260,6 +262,7 @@ public enum DialogType
     StartWorkSession,
     ResumeJob,
     AppSettings,
+    UnsavedCoverage,
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -715,15 +715,25 @@ public partial class MainViewModel
         // Field close and resume commands
         CloseFieldCommand = new AsyncRelayCommand(async () =>
         {
-            await CloseFieldAsync();
-
-            // Disconnect NTRIP if connected
-            if (_ntripService.IsConnected)
+            async Task FinishCloseAsync()
             {
-                await _ntripService.DisconnectAsync();
+                await CloseFieldAsync();
+
+                // Disconnect NTRIP if connected
+                if (_ntripService.IsConnected)
+                {
+                    await _ntripService.DisconnectAsync();
+                }
+
+                StatusMessage = "Field closed";
             }
 
-            StatusMessage = "Field closed";
+            // Warn before dropping coverage painted with no active job. If the
+            // guard shows its prompt, the close runs from one of its buttons.
+            if (!TryShowUnsavedCoverageGuard(() => _ = FinishCloseAsync()))
+            {
+                await FinishCloseAsync();
+            }
         });
 
         // "Drive In" — AgOpen-style nearby-field shortcut. Looks for fields

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.CoverageGuard.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.CoverageGuard.cs
@@ -1,0 +1,122 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using AgValoniaGPS.Models.State;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// MainViewModel partial: guards against silently discarding worked coverage
+/// that was painted with no active job. Coverage only persists as part of a
+/// job (<see cref="CloseFieldAsync"/> skips the save when ActiveJob is null),
+/// so a field-only session that painted coverage would lose it on close.
+///
+/// Rather than nag at "Open Field Only" (a click on every use, even when no
+/// work happens), we warn at the moment of loss: when a close is requested and
+/// there is painted coverage with no job, offer Save-to-a-job / Discard /
+/// Cancel. The coverage is already in memory, so "Save to a job" creates a job
+/// and the normal close save captures it — nothing is lost.
+/// </summary>
+public partial class MainViewModel
+{
+    // The close work to run once the user resolves the prompt (Save or Discard).
+    // For the in-app Close Field command this finishes the close; for app-exit
+    // the platform passes an action that also tears the window down.
+    private Action? _pendingUnsavedCoverageProceed;
+
+    private string _unsavedCoverageMessage = string.Empty;
+    public string UnsavedCoverageMessage
+    {
+        get => _unsavedCoverageMessage;
+        private set
+        {
+            if (_unsavedCoverageMessage != value)
+            {
+                _unsavedCoverageMessage = value;
+                OnPropertyChanged(nameof(UnsavedCoverageMessage));
+            }
+        }
+    }
+
+    public ICommand? SaveCoverageToJobCommand { get; private set; }
+    public ICommand? DiscardCoverageAndCloseCommand { get; private set; }
+    public ICommand? CancelUnsavedCoverageCommand { get; private set; }
+
+    private void InitializeCoverageGuardCommands()
+    {
+        // Save: create a job for the orphan coverage, then let the close run —
+        // CloseFieldAsync now sees an active job and saves the coverage under it.
+        SaveCoverageToJobCommand = new RelayCommand(() =>
+        {
+            var proceed = _pendingUnsavedCoverageProceed;
+            _pendingUnsavedCoverageProceed = null;
+            State.UI.CloseDialog();
+
+            try
+            {
+                if (ActiveField != null)
+                {
+                    // taskName: null → JobService builds a unique date-based
+                    // default name and persists the job immediately.
+                    var job = _jobService.CreateJob(
+                        ActiveField.Name,
+                        workType: string.Empty,
+                        notes: string.Empty);
+                    _logger.LogDebug("[CoverageGuard] Created job '{TaskName}' to save orphan coverage", job.TaskName);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[CoverageGuard] Failed to create job for unsaved coverage");
+            }
+
+            proceed?.Invoke();
+        });
+
+        // Discard: run the close with no job, so the coverage is dropped.
+        DiscardCoverageAndCloseCommand = new RelayCommand(() =>
+        {
+            var proceed = _pendingUnsavedCoverageProceed;
+            _pendingUnsavedCoverageProceed = null;
+            State.UI.CloseDialog();
+            proceed?.Invoke();
+        });
+
+        // Cancel: abandon the close entirely, stay in the field.
+        CancelUnsavedCoverageCommand = new RelayCommand(() =>
+        {
+            _pendingUnsavedCoverageProceed = null;
+            State.UI.CloseDialog();
+        });
+    }
+
+    /// <summary>
+    /// If the current session has painted coverage with no active job, shows the
+    /// unsaved-coverage prompt and returns <c>true</c> (the caller must NOT close
+    /// now — one of the dialog buttons will invoke <paramref name="onProceed"/>).
+    /// Returns <c>false</c> when there is nothing at risk, in which case the
+    /// caller should proceed with the close itself.
+    /// </summary>
+    public bool TryShowUnsavedCoverageGuard(Action onProceed)
+    {
+        if (ActiveField == null
+            || _jobService.ActiveJob != null
+            || _coverageMapService.PatchCount <= 0)
+        {
+            return false;
+        }
+
+        _pendingUnsavedCoverageProceed = onProceed;
+        UnsavedCoverageMessage =
+            "You've worked this field without an open job, so the coverage " +
+            "won't be saved. Save it to a job, or it will be lost.";
+        State.UI.ShowDialog(DialogType.UnsavedCoverage);
+        return true;
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -444,6 +444,7 @@ public partial class MainViewModel : ObservableObject
         InitializeSettingsCommands();
         InitializeHotkeyCommands();
         InitializeChartCommands();
+        InitializeCoverageGuardCommands();
 
         // Load display settings first, then restore our app settings on top
         // This ensures AppSettings takes precedence over DisplaySettings

--- a/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogOverlayHost.axaml
@@ -41,6 +41,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <dialogs:BoundaryMapDialogPanel/>
         <dialogs:NumericInputDialogPanel/>
         <dialogs:ConfirmationDialogPanel/>
+        <dialogs:UnsavedCoveragePanel/>
         <dialogs:ErrorDialogPanel/>
         <dialogs:AgShareSettingsDialogPanel/>
         <dialogs:AgShareUploadDialogPanel/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/UnsavedCoveragePanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/UnsavedCoveragePanel.axaml
@@ -1,0 +1,73 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2026 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="440" d:DesignHeight="260"
+             x:Class="AgValoniaGPS.Views.Controls.Dialogs.UnsavedCoveragePanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding State.UI.IsUnsavedCoverageDialogVisible}"
+             IsHitTestVisible="{Binding State.UI.IsUnsavedCoverageDialogVisible}">
+
+    <Grid>
+        <!-- Backdrop. Clicking it is the safe choice: cancel the close. -->
+        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                MinWidth="360" MaxWidth="440">
+            <StackPanel Spacing="16">
+                <TextBlock Text="Unsaved coverage" FontSize="20" FontWeight="Bold"
+                           Foreground="#E74C3C" HorizontalAlignment="Center"/>
+
+                <TextBlock Text="{Binding UnsavedCoverageMessage}" FontSize="14"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" TextWrapping="Wrap"
+                           HorizontalAlignment="Center" TextAlignment="Center"
+                           Margin="0,8"/>
+
+                <Grid ColumnDefinitions="Auto,*,*" ColumnSpacing="8" Margin="0,12,0,0">
+                    <Button Grid.Column="0" Content="Cancel"
+                            Command="{Binding CancelUnsavedCoverageCommand}"
+                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Height="50" FontSize="15" FontWeight="Bold"
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                            Padding="14,0" CornerRadius="6"/>
+                    <Button Grid.Column="1" Content="Discard &amp; close"
+                            Command="{Binding DiscardCoverageAndCloseCommand}"
+                            Background="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Height="50" FontSize="15" FontWeight="Bold"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                            Padding="4,0" CornerRadius="6"/>
+                    <Button Grid.Column="2" Content="Save to a job"
+                            Command="{Binding SaveCoverageToJobCommand}"
+                            Background="#27AE60"
+                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Height="50" FontSize="15" FontWeight="Bold"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                            Padding="4,0" CornerRadius="6"/>
+                </Grid>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/UnsavedCoveragePanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/UnsavedCoveragePanel.axaml.cs
@@ -1,0 +1,37 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace AgValoniaGPS.Views.Controls.Dialogs;
+
+public partial class UnsavedCoveragePanel : UserControl
+{
+    public UnsavedCoveragePanel()
+    {
+        InitializeComponent();
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Clicking the backdrop is the safe choice: cancel the close.
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        {
+            vm.CancelUnsavedCoverageCommand?.Execute(null);
+        }
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 17
+#define VERSION_PATCH 18
 
-#define VERSION "26.5.17"
+#define VERSION "26.5.18"
 #define VERSION_DATE "2026-05-27"


### PR DESCRIPTION
Closes #443.

## Problem
Coverage only persists as part of a **job**. A field opened via **Open Field Only** (no job) silently dropped any painted coverage on close/reopen — a real data-loss footgun if the user forgot to start a job. (Surfaced while testing #439.)

## Approach
Don't nag at *Open Field Only* — that taxes the common case with an extra click even when no work happens. Instead, **warn at the moment of loss**: when a close is requested and the session has painted coverage with **no active job**, show an actionable 3-button prompt:

> **Unsaved coverage** — You've worked this field without an open job, so the coverage won't be saved.
> `[Cancel]` `[Discard & close]` `[Save to a job]`

Because the coverage is already in memory, **Save to a job** creates a job (auto date-named via `JobService.CreateJob`) and the normal close save captures it — nothing is lost. This is the standard "unsaved changes" editor pattern: zero friction until you try to walk away from real work.

## Implementation
- New `DialogType.UnsavedCoverage` + `UnsavedCoveragePanel` registered in the shared `DialogOverlayHost` (per CLAUDE.md dialog convention).
- `TryShowUnsavedCoverageGuard(Action onProceed)` on `MainViewModel`: if `ActiveJob == null && PatchCount > 0`, shows the prompt and returns true (close waits for a button); otherwise returns false and the caller closes normally.
- Wired at the two real loss vectors: the in-app **Close Field** command and the **Desktop app-exit** path (`MainWindow_Closing`). The mobile explicit-close goes through the same shared command.
- `CloseFieldAsync` stays the unguarded close primitive; the guard wraps the call sites, so there's no recursion.

### Detection detail
Uses the live cell count (`ICoverageMapService.PatchCount`, which now returns `GetTotalCellCount()`). `TotalWorkedArea` is only set on **load**, never incremented during live painting, so it reads 0 for in-session coverage and can't be used for this check.

## Testing
- Desktop build clean.
- Manually verified on Desktop (reporter confirmed): field-only + painted coverage → dialog appears on Close Field; **Save to a job** persists coverage (present on reopen); **Discard** drops it; **Cancel** / backdrop stays in field; closing with no coverage or with an active job shows no dialog. App-quit path gated the same way.

## Notes
- Mobile process-kill (non-graceful) is not covered; the deliberate Close Field action is, via the shared command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)