### PR TITLE
UI: status strip + on-map HUD overlays (frameless window, camera pad, nav cleanup)

### DIFF
--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -114,6 +114,12 @@ public static class ServiceCollectionExtensions
         // Audio service (cross-platform sound effects)
         services.AddSingleton<IAudioService, AgValoniaGPS.Android.Services.AudioService>();
 
+        // Battery service — subscribes to the sticky ACTION_BATTERY_CHANGED
+        // broadcast via Application.Context (no polling needed).
+        services.AddSingleton<IBatteryService>(_ =>
+            new AgValoniaGPS.Android.Services.AndroidBatteryService(
+                global::Android.App.Application.Context!));
+
         // Module communication service (work switch, steer switch logic)
         services.AddSingleton<IModuleCommunicationService, ModuleCommunicationService>();
 

--- a/Platforms/AgValoniaGPS.Android/Services/AndroidBatteryService.cs
+++ b/Platforms/AgValoniaGPS.Android/Services/AndroidBatteryService.cs
@@ -1,0 +1,113 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using AgValoniaGPS.Services.Interfaces;
+using Android.Content;
+using Android.OS;
+using Avalonia.Threading;
+
+// Android.OS.BatteryStatus collides with our AgValoniaGPS.Models.BatteryStatus
+// record. Alias both so each call site can pick the right type explicitly.
+using AppBatteryStatus = AgValoniaGPS.Models.BatteryStatus;
+using AndroidBatteryStatusEnum = Android.OS.BatteryStatus;
+
+namespace AgValoniaGPS.Android.Services;
+
+/// <summary>
+/// Android battery reader. Subscribes to the sticky
+/// <c>ACTION_BATTERY_CHANGED</c> broadcast — Android delivers it immediately
+/// on registration AND on every level/state change, so no polling timer is
+/// needed.
+/// </summary>
+public sealed class AndroidBatteryService : IBatteryService, IDisposable
+{
+    private readonly Context _context;
+    private BatteryReceiver? _receiver;
+    private AppBatteryStatus _current = AppBatteryStatus.Unavailable;
+    private readonly object _gate = new();
+
+    public AndroidBatteryService(Context context)
+    {
+        _context = context;
+    }
+
+    public AppBatteryStatus CurrentStatus
+    {
+        get { lock (_gate) return _current; }
+    }
+
+    public event EventHandler<AppBatteryStatus>? StatusChanged;
+
+    public void Start()
+    {
+        if (_receiver is not null) return;
+        _receiver = new BatteryReceiver(this);
+        var filter = new IntentFilter(Intent.ActionBatteryChanged);
+        _context.RegisterReceiver(_receiver, filter);
+    }
+
+    public void Stop()
+    {
+        if (_receiver is null) return;
+        try { _context.UnregisterReceiver(_receiver); } catch { /* not registered */ }
+        _receiver.Dispose();
+        _receiver = null;
+    }
+
+    public void Dispose() => Stop();
+
+    private void OnBatteryIntent(Intent intent)
+    {
+        AppBatteryStatus next;
+        if (AgValoniaGPS.Services.BatteryForceMarker.IsEnabled())
+        {
+            next = AgValoniaGPS.Services.BatteryForceMarker.FakeStatus;
+        }
+        else
+        {
+            int level = intent.GetIntExtra(BatteryManager.ExtraLevel, -1);
+            int scale = intent.GetIntExtra(BatteryManager.ExtraScale, -1);
+            int status = intent.GetIntExtra(BatteryManager.ExtraStatus, -1);
+
+            if (level < 0 || scale <= 0)
+            {
+                next = AppBatteryStatus.Unavailable;
+            }
+            else
+            {
+                bool charging = status == (int)AndroidBatteryStatusEnum.Charging
+                             || status == (int)AndroidBatteryStatusEnum.Full;
+                next = new AppBatteryStatus
+                {
+                    IsAvailable = true,
+                    Level = Math.Clamp((double)level / scale, 0.0, 1.0),
+                    IsCharging = charging,
+                };
+            }
+        }
+
+        bool changed;
+        lock (_gate)
+        {
+            changed = !_current.Equals(next);
+            _current = next;
+        }
+        if (changed)
+        {
+            Dispatcher.UIThread.Post(() => StatusChanged?.Invoke(this, next));
+        }
+    }
+
+    private sealed class BatteryReceiver : BroadcastReceiver
+    {
+        private readonly AndroidBatteryService _owner;
+        public BatteryReceiver(AndroidBatteryService owner) { _owner = owner; }
+        public override void OnReceive(Context? context, Intent? intent)
+        {
+            if (intent is not null) _owner.OnBatteryIntent(intent);
+        }
+    }
+}

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -44,6 +44,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:SkiaMapControl x:Name="MapControl" Margin="5"
                                          IsGridVisible="{Binding IsGridOn}"/>
 
+                <!-- Light-dismiss scrim: present only while a left-nav fly-out is
+                     open; a tap on the map closes the open menu. ZIndex 8 keeps it
+                     below the left nav (9) so menus stay clickable. -->
+                <Border ZIndex="8" Background="Transparent"
+                        IsVisible="{Binding IsAnyNavFlyoutOpen}"
+                        PointerPressed="NavScrim_PointerPressed"/>
+
                 <!-- LIGHT BAR: Centered at top (#144) -->
                 <panels:LightBarPanel x:Name="LightBarPanel"
                                       ZIndex="5"

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -84,7 +84,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             ZIndex="9"
                                             HorizontalAlignment="Left"
                                             VerticalAlignment="Top"
-                                            Margin="8,10,0,0"
+                                            Margin="0,10,0,0"
                                             DataContext="{Binding}"/>
 
                 <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad.
@@ -92,7 +92,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                      it and above the camera-pad spacer so its bottom
                      position stays fixed regardless of nav visibility. -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                            ZIndex="10" Margin="0,0,8,8" Spacing="4">
+                            ZIndex="10" Margin="0,0,0,8" Spacing="4">
                     <panels:HeadingReadout x:Name="HeadingReadout"
                                            HorizontalAlignment="Right"
                                            DataContext="{Binding}"/>
@@ -103,18 +103,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                              HorizontalAlignment="Right"
                                              DataContext="{Binding}"/>
                     <Border Height="12"/>
-                    <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
-                            HorizontalAlignment="Center"/>
-                    <Button Classes="ZoomButton" Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
-                            HorizontalAlignment="Center"/>
-                    <Button Command="{Binding ToggleCameraModeCommand}"
-                            Width="64" Height="64"
-                            HorizontalAlignment="Center"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            CornerRadius="0" Background="#4A90D9">
-                        <TextBlock Text="{Binding CameraModeLabel}" FontSize="20" FontWeight="Bold"
-                                   Foreground="White" HorizontalAlignment="Center"/>
-                    </Button>
+                    <!-- On-map 4-way camera pad: tilt (vertical) / zoom (horizontal) /
+                         mode cycle (center). Replaces the old zoom +/- + mode cluster. -->
+                    <panels:CameraPadControl x:Name="CameraPad"
+                                             HorizontalAlignment="Right"
+                                             DataContext="{Binding}"/>
                 </StackPanel>
 
                 <!-- Time. Transparent; sits just above the bottom nav, left
@@ -130,7 +123,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel ZIndex="10"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Bottom"
-                            Margin="0,0,0,8"
+                            Margin="0,0,0,0"
                             Spacing="4">
                     <panels:SimulatorPanel x:Name="SimulatorBarPanel"
                                            HorizontalAlignment="Center"

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -87,20 +87,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Margin="0,10,0,0"
                                             DataContext="{Binding}"/>
 
-                <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad.
-                     Heading sits just above the right nav; Roll sits below
-                     it and above the camera-pad spacer so its bottom
-                     position stays fixed regardless of nav visibility. -->
+                <!-- Heading now lives in the top status strip, right of speed. -->
+
+                <!-- RIGHT SIDEBAR + Roll gauge + Camera pad. Lifted off the bottom
+                     so the camera pad's tilt-down clears the bottom bar. -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                            ZIndex="10" Margin="0,0,0,8" Spacing="4">
-                    <panels:HeadingReadout x:Name="HeadingReadout"
-                                           HorizontalAlignment="Right"
-                                           DataContext="{Binding}"/>
+                            ZIndex="10" Margin="0,0,0,70" Spacing="4">
                     <panels:RightNavigationPanel x:Name="RightNavPanel"
                                                  HorizontalAlignment="Right"
                                                  DataContext="{Binding}"/>
                     <panels:RollGaugeReadout x:Name="RollGauge"
                                              HorizontalAlignment="Right"
+                                             RenderTransformOrigin="0.5,0.5"
+                                             RenderTransform="translate(15px,-5px) scale(1.175,1.4375)"
                                              DataContext="{Binding}"/>
                     <Border Height="12"/>
                     <!-- On-map 4-way camera pad: tilt (vertical) / zoom (horizontal) /

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -35,14 +35,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Grid RowDefinitions="Auto,*">
 
             <!-- Top Status Bar -->
-            <Border Grid.Row="0" Background="#2d2d2d" Padding="10">
-                <Grid ColumnDefinitions="Auto,*,Auto">
-                    <!-- Left: RTK Status and Diagnostics -->
-                    <panels:StatusBarPanel Grid.Column="0" DataContext="{Binding}"/>
-
-                    <!-- Right: Field Statistics (when field is active) -->
-                    <panels:FieldStatsPanel Grid.Column="2" DataContext="{Binding}"/>
-                </Grid>
+            <Border Grid.Row="0" Background="#2d2d2d" Padding="6,4">
+                <panels:StatusBarPanel DataContext="{Binding}"/>
             </Border>
 
             <!-- Main Content Area - SkiaMap with overlay panels -->
@@ -57,6 +51,34 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                       VerticalAlignment="Top"
                                       Margin="0,4,0,0"/>
 
+
+                <!-- DEV OVERLAY: FPS / latency / raw Lat / raw Lon. Gated by a
+                     file-flag (.show_dev_overlay) in the AgValoniaGPS Documents
+                     folder so dev users can toggle it without it appearing in the UI. -->
+                <panels:DevOverlayPanel x:Name="DevOverlay"
+                                        ZIndex="6"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Top"
+                                        Margin="0,4,8,0"
+                                        IsVisible="{Binding IsDevOverlayVisible}"
+                                        DataContext="{Binding}"/>
+
+                <!-- FIELD STATS DETAIL: stacked below the HeadingReadout. -->
+                <panels:FieldStatsPanel x:Name="FieldStats"
+                                        ZIndex="6"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Top"
+                                        Margin="68,72,0,0"
+                                        DataContext="{Binding}"/>
+
+                <!-- GPS DETAIL: shares the same slot as Field-Stats. -->
+                <panels:GpsDetailPanel x:Name="GpsDetail"
+                                       ZIndex="7"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Top"
+                                       Margin="68,72,0,0"
+                                       DataContext="{Binding}"/>
+
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"
                                             ZIndex="9"
@@ -65,11 +87,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Margin="8,10,0,0"
                                             DataContext="{Binding}"/>
 
-                <!-- RIGHT SIDEBAR + Zoom/Compass stacked vertically on right edge -->
+                <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad.
+                     Heading sits just above the right nav; Roll sits below
+                     it and above the camera-pad spacer so its bottom
+                     position stays fixed regardless of nav visibility. -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                             ZIndex="10" Margin="0,0,8,8" Spacing="4">
+                    <panels:HeadingReadout x:Name="HeadingReadout"
+                                           HorizontalAlignment="Right"
+                                           DataContext="{Binding}"/>
                     <panels:RightNavigationPanel x:Name="RightNavPanel"
+                                                 HorizontalAlignment="Right"
                                                  DataContext="{Binding}"/>
+                    <panels:RollGaugeReadout x:Name="RollGauge"
+                                             HorizontalAlignment="Right"
+                                             DataContext="{Binding}"/>
                     <Border Height="12"/>
                     <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
                             HorizontalAlignment="Center"/>
@@ -84,6 +116,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Foreground="White" HorizontalAlignment="Center"/>
                     </Button>
                 </StackPanel>
+
+                <!-- Time. Transparent; sits just above the bottom nav, left
+                     of the camera-pad column. -->
+                <panels:TimeReadout x:Name="TimeReadout"
+                                    ZIndex="10"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Bottom"
+                                    Margin="0,0,144,8"
+                                    DataContext="{Binding}"/>
 
                 <!-- BOTTOM: Simulator bar above section control above bottom navigation -->
                 <StackPanel ZIndex="10"
@@ -122,6 +163,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Map Banners (Flag Placement, AB Creation) -->
         <panels:MapBannersPanel DataContext="{Binding}"/>
+
+        <!-- On-map U-Turn + Lateral overlay (manual turn / lateral-shift arrows) -->
+        <panels:TurnLateralOverlayPanel DataContext="{Binding}" ZIndex="15"/>
 
         <!-- Modal Dialog Overlays (shared across platforms) -->
         <controls:DialogOverlayHost DataContext="{Binding}"/>

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml.cs
@@ -301,4 +301,12 @@ public partial class MainView : UserControl
             }));
         }
     }
+
+    // Light-dismiss: tapping the map area while a left-nav fly-out is open
+    // closes the menu (the scrim is only hit-testable while one is open).
+    private void NavScrim_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        _viewModel?.CloseAllNavFlyouts();
+        e.Handled = true;
+    }
 }

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -114,6 +114,11 @@ public static class ServiceCollectionExtensions
         // Audio service (cross-platform sound effects)
         services.AddSingleton<IAudioService, AgValoniaGPS.Desktop.Services.AudioService>();
 
+        // Battery service — per-platform reader (Windows P/Invoke, macOS pmset,
+        // Linux /sys/class/power_supply). Reports Unavailable on machines with
+        // no battery so the strip icon hides itself.
+        services.AddSingleton<IBatteryService, AgValoniaGPS.Desktop.Services.DesktopBatteryService>();
+
         // Module communication service (work switch, steer switch logic)
         services.AddSingleton<IModuleCommunicationService, ModuleCommunicationService>();
 

