### PR TITLE
fix: V-flip Windows imagery layer to correct N/S inversion

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.Coverage.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.Coverage.cs
@@ -92,13 +92,15 @@ public partial class SkiaMapControl
     private static readonly bool UseSeparateImageryLayer =
         !OperatingSystem.IsIOS() && !OperatingSystem.IsMacOS();
 
-    // #439: only the Android Skia build decodes the separate-layer imagery
-    // SKImage with the opposite row order, so its raw blit renders N↔S
-    // inverted. Coverage (our own row-0-is-south bitmap) is correct on every
-    // platform, so this is isolated to the decoded PNG on Android. The draw in
+    // #439: the Android Skia build decodes the separate-layer imagery SKImage
+    // with the opposite row order, so its raw blit renders N↔S inverted. The
+    // Windows Desktop Skia build (ANGLE/D3D backend) decodes the same way and
+    // is inverted too; macOS/Linux Desktop and iPad are correct. Coverage (our
+    // own row-0-is-south bitmap) is correct on every platform, so this is
+    // isolated to the decoded PNG on the affected backends. The draw in
     // DrawCoverageBitmap applies a vertical flip only when this is set.
     private static readonly bool ImageryNeedsVerticalFlip =
-        OperatingSystem.IsAndroid();
+        OperatingSystem.IsAndroid() || OperatingSystem.IsWindows();
 
     // ------------------------------------------------------------------
     // ISharedMapControl coverage entry points

--- a/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/SkiaMapControl.cs
@@ -1869,14 +1869,15 @@ public partial class SkiaMapControl : Control, ISharedMapControl
                     var bgDst = new SKRect(
                         (float)s.BgMinX, (float)s.BgMinY,
                         (float)s.BgMaxX, (float)s.BgMaxY);
-                    // Android (#439): the GL/Adreno Skia build decodes this PNG
-                    // SKImage with the opposite row order from the Desktop build,
-                    // so the raw blit lands N↔S inverted. Coverage is unaffected
-                    // (it's our own bitmap, row 0 = south, and paints correctly
-                    // under the vehicle), so the flip is specific to the decoded
-                    // imagery SKImage on this one platform. V-flip the draw about
-                    // the rect's vertical midpoint to cancel it. Desktop/Apple are
-                    // correct already and must not be flipped.
+                    // #439: on Android (GL/Adreno) and Windows Desktop
+                    // (ANGLE/D3D) the Skia build decodes this PNG SKImage with the
+                    // opposite row order, so the raw blit lands N↔S inverted.
+                    // Coverage is unaffected (it's our own bitmap, row 0 = south,
+                    // and paints correctly under the vehicle), so the flip is
+                    // specific to the decoded imagery SKImage on those backends.
+                    // V-flip the draw about the rect's vertical midpoint to cancel
+                    // it. macOS/Linux Desktop and Apple are correct already and
+                    // must not be flipped (see ImageryNeedsVerticalFlip).
                     if (ImageryNeedsVerticalFlip)
                     {
                         float bgMidY = (float)((s.BgMinY + s.BgMaxY) * 0.5);

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 18
+#define VERSION_PATCH 19
 
-#define VERSION "26.5.18"
-#define VERSION_DATE "2026-05-27"
+#define VERSION "26.5.19"
+#define VERSION_DATE "2026-05-28"


### PR DESCRIPTION
## Summary

The separate-layer field imagery rendered **N/S inverted on Windows Desktop** — the same symptom fixed for Android in #439. macOS/Linux Desktop and iPad render the same field and code correctly.

## Root cause

Identical to #439. Coverage and imagery are drawn by the same `canvas.DrawImage` call under the same transform, yet only imagery flips. Coverage (our own row-0-is-south bitmap) paints correctly under the vehicle, ruling out a global Y-origin flip. The Windows Skia build (ANGLE/D3D backend) decodes the separate-layer imagery `SKImage` with the opposite row order from the macOS/Linux build, so the raw blit lands inverted — the same data difference that affects the Android build.

## Fix

Extend the existing `ImageryNeedsVerticalFlip` gate to include `OperatingSystem.IsWindows()`, reusing the #439 V-flip about the rect's vertical midpoint. Coverage and the macOS/Linux/Apple paths are untouched. No new code path.

```csharp
private static readonly bool ImageryNeedsVerticalFlip =
    OperatingSystem.IsAndroid() || OperatingSystem.IsWindows();
```

## Verification

Verified on Windows 11 by loading a field with imagery: the rendered background now matches the north-up source PNG (forest north, green field and driveway south, plowed field SE) and aligns with the field boundary. Previously it was the vertical mirror.

Also bumps `sys/version.h` to 26.5.19, matching the #439 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
