### PR TITLE
UI: move AgShare API button from File Menu to Field Ops

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FieldOperationsPanel.axaml
@@ -117,6 +117,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <TextBlock Text="AgShare Download" VerticalAlignment="Center" FontSize="12"/>
                         </StackPanel>
                     </Button>
+                    <Button Classes="ModernButton" Command="{Binding ShowAgShareSettingsDialogCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+                            <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png" Width="28" Height="28"/>
+                            <TextBlock Text="{loc:Localize AgShareApi}" VerticalAlignment="Center" FontSize="12"/>
+                        </StackPanel>
+                    </Button>
                 </UniformGrid>
 
                 <!-- Active field/job pill at the bottom so showing / hiding it

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -71,7 +71,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
                 <!-- Help & Info -->
-                <Button Classes="MenuListButton" Content="{loc:Localize AgShareApi}"       HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowAgShareSettingsDialogCommand}"/>
                 <Button Classes="MenuListButton" Content="{loc:Localize Help}"             HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowHelpDialogCommand}"/>
                 <Button Classes="MenuListButton" Content="{loc:Localize About}"            HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowAboutDialogCommand}"/>
                 <Button Classes="MenuListButton" Content="{loc:Localize BugReportDump}"    HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowBugReportDialogCommand}"/>

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 26
+#define VERSION_PATCH 27
 
-#define VERSION "26.5.26"
+#define VERSION "26.5.27"
 #define VERSION_DATE "2026-05-29"


### PR DESCRIPTION
Groups the **AgShare API** (settings) button with the other AgShare actions where users expect it.

- Removed it from the File Menu's Help & Info list.
- Added it to the **Field Operations** AgShare group (after Upload/Download), restyled as a `ModernButton` with the **AgShare icon** to match the rest of that panel.
- Same `ShowAgShareSettingsDialogCommand` — no behavior change, just relocation + styling.

Build clean; 1354 tests pass. v26.5.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)