--- a/Platforms/AgValoniaGPS.Desktop/Services/DesktopBatteryService.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Services/DesktopBatteryService.cs
@@ -1,0 +1,203 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services.Interfaces;
+using Avalonia.Threading;
+
+namespace AgValoniaGPS.Desktop.Services;
+
+/// <summary>
+/// Desktop battery reader. Polls every 15 s on a background timer.
+///
+/// <list type="bullet">
+///   <item>Windows: <c>GetSystemPowerStatus</c> P/Invoke.</item>
+///   <item>macOS: shell out to <c>pmset -g batt</c> and parse the percentage + status.</item>
+///   <item>Linux: read <c>/sys/class/power_supply/BAT*/capacity</c> and <c>status</c>.</item>
+///   <item>Other / no battery: report <see cref="BatteryStatus.Unavailable"/>.</item>
+/// </list>
+///
+/// The icon in the strip is hidden when the reading is unavailable, so a
+/// plain desktop without a battery silently drops the slot.
+/// </summary>
+public sealed class DesktopBatteryService : IBatteryService, IDisposable
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(15);
+
+    private Timer? _timer;
+    private BatteryStatus _current = BatteryStatus.Unavailable;
+    private readonly object _gate = new();
+
+    public BatteryStatus CurrentStatus
+    {
+        get { lock (_gate) return _current; }
+    }
+
+    public event EventHandler<BatteryStatus>? StatusChanged;
+
+    public void Start()
+    {
+        if (_timer is not null) return;
+        // Fire immediately, then on a 15 s cadence.
+        _timer = new Timer(_ => Poll(), null, TimeSpan.Zero, PollInterval);
+    }
+
+    public void Stop()
+    {
+        _timer?.Dispose();
+        _timer = null;
+    }
+
+    public void Dispose() => Stop();
+
+    private void Poll()
+    {
+        BatteryStatus next;
+        try
+        {
+            if (AgValoniaGPS.Services.BatteryForceMarker.IsEnabled())
+                next = AgValoniaGPS.Services.BatteryForceMarker.FakeStatus;
+            else if (OperatingSystem.IsWindows())      next = ReadWindows();
+            else if (OperatingSystem.IsMacOS())        next = ReadMacOS();
+            else if (OperatingSystem.IsLinux())        next = ReadLinux();
+            else                                        next = BatteryStatus.Unavailable;
+        }
+        catch
+        {
+            next = BatteryStatus.Unavailable;
+        }
+
+        bool changed;
+        lock (_gate)
+        {
+            changed = !_current.Equals(next);
+            _current = next;
+        }
+        if (changed)
+        {
+            Dispatcher.UIThread.Post(() => StatusChanged?.Invoke(this, next));
+        }
+    }
+
+    // --- Windows ---------------------------------------------------------
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SYSTEM_POWER_STATUS
+    {
+        public byte ACLineStatus;
+        public byte BatteryFlag;
+        public byte BatteryLifePercent;
+        public byte SystemStatusFlag;
+        public int  BatteryLifeTime;
+        public int  BatteryFullLifeTime;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetSystemPowerStatus(out SYSTEM_POWER_STATUS status);
+
+    private static BatteryStatus ReadWindows()
+    {
+        if (!GetSystemPowerStatus(out var s)) return BatteryStatus.Unavailable;
+        // BatteryFlag 128 = "no system battery" → desktop without a battery.
+        if ((s.BatteryFlag & 128) != 0) return BatteryStatus.Unavailable;
+        if (s.BatteryLifePercent == 255) return BatteryStatus.Unavailable;
+        return new BatteryStatus
+        {
+            IsAvailable = true,
+            Level = s.BatteryLifePercent / 100.0,
+            IsCharging = s.ACLineStatus == 1,
+        };
+    }
+
+    // --- macOS -----------------------------------------------------------
+
+    private static BatteryStatus ReadMacOS()
+    {
+        var psi = new ProcessStartInfo("/usr/bin/pmset", "-g batt")
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        using var proc = Process.Start(psi);
+        if (proc is null) return BatteryStatus.Unavailable;
+        var output = proc.StandardOutput.ReadToEnd();
+        proc.WaitForExit(2000);
+
+        // Output line of interest: "  -InternalBattery-0 ... 73%; charging; ..."
+        int pctIdx = output.IndexOf('%');
+        if (pctIdx < 0) return BatteryStatus.Unavailable;
+        int start = pctIdx;
+        while (start > 0 && (char.IsDigit(output[start - 1]) || output[start - 1] == '.'))
+            start--;
+        var pctText = output.AsSpan(start, pctIdx - start);
+        if (!double.TryParse(pctText, NumberStyles.Float, CultureInfo.InvariantCulture, out var pct))
+            return BatteryStatus.Unavailable;
+
+        bool charging = output.Contains("charging", StringComparison.OrdinalIgnoreCase)
+                     && !output.Contains("discharging", StringComparison.OrdinalIgnoreCase);
+
+        return new BatteryStatus
+        {
+            IsAvailable = true,
+            Level = Math.Clamp(pct / 100.0, 0.0, 1.0),
+            IsCharging = charging,
+        };
+    }
+
+    // --- Linux -----------------------------------------------------------
+
+    private static BatteryStatus ReadLinux()
+    {
+        const string root = "/sys/class/power_supply";
+        if (!Directory.Exists(root)) return BatteryStatus.Unavailable;
+
+        foreach (var dir in Directory.EnumerateDirectories(root))
+        {
+            if (!Path.GetFileName(dir).StartsWith("BAT", StringComparison.Ordinal)) continue;
+            var capacityPath = Path.Combine(dir, "capacity");
+            var statusPath = Path.Combine(dir, "status");
+            if (!File.Exists(capacityPath)) continue;
+
+            var capacityText = File.ReadAllText(capacityPath).Trim();
+            if (!int.TryParse(capacityText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var cap))
+                continue;
+
+            bool charging = false;
+            if (File.Exists(statusPath))
+            {
+                var statusText = File.ReadAllText(statusPath).Trim();
+                charging = statusText.Equals("Charging", StringComparison.OrdinalIgnoreCase)
+                        || statusText.Equals("Full", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return new BatteryStatus
+            {
+                IsAvailable = true,
+                Level = Math.Clamp(cap / 100.0, 0.0, 1.0),
+                IsCharging = charging,
+            };
+        }
+        return BatteryStatus.Unavailable;
+    }
+}

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -29,6 +29,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         Icon="/Assets/avalonia-logo.ico"
         Title="AgValoniaGPS"
         ToolTip.ServiceEnabled="False"
+        SystemDecorations="BorderOnly"
         Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
 
     <!-- Styles are now in shared SharedStyles.axaml -->
@@ -46,16 +47,37 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         PointerReleased="MapOverlay_PointerReleased"
                         PointerWheelChanged="MapOverlay_PointerWheelChanged" />
 
-        <!-- Row 0: Top status bar area -->
-        <Grid Grid.Row="0" ZIndex="20" Margin="8,8,8,4" ColumnDefinitions="Auto,*,Auto">
-            <Border Classes="FloatingPanel" Grid.Column="0" IsHitTestVisible="True">
-                <panels:StatusBarPanel DataContext="{Binding}"/>
-            </Border>
-            <Border Classes="FloatingPanel" Grid.Column="2" IsHitTestVisible="True"
-                    IsVisible="{Binding HasActiveField}">
-                <panels:FieldStatsPanel DataContext="{Binding}"/>
-            </Border>
-        </Grid>
+        <!-- Row 0: Top status bar area. SystemDecorations is BorderOnly so we
+             provide our own Min/Max/Close on the right end of the strip; the
+             rest of the strip background acts as a drag handle for moving the
+             window. The strip background spans edge-to-edge so the window
+             controls visually sit on the same surface as the readouts. -->
+        <Border Grid.Row="0" Classes="FloatingPanel" ZIndex="20"
+                IsHitTestVisible="True"
+                PointerPressed="StatusBar_OnPointerPressed"
+                Padding="0">
+            <Grid ColumnDefinitions="*,Auto">
+                <!-- Margin shrunk top/bottom from 15 → 5 to drop the strip
+                     20 px (10 each side) without changing element sizes. -->
+                <panels:StatusBarPanel Grid.Column="0" Margin="15,5" DataContext="{Binding}"/>
+                <!-- Custom window controls (frameless build). -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="0"
+                            VerticalAlignment="Stretch">
+                    <Button Classes="WindowControl" Click="WindowMinimize_Click"
+                            ToolTip.Tip="Minimize">
+                        <TextBlock Text="—" FontSize="14" FontWeight="Bold"/>
+                    </Button>
+                    <Button Classes="WindowControl" Click="WindowMaximize_Click"
+                            ToolTip.Tip="Maximize / Restore">
+                        <TextBlock Text="☐" FontSize="14" FontWeight="Bold"/>
+                    </Button>
+                    <Button Classes="WindowControl WindowControlClose" Click="WindowClose_Click"
+                            ToolTip.Tip="Close">
+                        <TextBlock Text="✕" FontSize="14" FontWeight="Bold"/>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
 
         <!-- Row 1: All panels live here, below the status bar -->
         <Grid Grid.Row="1">
@@ -67,6 +89,39 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                               VerticalAlignment="Top"
                               Margin="0,4,0,0"/>
 
+
+        <!-- DEV OVERLAY: FPS / latency / raw Lat / raw Lon. Gated by a
+             file-flag (.show_dev_overlay) in the AgValoniaGPS Documents
+             folder so dev users can toggle it without it appearing in the UI. -->
+        <panels:DevOverlayPanel x:Name="DevOverlay"
+                                ZIndex="6"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Margin="0,4,8,0"
+                                IsVisible="{Binding IsDevOverlayVisible}"
+                                DataContext="{Binding}"/>
+
+        <!-- FIELD STATS DETAIL: AgOpen-style vertical card. Anchored on the
+             LEFT, just right of the LeftNavigationPanel and stacked below the
+             on-map HeadingReadout so the two don't collide. -->
+        <panels:FieldStatsPanel x:Name="FieldStats"
+                                ZIndex="6"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Margin="68,72,0,0"
+                                DataContext="{Binding}"/>
+
+        <!-- GPS DETAIL: AgOpen-style vertical card. Shares the same slot as
+             the Field-Stats card (below the HeadingReadout); if both are
+             toggled on they overlap and the user picks which one to keep
+             open. Toggled from the strip's fix dot / RTK label. -->
+        <panels:GpsDetailPanel x:Name="GpsDetail"
+                               ZIndex="7"
+                               HorizontalAlignment="Left"
+                               VerticalAlignment="Top"
+                               Margin="68,72,0,0"
+                               DataContext="{Binding}"/>
+
         <!-- LEFT SIDEBAR: Anchored to left edge -->
         <panels:LeftNavigationPanel x:Name="LeftNavPanel"
                                     ZIndex="9"
@@ -75,12 +130,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Margin="8,8,0,0"
                                     DataContext="{Binding}"/>
 
-        <!-- RIGHT SIDEBAR + Zoom/Compass stacked vertically on right edge -->
+        <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad. Heading sits
+             just above the right nav; the gauge sits BELOW the right nav
+             and ABOVE the spacer/camera pad so its bottom position stays
+             fixed regardless of whether the right nav is shown. -->
         <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                     ZIndex="10" Margin="0,0,8,8" Spacing="4">
-            <!-- Right navigation buttons -->
+            <!-- Heading readout — sits just above the right nav. -->
+            <panels:HeadingReadout x:Name="HeadingReadout"
+                                   HorizontalAlignment="Right"
+                                   DataContext="{Binding}"/>
+            <!-- Right navigation buttons (collapses when no field). -->
             <panels:RightNavigationPanel x:Name="RightNavPanel"
+                                         HorizontalAlignment="Right"
                                          DataContext="{Binding}"/>
+            <!-- Roll gauge — just above the zoom-control spacer. -->
+            <panels:RollGaugeReadout x:Name="RollGauge"
+                                     HorizontalAlignment="Right"
+                                     DataContext="{Binding}"/>
             <!-- Spacer before zoom controls -->
             <Border Height="12"/>
             <!-- Zoom and compass controls -->
@@ -98,6 +165,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                            Foreground="White" HorizontalAlignment="Center"/>
             </Button>
         </StackPanel>
+
+        <!-- Time. Transparent; sits just above the bottom nav, left of the
+             camera-pad column. -->
+        <panels:TimeReadout x:Name="TimeReadout"
+                            ZIndex="10"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            Margin="0,0,144,8"
+                            DataContext="{Binding}"/>
 
         <!-- BOTTOM: Simulator bar above section control above bottom navigation -->
         <StackPanel ZIndex="10"
@@ -140,6 +216,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <!-- Map Banners (Flag Placement, AB Creation) -->
     <panels:MapBannersPanel DataContext="{Binding}" ZIndex="20"/>
+
+    <!-- On-map U-Turn + Lateral overlay (manual turn / lateral-shift arrows) -->
+    <panels:TurnLateralOverlayPanel DataContext="{Binding}" ZIndex="15"/>
 
     <!-- Modal Dialog Overlays (shared across platforms) -->
     <controls:DialogOverlayHost DataContext="{Binding}" ZIndex="100"/>

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -30,6 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         Title="AgValoniaGPS"
         ToolTip.ServiceEnabled="False"
         SystemDecorations="BorderOnly"
+        MinWidth="1200" MinHeight="720"
         Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
 
     <!-- Styles are now in shared SharedStyles.axaml -->
@@ -127,7 +128,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     ZIndex="9"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Top"
-                                    Margin="8,8,0,0"
+                                    Margin="0,8,0,0"
                                     DataContext="{Binding}"/>
 
         <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad. Heading sits
@@ -135,7 +136,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              and ABOVE the spacer/camera pad so its bottom position stays
              fixed regardless of whether the right nav is shown. -->
         <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                    ZIndex="10" Margin="0,0,8,8" Spacing="4">
+                    ZIndex="10" Margin="0,0,0,8" Spacing="4">
             <!-- Heading readout — sits just above the right nav. -->
             <panels:HeadingReadout x:Name="HeadingReadout"
                                    HorizontalAlignment="Right"
@@ -144,26 +145,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <panels:RightNavigationPanel x:Name="RightNavPanel"
                                          HorizontalAlignment="Right"
                                          DataContext="{Binding}"/>
-            <!-- Roll gauge — just above the zoom-control spacer. -->
+            <!-- Roll gauge — just above the camera-pad spacer. -->
             <panels:RollGaugeReadout x:Name="RollGauge"
                                      HorizontalAlignment="Right"
                                      DataContext="{Binding}"/>
-            <!-- Spacer before zoom controls -->
+            <!-- Spacer before the camera pad -->
             <Border Height="12"/>
-            <!-- Zoom and compass controls -->
-            <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
-                    HorizontalAlignment="Center"/>
-            <Button Classes="ZoomButton" Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
-                    HorizontalAlignment="Center"/>
-            <Button Command="{Binding ToggleCameraModeCommand}"
-                    Width="64" Height="64"
-                    HorizontalAlignment="Center"
-                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                    CornerRadius="0" Background="#4A90D9"
-                    ToolTip.Tip="Camera mode: North-Up / Heading-Up / Free">
-                <TextBlock Text="{Binding CameraModeLabel}" FontSize="20" FontWeight="Bold"
-                           Foreground="White" HorizontalAlignment="Center"/>
-            </Button>
+            <!-- On-map 4-way camera pad: tilt (vertical) / zoom (horizontal) /
+                 mode cycle (center). Replaces the old zoom +/- + mode cluster. -->
+            <panels:CameraPadControl x:Name="CameraPad"
+                                     HorizontalAlignment="Right"
+                                     DataContext="{Binding}"/>
         </StackPanel>
 
         <!-- Time. Transparent; sits just above the bottom nav, left of the
@@ -179,7 +171,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel ZIndex="10"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Bottom"
-                    Margin="0,0,0,8"
+                    Margin="0,0,0,0"
                     Spacing="4">
             <panels:SimulatorPanel x:Name="SimulatorBarPanel"
                                    HorizontalAlignment="Center"

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -131,16 +131,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Margin="0,8,0,0"
                                     DataContext="{Binding}"/>
 
-        <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad. Heading sits
-             just above the right nav; the gauge sits BELOW the right nav
-             and ABOVE the spacer/camera pad so its bottom position stays
-             fixed regardless of whether the right nav is shown. -->
+        <!-- Heading now lives in the top status strip, right of speed. -->
+
+        <!-- RIGHT SIDEBAR + Roll gauge + Camera pad. Lifted off the bottom so the
+             camera pad's tilt-down clears the bottom bar when the nav is full. -->
         <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                    ZIndex="10" Margin="0,0,0,8" Spacing="4">
-            <!-- Heading readout — sits just above the right nav. -->
-            <panels:HeadingReadout x:Name="HeadingReadout"
-                                   HorizontalAlignment="Right"
-                                   DataContext="{Binding}"/>
+                    ZIndex="10" Margin="0,0,0,70" Spacing="4">
             <!-- Right navigation buttons (collapses when no field). -->
             <panels:RightNavigationPanel x:Name="RightNavPanel"
                                          HorizontalAlignment="Right"
@@ -148,6 +144,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Roll gauge — just above the camera-pad spacer. -->
             <panels:RollGaugeReadout x:Name="RollGauge"
                                      HorizontalAlignment="Right"
+                                     RenderTransformOrigin="0.5,0.5"
+                                     RenderTransform="translate(15px,-5px) scale(1.175,1.4375)"
                                      DataContext="{Binding}"/>
             <!-- Spacer before the camera pad -->
             <Border Height="12"/>

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -83,6 +83,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Row 1: All panels live here, below the status bar -->
         <Grid Grid.Row="1">
 
+        <!-- Light-dismiss scrim: present only while a left-nav fly-out is open; a
+             tap on the map area closes the open menu. ZIndex 8 keeps it below the
+             left nav (9) so the nav bar + fly-outs stay clickable. -->
+        <Border ZIndex="8" Background="Transparent"
+                IsVisible="{Binding IsAnyNavFlyoutOpen}"
+                PointerPressed="NavScrim_PointerPressed"/>
+
         <!-- LIGHT BAR: Centered below status bar (#144) -->
         <panels:LightBarPanel x:Name="LightBarPanel"
                               ZIndex="5"

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -563,6 +563,36 @@ public partial class MainWindow : Window
         }
     }
 
+    // --- Custom window controls (frameless build). The status strip's
+    // background drags the window; the three buttons at its right end do
+    // Min / Max-toggle / Close. ---
+
+    private void StatusBar_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // A button or other interactive element inside the strip already
+        // handled the press — don't intercept it as a window drag.
+        if (e.Handled) return;
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+        BeginMoveDrag(e);
+    }
+
+    private void WindowMinimize_Click(object? sender, RoutedEventArgs e)
+    {
+        WindowState = WindowState.Minimized;
+    }
+
+    private void WindowMaximize_Click(object? sender, RoutedEventArgs e)
+    {
+        WindowState = WindowState == WindowState.Maximized
+            ? WindowState.Normal
+            : WindowState.Maximized;
+    }
+
+    private void WindowClose_Click(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
     // Map overlay event handlers that forward to MapControl
     private void MapOverlay_PointerPressed(object? sender, PointerPressedEventArgs e)
     {

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml.cs
@@ -576,6 +576,14 @@ public partial class MainWindow : Window
         BeginMoveDrag(e);
     }
 
+    // Light-dismiss: tapping the map area while a left-nav fly-out is open
+    // closes the menu (the scrim is only hit-testable while one is open).
+    private void NavScrim_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        ViewModel?.CloseAllNavFlyouts();
+        e.Handled = true;
+    }
+
     private void WindowMinimize_Click(object? sender, RoutedEventArgs e)
     {
         WindowState = WindowState.Minimized;

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -114,6 +114,10 @@ public static class ServiceCollectionExtensions
         // Audio service (cross-platform sound effects)
         services.AddSingleton<IAudioService, AgValoniaGPS.iOS.Services.AudioService>();
 
+        // Battery service — UIDevice.BatteryLevel / BatteryState via
+        // NSNotificationCenter (no polling needed).
+        services.AddSingleton<IBatteryService, AgValoniaGPS.iOS.Services.IOSBatteryService>();
+
         // Module communication service (work switch, steer switch logic)
         services.AddSingleton<IModuleCommunicationService, ModuleCommunicationService>();
 

--- a/Platforms/AgValoniaGPS.iOS/Services/IOSBatteryService.cs
+++ b/Platforms/AgValoniaGPS.iOS/Services/IOSBatteryService.cs
@@ -1,0 +1,115 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using System;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services.Interfaces;
+using Avalonia.Threading;
+using Foundation;
+using UIKit;
+
+namespace AgValoniaGPS.iOS.Services;
+
+/// <summary>
+/// iOS battery reader backed by <c>UIDevice.CurrentDevice</c>. iOS notifies
+/// us via <c>BatteryLevelDidChangeNotification</c> and
+/// <c>BatteryStateDidChangeNotification</c>; we publish each change on the
+/// dispatcher thread so bindings can react without explicit polling.
+/// </summary>
+public sealed class IOSBatteryService : IBatteryService, IDisposable
+{
+    private NSObject? _levelObserver;
+    private NSObject? _stateObserver;
+    private BatteryStatus _current = BatteryStatus.Unavailable;
+    private readonly object _gate = new();
+    private bool _started;
+
+    public BatteryStatus CurrentStatus
+    {
+        get { lock (_gate) return _current; }
+    }
+
+    public event EventHandler<BatteryStatus>? StatusChanged;
+
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+
+        UIDevice.CurrentDevice.BatteryMonitoringEnabled = true;
+
+        _levelObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+            UIDevice.BatteryLevelDidChangeNotification, _ => Read());
+        _stateObserver = NSNotificationCenter.DefaultCenter.AddObserver(
+            UIDevice.BatteryStateDidChangeNotification, _ => Read());
+
+        // Prime with the current reading.
+        Read();
+    }
+
+    public void Stop()
+    {
+        if (!_started) return;
+        _started = false;
+
+        if (_levelObserver is not null)
+        {
+            NSNotificationCenter.DefaultCenter.RemoveObserver(_levelObserver);
+            _levelObserver.Dispose();
+            _levelObserver = null;
+        }
+        if (_stateObserver is not null)
+        {
+            NSNotificationCenter.DefaultCenter.RemoveObserver(_stateObserver);
+            _stateObserver.Dispose();
+            _stateObserver = null;
+        }
+
+        UIDevice.CurrentDevice.BatteryMonitoringEnabled = false;
+    }
+
+    public void Dispose() => Stop();
+
+    private void Read()
+    {
+        BatteryStatus next;
+        if (AgValoniaGPS.Services.BatteryForceMarker.IsEnabled())
+        {
+            next = AgValoniaGPS.Services.BatteryForceMarker.FakeStatus;
+        }
+        else
+        {
+            var device = UIDevice.CurrentDevice;
+            var level = device.BatteryLevel;       // 0.0-1.0; -1 when unknown
+            var state = device.BatteryState;
+
+            if (level < 0 || state == UIDeviceBatteryState.Unknown)
+            {
+                next = BatteryStatus.Unavailable;
+            }
+            else
+            {
+                next = new BatteryStatus
+                {
+                    IsAvailable = true,
+                    Level = level,
+                    IsCharging = state == UIDeviceBatteryState.Charging
+                              || state == UIDeviceBatteryState.Full,
+                };
+            }
+        }
+
+        bool changed;
+        lock (_gate)
+        {
+            changed = !_current.Equals(next);
+            _current = next;
+        }
+        if (changed)
+        {
+            Dispatcher.UIThread.Post(() => StatusChanged?.Invoke(this, next));
+        }
+    }
+}

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -44,6 +44,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <controls:SkiaMapControl x:Name="MapControl" Margin="5"
                                          IsGridVisible="{Binding IsGridOn}"/>
 
+                <!-- Light-dismiss scrim: present only while a left-nav fly-out is
+                     open; a tap on the map closes the open menu. ZIndex 8 keeps it
+                     below the left nav (9) so menus stay clickable. -->
+                <Border ZIndex="8" Background="Transparent"
+                        IsVisible="{Binding IsAnyNavFlyoutOpen}"
+                        PointerPressed="NavScrim_PointerPressed"/>
+
                 <!-- LIGHT BAR: Centered at top (#144) -->
                 <panels:LightBarPanel x:Name="LightBarPanel"
                                       ZIndex="5"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -84,7 +84,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             ZIndex="9"
                                             HorizontalAlignment="Left"
                                             VerticalAlignment="Top"
-                                            Margin="8,10,0,0"
+                                            Margin="0,10,0,0"
                                             DataContext="{Binding}"/>
 
                 <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad.
@@ -92,7 +92,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                      it and above the camera-pad spacer so its bottom
                      position stays fixed regardless of nav visibility. -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                            ZIndex="10" Margin="0,0,8,8" Spacing="4">
+                            ZIndex="10" Margin="0,0,0,8" Spacing="4">
                     <panels:HeadingReadout x:Name="HeadingReadout"
                                            HorizontalAlignment="Right"
                                            DataContext="{Binding}"/>
@@ -103,18 +103,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                              HorizontalAlignment="Right"
                                              DataContext="{Binding}"/>
                     <Border Height="12"/>
-                    <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
-                            HorizontalAlignment="Center"/>
-                    <Button Classes="ZoomButton" Content="-" Command="{Binding ZoomOutCommand}" ClickMode="Press"
-                            HorizontalAlignment="Center"/>
-                    <Button Command="{Binding ToggleCameraModeCommand}"
-                            Width="64" Height="64"
-                            HorizontalAlignment="Center"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            CornerRadius="0" Background="#4A90D9">
-                        <TextBlock Text="{Binding CameraModeLabel}" FontSize="20" FontWeight="Bold"
-                                   Foreground="White" HorizontalAlignment="Center"/>
-                    </Button>
+                    <!-- On-map 4-way camera pad: tilt (vertical) / zoom (horizontal) /
+                         mode cycle (center). Replaces the old zoom +/- + mode cluster. -->
+                    <panels:CameraPadControl x:Name="CameraPad"
+                                             HorizontalAlignment="Right"
+                                             DataContext="{Binding}"/>
                 </StackPanel>
 
                 <!-- Time. Transparent; sits just above the bottom nav, left
@@ -130,7 +123,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel ZIndex="10"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Bottom"
-                            Margin="0,0,0,8"
+                            Margin="0,0,0,0"
                             Spacing="4">
                     <panels:SimulatorPanel x:Name="SimulatorBarPanel"
                                            HorizontalAlignment="Center"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -35,14 +35,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Grid RowDefinitions="Auto,*">
 
             <!-- Top Status Bar -->
-            <Border Grid.Row="0" Background="#2d2d2d" Padding="10">
-                <Grid ColumnDefinitions="Auto,*,Auto">
-                    <!-- Left: RTK Status and Diagnostics -->
-                    <panels:StatusBarPanel Grid.Column="0" DataContext="{Binding}"/>
-
-                    <!-- Right: Field Statistics (when field is active) -->
-                    <panels:FieldStatsPanel Grid.Column="2" DataContext="{Binding}"/>
-                </Grid>
+            <Border Grid.Row="0" Background="#2d2d2d" Padding="6,4">
+                <panels:StatusBarPanel DataContext="{Binding}"/>
             </Border>
 
             <!-- Main Content Area - SkiaMap with overlay panels -->
@@ -57,6 +51,34 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                       VerticalAlignment="Top"
                                       Margin="0,4,0,0"/>
 
+
+                <!-- DEV OVERLAY: FPS / latency / raw Lat / raw Lon. Gated by a
+                     file-flag (.show_dev_overlay) in the AgValoniaGPS Documents
+                     folder so dev users can toggle it without it appearing in the UI. -->
+                <panels:DevOverlayPanel x:Name="DevOverlay"
+                                        ZIndex="6"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Top"
+                                        Margin="0,4,8,0"
+                                        IsVisible="{Binding IsDevOverlayVisible}"
+                                        DataContext="{Binding}"/>
+
+                <!-- FIELD STATS DETAIL: stacked below the HeadingReadout. -->
+                <panels:FieldStatsPanel x:Name="FieldStats"
+                                        ZIndex="6"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Top"
+                                        Margin="68,72,0,0"
+                                        DataContext="{Binding}"/>
+
+                <!-- GPS DETAIL: shares the same slot as Field-Stats. -->
+                <panels:GpsDetailPanel x:Name="GpsDetail"
+                                       ZIndex="7"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Top"
+                                       Margin="68,72,0,0"
+                                       DataContext="{Binding}"/>
+
                 <!-- LEFT SIDEBAR: Anchored to left edge -->
                 <panels:LeftNavigationPanel x:Name="LeftNavPanel"
                                             ZIndex="9"
@@ -65,11 +87,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Margin="8,10,0,0"
                                             DataContext="{Binding}"/>
 
-                <!-- RIGHT SIDEBAR + Zoom/Compass stacked vertically on right edge -->
+                <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad.
+                     Heading sits just above the right nav; Roll sits below
+                     it and above the camera-pad spacer so its bottom
+                     position stays fixed regardless of nav visibility. -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
                             ZIndex="10" Margin="0,0,8,8" Spacing="4">
+                    <panels:HeadingReadout x:Name="HeadingReadout"
+                                           HorizontalAlignment="Right"
+                                           DataContext="{Binding}"/>
                     <panels:RightNavigationPanel x:Name="RightNavPanel"
+                                                 HorizontalAlignment="Right"
                                                  DataContext="{Binding}"/>
+                    <panels:RollGaugeReadout x:Name="RollGauge"
+                                             HorizontalAlignment="Right"
+                                             DataContext="{Binding}"/>
                     <Border Height="12"/>
                     <Button Classes="ZoomButton" Content="+" Command="{Binding ZoomInCommand}" ClickMode="Press"
                             HorizontalAlignment="Center"/>
@@ -84,6 +116,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                    Foreground="White" HorizontalAlignment="Center"/>
                     </Button>
                 </StackPanel>
+
+                <!-- Time. Transparent; sits just above the bottom nav, left
+                     of the camera-pad column. -->
+                <panels:TimeReadout x:Name="TimeReadout"
+                                    ZIndex="10"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Bottom"
+                                    Margin="0,0,144,8"
+                                    DataContext="{Binding}"/>
 
                 <!-- BOTTOM: Simulator bar above section control above bottom navigation -->
                 <StackPanel ZIndex="10"
@@ -122,6 +163,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
         <!-- Map Banners (Flag Placement, AB Creation) -->
         <panels:MapBannersPanel DataContext="{Binding}"/>
+
+        <!-- On-map U-Turn + Lateral overlay (manual turn / lateral-shift arrows) -->
+        <panels:TurnLateralOverlayPanel DataContext="{Binding}" ZIndex="15"/>
 
         <!-- Modal Dialog Overlays (shared across platforms) -->
         <controls:DialogOverlayHost DataContext="{Binding}" ZIndex="100"/>

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -87,20 +87,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Margin="0,10,0,0"
                                             DataContext="{Binding}"/>
 
-                <!-- HEADING + RIGHT SIDEBAR + Roll gauge + Camera pad.
-                     Heading sits just above the right nav; Roll sits below
-                     it and above the camera-pad spacer so its bottom
-                     position stays fixed regardless of nav visibility. -->
+                <!-- Heading now lives in the top status strip, right of speed. -->
+
+                <!-- RIGHT SIDEBAR + Roll gauge + Camera pad. Lifted off the bottom
+                     so the camera pad's tilt-down clears the bottom bar. -->
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                            ZIndex="10" Margin="0,0,0,8" Spacing="4">
-                    <panels:HeadingReadout x:Name="HeadingReadout"
-                                           HorizontalAlignment="Right"
-                                           DataContext="{Binding}"/>
+                            ZIndex="10" Margin="0,0,0,70" Spacing="4">
                     <panels:RightNavigationPanel x:Name="RightNavPanel"
                                                  HorizontalAlignment="Right"
                                                  DataContext="{Binding}"/>
                     <panels:RollGaugeReadout x:Name="RollGauge"
                                              HorizontalAlignment="Right"
+                                             RenderTransformOrigin="0.5,0.5"
+                                             RenderTransform="translate(15px,-5px) scale(1.175,1.4375)"
                                              DataContext="{Binding}"/>
                     <Border Height="12"/>
                     <!-- On-map 4-way camera pad: tilt (vertical) / zoom (horizontal) /

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml.cs
@@ -342,4 +342,11 @@ public partial class MainView : UserControl
 
     // Section control is now anchored (no drag needed)
 
+    // Light-dismiss: tapping the map area while a left-nav fly-out is open
+    // closes the menu (the scrim is only hit-testable while one is open).
+    private void NavScrim_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        _viewModel?.CloseAllNavFlyouts();
+        e.Handled = true;
+    }
 }

--- a/Shared/AgValoniaGPS.Models/AppSettings.cs
+++ b/Shared/AgValoniaGPS.Models/AppSettings.cs
@@ -81,6 +81,13 @@ namespace AgValoniaGPS.Models
         public int DayStartHour { get; set; } = 6;
         public int NightStartHour { get; set; } = 20;
 
+        // On-map field-stats detail card. Toggled from the strip; default OFF.
+        public bool FieldStatsOnMapVisible { get; set; } = false;
+
+        // On-map GPS detail card. Toggled from the strip's Modules button;
+        // default OFF. Shares the same on-map slot as the field-stats card.
+        public bool GpsDetailOverlayVisible { get; set; } = false;
+
         // Camera view (CameraZoom/Pitch/Mode) and the current day/night value
         // (IsDayMode) are "where the app was" → persistent state, in
         // PersistentAppState. The AutoDayNight *preference* below stays config.
@@ -112,6 +119,15 @@ namespace AgValoniaGPS.Models
         // GPS settings
         public int GpsUpdateRate { get; set; } = 10; // Hz
         public bool UseRtk { get; set; } = true;
+
+        // Module presence — which modules the user expects to be present.
+        // Drives the aggregate Module-status indicator in the top status strip.
+        // Toggle UI ships with the Network panel (next commit); defaults match
+        // the previous behavior of always expecting all four.
+        public bool IsGpsConfigured { get; set; } = true;
+        public bool IsImuConfigured { get; set; } = true;
+        public bool IsAutoSteerConfigured { get; set; } = true;
+        public bool IsMachineConfigured { get; set; } = true;
 
         // Field management. The Fields directory is a storage-location
         // preference (config); the open-field / last-field POINTER is state →

--- a/Shared/AgValoniaGPS.Models/BatteryStatus.cs
+++ b/Shared/AgValoniaGPS.Models/BatteryStatus.cs
@@ -1,0 +1,37 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace AgValoniaGPS.Models;
+
+/// <summary>
+/// Snapshot of the device's battery state. Used by the strip's battery icon.
+/// <see cref="IsAvailable"/> is false on machines without a battery (most
+/// desktops) or when the platform API didn't return a usable reading; the
+/// icon hides in that case.
+/// </summary>
+public readonly record struct BatteryStatus
+{
+    /// <summary>True when the platform exposes a real battery reading.</summary>
+    public bool IsAvailable { get; init; }
+
+    /// <summary>Charge fraction, 0.0 to 1.0. Undefined when <see cref="IsAvailable"/> is false.</summary>
+    public double Level { get; init; }
+
+    /// <summary>True when the device is plugged in / charging.</summary>
+    public bool IsCharging { get; init; }
+
+    public static BatteryStatus Unavailable => default;
+}

--- a/Shared/AgValoniaGPS.Models/Configuration/ConnectionConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ConnectionConfig.cs
@@ -212,4 +212,39 @@ public class ConnectionConfig : ObservableObject
         get => _maxHdop;
         set => SetProperty(ref _maxHdop, value);
     }
+
+    // Module presence — which modules the user expects to be present.
+    // Drives the aggregate Module-status indicator in the top status strip:
+    //   Green  = every configured module currently OK
+    //   Yellow = ≥1 configured module currently OK, ≥1 absent
+    //   Red    = no configured module currently OK
+    // Toggle UI ships with the Network panel (next commit); defaults make
+    // first-launch behavior the same as the previous four-letter cluster.
+    private bool _isGpsConfigured = true;
+    public bool IsGpsConfigured
+    {
+        get => _isGpsConfigured;
+        set => SetProperty(ref _isGpsConfigured, value);
+    }
+
+    private bool _isImuConfigured = true;
+    public bool IsImuConfigured
+    {
+        get => _isImuConfigured;
+        set => SetProperty(ref _isImuConfigured, value);
+    }
+
+    private bool _isAutoSteerConfigured = true;
+    public bool IsAutoSteerConfigured
+    {
+        get => _isAutoSteerConfigured;
+        set => SetProperty(ref _isAutoSteerConfigured, value);
+    }
+
+    private bool _isMachineConfigured = true;
+    public bool IsMachineConfigured
+    {
+        get => _isMachineConfigured;
+        set => SetProperty(ref _isMachineConfigured, value);
+    }
 }

--- a/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/DisplayConfig.cs
@@ -41,6 +41,26 @@ public class DisplayConfig : ObservableObject
         set => SetProperty(ref _compassVisible, value);
     }
 
+    // On-map field-stats detail card. Replaces the old auto-show-when-active
+    // top-right strip with an explicit strip toggle. Default OFF.
+    private bool _fieldStatsOnMapVisible;
+    public bool FieldStatsOnMapVisible
+    {
+        get => _fieldStatsOnMapVisible;
+        set => SetProperty(ref _fieldStatsOnMapVisible, value);
+    }
+
+    // On-map GPS detail card. Toggled by tapping the strip's Modules
+    // aggregate button (which still tracks colour for the aggregate). Lands
+    // at the same on-map slot as the Field-Stats card; if both are on they
+    // overlap and the user picks which one to keep open. Default OFF.
+    private bool _gpsDetailOverlayVisible;
+    public bool GpsDetailOverlayVisible
+    {
+        get => _gpsDetailOverlayVisible;
+        set => SetProperty(ref _gpsDetailOverlayVisible, value);
+    }
+
     private bool _speedVisible = true;
     public bool SpeedVisible
     {

--- a/Shared/AgValoniaGPS.Models/State/ModuleStatusKind.cs
+++ b/Shared/AgValoniaGPS.Models/State/ModuleStatusKind.cs
@@ -1,0 +1,34 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+namespace AgValoniaGPS.Models.State;
+
+/// <summary>
+/// Glanceable aggregate of the four hardware modules (GPS / IMU / AutoSteer / Machine),
+/// shown as a single coloured button in the top status strip. The "configured set" is
+/// the modules the user has marked as expected via the Network panel (defaults: all).
+/// </summary>
+public enum ModuleStatusKind
+{
+    /// <summary>Every configured module is currently producing data.</summary>
+    AllPresent,
+
+    /// <summary>At least one configured module is OK, at least one is absent.</summary>
+    PartiallyPresent,
+
+    /// <summary>No configured module is currently producing data.</summary>
+    NonePresent,
+}

--- a/Shared/AgValoniaGPS.Services/Battery/NullBatteryService.cs
+++ b/Shared/AgValoniaGPS.Services/Battery/NullBatteryService.cs
@@ -1,0 +1,34 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services.Battery;
+
+/// <summary>
+/// Fallback used in tests and on platforms where no battery is present.
+/// Always reports <see cref="BatteryStatus.Unavailable"/>; the strip's icon
+/// is hidden when bound to this.
+/// </summary>
+public sealed class NullBatteryService : IBatteryService
+{
+    public BatteryStatus CurrentStatus => BatteryStatus.Unavailable;
+    public event EventHandler<BatteryStatus>? StatusChanged { add { } remove { } }
+    public void Start() { }
+    public void Stop() { }
+}

--- a/Shared/AgValoniaGPS.Services/BatteryForceMarker.cs
+++ b/Shared/AgValoniaGPS.Services/BatteryForceMarker.cs
@@ -1,0 +1,59 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using AgValoniaGPS.Models;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Dev-mode override that fakes a battery reading so the strip icon renders
+/// on machines without a battery (Mac mini, desktop tower, etc.). Drop a
+/// <c>.force_battery</c> file into the AgValoniaGPS Documents folder and
+/// every platform's <see cref="Interfaces.IBatteryService"/> short-circuits
+/// to the fake reading instead of reporting Unavailable.
+/// </summary>
+public static class BatteryForceMarker
+{
+    public const string MarkerFileName = ".force_battery";
+
+    /// <summary>Fake reading published when the marker file is present.</summary>
+    public static readonly BatteryStatus FakeStatus = new()
+    {
+        IsAvailable = true,
+        Level = 0.65,
+        IsCharging = true,
+    };
+
+    public static bool IsEnabled()
+    {
+        try
+        {
+            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (string.IsNullOrEmpty(documents))
+            {
+                documents = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            }
+            if (string.IsNullOrEmpty(documents)) return false;
+            return File.Exists(Path.Combine(documents, "AgValoniaGPS", MarkerFileName));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Services/ConfigurationService.cs
+++ b/Shared/AgValoniaGPS.Services/ConfigurationService.cs
@@ -420,6 +420,8 @@ public class ConfigurationService(
         store.Display.HardwareMessagesEnabled = settings.HardwareMessagesEnabled;
         store.Display.DayStartHour = settings.DayStartHour;
         store.Display.NightStartHour = settings.NightStartHour;
+        store.Display.FieldStatsOnMapVisible = settings.FieldStatsOnMapVisible;
+        store.Display.GpsDetailOverlayVisible = settings.GpsDetailOverlayVisible;
         store.Display.DisplayResolutionMultiplier = settings.DisplayResolutionMultiplier;
         store.Display.AutoDayNight = settings.AutoDayNight;
 
@@ -435,6 +437,10 @@ public class ConfigurationService(
         store.Connections.AgShareEnabled = settings.AgShareEnabled;
         store.Connections.GpsUpdateRate = settings.GpsUpdateRate;
         store.Connections.UseRtk = settings.UseRtk;
+        store.Connections.IsGpsConfigured = settings.IsGpsConfigured;
+        store.Connections.IsImuConfigured = settings.IsImuConfigured;
+        store.Connections.IsAutoSteerConfigured = settings.IsAutoSteerConfigured;
+        store.Connections.IsMachineConfigured = settings.IsMachineConfigured;
 
         // Hotkey bindings
         if (settings.HotkeyBindings.Count > 0)
@@ -483,6 +489,8 @@ public class ConfigurationService(
         settings.HardwareMessagesEnabled = store.Display.HardwareMessagesEnabled;
         settings.DayStartHour = store.Display.DayStartHour;
         settings.NightStartHour = store.Display.NightStartHour;
+        settings.FieldStatsOnMapVisible = store.Display.FieldStatsOnMapVisible;
+        settings.GpsDetailOverlayVisible = store.Display.GpsDetailOverlayVisible;
         settings.DisplayResolutionMultiplier = store.Display.DisplayResolutionMultiplier;
         settings.AutoDayNight = store.Display.AutoDayNight;
 
@@ -498,6 +506,10 @@ public class ConfigurationService(
         settings.AgShareEnabled = store.Connections.AgShareEnabled;
         settings.GpsUpdateRate = store.Connections.GpsUpdateRate;
         settings.UseRtk = store.Connections.UseRtk;
+        settings.IsGpsConfigured = store.Connections.IsGpsConfigured;
+        settings.IsImuConfigured = store.Connections.IsImuConfigured;
+        settings.IsAutoSteerConfigured = store.Connections.IsAutoSteerConfigured;
+        settings.IsMachineConfigured = store.Connections.IsMachineConfigured;
 
         // Simulator config — only the Enabled preference (position is state).
         settings.SimulatorEnabled = store.Simulator.Enabled;

--- a/Shared/AgValoniaGPS.Services/DevOverlayMarker.cs
+++ b/Shared/AgValoniaGPS.Services/DevOverlayMarker.cs
@@ -1,0 +1,64 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+
+namespace AgValoniaGPS.Services;
+
+/// <summary>
+/// Cross-platform "is the dev overlay turned on?" check. Reads once at startup;
+/// users toggle by creating/removing the marker file and relaunching.
+///
+/// <para>
+/// Hotkeys can't be used on iPad / Android, and we don't want a Settings entry
+/// that a non-dev user could trip over — a file in the same Documents folder
+/// AgValoniaGPS already uses keeps the toggle out of the UI entirely.
+/// </para>
+///
+/// <para>Marker file: <c>&lt;Documents&gt;/AgValoniaGPS/.show_dev_overlay</c></para>
+/// </summary>
+public static class DevOverlayMarker
+{
+    public const string MarkerFileName = ".show_dev_overlay";
+
+    /// <summary>
+    /// Returns true when the marker file exists in the AgValoniaGPS Documents
+    /// folder. Safe to call before any service is wired; falls back to
+    /// <c>false</c> on any I/O exception.
+    /// </summary>
+    public static bool IsEnabled()
+    {
+        try
+        {
+            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (string.IsNullOrEmpty(documents))
+            {
+                documents = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            }
+            if (string.IsNullOrEmpty(documents))
+            {
+                return false;
+            }
+            var path = Path.Combine(documents, "AgValoniaGPS", MarkerFileName);
+            return File.Exists(path);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Services/Interfaces/IBatteryService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IBatteryService.cs
@@ -1,0 +1,40 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using AgValoniaGPS.Models;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// Reads the host device's battery state on a slow (~15 s) polling cadence.
+/// Each platform contributes its own implementation; the Null variant is used
+/// on platforms where no battery is present so callers can bind unconditionally.
+/// </summary>
+public interface IBatteryService
+{
+    /// <summary>Latest cached reading. Safe to read from any thread.</summary>
+    BatteryStatus CurrentStatus { get; }
+
+    /// <summary>Fires on the dispatcher thread when the reading changes.</summary>
+    event EventHandler<BatteryStatus>? StatusChanged;
+
+    /// <summary>Begin polling. Idempotent.</summary>
+    void Start();
+
+    /// <summary>Stop polling and release resources.</summary>
+    void Stop();
+}

--- a/Shared/AgValoniaGPS.Services/Interfaces/IFieldStatisticsService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IFieldStatisticsService.cs
@@ -30,6 +30,12 @@ namespace AgValoniaGPS.Services.Interfaces
         /// </summary>
         FieldStatistics Statistics { get; }
 
+        /// <summary>Actual area covered (worked area minus overlap), square metres.</summary>
+        double ActualAreaCovered { get; }
+
+        /// <summary>Overlap as a percentage (0–100).</summary>
+        double OverlapPercent { get; }
+
         /// <summary>
         /// Event raised when statistics are updated
         /// </summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
@@ -28,36 +28,61 @@ public partial class MainViewModel
 {
     private void InitializeNavigationCommands()
     {
-        // Panel toggle commands
+        // When any dialog opens (e.g. a fly-out item launches one), dismiss the
+        // open left-nav fly-out so menus don't linger behind the dialog.
+        State.UI.DialogChanged += (_, e) =>
+        {
+            if (e.Current != Models.State.DialogType.None)
+                CloseAllNavFlyouts();
+        };
+
+        // Panel toggle commands. Only one left-nav fly-out is open at a time:
+        // each toggle closes the others first, then opens (or closes) its own.
         ToggleViewSettingsPanelCommand = new RelayCommand(() =>
         {
-            IsViewSettingsPanelVisible = !IsViewSettingsPanelVisible;
+            bool open = !IsViewSettingsPanelVisible;
+            CloseAllNavFlyouts();
+            IsViewSettingsPanelVisible = open;
         });
 
         ToggleFileMenuPanelCommand = new RelayCommand(() =>
         {
-            IsFileMenuPanelVisible = !IsFileMenuPanelVisible;
+            bool open = !IsFileMenuPanelVisible;
+            CloseAllNavFlyouts();
+            IsFileMenuPanelVisible = open;
         });
 
         ToggleToolsPanelCommand = new RelayCommand(() =>
         {
-            IsToolsPanelVisible = !IsToolsPanelVisible;
+            bool open = !IsToolsPanelVisible;
+            CloseAllNavFlyouts();
+            IsToolsPanelVisible = open;
         });
 
         ToggleConfigurationPanelCommand = new RelayCommand(() =>
         {
-            IsConfigurationPanelVisible = !IsConfigurationPanelVisible;
+            bool open = !IsConfigurationPanelVisible;
+            CloseAllNavFlyouts();
+            IsConfigurationPanelVisible = open;
         });
 
         ToggleFieldOperationsPanelCommand = new RelayCommand(() =>
         {
-            IsFieldOperationsPanelVisible = !IsFieldOperationsPanelVisible;
+            bool open = !IsFieldOperationsPanelVisible;
+            CloseAllNavFlyouts();
+            IsFieldOperationsPanelVisible = open;
         });
 
         ToggleFieldToolsPanelCommand = new RelayCommand(() =>
         {
-            IsFieldToolsPanelVisible = !IsFieldToolsPanelVisible;
+            bool open = !IsFieldToolsPanelVisible;
+            CloseAllNavFlyouts();
+            IsFieldToolsPanelVisible = open;
         });
+
+        // The fly-out close (X) is a pure close, not a toggle: a toggle would
+        // re-open the panel because the bubbling item-close already shut it.
+        CloseAllNavFlyoutsCommand = new RelayCommand(CloseAllNavFlyouts);
 
         ToggleAutoTrackCommand = new RelayCommand(() =>
         {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -75,6 +75,7 @@ public partial class MainViewModel
         {
             SetProperty(ref _speed, value);
             OnPropertyChanged(nameof(SpeedKmh));
+            OnPropertyChanged(nameof(SpeedLargeValue));
             OnPropertyChanged(nameof(IsReversing));
         }
     }
@@ -84,6 +85,19 @@ public partial class MainViewModel
 
     /// <summary>Speed in km/h for display (absolute value).</summary>
     public double SpeedKmh => Math.Abs(_speed) * 3.6;
+
+    /// <summary>
+    /// Speed in the user's preferred units (km/h when metric, mph when
+    /// imperial). Used by the large speed slot in the top status strip.
+    /// </summary>
+    public double SpeedLargeValue =>
+        Models.Configuration.ConfigurationStore.Instance.IsMetric
+            ? SpeedKmh
+            : SpeedKmh * 0.621371;
+
+    /// <summary>Unit label that pairs with <see cref="SpeedLargeValue"/>.</summary>
+    public string SpeedLargeUnit =>
+        Models.Configuration.ConfigurationStore.Instance.IsMetric ? "km/h" : "mph";
 
     public int SatelliteCount
     {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.StatusStrip.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.StatusStrip.cs
@@ -1,0 +1,146 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Globalization;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// Status-strip rotator: drives the two-line text stack at the left of the
+/// strip. The top line is a static "Fix • Age" readout; the bottom line
+/// cycles every <see cref="RotationIntervalSeconds"/> through field name,
+/// field stats, and the selected AB-line's heading info. A pause button
+/// stops the cycle so the user can settle on one page.
+/// </summary>
+public partial class MainViewModel
+{
+    private const int RotationIntervalSeconds = 5;
+
+    /// <summary>Pages the bottom line cycles through.</summary>
+    public enum StatusStripPage
+    {
+        Field,
+        Stats,
+        AbLine,
+    }
+
+    private DispatcherTimer? _statusStripRotationTimer;
+    private StatusStripPage _statusStripPage = StatusStripPage.Field;
+    private bool _isStatusStripRotationPaused;
+
+    /// <summary>
+    /// Bottom line: rotates through field / stats / AB-line content. Falls
+    /// back to placeholders when the relevant data isn't available so the
+    /// row never shrinks unexpectedly.
+    /// </summary>
+    public string StatusStripRotatingLine
+    {
+        get
+        {
+            return _statusStripPage switch
+            {
+                StatusStripPage.Field => HasActiveField
+                    ? FormatFieldLine(ActiveFieldName, CurrentJobTaskName)
+                    : "No field",
+
+                StatusStripPage.Stats => HasActiveField
+                    ? $"Done {WorkedAreaDisplay}  Left {RemainingPercent:F0}%  Rate {WorkRateDisplay}"
+                    : "—",
+
+                StatusStripPage.AbLine => SelectedTrack is { } track && track.Points.Count >= 2
+                    ? FormatAbLineLine(track.Name, track.HeadingDegrees)
+                    : "No AB Line",
+
+                _ => string.Empty,
+            };
+        }
+    }
+
+    private static string FormatFieldLine(string? fieldName, string? jobName)
+    {
+        var field = string.IsNullOrEmpty(fieldName) ? "—" : fieldName;
+        return string.IsNullOrEmpty(jobName)
+            ? $"Field: {field}"
+            : $"Field: {field}  Job: {jobName}";
+    }
+
+    private static string FormatAbLineLine(string name, double headingDeg)
+    {
+        var primary = ((headingDeg % 360) + 360) % 360;
+        var reciprocal = (primary + 180) % 360;
+        return string.Create(CultureInfo.InvariantCulture,
+            $"AB Line: {name}  {primary:F1}°, {reciprocal:F1}°");
+    }
+
+    /// <summary>True when the user has tapped the pause button on the strip.</summary>
+    public bool IsStatusStripRotationPaused
+    {
+        get => _isStatusStripRotationPaused;
+        set
+        {
+            if (SetProperty(ref _isStatusStripRotationPaused, value))
+            {
+                if (value) _statusStripRotationTimer?.Stop();
+                else _statusStripRotationTimer?.Start();
+            }
+        }
+    }
+
+    /// <summary>Pause-button command bound from the strip.</summary>
+    public IRelayCommand ToggleStatusStripRotationCommand { get; private set; } = null!;
+
+    /// <summary>
+    /// Called from the MainViewModel constructor after services are wired.
+    /// Starts the rotation timer and installs the pause command.
+    /// </summary>
+    private void InitializeStatusStripRotation()
+    {
+        ToggleStatusStripRotationCommand = new RelayCommand(() =>
+            IsStatusStripRotationPaused = !IsStatusStripRotationPaused);
+
+        _statusStripRotationTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(RotationIntervalSeconds),
+        };
+        _statusStripRotationTimer.Tick += (_, _) => AdvanceStatusStripPage();
+        _statusStripRotationTimer.Start();
+    }
+
+    private void AdvanceStatusStripPage()
+    {
+        _statusStripPage = _statusStripPage switch
+        {
+            StatusStripPage.Field => StatusStripPage.Stats,
+            StatusStripPage.Stats => StatusStripPage.AbLine,
+            _ => StatusStripPage.Field,
+        };
+        OnPropertyChanged(nameof(StatusStripRotatingLine));
+    }
+
+    /// <summary>
+    /// Re-raise the rotating bottom line when its underlying data changes
+    /// (field opened, track selected, area updated). Cheap — bound to a
+    /// single TextBlock. The top line binds directly to State.Vehicle so it
+    /// updates without going through here.
+    /// </summary>
+    internal void RaiseStatusStripChanged()
+    {
+        OnPropertyChanged(nameof(StatusStripRotatingLine));
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -52,38 +52,44 @@ public partial class MainViewModel
     public bool IsViewSettingsPanelVisible
     {
         get => _isViewSettingsPanelVisible;
-        set => SetProperty(ref _isViewSettingsPanelVisible, value);
+        set { SetProperty(ref _isViewSettingsPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
     }
 
     public bool IsFileMenuPanelVisible
     {
         get => _isFileMenuPanelVisible;
-        set => SetProperty(ref _isFileMenuPanelVisible, value);
+        set { SetProperty(ref _isFileMenuPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
     }
 
     public bool IsToolsPanelVisible
     {
         get => _isToolsPanelVisible;
-        set => SetProperty(ref _isToolsPanelVisible, value);
+        set { SetProperty(ref _isToolsPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
     }
 
     public bool IsConfigurationPanelVisible
     {
         get => _isConfigurationPanelVisible;
-        set => SetProperty(ref _isConfigurationPanelVisible, value);
+        set { SetProperty(ref _isConfigurationPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
     }
 
     public bool IsFieldOperationsPanelVisible
     {
         get => _isFieldOperationsPanelVisible;
-        set => SetProperty(ref _isFieldOperationsPanelVisible, value);
+        set { SetProperty(ref _isFieldOperationsPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
     }
 
     public bool IsFieldToolsPanelVisible
     {
         get => _isFieldToolsPanelVisible;
-        set => SetProperty(ref _isFieldToolsPanelVisible, value);
+        set { SetProperty(ref _isFieldToolsPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
     }
+
+    /// <summary>True while any left-nav fly-out is open. Drives the light-dismiss
+    /// scrim that closes the open menu when the operator taps outside it.</summary>
+    public bool IsAnyNavFlyoutOpen =>
+        IsViewSettingsPanelVisible || IsFileMenuPanelVisible || IsToolsPanelVisible
+        || IsConfigurationPanelVisible || IsFieldOperationsPanelVisible || IsFieldToolsPanelVisible;
 
     public bool IsSimulatorPanelVisible
     {
@@ -107,6 +113,21 @@ public partial class MainViewModel
     {
         get => _isXTEChartPanelVisible;
         set => SetProperty(ref _isXTEChartPanelVisible, value);
+    }
+
+    /// <summary>
+    /// Close every left-nav fly-out menu. Used to enforce "one menu open at a
+    /// time" (a toggle closes the others first) and to dismiss the open menu
+    /// when one of its items launches a dialog.
+    /// </summary>
+    public void CloseAllNavFlyouts()
+    {
+        IsViewSettingsPanelVisible = false;
+        IsFileMenuPanelVisible = false;
+        IsToolsPanelVisible = false;
+        IsConfigurationPanelVisible = false;
+        IsFieldOperationsPanelVisible = false;
+        IsFieldToolsPanelVisible = false;
     }
 
     #endregion

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -17,6 +17,7 @@
 using System;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Services;
 using Avalonia.Threading;
 
@@ -375,13 +376,140 @@ public partial class MainViewModel
     public bool IsManualUTurnVisible => IsAutoSteerEngaged && !IsActiveTrackClosed;
 
     /// <summary>
-    /// Notify IsUTurnButtonVisible when IsAutoSteerAvailable changes.
-    /// Called from MainViewModel.Guidance.cs when track state changes.
+    /// On-map U-Turn overlay (the two yellow manual-turn arrows). Same conditions
+    /// as the manual U-turn buttons, additionally gated by the Screen &amp; Alerts
+    /// "U-Turn" on-screen-button toggle (<see cref="DisplayConfig.UTurnButtonVisible"/>).
+    /// </summary>
+    public bool IsUTurnOverlayVisible =>
+        ConfigurationStore.Instance.Display.UTurnButtonVisible && IsManualUTurnVisible;
+
+    /// <summary>
+    /// On-map Lateral overlay (the two cyan shift arrows). Shown only while
+    /// autosteer is engaged (same gate as the U-turn overlay), additionally
+    /// gated by the Screen &amp; Alerts "Lateral" on-screen-button toggle
+    /// (<see cref="DisplayConfig.LateralButtonVisible"/>) — previously orphaned.
+    /// </summary>
+    public bool IsLateralOverlayVisible =>
+        ConfigurationStore.Instance.Display.LateralButtonVisible && IsManualUTurnVisible;
+
+    /// <summary>
+    /// Notify IsUTurnButtonVisible and the on-map overlay visibilities when their
+    /// inputs change. Called from MainViewModel.Guidance.cs when track state
+    /// changes and from the ConfigStore.Display subscription when the on-screen-
+    /// button toggles flip.
     /// </summary>
     private void RaiseUTurnButtonVisibleChanged()
     {
         OnPropertyChanged(nameof(IsUTurnButtonVisible));
+        OnPropertyChanged(nameof(IsUTurnOverlayVisible));
+        OnPropertyChanged(nameof(IsLateralOverlayVisible));
     }
+
+    /// <summary>
+    /// Aggregate of the four module-status flags shown in the top status strip,
+    /// replacing the per-letter G/I/A/M cluster. Configured set comes from
+    /// <see cref="ConnectionConfig.IsGpsConfigured"/> etc.; presence comes from
+    /// <see cref="ConnectionState.IsGpsDataOk"/> etc.
+    /// </summary>
+    public ModuleStatusKind ModuleStatusKind
+    {
+        get
+        {
+            var cfg = ConfigurationStore.Instance.Connections;
+            var st = State.Connections;
+            int configured = 0;
+            int present = 0;
+
+            if (cfg.IsGpsConfigured)       { configured++; if (st.IsGpsDataOk)       present++; }
+            if (cfg.IsImuConfigured)       { configured++; if (st.IsImuDataOk)       present++; }
+            if (cfg.IsAutoSteerConfigured) { configured++; if (st.IsAutoSteerDataOk) present++; }
+            if (cfg.IsMachineConfigured)   { configured++; if (st.IsMachineDataOk)   present++; }
+
+            if (configured == 0 || present == 0) return ModuleStatusKind.NonePresent;
+            if (present == configured) return ModuleStatusKind.AllPresent;
+            return ModuleStatusKind.PartiallyPresent;
+        }
+    }
+
+    private void RaiseModuleStatusKindChanged()
+    {
+        OnPropertyChanged(nameof(ModuleStatusKind));
+    }
+
+    /// <summary>
+    /// On-map Dev overlay (FPS / Latency / Lat / Lon). Read once at startup
+    /// from a file-flag in the AgValoniaGPS Documents folder so the toggle
+    /// works on iPad/Android (where hotkeys aren't available) without
+    /// surfacing in the UI.
+    /// </summary>
+    public bool IsDevOverlayVisible { get; } = Services.DevOverlayMarker.IsEnabled();
+
+    private BatteryStatus _batteryStatus;
+
+    /// <summary>
+    /// Latest battery reading from the per-platform <see cref="IBatteryService"/>.
+    /// The status-strip battery icon binds to the derived properties below.
+    /// </summary>
+    public BatteryStatus BatteryStatus => _batteryStatus;
+
+    /// <summary>Battery level as a 0-1 fraction. Meaningless when <see cref="IsBatteryAvailable"/> is false.</summary>
+    public double BatteryLevel => _batteryStatus.Level;
+
+    /// <summary>True when the device is currently plugged in.</summary>
+    public bool IsBatteryCharging => _batteryStatus.IsCharging;
+
+    /// <summary>True when the platform exposed a real reading. The icon hides when this is false.</summary>
+    public bool IsBatteryAvailable => _batteryStatus.IsAvailable;
+
+    /// <summary>
+    /// On-map field-stats detail card. Replaces the old auto-show-when-active
+    /// top-right strip; toggled from the strip button. Persists via
+    /// <see cref="DisplayConfig.FieldStatsOnMapVisible"/>.
+    /// </summary>
+    public bool IsFieldStatsOnMapVisible
+    {
+        get => ConfigurationStore.Instance.Display.FieldStatsOnMapVisible;
+        set
+        {
+            if (ConfigurationStore.Instance.Display.FieldStatsOnMapVisible != value)
+            {
+                ConfigurationStore.Instance.Display.FieldStatsOnMapVisible = value;
+                OnPropertyChanged();
+                _settingsService.Save();
+            }
+        }
+    }
+
+    /// <summary>Strip button: flips <see cref="IsFieldStatsOnMapVisible"/>.</summary>
+    public CommunityToolkit.Mvvm.Input.IRelayCommand ToggleFieldStatsOnMapCommand =>
+        _toggleFieldStatsOnMapCommand ??= new CommunityToolkit.Mvvm.Input.RelayCommand(
+            () => IsFieldStatsOnMapVisible = !IsFieldStatsOnMapVisible);
+    private CommunityToolkit.Mvvm.Input.IRelayCommand? _toggleFieldStatsOnMapCommand;
+
+    /// <summary>
+    /// On-map GPS detail card. Toggled by tapping the strip's Modules
+    /// aggregate button (the button still shows the aggregate dot colour).
+    /// Shares the on-map slot with the Field-Stats card.
+    /// </summary>
+    public bool IsGpsDetailOverlayVisible
+    {
+        get => ConfigurationStore.Instance.Display.GpsDetailOverlayVisible;
+        set
+        {
+            if (ConfigurationStore.Instance.Display.GpsDetailOverlayVisible != value)
+            {
+                ConfigurationStore.Instance.Display.GpsDetailOverlayVisible = value;
+                OnPropertyChanged();
+                _settingsService.Save();
+            }
+        }
+    }
+
+    /// <summary>Modules button: flips <see cref="IsGpsDetailOverlayVisible"/>.</summary>
+    public CommunityToolkit.Mvvm.Input.IRelayCommand ToggleGpsDetailOverlayCommand =>
+        _toggleGpsDetailOverlayCommand ??= new CommunityToolkit.Mvvm.Input.RelayCommand(
+            () => IsGpsDetailOverlayVisible = !IsGpsDetailOverlayVisible);
+    private CommunityToolkit.Mvvm.Input.IRelayCommand? _toggleGpsDetailOverlayCommand;
 
     #endregion
 }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3593,6 +3593,7 @@ public partial class MainViewModel : ObservableObject
     public ICommand? ToggleConfigurationPanelCommand { get; private set; }
     public ICommand? ToggleFieldOperationsPanelCommand { get; private set; }
     public ICommand? ToggleFieldToolsPanelCommand { get; private set; }
+    public ICommand? CloseAllNavFlyoutsCommand { get; private set; }
     public ICommand? ToggleAutoTrackCommand { get; private set; }
     public ICommand? ToggleGridCommand { get; private set; }
     public ICommand? ToggleDayNightCommand { get; private set; }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -57,6 +57,7 @@ public partial class MainViewModel : ObservableObject
     private readonly AgValoniaGPS.Services.Interfaces.IGpsSimulationService _simulatorService;
     private readonly ISettingsService _settingsService;
     private readonly IPersistentStateService _persistentStateService;
+    private readonly IBatteryService _batteryService;
     private readonly IMapService _mapService;
     private readonly IBoundaryRecordingService _boundaryRecordingService;
     private readonly IBoundaryBuilderService _boundaryBuilderService;
@@ -222,12 +223,31 @@ public partial class MainViewModel : ObservableObject
         ILogger<MainViewModel> logger,
         ApplicationState appState,
         IPersistentStateService persistentStateService,
+        IBatteryService batteryService,
         ISteerMachineLoopService? controlLoop = null,
         IPositionEstimator? positionEstimator = null)
     {
         _logger = logger;
         _persistentStateService = persistentStateService;
+        _batteryService = batteryService;
         _tramLineService = tramLineService;
+
+        // Battery icon in the strip — start the per-platform reader, prime with
+        // its initial reading, and refresh on each StatusChanged notification.
+        _batteryService.StatusChanged += (_, status) =>
+        {
+            _batteryStatus = status;
+            OnPropertyChanged(nameof(BatteryStatus));
+            OnPropertyChanged(nameof(BatteryLevel));
+            OnPropertyChanged(nameof(IsBatteryCharging));
+            OnPropertyChanged(nameof(IsBatteryAvailable));
+        };
+        _batteryService.Start();
+        _batteryStatus = _batteryService.CurrentStatus;
+
+        // Status-strip rotator: cycles the bottom of the two-line text stack
+        // through field name / stats / AB-line every 5 s, with a pause button.
+        InitializeStatusStripRotation();
 
         // Sync GuidanceConfig.TramDisplay -> TramConfig.DisplayMode and regenerate
         ConfigStore.Guidance.PropertyChanged += (_, e) =>
@@ -243,6 +263,38 @@ public partial class MainViewModel : ObservableObject
             {
                 ConfigStore.Tram.Passes = ConfigStore.Guidance.TramPasses;
                 UpdateTramLines(SelectedTrack);
+            }
+        };
+
+        // The Screen & Alerts "On-Screen Buttons" toggles gate the on-map U-Turn
+        // and Lateral overlays. Refresh those computed visibilities when the user
+        // flips a toggle so the overlays appear/disappear live.
+        ConfigStore.Display.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(Models.Configuration.DisplayConfig.UTurnButtonVisible))
+            {
+                OnPropertyChanged(nameof(IsUTurnButtonVisible));
+                OnPropertyChanged(nameof(IsUTurnOverlayVisible));
+            }
+            else if (e.PropertyName == nameof(Models.Configuration.DisplayConfig.LateralButtonVisible))
+            {
+                OnPropertyChanged(nameof(IsLateralOverlayVisible));
+            }
+        };
+
+        // Aggregate module-status indicator (replaces the four-letter G/I/A/M
+        // cluster). Refresh when either the configured set or the live data-ok
+        // flags change. State.Connections is wired in the post-_appState block.
+        ConfigStore.Connections.PropertyChanged += (_, e) =>
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(Models.Configuration.ConnectionConfig.IsGpsConfigured):
+                case nameof(Models.Configuration.ConnectionConfig.IsImuConfigured):
+                case nameof(Models.Configuration.ConnectionConfig.IsAutoSteerConfigured):
+                case nameof(Models.Configuration.ConnectionConfig.IsMachineConfigured):
+                    RaiseModuleStatusKindChanged();
+                    break;
             }
         };
         _udpService = udpService;
@@ -290,6 +342,7 @@ public partial class MainViewModel : ObservableObject
         {
             OnPropertyChanged(nameof(CurrentJobTaskName));
             OnPropertyChanged(nameof(CurrentFieldAndJobLabel));
+            RaiseStatusStripChanged();
         };
         _gpsPipelineService = gpsPipelineService;
         _controlLoop = controlLoop;
@@ -297,6 +350,23 @@ public partial class MainViewModel : ObservableObject
         _intents = intents;
         _appState = appState;
         _fieldPlaneFileService = new FieldPlaneFileService();
+
+        // Live half of the aggregate module-status indicator (see the
+        // ConfigStore.Connections subscription above for the configured-set
+        // half). Only the four data-ok flags participate; IP and engaged flags
+        // do not affect the colour.
+        _appState.Connections.PropertyChanged += (_, e) =>
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(Models.State.ConnectionState.IsGpsDataOk):
+                case nameof(Models.State.ConnectionState.IsImuDataOk):
+                case nameof(Models.State.ConnectionState.IsAutoSteerDataOk):
+                case nameof(Models.State.ConnectionState.IsMachineDataOk):
+                    RaiseModuleStatusKindChanged();
+                    break;
+            }
+        };
 
         // Subscribe to events
         _gpsService.GpsDataUpdated += OnGpsDataUpdated;
@@ -412,6 +482,9 @@ public partial class MainViewModel : ObservableObject
                 OnPropertyChanged(nameof(BoundaryAreaDisplay));
                 OnPropertyChanged(nameof(WorkRateDisplay));
                 OnPropertyChanged(nameof(SimulatorSpeedDisplay));
+                OnPropertyChanged(nameof(SpeedLargeValue));
+                OnPropertyChanged(nameof(SpeedLargeUnit));
+                RaiseStatusStripChanged();
             }
         };
 
@@ -1227,6 +1300,50 @@ public partial class MainViewModel : ObservableObject
         }
     }
 
+    /// <summary>Worked area minus overlap, formatted for the AgOpen-style stats card.</summary>
+    public string ActualAreaDisplay => FormatArea(_fieldStatistics.ActualAreaCovered);
+
+    /// <summary>Remaining boundary area = total minus worked, formatted.</summary>
+    public string RemainingAreaDisplay
+    {
+        get
+        {
+            double remaining = WorkableAreaSqM - _coverageMapService.TotalWorkedArea;
+            return FormatArea(Math.Max(0, remaining));
+        }
+    }
+
+    /// <summary>Percentage of the boundary that has been worked.</summary>
+    public double WorkedPercent
+    {
+        get
+        {
+            double workable = WorkableAreaSqM;
+            if (workable <= 0) return 0;
+            return Math.Clamp((_coverageMapService.TotalWorkedArea / workable) * 100.0, 0, 100);
+        }
+    }
+
+    /// <summary>Overlap percent from the field-statistics service.</summary>
+    public double OverlapPercent => _fieldStatistics.OverlapPercent;
+
+    /// <summary>
+    /// Hours remaining at the current work rate. Returns <c>∞</c> when the
+    /// instantaneous rate is zero (stopped) so the card mirrors AgOpen's
+    /// readout instead of showing a confusing 0.
+    /// </summary>
+    public string HoursRemainingDisplay
+    {
+        get
+        {
+            double rateSqMPerHour = Speed * 3600 * ToolWidth;
+            if (rateSqMPerHour <= 0) return "∞";
+            double remainingSqM = Math.Max(0, WorkableAreaSqM - _coverageMapService.TotalWorkedArea);
+            double hours = remainingSqM / rateSqMPerHour;
+            return $"{hours:F1}";
+        }
+    }
+
     // Helper method to format area with metric/imperial support
     private string FormatArea(double squareMeters)
     {
@@ -1245,6 +1362,12 @@ public partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(WorkedAreaDisplay));
         OnPropertyChanged(nameof(RemainingPercent));
         OnPropertyChanged(nameof(WorkRateDisplay));
+        OnPropertyChanged(nameof(ActualAreaDisplay));
+        OnPropertyChanged(nameof(RemainingAreaDisplay));
+        OnPropertyChanged(nameof(WorkedPercent));
+        OnPropertyChanged(nameof(OverlapPercent));
+        OnPropertyChanged(nameof(HoursRemainingDisplay));
+        RaiseStatusStripChanged();
     }
 
     /// <summary>
@@ -1275,6 +1398,7 @@ public partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(ActiveFieldName));
         OnPropertyChanged(nameof(ActiveFieldArea));
         OnPropertyChanged(nameof(HasActiveField));
+        RaiseStatusStripChanged();
     }
 
     // Pending intents consumed by the next OpenFieldAsync. Set by the
@@ -2078,6 +2202,7 @@ public partial class MainViewModel : ObservableObject
                 OnPropertyChanged(nameof(IsActiveTrackClosed));
                 OnPropertyChanged(nameof(IsManualUTurnVisible));
                 RaiseUTurnButtonVisibleChanged();
+                RaiseStatusStripChanged();
 
                 // Sync to pipeline so guidance computes on background thread
                 SyncGuidanceStateToPipeline();

--- a/Shared/AgValoniaGPS.Views/Controls/BatteryIndicator.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/BatteryIndicator.axaml
@@ -1,0 +1,57 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="16" d:DesignHeight="26"
+             x:Class="AgValoniaGPS.Views.Controls.BatteryIndicator"
+             x:Name="Root">
+
+    <!--
+    Vertical battery icon for the status strip. Glanceable charger-state
+    indicator — fill colour + lightning bolt say "is the charger plugged in?"
+    Exact percentage is intentionally omitted. Bound to MainViewModel.BatteryLevel
+    / IsBatteryCharging / IsBatteryAvailable. Hides itself when the platform
+    has no reading.
+    -->
+    <Grid Width="16" Height="26" VerticalAlignment="Center">
+        <!-- Cap on top, centred horizontally. -->
+        <Rectangle Width="6" Height="2"
+                   Fill="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                   HorizontalAlignment="Center" VerticalAlignment="Top"/>
+        <!-- Body outline. -->
+        <Border BorderBrush="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                BorderThickness="1.5" CornerRadius="2"
+                Width="14" Height="22"
+                HorizontalAlignment="Center" VerticalAlignment="Bottom"/>
+        <!-- Fill bar; height set in code-behind from Level, anchored bottom. -->
+        <Rectangle x:Name="FillBar" Width="10"
+                   Fill="LimeGreen"
+                   HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                   Margin="0,0,0,3"/>
+        <!-- Lightning bolt when charging. -->
+        <Path x:Name="ChargeBolt"
+              Data="M8,5 L4,14 L7,14 L5,21 L11,11 L8,11 Z"
+              Fill="Yellow"
+              Stroke="Black" StrokeThickness="0.5"
+              IsVisible="False"
+              HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/BatteryIndicator.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/BatteryIndicator.axaml.cs
@@ -1,0 +1,80 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+
+namespace AgValoniaGPS.Views.Controls;
+
+public partial class BatteryIndicator : UserControl
+{
+    public static readonly StyledProperty<double> LevelProperty =
+        AvaloniaProperty.Register<BatteryIndicator, double>(nameof(Level), 0.0);
+
+    public static readonly StyledProperty<bool> IsChargingProperty =
+        AvaloniaProperty.Register<BatteryIndicator, bool>(nameof(IsCharging), false);
+
+    public double Level
+    {
+        get => GetValue(LevelProperty);
+        set => SetValue(LevelProperty, value);
+    }
+
+    public bool IsCharging
+    {
+        get => GetValue(IsChargingProperty);
+        set => SetValue(IsChargingProperty, value);
+    }
+
+    public BatteryIndicator()
+    {
+        InitializeComponent();
+        Render();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == LevelProperty || change.Property == IsChargingProperty)
+        {
+            Render();
+        }
+    }
+
+    private void Render()
+    {
+        var fill = this.FindControl<Rectangle>("FillBar");
+        var bolt = this.FindControl<Avalonia.Controls.Shapes.Path>("ChargeBolt");
+        if (fill is null || bolt is null) return;
+
+        var clamped = Math.Clamp(Level, 0.0, 1.0);
+        // Inner fill region is 18 px tall (22 px outer body minus 3 px top
+        // breathing room minus 1 px floor margin); fill grows up from the
+        // bottom so a drop in level shrinks the bar visually.
+        fill.Height = 18.0 * clamped;
+
+        // Colour bands: ≥40 % green, ≥15 % gold, otherwise red.
+        IBrush brush = clamped >= 0.4 ? Brushes.LimeGreen
+                       : clamped >= 0.15 ? Brushes.Gold
+                       : Brushes.OrangeRed;
+        fill.Fill = brush;
+
+        bolt.IsVisible = IsCharging;
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BottomNavigationPanel.axaml
@@ -38,7 +38,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Border.FloatingPanel">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="0"/>
-            <Setter Property="Padding" Value="6"/>
+            <!-- Outer (bottom) padding removed so the buttons sit flush to the
+                 bottom window edge; inner (left/top/right) gaps preserved. -->
+            <Setter Property="Padding" Value="6,6,6,0"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/CameraPadControl.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/CameraPadControl.axaml
@@ -1,0 +1,98 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2026 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+-->
+<!--
+On-map 4-way camera pad. Replaces the old right-edge zoom +/- and camera-mode
+cluster. Vertical axis = tilt (Up = toward overhead/2D, Down = toward horizon/3D);
+horizontal axis = zoom (Left = out, Right = in); center = camera-mode cycle
+(H -> N -> M -> C, shows CameraModeLabel). The directional keys are RepeatButtons:
+a tap fires once, press-and-hold repeats (Delay then Interval); the center is a
+single-tap Button.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="150" d:DesignHeight="150"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.CameraPadControl"
+             x:DataType="vm:MainViewModel">
+
+    <UserControl.Styles>
+        <!-- Directional (tilt/zoom) keys: tap = one step, hold = repeat. -->
+        <Style Selector="RepeatButton.CamPadDir">
+            <Setter Property="Width" Value="44"/>
+            <Setter Property="Height" Value="44"/>
+            <Setter Property="FontSize" Value="20"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Delay" Value="350"/>
+            <Setter Property="Interval" Value="120"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="CornerRadius" Value="0"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </Style>
+        <Style Selector="RepeatButton.CamPadDir:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+        </Style>
+        <Style Selector="RepeatButton.CamPadDir:pressed">
+            <Setter Property="Background" Value="#4A90D9"/>
+        </Style>
+    </UserControl.Styles>
+
+    <!-- 3x3 cross: corners empty, edges = directions, center = mode cycle. -->
+    <Grid ColumnDefinitions="44,44,44" RowDefinitions="44,44,44" RowSpacing="2" ColumnSpacing="2">
+        <!-- Tilt up: toward overhead (2D at full up) -->
+        <RepeatButton Classes="CamPadDir"
+                      Grid.Row="0" Grid.Column="1" Content="&#x25B2;"
+                      Command="{Binding IncreaseCameraPitchCommand}"
+                      ToolTip.Tip="Tilt toward overhead (2D)"/>
+
+        <!-- Zoom out -->
+        <RepeatButton Classes="CamPadDir"
+                      Grid.Row="1" Grid.Column="0" Content="&#x2212;"
+                      Command="{Binding ZoomOutCommand}"
+                      ToolTip.Tip="Zoom out"/>
+
+        <!-- Center: camera-mode cycle (single tap) -->
+        <Button Grid.Row="1" Grid.Column="1"
+                Width="44" Height="44"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                CornerRadius="0" BorderThickness="0" Background="#4A90D9"
+                Cursor="Hand"
+                Command="{Binding ToggleCameraModeCommand}"
+                ToolTip.Tip="Camera mode: Heading-Up / North-Up / Map / Center">
+            <TextBlock Text="{Binding CameraModeLabel}" FontSize="16" FontWeight="Bold"
+                       Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Button>
+
+        <!-- Zoom in -->
+        <RepeatButton Classes="CamPadDir"
+                      Grid.Row="1" Grid.Column="2" Content="+"
+                      Command="{Binding ZoomInCommand}"
+                      ToolTip.Tip="Zoom in"/>
+
+        <!-- Tilt down: toward horizon (3D) -->
+        <RepeatButton Classes="CamPadDir"
+                      Grid.Row="2" Grid.Column="1" Content="&#x25BC;"
+                      Command="{Binding DecreaseCameraPitchCommand}"
+                      ToolTip.Tip="Tilt toward horizon (3D)"/>
+    </Grid>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/CameraPadControl.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/CameraPadControl.axaml.cs
@@ -1,0 +1,33 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+/// <summary>
+/// On-map 4-way camera pad. Tilt (vertical) / zoom (horizontal) directional keys
+/// are RepeatButtons that tap-to-step and hold-to-repeat via their Command
+/// bindings; the center key cycles camera mode. All behavior is in the bound
+/// commands, so the control needs no code-behind beyond initialization.
+/// </summary>
+public partial class CameraPadControl : UserControl
+{
+    public CameraPadControl()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ConfigurationPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Main Panel -->
         <controls:FloatingPanel x:Name="FP"
                                 Title="{loc:Localize VehicleConfiguration}"
-                                CloseCommand="{Binding ToggleConfigurationPanelCommand}">
+                                CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
 
             <controls:FloatingPanel.PanelContent>
                 <Border Background="#DD1E8449" CornerRadius="6" Padding="8,4" Margin="0,8,0,0">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/DevOverlayPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/DevOverlayPanel.axaml
@@ -1,0 +1,46 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             mc:Ignorable="d"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.DevOverlayPanel"
+             x:DataType="vm:MainViewModel"
+             IsHitTestVisible="False">
+
+    <!--
+    On-map Dev overlay: FPS / GPS→PGN latency / raw Lat / raw Lon. Read by a
+    file-flag at startup (see DevOverlayMarker) so the toggle works on iPad
+    and Android without a UI control. Not visible to non-dev users.
+    -->
+    <Border Background="#B0000000" CornerRadius="4" Padding="8,4">
+        <StackPanel Orientation="Horizontal" Spacing="16">
+            <TextBlock Text="{Binding CurrentFps, StringFormat='FPS {0:F0}'}"
+                       Foreground="#2ECC71" FontSize="12" FontWeight="Bold"/>
+            <TextBlock Text="{Binding GpsToPgnLatencyMs, StringFormat='Lat {0:F2} ms'}"
+                       Foreground="#F39C12" FontSize="12" FontWeight="Bold"/>
+            <TextBlock Text="{Binding Latitude, StringFormat='{}{0:F8}'}"
+                       Foreground="#3498DB" FontSize="12" FontWeight="Bold"/>
+            <TextBlock Text="{Binding Longitude, StringFormat='{}{0:F8}'}"
+                       Foreground="#3498DB" FontSize="12" FontWeight="Bold"/>
+        </StackPanel>
+    </Border>
+
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/DevOverlayPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/DevOverlayPanel.axaml.cs
@@ -1,0 +1,27 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class DevOverlayPanel : UserControl
+{
+    public DevOverlayPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
@@ -27,7 +27,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <controls:FloatingPanel x:Name="FP"
                             Title="Field Operations"
-                            CloseCommand="{Binding ToggleFieldOperationsPanelCommand}">
+                            CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
 
         <!-- All UI moves into PanelContent so we can group buttons into the
              three sections (Create Field / Work Field / AgShare) with

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml.cs
@@ -18,6 +18,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -31,6 +32,10 @@ public partial class FieldOperationsPanel : UserControl
         var fp = this.FindControl<FloatingPanel>("FP");
         if (fp != null)
             fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
+        // Picking any item dismisses the menu (command still runs — not handled).
+        AddHandler(Button.ClickEvent, CloseOnItemClick, RoutingStrategies.Bubble);
     }
 
+    private void CloseOnItemClick(object? sender, RoutedEventArgs e)
+        => (DataContext as AgValoniaGPS.ViewModels.MainViewModel)?.CloseAllNavFlyouts();
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldStatsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldStatsPanel.axaml
@@ -22,28 +22,90 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Panels.FieldStatsPanel"
-             x:DataType="vm:MainViewModel"
-             IsVisible="{Binding HasActiveField}">
+             x:DataType="vm:MainViewModel">
 
-    <StackPanel Orientation="Horizontal" Spacing="18">
-        <TextBlock Text="{Binding CurrentFieldAndJobLabel}" Foreground="#3498DB" FontSize="13" FontWeight="Bold"
-                   IsVisible="{Binding CurrentFieldName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-        <StackPanel Orientation="Horizontal" Spacing="4">
-            <TextBlock Text="Field:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
-            <TextBlock Text="{Binding BoundaryAreaDisplay}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13" FontWeight="Bold"/>
+    <!--
+    AgOpen-style on-map field-stats detail card. Replaces the old auto-show
+    top-right horizontal strip. Visibility is now driven by the strip's
+    field-stats toggle (IsFieldStatsOnMapVisible) AND requires an active
+    field; default OFF.
+    -->
+    <UserControl.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+            <Binding Path="IsFieldStatsOnMapVisible"/>
+            <Binding Path="HasActiveField"/>
+        </MultiBinding>
+    </UserControl.IsVisible>
+
+    <UserControl.Styles>
+        <Style Selector="TextBlock.SectionHeader">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="0,6,0,2"/>
+        </Style>
+        <Style Selector="TextBlock.RowLabel">
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+        </Style>
+        <Style Selector="TextBlock.RowValue">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="TextAlignment" Value="Right"/>
+        </Style>
+        <Style Selector="Separator.SectionRule">
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
+            <Setter Property="Height" Value="1"/>
+            <Setter Property="Margin" Value="0,2,0,0"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Background="#CC1E1E1E" CornerRadius="6" Padding="10,6" MinWidth="160">
+        <StackPanel Spacing="2">
+            <!-- Total -->
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Total:" Classes="RowLabel" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="1" Text="{Binding BoundaryAreaDisplay}" Classes="RowValue"/>
+            </Grid>
+
+            <!-- Worked section -->
+            <TextBlock Text="Worked" Classes="SectionHeader"/>
+            <Separator Classes="SectionRule"/>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Applied:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding WorkedAreaDisplay}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Remain:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding RemainingAreaDisplay}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding WorkedPercent, StringFormat='{}{0:F1}%'}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding HoursRemainingDisplay, StringFormat='{}{0} Hrs'}" Classes="RowValue"/>
+            </Grid>
+
+            <!-- Actual section -->
+            <TextBlock Text="Actual" Classes="SectionHeader"/>
+            <Separator Classes="SectionRule"/>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Applied:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding ActualAreaDisplay}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Overlap:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding OverlapPercent, StringFormat='{}{0:F1}%'}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Rate:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding WorkRateDisplay}" Classes="RowValue"/>
+            </Grid>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Spacing="4">
-            <TextBlock Text="Done:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
-            <TextBlock Text="{Binding WorkedAreaDisplay}" Foreground="#2ECC71" FontSize="13" FontWeight="Bold"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Spacing="4">
-            <TextBlock Text="Left:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
-            <TextBlock Text="{Binding RemainingPercent, StringFormat='{}{0:F1}%'}" Foreground="#F39C12" FontSize="13" FontWeight="Bold"/>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Spacing="4">
-            <TextBlock Text="Rate:" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="13"/>
-            <TextBlock Text="{Binding WorkRateDisplay}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="13" FontWeight="Bold"/>
-        </StackPanel>
-    </StackPanel>
+    </Border>
 
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml
@@ -27,7 +27,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
   <controls:FloatingPanel x:Name="FP"
                           Title="{loc:Localize FieldTools}"
-                          CloseCommand="{Binding ToggleFieldToolsPanelCommand}">
+                          CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
 
     <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/Headache.png"
                          Text="Field Builder"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldToolsPanel.axaml.cs
@@ -18,6 +18,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -31,5 +32,10 @@ public partial class FieldToolsPanel : UserControl
         var fp = this.FindControl<FloatingPanel>("FP");
         if (fp != null)
             fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
+        // Picking any item dismisses the menu (command still runs — not handled).
+        AddHandler(Button.ClickEvent, CloseOnItemClick, RoutingStrategies.Bubble);
     }
+
+    private void CloseOnItemClick(object? sender, RoutedEventArgs e)
+        => (DataContext as AgValoniaGPS.ViewModels.MainViewModel)?.CloseAllNavFlyouts();
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -41,7 +41,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
     <controls:FloatingPanel x:Name="FP"
                             Title="{loc:Localize ApplicationSettings}"
-                            CloseCommand="{Binding ToggleFileMenuPanelCommand}">
+                            CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
         <controls:FloatingPanel.PanelContent>
             <StackPanel Spacing="4">
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml.cs
@@ -18,6 +18,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -31,5 +32,11 @@ public partial class FileMenuPanel : UserControl
         var fp = this.FindControl<FloatingPanel>("FP");
         if (fp != null)
             fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
+        // Picking any item dismisses the menu. Click bubbles to here before the
+        // bound command runs; we don't mark it handled, so the command still runs.
+        AddHandler(Button.ClickEvent, CloseOnItemClick, RoutingStrategies.Bubble);
     }
+
+    private void CloseOnItemClick(object? sender, RoutedEventArgs e)
+        => (DataContext as AgValoniaGPS.ViewModels.MainViewModel)?.CloseAllNavFlyouts();
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/GpsDetailPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/GpsDetailPanel.axaml
@@ -1,0 +1,104 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             mc:Ignorable="d"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.GpsDetailPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding IsGpsDetailOverlayVisible}">
+
+    <!--
+    AgOpen-style on-map GPS detail card. Lands at the same left-anchored
+    slot as the field-stats card; if both are toggled on they overlap and
+    the user picks which one to keep open (Brian's stance — both belong on
+    the same slot, the user manages the conflict).
+    -->
+    <UserControl.Styles>
+        <Style Selector="TextBlock.RowLabel">
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
+        </Style>
+        <Style Selector="TextBlock.RowValue">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="TextAlignment" Value="Right"/>
+        </Style>
+        <Style Selector="TextBlock.LatLon">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="#F1C40F"/>
+            <Setter Property="TextAlignment" Value="Left"/>
+        </Style>
+        <Style Selector="Separator.SectionRule">
+            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
+            <Setter Property="Height" Value="1"/>
+            <Setter Property="Margin" Value="0,4,0,4"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Background="#CC1E1E1E" CornerRadius="6" Padding="10,6" MinWidth="170">
+        <StackPanel Spacing="2">
+            <!-- Lat / Lon up top, like AgOpen. -->
+            <TextBlock Classes="LatLon" Text="{Binding Latitude, StringFormat='{}{0:F7}'}"/>
+            <TextBlock Classes="LatLon" Text="{Binding Longitude, StringFormat='{}{0:F7}'}"/>
+
+            <Separator Classes="SectionRule"/>
+
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Elev:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding State.Vehicle.Altitude, StringFormat='{}{0:F1}'}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="# Sats:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding State.Vehicle.SatelliteCount}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="HDOP:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding State.Vehicle.Hdop, StringFormat='{}{0:F2}'}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Fix:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding State.Vehicle.FixQualityText}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Age:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding State.Vehicle.Age, StringFormat='{}{0:F1}'}" Classes="RowValue"/>
+            </Grid>
+
+            <Separator Classes="SectionRule"/>
+
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="Heading:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding Heading, StringFormat='{}{0:F1}°'}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="IMU Roll:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding RollDegrees, StringFormat='{}{0:F1}°'}" Classes="RowValue"/>
+            </Grid>
+            <Grid ColumnDefinitions="Auto,*">
+                <TextBlock Grid.Column="0" Text="FPS:" Classes="RowLabel"/>
+                <TextBlock Grid.Column="1" Text="{Binding CurrentFps, StringFormat='{}{0:F0}'}" Classes="RowValue"/>
+            </Grid>
+        </StackPanel>
+    </Border>
+
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/GpsDetailPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/GpsDetailPanel.axaml.cs
@@ -1,0 +1,27 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class GpsDetailPanel : UserControl
+{
+    public GpsDetailPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingReadout.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingReadout.axaml
@@ -1,0 +1,47 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="120" d:DesignHeight="50"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.HeadingReadout"
+             x:DataType="vm:MainViewModel"
+             IsHitTestVisible="False">
+
+    <!--
+    On-map heading readout. AgOpen-style large degree number with a small
+    "HDG" label underneath. Anchored upper-left of the map area near the
+    speed slot in the strip; always visible (not a toggle).
+    -->
+    <StackPanel Spacing="0">
+        <!-- Heading in 000.0° form so the width stays constant whether the
+             value is single-, double- or triple-digit. -->
+        <TextBlock Text="{Binding Heading, StringFormat='{}{0:000.0}°'}"
+                   Foreground="#E91E90"
+                   FontSize="26" FontWeight="Bold"
+                   HorizontalAlignment="Center"/>
+        <TextBlock Text="HDG"
+                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                   FontSize="10"
+                   HorizontalAlignment="Center"
+                   Margin="0,-4,0,0"/>
+    </StackPanel>
+
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingReadout.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingReadout.axaml.cs
@@ -1,0 +1,27 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class HeadingReadout : UserControl
+{
+    public HeadingReadout()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
@@ -33,7 +33,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Border.FloatingPanel">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="0"/>
-            <Setter Property="Padding" Value="8"/>
+            <!-- Outer (left) padding removed so the buttons sit flush to the left
+                 window edge; inner (right/top/bottom) gaps preserved. -->
+            <Setter Property="Padding" Value="0,8,8,8"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RightNavigationPanel.axaml
@@ -38,7 +38,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="Border.FloatingPanel">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="CornerRadius" Value="0"/>
-            <Setter Property="Padding" Value="8"/>
+            <!-- Outer (right) padding removed so the buttons sit flush to the right
+                 window edge; inner (left/top/bottom) gaps preserved. -->
+            <Setter Property="Padding" Value="8,8,0,8"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml
@@ -1,0 +1,79 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="80"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.RollGaugeReadout"
+             x:DataType="vm:MainViewModel"
+             Background="Transparent"
+             IsHitTestVisible="False">
+
+    <!--
+    AgOpen-style roll gauge. Two pink curved arcs flank a centred degree
+    number; each arc carries four outward tick marks (two above and two
+    below horizontal). A long green horizon line through the centre tilts
+    by the current roll angle, with a small white dot fixed at centre as
+    the level reference.
+    -->
+    <Grid Width="200" Height="80">
+
+        <!-- Left pink arc + four outward ticks. -->
+        <Path Stroke="#E91E90" StrokeThickness="2.5" StrokeLineCap="Round"
+              Data="M 80,12 A 22,28 0 0 0 80,68
+                    M 69,20 L 61,20
+                    M 62,30 L 54,30
+                    M 62,50 L 54,50
+                    M 69,60 L 61,60"/>
+
+        <!-- Right pink arc + four outward ticks, mirrored. -->
+        <Path Stroke="#E91E90" StrokeThickness="2.5" StrokeLineCap="Round"
+              Data="M 120,12 A 22,28 0 0 1 120,68
+                    M 131,20 L 139,20
+                    M 138,30 L 146,30
+                    M 138,50 L 146,50
+                    M 131,60 L 139,60"/>
+
+        <!-- Tilting green horizon line through the centre. Extends 2 px past
+             each arc's outermost point (left arc leftmost x=58, right arc
+             rightmost x=142) so it visibly bisects both arcs. Rotates around
+             centre. -->
+        <Line StartPoint="56,40" EndPoint="144,40"
+              Stroke="#2ECC71" StrokeThickness="4" StrokeLineCap="Round"
+              RenderTransformOrigin="0.5,0.5">
+            <Line.RenderTransform>
+                <RotateTransform Angle="{Binding RollDegrees}"/>
+            </Line.RenderTransform>
+        </Line>
+
+        <!-- Static centre dot — the level reference. -->
+        <Ellipse Width="6" Height="6" Fill="White"
+                 HorizontalAlignment="Center" VerticalAlignment="Center"/>
+
+        <!-- Roll degrees, big and centred above the horizon line. -->
+        <TextBlock Text="{Binding RollDegrees, StringFormat='{}{0:F0}'}"
+                   Foreground="White"
+                   FontSize="32" FontWeight="Bold"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   Margin="0,0,0,28"/>
+    </Grid>
+
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml
@@ -40,6 +40,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
               Data="M 80,12 A 22,28 0 0 0 80,68
                     M 69,20 L 61,20
                     M 62,30 L 54,30
+                    M 58,40 L 50,40
                     M 62,50 L 54,50
                     M 69,60 L 61,60"/>
 
@@ -48,6 +49,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
               Data="M 120,12 A 22,28 0 0 1 120,68
                     M 131,20 L 139,20
                     M 138,30 L 146,30
+                    M 142,40 L 150,40
                     M 138,50 L 146,50
                     M 131,60 L 139,60"/>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml.cs
@@ -1,0 +1,27 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class RollGaugeReadout : UserControl
+{
+    public RollGaugeReadout()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
@@ -20,113 +20,201 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Panels.StatusBarPanel"
              x:DataType="vm:MainViewModel">
 
     <UserControl.Styles>
-        <!-- Compact letter-indicator button for G/I/A/M. Letter color tracks
-             connection status; click opens a Flyout with module details. -->
-        <Style Selector="Button.StatusIndicator">
+        <!-- Aggregate Modules indicator (replaces the four-letter G/I/A/M
+             cluster). Dot colour tracks ModuleStatusKind; click opens a
+             Flyout that breaks the aggregate back down per-module. -->
+        <Style Selector="Button.ModulesAggregate">
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="6,2"/>
-            <Setter Property="MinWidth" Value="24"/>
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
-        <Style Selector="Button.StatusIndicator:pointerover /template/ ContentPresenter">
+        <Style Selector="Button.ModulesAggregate:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
-        <Style Selector="Button.StatusIndicator TextBlock">
-            <Setter Property="FontSize" Value="16"/>
-            <Setter Property="FontWeight" Value="Bold"/>
+        <!-- Pause-rotation tap target. Borderless square that toggles the
+             auto-cycling of the bottom line. -->
+        <Style Selector="Button.RotatorPause">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="4,2"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.RotatorPause:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
-    <StackPanel Spacing="6">
-        <!-- Line 1: existing readouts on the left, G/I/A/M indicators on the right. -->
-        <Grid ColumnDefinitions="*,Auto">
-            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="20">
-                <!-- Widths fixed so values don't reflow the bar as digits change (#277). -->
-                <Ellipse Width="12" Height="12"
-                         Fill="{Binding State.Vehicle.FixQualityText, Converter={StaticResource FixQualityToColorConverter}}"/>
-                <TextBlock Width="75" Text="{Binding State.Vehicle.FixQualityText}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14" FontWeight="Bold"/>
-                <TextBlock Width="100" Text="{Binding SpeedKmh, StringFormat='{}{0:F1} km/h'}" Foreground="#E67E22" FontSize="14" FontWeight="Bold"/>
-                <TextBlock Width="70" Text="{Binding Heading, StringFormat='{}{0:F0}deg'}" Foreground="#E91E90" FontSize="14" FontWeight="Bold"/>
-                <TextBlock Width="95" Text="{Binding RollDegrees, StringFormat='Roll {0:F1}'}" Foreground="#9B59B6" FontSize="14" FontWeight="Bold"/>
-                <TextBlock Width="80" Text="{Binding CurrentTime}" Foreground="#95A5A6" FontSize="14"/>
+    <!-- Single-row strip. AgOpen-style packing: pause button, then a two-line
+         text stack (Fix/Age on top, rotating field info on the bottom),
+         then the live readouts, then battery + aggregate Modules. -->
+    <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+        <!-- Pause/play for the rotating bottom line. -->
+        <Button Grid.Column="0" Classes="RotatorPause"
+                Command="{Binding ToggleStatusStripRotationCommand}"
+                ToolTip.Tip="Pause / resume rotating field info">
+            <TextBlock FontSize="16" FontWeight="Bold"
+                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                       Text="{Binding IsStatusStripRotationPaused, Converter={StaticResource BoolToPlayPauseConverter}}"/>
+        </Button>
+
+        <!-- Two-line text stack: Fix/Age on top, rotating field info on the
+             bottom. Width fixed so the live readouts to the right don't
+             reflow when the rotating line changes pages. -->
+        <Grid Grid.Column="1" RowDefinitions="Auto,Auto" Margin="6,0,12,0" Width="350"
+              VerticalAlignment="Center">
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6">
+                <!-- Fix dot + RTK label form one tap target that toggles the
+                     on-map GPS detail card (lands at the same left slot as
+                     the Field-Stats card; the user manages which one they
+                     want there). Dot colour tracks fix quality. -->
+                <Button Classes="RotatorPause" Padding="2,1"
+                        Command="{Binding ToggleGpsDetailOverlayCommand}"
+                        ToolTip.Tip="Toggle GPS detail card on the map">
+                    <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                        <Ellipse Width="12" Height="12" VerticalAlignment="Center"
+                                 Fill="{Binding State.Vehicle.FixQualityText, Converter={StaticResource FixQualityToColorConverter}}"/>
+                        <TextBlock Text="{Binding State.Vehicle.FixQualityText}"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                   FontSize="16" FontWeight="Bold"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+                <TextBlock Text="{Binding State.Vehicle.Age, StringFormat='Age: {0:F1}'}"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                           FontSize="16" FontWeight="Bold"
+                           VerticalAlignment="Center"/>
             </StackPanel>
-
-            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="2" Margin="10,0,0,0">
-                <!-- G: GPS -->
-                <Button Classes="StatusIndicator">
-                    <TextBlock Text="G"
-                               Foreground="{Binding State.Connections.IsGpsDataOk, Converter={StaticResource BoolToColorConverter}}"/>
-                    <Button.Flyout>
-                        <Flyout Placement="Bottom">
-                            <StackPanel Spacing="4" MinWidth="180">
-                                <TextBlock Text="GPS" FontWeight="Bold" FontSize="14"/>
-                                <TextBlock Text="{Binding State.Vehicle.FixQualityText, StringFormat='Fix: {0}'}" FontSize="13"/>
-                                <TextBlock Text="{Binding State.Vehicle.SatelliteCount, StringFormat='Satellites: {0}'}" FontSize="13"/>
-                            </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-
-                <!-- I: IMU -->
-                <Button Classes="StatusIndicator">
-                    <TextBlock Text="I"
-                               Foreground="{Binding State.Connections.IsImuDataOk, Converter={StaticResource BoolToColorConverter}}"/>
-                    <Button.Flyout>
-                        <Flyout Placement="Bottom">
-                            <StackPanel Spacing="4" MinWidth="180">
-                                <TextBlock Text="IMU" FontWeight="Bold" FontSize="14"/>
-                                <TextBlock Text="{Binding State.Connections.ImuIpAddress, TargetNullValue='No module detected', StringFormat='IP: {0}'}" FontSize="13"/>
-                            </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-
-                <!-- A: AutoSteer -->
-                <Button Classes="StatusIndicator">
-                    <TextBlock Text="A"
-                               Foreground="{Binding State.Connections.IsAutoSteerDataOk, Converter={StaticResource BoolToColorConverter}}"/>
-                    <Button.Flyout>
-                        <Flyout Placement="Bottom">
-                            <StackPanel Spacing="4" MinWidth="180">
-                                <TextBlock Text="AutoSteer" FontWeight="Bold" FontSize="14"/>
-                                <TextBlock Text="{Binding State.Connections.AutoSteerIpAddress, TargetNullValue='No module detected', StringFormat='IP: {0}'}" FontSize="13"/>
-                            </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-
-                <!-- M: Machine -->
-                <Button Classes="StatusIndicator">
-                    <TextBlock Text="M"
-                               Foreground="{Binding State.Connections.IsMachineDataOk, Converter={StaticResource BoolToColorConverter}}"/>
-                    <Button.Flyout>
-                        <Flyout Placement="Bottom">
-                            <StackPanel Spacing="4" MinWidth="180">
-                                <TextBlock Text="Machine" FontWeight="Bold" FontSize="14"/>
-                                <TextBlock Text="{Binding State.Connections.MachineIpAddress, TargetNullValue='No module detected', StringFormat='IP: {0}'}" FontSize="13"/>
-                            </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-            </StackPanel>
+            <TextBlock Grid.Row="1"
+                       Text="{Binding StatusStripRotatingLine}"
+                       Foreground="#3498DB"
+                       FontSize="16" FontWeight="Bold"
+                       TextTrimming="CharacterEllipsis"/>
         </Grid>
 
-        <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,2"/>
+        <!-- Live readouts row deliberately empty: Heading + Roll + Time are
+             all on-map now (HeadingReadout upper-left, RollGaugeReadout
+             lower-right). Speed lives in the large slot at the right of
+             the strip. The column is kept so the strip still expands. -->
+        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="20" VerticalAlignment="Center"/>
 
-        <StackPanel Orientation="Horizontal" Spacing="20">
-            <TextBlock Width="85"  Text="{Binding CurrentFps, StringFormat='FPS: {0:F0}'}" Foreground="#2ECC71" FontSize="14" FontWeight="Bold"/>
-            <TextBlock Width="110" Text="{Binding GpsToPgnLatencyMs, StringFormat='Lat: {0:F2}ms'}" Foreground="#F39C12" FontSize="14" FontWeight="Bold"/>
-            <TextBlock Width="160" Text="{Binding Latitude, StringFormat='Lat: {0:F8}'}" Foreground="#3498DB" FontSize="14" FontWeight="Bold"/>
-            <TextBlock Width="170" Text="{Binding Longitude, StringFormat='Lon: {0:F8}'}" Foreground="#3498DB" FontSize="14" FontWeight="Bold"/>
+        <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0">
+            <!-- Field-stats on-map toggle. Glyph: an irregular field-shaped
+                 polygon with a big "i" inside. Stroke + letter both track
+                 the active/inactive colour so the active state stays
+                 readable at a glance. -->
+            <Button Classes="RotatorPause"
+                    Command="{Binding ToggleFieldStatsOnMapCommand}"
+                    ToolTip.Tip="Toggle field-stats card on the map">
+                <Grid Width="38" Height="30">
+                    <Polygon Points="5,7 18,2 33,8 31,26 13,28 4,20"
+                             Stroke="{Binding IsFieldStatsOnMapVisible, Converter={StaticResource BoolToColorConverter}}"
+                             StrokeThickness="2"
+                             Fill="Transparent"/>
+                    <TextBlock Text="i" FontSize="22" FontWeight="Bold"
+                               Foreground="{Binding IsFieldStatsOnMapVisible, Converter={StaticResource BoolToColorConverter}}"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               Margin="0,-1,0,0"/>
+                </Grid>
+            </Button>
+
+            <!-- Battery icon (hidden on machines without a battery). -->
+            <controls:BatteryIndicator
+                Level="{Binding BatteryLevel}"
+                IsCharging="{Binding IsBatteryCharging}"
+                IsVisible="{Binding IsBatteryAvailable}"
+                VerticalAlignment="Center"/>
+
+        <!-- Aggregate module-status indicator. Colour tracks Green = all
+             configured modules present, Yellow = ≥1 absent, Red = none.
+             Tap opens a flyout listing per-module connection state until
+             the Network panel ships. The GPS-detail overlay is toggled
+             from the fix dot at top-left of the strip, not from here. -->
+        <Button Classes="ModulesAggregate"
+                ToolTip.Tip="Module status: GPS / IMU / AutoSteer / Machine">
+            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                <Ellipse Width="14" Height="14"
+                         Fill="{Binding ModuleStatusKind, Converter={StaticResource ModuleStatusKindToColorConverter}}"/>
+                <TextBlock Text="Modules" FontSize="16" FontWeight="Bold"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                           VerticalAlignment="Center"/>
+            </StackPanel>
+            <Button.Flyout>
+                <Flyout Placement="Bottom">
+                    <StackPanel Spacing="6" MinWidth="220">
+                        <TextBlock Text="Modules" FontWeight="Bold" FontSize="14"/>
+                        <Grid ColumnDefinitions="Auto,80,*">
+                            <Ellipse Grid.Column="0" Width="10" Height="10" VerticalAlignment="Center"
+                                     Fill="{Binding State.Connections.IsGpsDataOk, Converter={StaticResource BoolToColorConverter}}"/>
+                            <TextBlock Grid.Column="1" Text="GPS" Margin="8,0,0,0" FontSize="13"/>
+                            <TextBlock Grid.Column="2" Text="{Binding State.Vehicle.FixQualityText}" FontSize="12"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                                       TextAlignment="Right"/>
+                        </Grid>
+                        <Grid ColumnDefinitions="Auto,80,*">
+                            <Ellipse Grid.Column="0" Width="10" Height="10" VerticalAlignment="Center"
+                                     Fill="{Binding State.Connections.IsImuDataOk, Converter={StaticResource BoolToColorConverter}}"/>
+                            <TextBlock Grid.Column="1" Text="IMU" Margin="8,0,0,0" FontSize="13"/>
+                            <TextBlock Grid.Column="2"
+                                       Text="{Binding State.Connections.ImuIpAddress, TargetNullValue='Not detected'}"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                                       TextAlignment="Right"/>
+                        </Grid>
+                        <Grid ColumnDefinitions="Auto,80,*">
+                            <Ellipse Grid.Column="0" Width="10" Height="10" VerticalAlignment="Center"
+                                     Fill="{Binding State.Connections.IsAutoSteerDataOk, Converter={StaticResource BoolToColorConverter}}"/>
+                            <TextBlock Grid.Column="1" Text="AutoSteer" Margin="8,0,0,0" FontSize="13"/>
+                            <TextBlock Grid.Column="2"
+                                       Text="{Binding State.Connections.AutoSteerIpAddress, TargetNullValue='Not detected'}"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                                       TextAlignment="Right"/>
+                        </Grid>
+                        <Grid ColumnDefinitions="Auto,80,*">
+                            <Ellipse Grid.Column="0" Width="10" Height="10" VerticalAlignment="Center"
+                                     Fill="{Binding State.Connections.IsMachineDataOk, Converter={StaticResource BoolToColorConverter}}"/>
+                            <TextBlock Grid.Column="1" Text="Machine" Margin="8,0,0,0" FontSize="13"/>
+                            <TextBlock Grid.Column="2"
+                                       Text="{Binding State.Connections.MachineIpAddress, TargetNullValue='Not detected'}"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                                       TextAlignment="Right"/>
+                        </Grid>
+                        <TextBlock Text="Set which modules to expect in the Network panel."
+                                   FontSize="11"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                                   Margin="0,4,0,0"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Flyout>
+            </Button.Flyout>
+        </Button>
+
+            <!-- Large Speed slot — AgOpen-style. Value tracks the user's
+                 metric/imperial preference. Units sit small beside it. -->
+            <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center" Margin="6,0,0,0">
+                <TextBlock Text="{Binding SpeedLargeValue, StringFormat='{}{0:F1}'}"
+                           Foreground="#E67E22"
+                           FontSize="26" FontWeight="Bold"
+                           VerticalAlignment="Center"/>
+                <TextBlock Text="{Binding SpeedLargeUnit}"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                           FontSize="13" FontWeight="Bold"
+                           VerticalAlignment="Bottom"
+                           Margin="2,0,0,4"/>
+            </StackPanel>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              xmlns:controls="clr-namespace:AgValoniaGPS.Views.Controls;assembly=AgValoniaGPS.Views"
+             xmlns:panels="clr-namespace:AgValoniaGPS.Views.Controls.Panels;assembly=AgValoniaGPS.Views"
              mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Panels.StatusBarPanel"
              x:DataType="vm:MainViewModel">
@@ -203,17 +204,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- Large Speed slot — AgOpen-style. Value tracks the user's
                  metric/imperial preference. Units sit small beside it. -->
-            <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center" Margin="6,0,0,0">
+            <StackPanel Spacing="0" VerticalAlignment="Center" Margin="6,0,0,0">
                 <TextBlock Text="{Binding SpeedLargeValue, StringFormat='{}{0:F1}'}"
                            Foreground="#E67E22"
                            FontSize="26" FontWeight="Bold"
-                           VerticalAlignment="Center"/>
+                           HorizontalAlignment="Center"/>
+                <!-- Unit below the number to match the heading readout's layout. -->
                 <TextBlock Text="{Binding SpeedLargeUnit}"
-                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
-                           FontSize="13" FontWeight="Bold"
-                           VerticalAlignment="Bottom"
-                           Margin="2,0,0,4"/>
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                           FontSize="10"
+                           HorizontalAlignment="Center"
+                           Margin="0,-4,0,0"/>
             </StackPanel>
+
+            <!-- Heading, to the right of speed (moved off the map; the strip
+                 has room and it sits next to speed as the operator expected). -->
+            <panels:HeadingReadout VerticalAlignment="Center" Margin="14,0,0,0"
+                                   DataContext="{Binding}"/>
         </StackPanel>
     </Grid>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/TimeReadout.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/TimeReadout.axaml
@@ -1,0 +1,36 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="120" d:DesignHeight="32"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.TimeReadout"
+             x:DataType="vm:MainViewModel"
+             Background="Transparent"
+             IsHitTestVisible="False">
+
+    <!-- Transparent time readout. Separated from the roll gauge so each
+         lives in its own spot — Roll up high, Time near the bottom nav. -->
+    <TextBlock Text="{Binding CurrentTime}"
+               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+               FontSize="18" FontWeight="Bold"
+               VerticalAlignment="Center"/>
+
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/TimeReadout.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/TimeReadout.axaml.cs
@@ -1,0 +1,27 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class TimeReadout : UserControl
+{
+    public TimeReadout()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
@@ -27,7 +27,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
   <controls:FloatingPanel x:Name="FP"
                           Title="Tools"
-                          CloseCommand="{Binding ToggleToolsPanelCommand}">
+                          CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
     <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png"
                          Text="{loc:Localize SteerWizard}"
                          Command="{Binding ShowSteerWizardCommand}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml.cs
@@ -18,6 +18,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -31,5 +32,10 @@ public partial class ToolsPanel : UserControl
         var fp = this.FindControl<FloatingPanel>("FP");
         if (fp != null)
             fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
+        // Picking any item dismisses the menu (command still runs — not handled).
+        AddHandler(Button.ClickEvent, CloseOnItemClick, RoutingStrategies.Bubble);
     }
+
+    private void CloseOnItemClick(object? sender, RoutedEventArgs e)
+        => (DataContext as AgValoniaGPS.ViewModels.MainViewModel)?.CloseAllNavFlyouts();
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/TurnLateralOverlayPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/TurnLateralOverlayPanel.axaml
@@ -1,0 +1,122 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2026 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+-->
+<!--
+On-map U-Turn + Lateral overlay (AgOpen-style). Replaces the old right-rail
+direction+distance button and manual L/R pair. Two yellow manual-turn arrows
+(left/right) trigger a manual U-turn; two cyan arrows shift the guidance line
+laterally. A compact indicator shows the armed auto-turn's skip count + pending
+direction. Distance-to-turn now lives on the LightBar HUD, not here.
+
+Transparent container: only the buttons hit-test, so empty space passes pointer
+events through to the map. Each group's visibility is gated by the matching
+Screen & Alerts "On-Screen Buttons" toggle (UTurnButtonVisible / LateralButtonVisible).
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.TurnLateralOverlayPanel"
+             x:DataType="vm:MainViewModel"
+             HorizontalAlignment="Left" VerticalAlignment="Top"
+             Margin="100,90,0,0"
+             Background="{x:Null}">
+
+    <UserControl.Styles>
+        <!-- Icon-only on-map action button: no box, just the glyph. A subtle
+             highlight appears on hover so the hit target is discoverable. -->
+        <Style Selector="Button.MapArrow">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="Padding" Value="6"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.MapArrow:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#30FFFFFF"/>
+        </Style>
+        <Style Selector="Button.MapArrow TextBlock">
+            <Setter Property="FontSize" Value="44"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+    </UserControl.Styles>
+
+    <StackPanel Spacing="6" HorizontalAlignment="Left">
+
+        <!-- U-Turn: two separate manual-turn arrows (one L, one R). Drawn as an
+             actual U-turn shape (up, 180° around, back down with arrowhead) so it
+             can't be mistaken for a plain left/right arrow. -->
+        <StackPanel Orientation="Horizontal" Spacing="16" HorizontalAlignment="Left"
+                    IsVisible="{Binding IsUTurnOverlayVisible}">
+            <Button Classes="MapArrow" ToolTip.Tip="Manual U-Turn Left"
+                    Command="{Binding ManualYouTurnLeftCommand}">
+                <Viewbox Width="42" Height="42">
+                    <Canvas Width="40" Height="44">
+                        <!-- Enter up the right leg, arch over, exit down the left leg. -->
+                        <Path Stroke="#FFE000" StrokeThickness="4"
+                              StrokeLineCap="Round" StrokeJoin="Round"
+                              Data="M26,38 L26,18 C26,8 14,8 14,18 L14,30"/>
+                        <Polygon Points="9,30 19,30 14,40" Fill="#FFE000"/>
+                    </Canvas>
+                </Viewbox>
+            </Button>
+            <Button Classes="MapArrow" ToolTip.Tip="Manual U-Turn Right"
+                    Command="{Binding ManualYouTurnRightCommand}">
+                <Viewbox Width="42" Height="42">
+                    <Canvas Width="40" Height="44">
+                        <!-- Mirror: enter up the left leg, arch over, exit down the right leg. -->
+                        <Path Stroke="#FFE000" StrokeThickness="4"
+                              StrokeLineCap="Round" StrokeJoin="Round"
+                              Data="M14,38 L14,18 C14,8 26,8 26,18 L26,30"/>
+                        <Polygon Points="21,30 31,30 26,40" Fill="#FFE000"/>
+                    </Canvas>
+                </Viewbox>
+            </Button>
+        </StackPanel>
+
+        <!-- Lateral: cyan shift arrows. Drawn as vectors with the same stroke
+             weight, canvas and viewbox as the U-turn icons so the two rows match. -->
+        <StackPanel Orientation="Horizontal" Spacing="28" HorizontalAlignment="Left"
+                    IsVisible="{Binding IsLateralOverlayVisible}">
+            <Button Classes="MapArrow" ToolTip.Tip="Shift guidance left"
+                    Command="{Binding NudgeLeftCommand}">
+                <Viewbox Width="42" Height="42">
+                    <Canvas Width="40" Height="44">
+                        <Path Stroke="#3FD0F0" StrokeThickness="4"
+                              StrokeLineCap="Round" StrokeJoin="Round"
+                              Data="M33,22 L15,22"/>
+                        <Polygon Points="15,16 15,28 5,22" Fill="#3FD0F0"/>
+                    </Canvas>
+                </Viewbox>
+            </Button>
+            <Button Classes="MapArrow" ToolTip.Tip="Shift guidance right"
+                    Command="{Binding NudgeRightCommand}">
+                <Viewbox Width="42" Height="42">
+                    <Canvas Width="40" Height="44">
+                        <Path Stroke="#3FD0F0" StrokeThickness="4"
+                              StrokeLineCap="Round" StrokeJoin="Round"
+                              Data="M7,22 L25,22"/>
+                        <Polygon Points="25,16 25,28 35,22" Fill="#3FD0F0"/>
+                    </Canvas>
+                </Viewbox>
+            </Button>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/TurnLateralOverlayPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/TurnLateralOverlayPanel.axaml.cs
@@ -1,0 +1,32 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+/// <summary>
+/// On-map U-Turn + Lateral overlay. Pure binding/layout — all behavior is in the
+/// bound MainViewModel commands (manual U-turn L/R, lateral nudge L/R) and the
+/// computed overlay-visibility properties.
+/// </summary>
+public partial class TurnLateralOverlayPanel : UserControl
+{
+    public TurnLateralOverlayPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ViewSettingsPanel.axaml
@@ -28,7 +28,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <controls:FloatingPanel x:Name="FP"
                             MinWidth="200"
                             Title="{loc:Localize ViewSettings}"
-                            CloseCommand="{Binding ToggleViewSettingsPanelCommand}">
+                            CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
         <controls:FloatingPanel.PanelContent>
             <StackPanel Spacing="4">
 

--- a/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
+++ b/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Globalization;
+using AgValoniaGPS.Models.State;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
@@ -185,6 +186,47 @@ public class FixQualityToColorConverter : IValueConverter
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();
+    }
+}
+
+/// <summary>
+/// Maps the rotator's paused/running state to a play/pause glyph. True =
+/// paused → ▶ (tap to resume); false = running → ⏸ (tap to pause).
+/// </summary>
+public class BoolToPlayPauseConverter : IValueConverter
+{
+    public static readonly BoolToPlayPauseConverter Instance = new();
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool paused && paused ? "▶" : "⏸";
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => BindingOperations.DoNothing;
+}
+
+/// <summary>
+/// Aggregate module-presence indicator: green when every configured module is
+/// producing data, yellow when ≥1 is missing, red when none are present.
+/// </summary>
+public class ModuleStatusKindToColorConverter : IValueConverter
+{
+    public static readonly ModuleStatusKindToColorConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is ModuleStatusKind kind)
+        {
+            return kind switch
+            {
+                ModuleStatusKind.AllPresent       => Brushes.LimeGreen,
+                ModuleStatusKind.PartiallyPresent => Brushes.Gold,
+                _                                  => Brushes.OrangeRed,
+            };
+        }
+        return Brushes.OrangeRed;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return BindingOperations.DoNothing;
     }
 }
 

--- a/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
@@ -27,6 +27,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <converters:BoolToColorConverter x:Key="BoolToColorConverter"/>
     <converters:BoolToStatusConverter x:Key="BoolToStatusConverter"/>
     <converters:FixQualityToColorConverter x:Key="FixQualityToColorConverter"/>
+    <converters:ModuleStatusKindToColorConverter x:Key="ModuleStatusKindToColorConverter"/>
+    <converters:BoolToPlayPauseConverter x:Key="BoolToPlayPauseConverter"/>
     <converters:FixQualityNameConverter x:Key="FixQualityNameConverter"/>
     <converters:BoolToSteerColorConverter x:Key="BoolToSteerColorConverter"/>
     <converters:BoolToSteerTextConverter x:Key="BoolToSteerTextConverter"/>

--- a/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
@@ -30,6 +30,30 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Setter Property="Padding" Value="15"/>
     </Style>
 
+    <!-- Custom Window Controls (frameless build): Min / Max / Close.
+         Three identical compact squares at the end of the status strip;
+         the Close variant flips to red on hover. -->
+    <Style Selector="Button.WindowControl">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="CornerRadius" Value="0"/>
+        <Setter Property="Padding" Value="14,0"/>
+        <Setter Property="MinWidth" Value="42"/>
+        <Setter Property="VerticalAlignment" Value="Stretch"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+    </Style>
+    <Style Selector="Button.WindowControl:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+    </Style>
+    <Style Selector="Button.WindowControlClose:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="#E81123"/>
+    </Style>
+    <Style Selector="Button.WindowControlClose:pointerover TextBlock">
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+
     <!-- Modern Button Style -->
     <Style Selector="Button.ModernButton">
         <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -1,6 +1,7 @@
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Battery;
 using AgValoniaGPS.Services.Interfaces;
 using AgValoniaGPS.Services.YouTurn;
 using AgValoniaGPS.ViewModels;
@@ -81,6 +82,7 @@ public class MainViewModelBuilder
             intents: Intents,
             logger: NullLogger<MainViewModel>.Instance,
             appState: new ApplicationState(),
-            persistentStateService: Substitute.For<IPersistentStateService>());
+            persistentStateService: Substitute.For<IPersistentStateService>(),
+            batteryService: new NullBatteryService());
     }
 }

--- a/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
@@ -1,6 +1,7 @@
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Services;
+using AgValoniaGPS.Services.Battery;
 using AgValoniaGPS.Services.Interfaces;
 using AgValoniaGPS.Services.YouTurn;
 using AgValoniaGPS.ViewModels;
@@ -85,6 +86,7 @@ public class MainViewModelBuilder
             intents: Intents,
             logger: NullLogger<MainViewModel>.Instance,
             appState: new ApplicationState(),
-            persistentStateService: Substitute.For<IPersistentStateService>());
+            persistentStateService: Substitute.For<IPersistentStateService>(),
+            batteryService: new NullBatteryService());
     }
 }

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 19
+#define VERSION_PATCH 20
 
-#define VERSION "26.5.19"
-#define VERSION_DATE "2026-05-28"
+#define VERSION "26.5.20"
+#define VERSION_DATE "2026-05-29"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 22
+#define VERSION_PATCH 23
 
-#define VERSION "26.5.22"
+#define VERSION "26.5.23"
 #define VERSION_DATE "2026-05-29"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 20
+#define VERSION_PATCH 22
 
-#define VERSION "26.5.20"
+#define VERSION "26.5.22"
 #define VERSION_DATE "2026-05-29"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 23
+#define VERSION_PATCH 24
 
-#define VERSION "26.5.23"
+#define VERSION "26.5.24"
 #define VERSION_DATE "2026-05-29"


### PR DESCRIPTION
Brings the **status-strip / on-map HUD** work from the parked `feature/ui-redesign` branch onto `develop` for testing, **without** the navigation redesign (no Field Tools ring / sectioned modal, no Start-Session hub, no Screen & Alerts collapse). `develop`'s existing nav is kept; only the strip, on-map readouts, and a few polish items are added.

## What's included
**Status strip / HUD**
- Reworked top strip: aggregate **Modules** status button (colour by configured + live data-ok), pause + rotating field-info text, field-stats toggle, vertical **battery** indicator (per-platform reader), large **Speed** (unit stacked below the number).
- **Heading** readout in the strip, right of Speed.
- **Dev overlay** (FPS / latency / Lat / Lon) gated by the `.show_dev_overlay` file flag.
- On-map cards/readouts: **GPS-detail** card (toggled by the fix dot), **field-stats** card, **Roll gauge** (with a 0° centre tick), **Time**.
- On-map **U-Turn / Lateral** manual overlays (gated by the on-screen-button toggles).

**Window / layout**
- Frameless desktop window with Min/Max/Close in an edge-to-edge strip; **1200×720** minimum size (Droid S7 view).
- On-map **camera pad** (tilt / zoom / mode) replacing the right-edge zoom +/- + mode cluster.
- Flush-to-edge Left/Right/Bottom nav panels; right column lifted so the camera pad's tilt-down stays visible with a full right nav.

**Left-nav fly-out cleanup (reduces panel clutter)**
- One menu open at a time; selecting an item, the **X**, a launched dialog, or **clicking outside** all dismiss the open menu.

## Notes for reviewers
- This was a reconciliation onto a base lacking the redesign's nav context, so the right-edge layout keeps develop's nav alongside the new camera pad. **Worth a visual pass on Desktop + a device.**
- Mobile (iOS/Android) layout changes are mirrored but have only been built, not run on-device in this pass.
- `sys/version.h` → 26.5.24. Build clean; all 1354 tests pass (109 + 880 + 221 + 146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)