### PR TITLE
Network IO panel: module IP readout + scan/subnet (AgIO parity) + NTRIP

### DIFF
--- a/Plans/NETWORK_IO_PLAN.md
+++ b/Plans/NETWORK_IO_PLAN.md
@@ -1,0 +1,114 @@
+# Network IO Panel — Implementation Plan
+
+Status: **planned** (2026-05-30). Combines NTRIP + an expanded module
+config/readout (per-module IP) + a module subnet-change action, porting the
+AgIO behaviour from `AgOpen_Snapshot/AgIO/`.
+
+## Decisions (locked)
+
+- **Surface:** left-nav **fly-out panel** (non-modal `FloatingPanel`, docked
+  beside the nav like Screen & Alerts / Field Ops). Stays open over the map.
+- **Per-module IPs:** obtain via **PGN 202 scan → PGN 203 reply** (authoritative
+  self-reported IP + subnet, includes GPS), with an explicit **Scan** button.
+- **IP change:** a single **Set-Subnet** button broadcasting **PGN 201** to all
+  modules (global /24 change — matches AgIO; there is no per-module IP set),
+  behind a confirmation.
+
+## Protocol (authoritative, from `AgOpen_Snapshot/AgIO/Source/`)
+
+Framing: `[0x80,0x81, src, PGN, len, …payload…, CRC]`, CRC = `unchecked (byte)`
+sum of bytes `[2 .. n-2]`. Module IDs: **120 GPS / 121 IMU / 123 Machine /
+126 Steer / 127 AgIO**. AgIO listens on **:9999**; modules listen on **:8888**.
+
+### Scan request — PGN 202 (host → modules)
+```
+{ 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 }
+```
+Sent to **255.255.255.255:8888**, once per up IPv4 NIC (socket bound to the
+NIC address : 9999, Broadcast + ReuseAddress + DontRoute).
+Module gate: `data[4]==3 && data[5]==202 && data[6]==202`.
+
+### Scan reply — PGN 203 (module → host, 13 bytes)
+```
+[0]=0x80 [1]=0x81 [2]=moduleID [3]=203 [4]=7
+[5..8]  = module IP   (4 octets)
+[9..11] = subnet      (3 octets)
+[12]    = CRC
+```
+`data[2]` selects which module's IP/subnet to store. Hello PGNs (126/123/121)
+carry liveness only — no IP.
+
+### Subnet change — PGN 201 (host → modules, 11 bytes)
+```
+{ 0x80, 0x81, 0x7F, 201, 5, 201, 201, oct1, oct2, oct3, 0x47 }
+```
+Broadcast to **255.255.255.255:8888** (same per-NIC pattern). All modules apply
+the new first-three octets and restart; the host octet is kept. After sending,
+AgIO persists the subnet and rebuilds its module endpoint to `subnet.255:8888`.
+Module gate: `data[4]==5 && data[5]==201 && data[6]==201`.
+
+> **CRC note:** AgIO hardcodes the trailing `0x47` for 201/202 and modules
+> validate only the magic bytes, not CRC. We replicate AgIO's exact bytes
+> (hardcoded `0x47`) for firmware compatibility. (Chris maintains the AiO
+> firmware, so this can later move to a real CRC on both sides if desired.)
+
+## What already exists (reuse)
+
+- **NTRIP** — `NtripClientService` / `INtripClientService`, `NtripProfileService`,
+  VM state+commands (`MainViewModel.Ntrip.cs`, `…Commands.Ntrip.cs`), and the
+  `NtripProfilesDialogPanel` / `NtripProfileEditorPanel` dialogs. Launched today
+  from File Menu → "NTRIP Profiles".
+- **UDP/modules** — `UdpCommunicationService` (listen :9999, hello PGN 200 →
+  :8888, subnet auto-lock, `GetModuleIpAddress(ModuleType)`); `ConnectionState`
+  already has `AutoSteerIpAddress` / `MachineIpAddress` / `ImuIpAddress`
+  (no GPS IP, no subnet yet).
+- **PGN plumbing** — `PgnMessage.PgnNumbers` registry (already defines
+  `HELLO_FROM_AGIO`=200, `SCAN_REPLY`=203), `PgnBuilder` outbound factory + CRC
+  helper. `Docs/PGN.md` documents 201/202/203.
+- **Nav conventions** — fly-out pattern (visibility prop + `Toggle…Command` +
+  `CloseAllNavFlyouts` + Canvas host + drag-wire) per the recent Screen & Alerts
+  work.
+
+## Build order
+
+### Phase 1 — protocol layer (Models/Services + tests)
+- `PgnMessage.PgnNumbers`: add `SET_SUBNET = 201`, `SCAN_REQUEST = 202`.
+- `PgnBuilder`: `BuildScanRequest()` and `BuildSubnetChange(byte o1, byte o2,
+  byte o3)` returning the exact AgIO byte arrays above.
+- Parse **PGN 203** in the UDP receive path → write IP + subnet (and GPS) into
+  `ConnectionState`. Add `…Subnet` fields and `GpsIpAddress` to `ConnectionState`.
+- `UdpCommunicationService`: add `SendGlobalBroadcast(byte[] pgn)` that iterates
+  up IPv4 NICs and sends to `255.255.255.255:8888` (Broadcast/ReuseAddress/
+  DontRoute). After a subnet change, repoint the service's own send endpoint to
+  `subnet.255:8888`.
+- Tests: 202/201 byte-exact build; 203 parse round-trip per module id.
+
+### Phase 2 — ViewModel
+- `MainViewModel.NetworkIO.cs` (new partial): observable module rows
+  (Type · IP · Subnet · Status · last-seen), subnet octet entry fields,
+  `ScanModulesCommand`, `SendSubnetCommand` (confirmation dialog → broadcast 201
+  → update send endpoint). Surface NTRIP status (connected, bytes) + Connect/
+  Disconnect, and a button to the existing Profiles dialog.
+- `IsNetworkIoPanelVisible` + `ToggleNetworkIoPanelCommand`; wire into
+  `IsAnyNavFlyoutOpen` and `CloseAllNavFlyouts`.
+
+### Phase 3 — UI + entry point
+- `Panels/NetworkIoPanel.axaml(.cs)` — `FloatingPanel` with a Modules section
+  (table + Scan + Set-Subnet row) and an NTRIP section (status + Profiles).
+- Add the nav button + Canvas host + drag-wire in `LeftNavigationPanel`.
+- Move the NTRIP entry: File Menu "NTRIP Profiles" → "Network IO" (the Profiles/
+  Editor dialogs remain, launched from inside the panel).
+
+### Phase 4 — persistence + polish
+- Persist the chosen subnet in `ConnectionConfig`; restore on startup.
+- DI: register any new service members across Desktop/iOS/Android.
+- Manual device pass (real modules) — Chris.
+
+## Open risks / notes
+- The host's own send endpoint must update immediately after a subnet change or
+  it loses the modules until restart (AgIO rebuilds `epModule`).
+- GPS IP only appears via PGN 203 (GPS data otherwise arrives as NMEA/PGN with no
+  tracked source IP today).
+- Global broadcast may need per-NIC iteration to traverse multiple interfaces
+  (matches AgIO); verify on the target tablet's networking.
+- Suggest a dedicated branch `feature/network-io` (not on the status-strip branch).

--- a/Shared/AgValoniaGPS.Models/PgnMessage.cs
+++ b/Shared/AgValoniaGPS.Models/PgnMessage.cs
@@ -146,9 +146,19 @@ public static class PgnNumbers
     public const byte HELLO_FROM_AGIO = 200;
 
     /// <summary>
-    /// Scan reply (0xCB = 203)
+    /// Scan reply FROM module — carries module IP + subnet (0xCB = 203)
     /// </summary>
     public const byte SCAN_REPLY = 203;
+
+    /// <summary>
+    /// Scan request / "who's out there" broadcast TO modules (0xCA = 202)
+    /// </summary>
+    public const byte SCAN_REQUEST = 202;
+
+    /// <summary>
+    /// Set module subnet (IP change) broadcast TO modules (0xC9 = 201)
+    /// </summary>
+    public const byte SET_SUBNET = 201;
 
     /// <summary>
     /// AutoSteer data (0xFD = 253)

--- a/Shared/AgValoniaGPS.Models/State/ConnectionState.cs
+++ b/Shared/AgValoniaGPS.Models/State/ConnectionState.cs
@@ -67,6 +67,13 @@ public class ConnectionState : ObservableObject
         set => SetProperty(ref _isGpsDataOk, value);
     }
 
+    private string? _gpsIpAddress;
+    public string? GpsIpAddress
+    {
+        get => _gpsIpAddress;
+        set => SetProperty(ref _gpsIpAddress, value);
+    }
+
     // NTRIP
     private bool _isNtripConnected;
     public bool IsNtripConnected
@@ -160,6 +167,15 @@ public class ConnectionState : ObservableObject
     {
         get => _imuIpAddress;
         set => SetProperty(ref _imuIpAddress, value);
+    }
+
+    // Detected module /24 subnet (first three octets, e.g. "192.168.5"), learned
+    // from a PGN 203 scan reply. Seeds the Network IO subnet-change entry.
+    private string? _moduleSubnet;
+    public string? ModuleSubnet
+    {
+        get => _moduleSubnet;
+        set => SetProperty(ref _moduleSubnet, value);
     }
 
     // Overall status

--- a/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
+++ b/Shared/AgValoniaGPS.Services/AutoSteer/PgnBuilder.cs
@@ -359,6 +359,50 @@ public static class PgnBuilder
         return crc;
     }
 
+    // ===== Module network config (AgIO parity: FormUDP.cs / UDP.designer.cs) =====
+    // These reproduce AgIO's exact wire bytes so the existing AiO board install
+    // base responds correctly. AgIO hardcodes the trailing CRC byte (0x47) for
+    // the scan (202) and set-subnet (201) packets and the modules validate only
+    // the magic bytes (data[5]/[6]), not the CRC — so we keep 0x47 verbatim.
+
+    /// <summary>
+    /// Build PGN 202 — "scan request" broadcast that asks every module to reply
+    /// with its IP/subnet (PGN 203). Exact AgIO bytes:
+    /// { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 }.
+    /// </summary>
+    public static byte[] BuildScanRequest()
+        => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SCAN_REQUEST, 3, 202, 202, 5, 0x47 };
+
+    /// <summary>
+    /// Build PGN 201 — "set subnet" broadcast. Changes the first three IP octets
+    /// (the /24) on ALL modules at once; the host octet is preserved by each
+    /// module. There is no per-module selector — this is global, matching AgIO.
+    /// Exact AgIO bytes: { 0x80, 0x81, 0x7F, 201, 5, 201, 201, o1, o2, o3, 0x47 }.
+    /// </summary>
+    public static byte[] BuildSubnetChange(byte octet1, byte octet2, byte octet3)
+        => new byte[] { HEADER1, HEADER2, SOURCE, PgnNumbers.SET_SUBNET, 5, 201, 201, octet1, octet2, octet3, 0x47 };
+
+    /// <summary>
+    /// Parse a PGN 203 scan reply (13 bytes): module id at [2], full module IP at
+    /// [5..8], subnet (3 octets) at [9..11]. Returns false if not a well-formed
+    /// scan reply. Pure so it can be unit-tested without sockets.
+    /// </summary>
+    public static bool TryParseScanReply(byte[] data, out byte moduleId, out string ip, out string subnet)
+    {
+        moduleId = 0;
+        ip = string.Empty;
+        subnet = string.Empty;
+
+        if (data == null || data.Length < 12) return false;
+        if (data[0] != HEADER1 || data[1] != HEADER2) return false;
+        if (data[3] != PgnNumbers.SCAN_REPLY) return false;
+
+        moduleId = data[2];
+        ip = $"{data[5]}.{data[6]}.{data[7]}.{data[8]}";
+        subnet = $"{data[9]}.{data[10]}.{data[11]}";
+        return true;
+    }
+
     /// <summary>
     /// Validate a received PGN checksum.
     /// </summary>

--- a/Shared/AgValoniaGPS.Services/Interfaces/IUdpCommunicationService.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IUdpCommunicationService.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -45,6 +46,11 @@ public interface IUdpCommunicationService
     /// Local IP address being used
     /// </summary>
     string? LocalIPAddress { get; }
+
+    /// <summary>
+    /// All non-loopback IPv4 addresses of the host's up network interfaces.
+    /// </summary>
+    IReadOnlyList<string> GetLocalIpAddresses();
 
     /// <summary>
     /// Start UDP communication service
@@ -84,6 +90,25 @@ public interface IUdpCommunicationService
     /// has been received from it yet. Dotted-quad string (no port).
     /// </summary>
     string? GetModuleIpAddress(ModuleType moduleType);
+
+    /// <summary>
+    /// The /24 subnet (first three octets, e.g. "192.168.5") most recently
+    /// reported by a module in a PGN 203 scan reply, or null if none seen.
+    /// </summary>
+    string? GetModuleSubnet();
+
+    /// <summary>
+    /// Broadcast a scan request (PGN 202) asking every module to reply with its
+    /// IP + subnet (PGN 203). Matches AgIO's FormUDP "Scan" button.
+    /// </summary>
+    void ScanModules();
+
+    /// <summary>
+    /// Broadcast a set-subnet command (PGN 201) changing the first three IP octets
+    /// (/24) on ALL modules at once, then re-arm discovery so the app follows the
+    /// modules onto their new subnet. Matches AgIO's "Send Subnet" button.
+    /// </summary>
+    void SetModuleSubnet(byte octet1, byte octet2, byte octet3);
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
+++ b/Shared/AgValoniaGPS.Services/UdpCommunicationService.cs
@@ -23,6 +23,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using AgValoniaGPS.Models;
+using AgValoniaGPS.Services.AutoSteer;
 using AgValoniaGPS.Services.Interfaces;
 
 namespace AgValoniaGPS.Services;
@@ -73,10 +74,13 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
     private DateTime _lastDataFromIMU = DateTime.MinValue;
 
     // Per-module remote IP from the most recent inbound packet. Populated from
-    // HELLO_FROM_* (and AutoSteer data PGNs, which also identify the module).
+    // HELLO_FROM_* (and AutoSteer data PGNs, which also identify the module), and
+    // authoritatively from a PGN 203 scan reply (which also carries GPS + subnet).
     private string? _autoSteerIp;
     private string? _machineIp;
     private string? _imuIp;
+    private string? _gpsIp;
+    private string? _moduleSubnet;
 
     private const int HELLO_TIMEOUT_MS = 2000; // 2 seconds for hello response
     private const int DATA_TIMEOUT_STEER_MACHINE_MS = 100; // 50Hz data = 20ms cycle, allow 100ms
@@ -347,7 +351,7 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
                 byte pgn = data[3];
 
                 // Track module connections based on hello messages
-                UpdateModuleConnection(pgn, remoteEndPoint);
+                UpdateModuleConnection(data, remoteEndPoint);
 
                 // Fire event
                 DataReceived?.Invoke(this, new UdpDataReceivedEventArgs
@@ -442,14 +446,32 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
         _perfTxWindowStart = DateTime.UtcNow;
     }
 
-    private void UpdateModuleConnection(byte pgn, IPEndPoint remoteEndPoint)
+    private void UpdateModuleConnection(byte[] data, IPEndPoint remoteEndPoint)
     {
         var now = DateTime.Now;
         var remoteIp = remoteEndPoint.Address.ToString();
+        byte pgn = data[3];
 
         // Track ALL PGNs as data - if we're getting any PGN from a module, it's sending data
         switch (pgn)
         {
+            // Scan reply: the module self-reports its full IP + subnet (and is the
+            // only inbound PGN that carries the GPS module's IP).
+            case PgnNumbers.SCAN_REPLY: // 203
+                if (PgnBuilder.TryParseScanReply(data, out byte moduleId, out string scanIp, out string scanSubnet))
+                {
+                    _moduleSubnet = scanSubnet;
+                    switch (moduleId)
+                    {
+                        case 126: _autoSteerIp = scanIp; break;
+                        case 123: _machineIp = scanIp; break;
+                        case 121: _imuIp = scanIp; break;
+                        case 120: _gpsIp = scanIp; break;
+                    }
+                    _lastModuleResponse = DateTime.UtcNow;
+                }
+                break;
+
             // AutoSteer PGNs
             case PgnNumbers.HELLO_FROM_AUTOSTEER: // 126
                 _lastHelloFromAutoSteer = now;
@@ -500,8 +522,94 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
         ModuleType.AutoSteer => _autoSteerIp,
         ModuleType.Machine   => _machineIp,
         ModuleType.IMU       => _imuIp,
+        ModuleType.GPS       => _gpsIp,
         _                    => null,
     };
+
+    /// <summary>
+    /// The /24 subnet (first three octets) most recently reported by a module in
+    /// a PGN 203 scan reply, or null if no scan reply has been seen.
+    /// </summary>
+    public string? GetModuleSubnet() => _moduleSubnet;
+
+    /// <summary>
+    /// Broadcast a scan request (PGN 202). Modules reply with PGN 203 (parsed in
+    /// <see cref="UpdateModuleConnection"/> into per-module IP + subnet).
+    /// </summary>
+    public void ScanModules() => SendModuleConfig(PgnBuilder.BuildScanRequest());
+
+    /// <summary>
+    /// Broadcast a set-subnet command (PGN 201, global /24 change), then re-arm
+    /// discovery so the next module hellos re-lock the new subnet.
+    /// </summary>
+    public void SetModuleSubnet(byte octet1, byte octet2, byte octet3)
+    {
+        SendModuleConfig(PgnBuilder.BuildSubnetChange(octet1, octet2, octet3));
+        ResetDiscovery();
+    }
+
+    /// <summary>
+    /// Send a module-config packet (scan request 202 / set-subnet 201) to the
+    /// GLOBAL broadcast 255.255.255.255:8888, once per up IPv4 NIC — matching
+    /// AgIO's FormUDP behaviour. Global (not directed subnet.255) broadcast is
+    /// deliberate so the packet reaches modules that are currently on a different
+    /// or unknown subnet. Also hits localhost for the simulator/ModSim.
+    /// </summary>
+    private void SendModuleConfig(byte[] data)
+    {
+        if (!IsConnected) return;
+
+        // Simulator / ModSim listens on loopback.
+        try { _udpSocket?.SendTo(data, _localhostEndpoint); } catch { }
+
+        var dest = new IPEndPoint(IPAddress.Broadcast, 8888);
+        try
+        {
+            foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (nic.OperationalStatus != OperationalStatus.Up) continue;
+                if (!nic.Supports(NetworkInterfaceComponent.IPv4)) continue;
+
+                foreach (var addr in nic.GetIPProperties().UnicastAddresses)
+                {
+                    if (addr.Address.AddressFamily != AddressFamily.InterNetwork) continue;
+                    if (IPAddress.IsLoopback(addr.Address)) continue;
+
+                    try
+                    {
+                        // Bind a transient socket to this NIC so the broadcast
+                        // actually egresses it (multi-homed tablets), exactly as
+                        // AgIO does. ReuseAddress lets us co-bind :9999 with the
+                        // main receive socket; replies still arrive on it.
+                        using var s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                        s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
+                        s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                        s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontRoute, true);
+                        s.Bind(new IPEndPoint(addr.Address, 9999));
+                        s.SendTo(data, dest);
+                    }
+                    catch { }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[UDP] SendModuleConfig failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Drop the locked send endpoint and refresh discovery so the next module
+    /// hellos re-lock the (possibly new) subnet. Call right after a subnet change
+    /// so the app follows the modules to their new /24 instead of waiting out the
+    /// module-timeout.
+    /// </summary>
+    private void ResetDiscovery()
+    {
+        _lockedEndpoint = null;
+        _discoveryEndpoints = GetBroadcastEndpoints();
+        _lastDiscoveryRefresh = DateTime.UtcNow;
+    }
 
     /// <summary>
     /// Lock outgoing packets to the subnet of a responding module.
@@ -579,6 +687,34 @@ public class UdpCommunicationService : IUdpCommunicationService, IDisposable
         catch { }
 
         return null;
+    }
+
+    /// <summary>
+    /// All non-loopback IPv4 addresses of the host's up network interfaces.
+    /// Lets the operator see which subnet the host is on so they can match the
+    /// modules' subnet.
+    /// </summary>
+    public IReadOnlyList<string> GetLocalIpAddresses()
+    {
+        var list = new List<string>();
+        try
+        {
+            foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (nic.OperationalStatus != OperationalStatus.Up) continue;
+                if (!nic.Supports(NetworkInterfaceComponent.IPv4)) continue;
+
+                foreach (var addr in nic.GetIPProperties().UnicastAddresses)
+                {
+                    if (addr.Address.AddressFamily != AddressFamily.InterNetwork) continue;
+                    if (IPAddress.IsLoopback(addr.Address)) continue;
+                    var s = addr.Address.ToString();
+                    if (!list.Contains(s)) list.Add(s);
+                }
+            }
+        }
+        catch { }
+        return list;
     }
 
     public void Dispose()

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
@@ -87,6 +87,13 @@ public partial class MainViewModel
             IsFieldToolsPanelVisible = open;
         });
 
+        ToggleNetworkIoPanelCommand = new RelayCommand(() =>
+        {
+            bool open = !IsNetworkIoPanelVisible;
+            CloseAllNavFlyouts();
+            IsNetworkIoPanelVisible = open;
+        });
+
         // The fly-out close (X) is a pure close, not a toggle: a toggle would
         // re-open the panel because the bubbling item-close already shut it.
         CloseAllNavFlyoutsCommand = new RelayCommand(CloseAllNavFlyouts);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Ntrip.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Ntrip.cs
@@ -44,6 +44,17 @@ public partial class MainViewModel
             SelectedNtripProfile = null;
         });
 
+        // Back: dismiss the dialog and reopen the Network IO panel it was
+        // launched from (CloseDialog fires DialogChanged with Current=None, so
+        // it does NOT re-close the fly-out we open here).
+        BackFromNtripProfilesCommand = new RelayCommand(() =>
+        {
+            State.UI.CloseDialog();
+            SelectedNtripProfile = null;
+            CloseAllNavFlyouts();
+            IsNetworkIoPanelVisible = true;
+        });
+
         AddNtripProfileCommand = new RelayCommand(() =>
         {
             EditingNtripProfile = _ntripProfileService.CreateNewProfile("New Profile");

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.NetworkIO.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.NetworkIO.cs
@@ -1,0 +1,122 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Windows.Input;
+using AgValoniaGPS.Models.Configuration;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// Network IO: module scan (PGN 202), per-module IP/subnet readout (from PGN 203
+/// replies, surfaced via <c>State.Connections</c>), and the global subnet change
+/// (PGN 201). Mirrors AgIO's FormUDP so the existing AiO board install base works
+/// unchanged. The protocol bytes live in the UDP service; the VM only coordinates.
+/// </summary>
+public partial class MainViewModel
+{
+    /// <summary>Broadcast PGN 202 and ask every module to report its IP/subnet.</summary>
+    public ICommand? ScanModulesCommand { get; private set; }
+
+    /// <summary>Confirm, then broadcast PGN 201 to set the /24 on all modules.</summary>
+    public ICommand? SendSubnetCommand { get; private set; }
+
+    // Set true once settings finish loading, so the persistent module-present
+    // checkboxes save on user change but not during the initial load.
+    private bool _configReady;
+
+    /// <summary>
+    /// Persistent module-present configuration (the Network IO checkboxes).
+    /// A module shows present only when it is configured AND responding.
+    /// Bound directly (ObservableObject); saved via the ConfigStore.Connections
+    /// subscription in the constructor.
+    /// </summary>
+    public ConnectionConfig ConnectionConfig => ConfigStore.Connections;
+
+    /// <summary>
+    /// The host's own IPv4 addresses (one per up NIC), newline-separated, so the
+    /// operator can see which subnet the host is on and match the modules to it.
+    /// </summary>
+    public string HostIpAddressesText
+    {
+        get
+        {
+            var ips = _udpService.GetLocalIpAddresses();
+            return ips.Count == 0 ? "—" : string.Join("\n", ips);
+        }
+    }
+
+    private int _subnetOctet1 = 192;
+    public int SubnetOctet1
+    {
+        get => _subnetOctet1;
+        set => SetProperty(ref _subnetOctet1, ClampOctet(value));
+    }
+
+    private int _subnetOctet2 = 168;
+    public int SubnetOctet2
+    {
+        get => _subnetOctet2;
+        set => SetProperty(ref _subnetOctet2, ClampOctet(value));
+    }
+
+    private int _subnetOctet3 = 5;
+    public int SubnetOctet3
+    {
+        get => _subnetOctet3;
+        set => SetProperty(ref _subnetOctet3, ClampOctet(value));
+    }
+
+    private static int ClampOctet(int v) => v < 0 ? 0 : (v > 255 ? 255 : v);
+
+    private void InitializeNetworkIoCommands()
+    {
+        ScanModulesCommand = new RelayCommand(() =>
+        {
+            _udpService.ScanModules();
+            OnPropertyChanged(nameof(HostIpAddressesText));
+            StatusMessage = "Scanning network for modules…";
+        });
+
+        SendSubnetCommand = new RelayCommand(() =>
+        {
+            int o1 = SubnetOctet1, o2 = SubnetOctet2, o3 = SubnetOctet3;
+            ShowConfirmationDialog(
+                "Change Module Subnet",
+                $"Set ALL connected modules to subnet {o1}.{o2}.{o3}.x and restart them?\n\n" +
+                "This changes every module at once (there is no per-module setting).",
+                () =>
+                {
+                    _udpService.SetModuleSubnet((byte)o1, (byte)o2, (byte)o3);
+                    StatusMessage = $"Sent subnet {o1}.{o2}.{o3}.x to all modules";
+                });
+        });
+
+        // When a scan reply reveals the modules' current /24, reflect it in the
+        // entry fields so the operator edits from the live value (AgIO behaviour).
+        State.Connections.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(State.Connections.ModuleSubnet)) return;
+            var subnet = State.Connections.ModuleSubnet;
+            if (string.IsNullOrEmpty(subnet)) return;
+            var parts = subnet.Split('.');
+            if (parts.Length != 3) return;
+            if (int.TryParse(parts[0], out int a)) SubnetOctet1 = a;
+            if (int.TryParse(parts[1], out int b)) SubnetOctet2 = b;
+            if (int.TryParse(parts[2], out int c)) SubnetOctet3 = c;
+        };
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Ntrip.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Ntrip.cs
@@ -127,6 +127,58 @@ public partial class MainViewModel
     }
 
     /// <summary>
+    /// Loads NTRIP profiles then, if a default profile exists with auto-connect
+    /// enabled, connects to it at startup. Keeps corrections flowing to the GPS
+    /// from app launch so there is no wait when a field is opened.
+    /// </summary>
+    private async Task LoadProfilesThenAutoConnectAsync()
+    {
+        try
+        {
+            await _ntripProfileService.LoadProfilesAsync();
+            await ConnectDefaultNtripProfileOnStartupAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading NTRIP profiles / startup auto-connect");
+        }
+    }
+
+    /// <summary>
+    /// Connects to the default NTRIP profile at startup (if one is set and its
+    /// auto-connect is enabled, and we are not already connected). A field-loaded
+    /// later that has its own profile will switch via <see cref="HandleNtripProfileForFieldAsync"/>.
+    /// </summary>
+    private async Task ConnectDefaultNtripProfileOnStartupAsync()
+    {
+        var profile = _ntripProfileService.DefaultProfile;
+        if (profile == null)
+        {
+            _logger.LogDebug("No default NTRIP profile; skipping startup auto-connect");
+            return;
+        }
+
+        if (!profile.AutoConnectOnFieldLoad)
+        {
+            _logger.LogDebug("Default NTRIP profile '{ProfileName}' has auto-connect disabled", profile.Name);
+            return;
+        }
+
+        if (_ntripService.IsConnected)
+            return;
+
+        // Mirror the field-load path: reflect the profile in the display props.
+        NtripCasterAddress = profile.CasterHost;
+        NtripCasterPort = profile.CasterPort;
+        NtripMountPoint = profile.MountPoint;
+        NtripUsername = profile.Username;
+        NtripPassword = profile.Password;
+
+        _logger.LogInformation("Auto-connecting default NTRIP profile '{ProfileName}' at startup", profile.Name);
+        await ConnectToNtripAsync();
+    }
+
+    /// <summary>
     /// Handles NTRIP profile connection when a field is loaded.
     /// Checks for field-specific profile or falls back to default profile.
     /// </summary>
@@ -145,6 +197,18 @@ public partial class MainViewModel
             if (!profile.AutoConnectOnFieldLoad)
             {
                 _logger.LogDebug("NTRIP profile '{ProfileName}' has auto-connect disabled", profile.Name);
+                return;
+            }
+
+            // Already connected to this exact caster (e.g. the default connected at
+            // startup, and this field uses the default) — leave it alone so
+            // corrections keep flowing without a disconnect/reconnect blip.
+            if (_ntripService.IsConnected &&
+                profile.CasterHost == NtripCasterAddress &&
+                profile.CasterPort == NtripCasterPort &&
+                profile.MountPoint == NtripMountPoint)
+            {
+                _logger.LogDebug("NTRIP already connected to '{ProfileName}' caster; keeping it", profile.Name);
                 return;
             }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -40,6 +40,7 @@ public partial class MainViewModel
     private bool _isConfigurationPanelVisible;
     private bool _isFieldOperationsPanelVisible;
     private bool _isFieldToolsPanelVisible;
+    private bool _isNetworkIoPanelVisible;
     private bool _isSimulatorPanelVisible;
     private bool _isSteerChartPanelVisible;
     private bool _isHeadingChartPanelVisible;
@@ -85,11 +86,18 @@ public partial class MainViewModel
         set { SetProperty(ref _isFieldToolsPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
     }
 
+    public bool IsNetworkIoPanelVisible
+    {
+        get => _isNetworkIoPanelVisible;
+        set { SetProperty(ref _isNetworkIoPanelVisible, value); OnPropertyChanged(nameof(IsAnyNavFlyoutOpen)); }
+    }
+
     /// <summary>True while any left-nav fly-out is open. Drives the light-dismiss
     /// scrim that closes the open menu when the operator taps outside it.</summary>
     public bool IsAnyNavFlyoutOpen =>
         IsScreenAlertsPanelVisible || IsFileMenuPanelVisible || IsToolsPanelVisible
-        || IsConfigurationPanelVisible || IsFieldOperationsPanelVisible || IsFieldToolsPanelVisible;
+        || IsConfigurationPanelVisible || IsFieldOperationsPanelVisible || IsFieldToolsPanelVisible
+        || IsNetworkIoPanelVisible;
 
     public bool IsSimulatorPanelVisible
     {
@@ -128,6 +136,7 @@ public partial class MainViewModel
         IsConfigurationPanelVisible = false;
         IsFieldOperationsPanelVisible = false;
         IsFieldToolsPanelVisible = false;
+        IsNetworkIoPanelVisible = false;
     }
 
     #endregion

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -294,6 +294,10 @@ public partial class MainViewModel : ObservableObject
                 case nameof(Models.Configuration.ConnectionConfig.IsAutoSteerConfigured):
                 case nameof(Models.Configuration.ConnectionConfig.IsMachineConfigured):
                     RaiseModuleStatusKindChanged();
+                    // Module-present checkboxes (Network IO panel) are persistent
+                    // config. Save on user change only — never during the initial
+                    // settings load (guarded by _configReady).
+                    if (_configReady) _configurationService.SaveAppSettings();
                     break;
             }
         };
@@ -513,6 +517,7 @@ public partial class MainViewModel : ObservableObject
         InitializeTrackManagementCommands();
         InitializeRecordedPathCommands();
         InitializeNtripCommands();
+        InitializeNetworkIoCommands();
         InitializeWizardCommands();
         InitializeSettingsCommands();
         InitializeHotkeyCommands();
@@ -524,6 +529,11 @@ public partial class MainViewModel : ObservableObject
         // IMPORTANT: Run synchronously to ensure settings are loaded before any save can occur
         _displaySettings.LoadSettings();
         RestoreSettings();
+
+        // Settings are now loaded; subsequent ConnectionConfig changes are
+        // user-driven and should persist (see the ConfigStore.Connections
+        // subscription above).
+        _configReady = true;
 
         // Apply theme variant based on saved day/night mode
         ApplyThemeVariant(IsDayMode);
@@ -690,8 +700,9 @@ public partial class MainViewModel : ObservableObject
         // Restore vehicle profile settings
         LoadDefaultVehicleProfile();
 
-        // Load NTRIP profiles
-        _ = _ntripProfileService.LoadProfilesAsync();
+        // Load NTRIP profiles, then auto-connect the default caster at startup so
+        // GPS gets RTCM corrections immediately (no wait when opening a field).
+        _ = LoadProfilesThenAutoConnectAsync();
 
         // Restore legacy NTRIP settings (used if no profiles exist)
         NtripCasterAddress = settings.NtripCasterIp;
@@ -881,6 +892,9 @@ public partial class MainViewModel : ObservableObject
                 State.Connections.AutoSteerIpAddress = _udpService.GetModuleIpAddress(ModuleType.AutoSteer);
                 State.Connections.MachineIpAddress = _udpService.GetModuleIpAddress(ModuleType.Machine);
                 State.Connections.ImuIpAddress = _udpService.GetModuleIpAddress(ModuleType.IMU);
+                // GPS IP + subnet are only known after a PGN 203 scan reply.
+                State.Connections.GpsIpAddress = _udpService.GetModuleIpAddress(ModuleType.GPS);
+                State.Connections.ModuleSubnet = _udpService.GetModuleSubnet();
 
                 // Legacy property updates (for existing bindings - will be removed in Phase 5)
                 IsAutoSteerDataOk = steerOk;
@@ -2369,6 +2383,7 @@ public partial class MainViewModel : ObservableObject
     // NTRIP Profiles commands
     public ICommand? ShowNtripProfilesDialogCommand { get; private set; }
     public ICommand? CloseNtripProfilesDialogCommand { get; private set; }
+    public ICommand? BackFromNtripProfilesCommand { get; private set; }
     public ICommand? AddNtripProfileCommand { get; private set; }
     public ICommand? EditNtripProfileCommand { get; private set; }
     public ICommand? DeleteNtripProfileCommand { get; private set; }
@@ -3593,6 +3608,7 @@ public partial class MainViewModel : ObservableObject
     public ICommand? ToggleConfigurationPanelCommand { get; private set; }
     public ICommand? ToggleFieldOperationsPanelCommand { get; private set; }
     public ICommand? ToggleFieldToolsPanelCommand { get; private set; }
+    public ICommand? ToggleNetworkIoPanelCommand { get; private set; }
     public ICommand? CloseAllNavFlyoutsCommand { get; private set; }
     public ICommand? ToggleAutoTrackCommand { get; private set; }
     public ICommand? ToggleGridCommand { get; private set; }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
@@ -96,54 +96,48 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 MinWidth="420"
                 MaxWidth="500"
                 Padding="20">
-            <StackPanel Spacing="12">
+            <StackPanel Spacing="8">
                 <!-- Header -->
-                <TextBlock Classes="Header" Text="{loc:Localize EditNtripProfile}"/>
+                <TextBlock Classes="Header" Text="{loc:Localize EditNtripProfile}" Margin="0,0,0,4"/>
 
-                <!-- Profile Name -->
-                <StackPanel>
-                    <TextBlock Classes="Label" Text="{loc:Localize ProfileName}"/>
-                    <TextBox Text="{Binding EditingNtripProfile.Name, FallbackValue='', TargetNullValue=''}" Watermark="e.g., Local Base Station"/>
-                </StackPanel>
-
-                <!-- Separator -->
-                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
-
-                <!-- Caster Settings Section -->
-                <TextBlock Text="{loc:Localize CasterSettings}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
-
-                <!-- Host -->
-                <StackPanel>
-                    <TextBlock Classes="Label" Text="{loc:Localize CasterHost}"/>
-                    <TextBox Text="{Binding EditingNtripProfile.CasterHost, FallbackValue='', TargetNullValue=''}" Watermark="e.g., rtk2go.com"/>
-                </StackPanel>
-
-                <!-- Port -->
-                <Grid ColumnDefinitions="*,*" Margin="0,0,0,0">
-                    <StackPanel Grid.Column="0" Margin="0,0,6,0">
-                        <TextBlock Classes="Label" Text="{loc:Localize Port}"/>
-                        <TextBox Text="{Binding EditingNtripProfile.CasterPort, FallbackValue=2101}" Watermark="2101"/>
-                    </StackPanel>
-                    <StackPanel Grid.Column="1" Margin="6,0,0,0">
-                        <TextBlock Classes="Label" Text="{loc:Localize MountPoint}"/>
-                        <TextBox Text="{Binding EditingNtripProfile.MountPoint, FallbackValue='', TargetNullValue=''}" Watermark="NEAR-RTCM3"/>
-                    </StackPanel>
+                <!-- Profile Name (label inline to save vertical space) -->
+                <Grid ColumnDefinitions="62,*">
+                    <TextBlock Grid.Column="0" Classes="Label" Text="Name" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBox Grid.Column="1" Text="{Binding EditingNtripProfile.Name, FallbackValue='', TargetNullValue=''}" Watermark="e.g., Local Base Station"/>
                 </Grid>
 
-                <!-- Credentials -->
-                <Grid ColumnDefinitions="*,*" Margin="0,0,0,0">
-                    <StackPanel Grid.Column="0" Margin="0,0,6,0">
-                        <TextBlock Classes="Label" Text="{loc:Localize Username}"/>
-                        <TextBox Text="{Binding EditingNtripProfile.Username, FallbackValue='', TargetNullValue=''}" Watermark="(optional)"/>
-                    </StackPanel>
-                    <StackPanel Grid.Column="1" Margin="6,0,0,0">
-                        <TextBlock Classes="Label" Text="{loc:Localize Password}"/>
-                        <TextBox Text="{Binding EditingNtripProfile.Password, FallbackValue='', TargetNullValue=''}" Watermark="(optional)" PasswordChar="*"/>
-                    </StackPanel>
+                <!-- Caster: Host -->
+                <Grid ColumnDefinitions="62,*">
+                    <TextBlock Grid.Column="0" Classes="Label" Text="Host" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBox Grid.Column="1" Text="{Binding EditingNtripProfile.CasterHost, FallbackValue='', TargetNullValue=''}" Watermark="e.g., rtk2go.com"/>
+                </Grid>
+
+                <!-- Port | Mount (labels inline) -->
+                <Grid ColumnDefinitions="*,*">
+                    <Grid Grid.Column="0" ColumnDefinitions="Auto,*" Margin="0,0,6,0">
+                        <TextBlock Grid.Column="0" Classes="Label" Text="Port" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <TextBox Grid.Column="1" Text="{Binding EditingNtripProfile.CasterPort, FallbackValue=2101}" Watermark="2101"/>
+                    </Grid>
+                    <Grid Grid.Column="1" ColumnDefinitions="Auto,*" Margin="6,0,0,0">
+                        <TextBlock Grid.Column="0" Classes="Label" Text="Mount" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <TextBox Grid.Column="1" Text="{Binding EditingNtripProfile.MountPoint, FallbackValue='', TargetNullValue=''}" Watermark="NEAR-RTCM3"/>
+                    </Grid>
+                </Grid>
+
+                <!-- User | Pass (labels inline) -->
+                <Grid ColumnDefinitions="*,*">
+                    <Grid Grid.Column="0" ColumnDefinitions="Auto,*" Margin="0,0,6,0">
+                        <TextBlock Grid.Column="0" Classes="Label" Text="User" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <TextBox Grid.Column="1" Text="{Binding EditingNtripProfile.Username, FallbackValue='', TargetNullValue=''}" Watermark="(optional)"/>
+                    </Grid>
+                    <Grid Grid.Column="1" ColumnDefinitions="Auto,*" Margin="6,0,0,0">
+                        <TextBlock Grid.Column="0" Classes="Label" Text="Pass" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <TextBox Grid.Column="1" Text="{Binding EditingNtripProfile.Password, FallbackValue='', TargetNullValue=''}" Watermark="(optional)" PasswordChar="*"/>
+                    </Grid>
                 </Grid>
 
                 <!-- Test Connection -->
-                <Grid ColumnDefinitions="Auto,*" Margin="0,8,0,0">
+                <Grid ColumnDefinitions="Auto,*">
                     <Button Grid.Column="0" Classes="DialogButton TestButton" Content="{loc:Localize TestConnection}"
                             Command="{Binding TestNtripConnectionCommand}"
                             IsEnabled="{Binding !IsTestingNtripConnection}"/>
@@ -154,29 +148,25 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Grid>
 
                 <!-- Separator -->
-                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,2"/>
 
                 <!-- Field Associations Section -->
                 <TextBlock Text="{loc:Localize AssociatedFields}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="14" FontWeight="SemiBold"/>
-                <TextBlock Text="{loc:Localize SelectFieldsThatWillUseThisNtripProfile}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="12" Margin="0,0,0,4"/>
 
                 <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" CornerRadius="4"
-                        MaxHeight="120" Padding="4">
+                        MaxHeight="96" Padding="4">
                     <ScrollViewer>
                         <ItemsControl ItemsSource="{Binding AvailableFieldsForProfile}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate x:DataType="ntrip:FieldAssociationItem">
                                     <CheckBox IsChecked="{Binding IsSelected}" Content="{Binding FieldName}"
-                                              Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13" Margin="4,2"/>
+                                              Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13" Margin="4,1"/>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
                     </ScrollViewer>
                 </Border>
-                <TextBlock Text="{loc:Localize FieldsNotSelectedWillUseTheDefaultProfileIfSet}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11" Margin="0,4,0,0"/>
-
-                <!-- Separator -->
-                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <TextBlock Text="{loc:Localize FieldsNotSelectedWillUseTheDefaultProfileIfSet}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" FontSize="11"/>
 
                 <!-- Options -->
                 <CheckBox IsChecked="{Binding EditingNtripProfile.AutoConnectOnFieldLoad, FallbackValue=True}"
@@ -185,17 +175,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <CheckBox IsChecked="{Binding EditingNtripProfile.IsDefault, FallbackValue=False}"
                           Content="{loc:Localize SetAsDefaultProfileForFieldsWithoutSpecificAssociation}"/>
 
-                <!-- Action Buttons -->
-                <Grid ColumnDefinitions="*,Auto,Auto" Margin="0,8,0,0">
-                    <!-- Spacer -->
-                    <Border Grid.Column="0"/>
-
-                    <!-- Cancel Button -->
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
+                <!-- Action Buttons: Back (to profile list) · Close (dismiss) · Save -->
+                <Grid ColumnDefinitions="Auto,Auto,*,Auto" Margin="0,6,0,0">
+                    <Button Grid.Column="0" Classes="DialogButton CancelButton" Content="Back"
                             Command="{Binding CancelNtripProfileEditCommand}" Margin="0,0,8,0"/>
-
-                    <!-- Save Button -->
-                    <Button Grid.Column="2" Classes="DialogButton" Content="{loc:Localize SaveProfile}"
+                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Close"
+                            Command="{Binding CloseNtripProfilesDialogCommand}"/>
+                    <Button Grid.Column="3" Classes="DialogButton" Content="{loc:Localize SaveProfile}"
                             Command="{Binding SaveNtripProfileCommand}"/>
                 </Grid>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
@@ -181,13 +181,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </ListBox.ItemTemplate>
                 </ListBox>
 
-                <!-- Action Buttons -->
-                <Grid Grid.Row="4" ColumnDefinitions="*,Auto" Margin="0,12,0,0">
-                    <!-- Spacer -->
-                    <Border Grid.Column="0"/>
+                <!-- Action Buttons: Back (to Network IO) · Close (dismiss) -->
+                <Grid Grid.Row="4" ColumnDefinitions="Auto,*,Auto" Margin="0,12,0,0">
+                    <Button Grid.Column="0" Classes="DialogButton CancelButton" Content="Back"
+                            Command="{Binding BackFromNtripProfilesCommand}"/>
 
                     <!-- Close Button -->
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Close}"
+                    <Button Grid.Column="2" Classes="DialogButton CancelButton" Content="{loc:Localize Close}"
                             Command="{Binding CloseNtripProfilesDialogCommand}"/>
                 </Grid>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/FileMenuPanel.axaml
@@ -60,10 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-                <!-- NTRIP Profiles -->
-                <Button Classes="MenuListButton" Content="{loc:Localize NtripProfiles}"    HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ShowNtripProfilesDialogCommand}"/>
-
-                <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
+                <!-- NTRIP moved to the Network IO panel (left-nav). -->
 
                 <!-- Simulator -->
                 <Button Classes="MenuListButton" Content="{loc:Localize Simulator}"        HorizontalAlignment="Stretch" Margin="0,2" ClickMode="Press" Command="{Binding ToggleSimulatorPanelCommand}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml
@@ -106,6 +106,36 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         Command="{Binding ShowAutoSteerConfigCommand}">
                     <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoSteerConf.png" Stretch="Uniform"/>
                 </Button>
+
+                <!-- 8. Network IO (modules + NTRIP). Vector network glyph (hub +
+                     nodes) using the theme foreground so it contrasts on the
+                     blue/gray button in both light and dark themes. -->
+                <Button Classes="LeftPanelButton" ToolTip.Tip="Network IO"
+                        Command="{Binding ToggleNetworkIoPanelCommand}">
+                    <Viewbox Stretch="Uniform">
+                        <Canvas Width="48" Height="48">
+                            <Canvas.Styles>
+                                <Style Selector="Line">
+                                    <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                    <Setter Property="StrokeThickness" Value="2.5"/>
+                                </Style>
+                                <Style Selector="Ellipse">
+                                    <Setter Property="Fill" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                </Style>
+                            </Canvas.Styles>
+                            <!-- spokes from the hub to each node -->
+                            <Line StartPoint="24,24" EndPoint="24,10"/>
+                            <Line StartPoint="24,24" EndPoint="11,37"/>
+                            <Line StartPoint="24,24" EndPoint="37,37"/>
+                            <!-- hub -->
+                            <Ellipse Canvas.Left="17" Canvas.Top="17" Width="14" Height="14"/>
+                            <!-- nodes -->
+                            <Ellipse Canvas.Left="18" Canvas.Top="4" Width="12" Height="12"/>
+                            <Ellipse Canvas.Left="5" Canvas.Top="31" Width="12" Height="12"/>
+                            <Ellipse Canvas.Left="31" Canvas.Top="31" Width="12" Height="12"/>
+                        </Canvas>
+                    </Viewbox>
+                </Button>
             </StackPanel>
         </Border>
 
@@ -116,6 +146,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Canvas.Left="90" Canvas.Top="0"
                                     ZIndex="15"
                                     DataContext="{Binding}"/>
+
+        <!-- Network IO Panel -->
+        <controls:NetworkIoPanel x:Name="NetworkIoPanelControl"
+                                 Canvas.Left="90" Canvas.Top="0"
+                                 ZIndex="15"
+                                 DataContext="{Binding}"/>
 
         <!-- File Menu Panel -->
         <controls:FileMenuPanel x:Name="FileMenuPanelControl"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
@@ -29,6 +29,7 @@ public partial class LeftNavigationPanel : UserControl
         // Wire up sub-panel drag events
         // SimulatorPanel moved to the window-level floating canvas (see platform views)
         WireUpSubPanelDrag<ScreenAlertsPanel>("ScreenAlertsPanelControl");
+        WireUpSubPanelDrag<NetworkIoPanel>("NetworkIoPanelControl");
         WireUpSubPanelDrag<FileMenuPanel>("FileMenuPanelControl");
         WireUpSubPanelDrag<ToolsPanel>("ToolsPanelControl");
         WireUpSubPanelDrag<ConfigurationPanel>("ConfigurationPanelControl");

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml
@@ -1,0 +1,203 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2026 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
+             xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
+             xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             x:Class="AgValoniaGPS.Views.Controls.Panels.NetworkIoPanel"
+             x:DataType="vm:MainViewModel"
+             IsVisible="{Binding IsNetworkIoPanelVisible}"
+             IsHitTestVisible="{Binding IsNetworkIoPanelVisible}">
+
+    <UserControl.Styles>
+        <Style Selector="TextBlock.NioHeader">
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Margin" Value="2,2,0,2"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="TextBlock.NioModule">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="TextBlock.NioIp">
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontFamily" Value="Consolas,Menlo,monospace"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+        </Style>
+        <Style Selector="Ellipse.NioDot">
+            <Setter Property="Width" Value="12"/>
+            <Setter Property="Height" Value="12"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="2,0,8,0"/>
+        </Style>
+        <Style Selector="TextBox.NioOctet">
+            <Setter Property="Width" Value="48"/>
+            <Setter Property="TextAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+    </UserControl.Styles>
+
+    <controls:FloatingPanel x:Name="FP"
+                            Title="{loc:Localize NetworkIo}"
+                            CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
+        <controls:FloatingPanel.PanelContent>
+            <!-- Sized to roughly the left-nav height; the three '*' gap rows
+                 spread the sections out vertically. -->
+            <Grid Width="380" Height="510"
+                  RowDefinitions="Auto,Auto,Auto,*,Auto,Auto,Auto,*,Auto,Auto,*,Auto,Auto,Auto,Auto">
+
+                <!-- ===== Modules ===== -->
+                <TextBlock Grid.Row="0" Text="{loc:Localize Modules}" Classes="NioHeader"/>
+
+                <!-- Checkbox = "module should be present" (persistent config). The
+                     status dot is green only when configured AND responding. -->
+                <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,*,Auto" RowDefinitions="Auto,Auto,Auto,Auto"
+                      Margin="2,0" ColumnSpacing="4">
+                    <!-- GPS -->
+                    <CheckBox Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"
+                              IsChecked="{Binding ConnectionConfig.IsGpsConfigured, Mode=TwoWay}"
+                              ToolTip.Tip="GPS module should be present"/>
+                    <Ellipse Grid.Row="0" Grid.Column="1" Classes="NioDot">
+                        <Ellipse.Fill>
+                            <MultiBinding Converter="{x:Static conv:ModulePresenceToColorConverter.Instance}">
+                                <Binding Path="ConnectionConfig.IsGpsConfigured"/>
+                                <Binding Path="State.Connections.IsGpsDataOk"/>
+                            </MultiBinding>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <TextBlock Grid.Row="0" Grid.Column="2" Classes="NioModule" Text="GPS"/>
+                    <TextBlock Grid.Row="0" Grid.Column="3" Classes="NioIp"
+                               Text="{Binding State.Connections.GpsIpAddress, TargetNullValue=—}"/>
+                    <!-- AutoSteer -->
+                    <CheckBox Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"
+                              IsChecked="{Binding ConnectionConfig.IsAutoSteerConfigured, Mode=TwoWay}"
+                              ToolTip.Tip="AutoSteer module should be present"/>
+                    <Ellipse Grid.Row="1" Grid.Column="1" Classes="NioDot">
+                        <Ellipse.Fill>
+                            <MultiBinding Converter="{x:Static conv:ModulePresenceToColorConverter.Instance}">
+                                <Binding Path="ConnectionConfig.IsAutoSteerConfigured"/>
+                                <Binding Path="State.Connections.IsAutoSteerDataOk"/>
+                            </MultiBinding>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <TextBlock Grid.Row="1" Grid.Column="2" Classes="NioModule" Text="AutoSteer"/>
+                    <TextBlock Grid.Row="1" Grid.Column="3" Classes="NioIp"
+                               Text="{Binding State.Connections.AutoSteerIpAddress, TargetNullValue=—}"/>
+                    <!-- Machine -->
+                    <CheckBox Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"
+                              IsChecked="{Binding ConnectionConfig.IsMachineConfigured, Mode=TwoWay}"
+                              ToolTip.Tip="Machine module should be present"/>
+                    <Ellipse Grid.Row="2" Grid.Column="1" Classes="NioDot">
+                        <Ellipse.Fill>
+                            <MultiBinding Converter="{x:Static conv:ModulePresenceToColorConverter.Instance}">
+                                <Binding Path="ConnectionConfig.IsMachineConfigured"/>
+                                <Binding Path="State.Connections.IsMachineDataOk"/>
+                            </MultiBinding>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <TextBlock Grid.Row="2" Grid.Column="2" Classes="NioModule" Text="Machine"/>
+                    <TextBlock Grid.Row="2" Grid.Column="3" Classes="NioIp"
+                               Text="{Binding State.Connections.MachineIpAddress, TargetNullValue=—}"/>
+                    <!-- IMU -->
+                    <CheckBox Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"
+                              IsChecked="{Binding ConnectionConfig.IsImuConfigured, Mode=TwoWay}"
+                              ToolTip.Tip="IMU module should be present"/>
+                    <Ellipse Grid.Row="3" Grid.Column="1" Classes="NioDot">
+                        <Ellipse.Fill>
+                            <MultiBinding Converter="{x:Static conv:ModulePresenceToColorConverter.Instance}">
+                                <Binding Path="ConnectionConfig.IsImuConfigured"/>
+                                <Binding Path="State.Connections.IsImuDataOk"/>
+                            </MultiBinding>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <TextBlock Grid.Row="3" Grid.Column="2" Classes="NioModule" Text="IMU"/>
+                    <TextBlock Grid.Row="3" Grid.Column="3" Classes="NioIp"
+                               Text="{Binding State.Connections.ImuIpAddress, TargetNullValue=—}"/>
+                </Grid>
+
+                <Button Grid.Row="2" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="2,4,2,0"
+                        ClickMode="Press" Command="{Binding ScanModulesCommand}"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="{loc:Localize ScanModules}" FontSize="12"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Button>
+
+                <!-- (Grid.Row 3 is a flexible gap) -->
+
+                <!-- ===== Subnet (global IP change, PGN 201) — label inline ===== -->
+                <Grid Grid.Row="4" ColumnDefinitions="Auto,*" Margin="2,0">
+                    <TextBlock Grid.Column="0" Text="{loc:Localize ModuleSubnet}" Classes="NioHeader" Margin="0,0,8,0"/>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center">
+                        <TextBox Classes="NioOctet" Text="{Binding SubnetOctet1, Mode=TwoWay}"/>
+                        <TextBlock Text="." VerticalAlignment="Center" Margin="3,0" FontWeight="Bold"/>
+                        <TextBox Classes="NioOctet" Text="{Binding SubnetOctet2, Mode=TwoWay}"/>
+                        <TextBlock Text="." VerticalAlignment="Center" Margin="3,0" FontWeight="Bold"/>
+                        <TextBox Classes="NioOctet" Text="{Binding SubnetOctet3, Mode=TwoWay}"/>
+                        <TextBlock Text=".x" VerticalAlignment="Center" Margin="3,0"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                    </StackPanel>
+                </Grid>
+                <Button Grid.Row="5" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="2,4,2,0"
+                        ClickMode="Press" Command="{Binding SendSubnetCommand}"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="{loc:Localize SendSubnetToModules}" FontSize="12"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Button>
+                <TextBlock Grid.Row="6" Text="Changes ALL modules at once, then restarts them."
+                           FontSize="11" TextWrapping="Wrap" Margin="2,2,2,0"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+
+                <!-- (Grid.Row 7 is a flexible gap) -->
+
+                <!-- ===== Host IPs ===== -->
+                <TextBlock Grid.Row="8" Text="{loc:Localize HostIps}" Classes="NioHeader"/>
+                <TextBlock Grid.Row="9" Text="{Binding HostIpAddressesText}" Classes="NioIp"
+                           HorizontalAlignment="Left" Margin="2,0,2,0"/>
+
+                <!-- (Grid.Row 10 is a flexible gap) -->
+
+                <!-- Rule between Host IPs and NTRIP -->
+                <Separator Grid.Row="11" Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,2"/>
+
+                <!-- ===== NTRIP — label inline with status ===== -->
+                <Grid Grid.Row="12" ColumnDefinitions="Auto,Auto,*" Margin="2,4,2,0">
+                    <TextBlock Grid.Column="0" Text="{loc:Localize Ntrip}" Classes="NioHeader" Margin="0,0,8,0"/>
+                    <Ellipse Grid.Column="1" Classes="NioDot"
+                             Fill="{Binding State.Connections.IsNtripConnected, Converter={StaticResource BoolToColorConverter}}"/>
+                    <TextBlock Grid.Column="2" Classes="NioModule" Text="{Binding NtripStatus}"/>
+                </Grid>
+                <TextBlock Grid.Row="13" Text="{Binding NtripBytesReceived}" FontSize="12" Margin="2,0,2,0"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                <Button Grid.Row="14" Classes="ModernButton" HorizontalAlignment="Stretch" Margin="2,4,2,0"
+                        ClickMode="Press" Command="{Binding ShowNtripProfilesDialogCommand}"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                    <TextBlock Text="{loc:Localize NtripProfiles}" FontSize="12"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Button>
+
+            </Grid>
+        </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
+
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml.cs
@@ -1,0 +1,16 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// Licensed under GNU GPL v3. See LICENSE.md.
+
+using Avalonia.Controls;
+
+namespace AgValoniaGPS.Views.Controls.Panels;
+
+public partial class NetworkIoPanel : UserControl
+{
+    public NetworkIoPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
+++ b/Shared/AgValoniaGPS.Views/Converters/BoolToColorConverter.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using AgValoniaGPS.Models.State;
 using Avalonia.Data;
@@ -24,6 +25,29 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 
 namespace AgValoniaGPS.Views.Converters;
+
+/// <summary>
+/// Network IO module status dot: inputs [configured, present].
+/// Not configured → gray (don't care); configured &amp; present → green;
+/// configured &amp; absent → red. "Present" = the module is responding
+/// (data-ok / scan reply).
+/// </summary>
+public class ModulePresenceToColorConverter : IMultiValueConverter
+{
+    public static readonly ModulePresenceToColorConverter Instance = new();
+
+    private static readonly IBrush PresentBrush = new SolidColorBrush(Color.Parse("#2ECC71")); // green
+    private static readonly IBrush AbsentBrush = new SolidColorBrush(Color.Parse("#E74C3C"));  // red
+    private static readonly IBrush NotConfiguredBrush = new SolidColorBrush(Color.Parse("#5A6473")); // gray
+
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        bool configured = values.Count > 0 && values[0] is bool c && c;
+        bool present = values.Count > 1 && values[1] is bool p && p;
+        if (!configured) return NotConfiguredBrush;
+        return present ? PresentBrush : AbsentBrush;
+    }
+}
 
 public class BoolToColorConverter : IValueConverter
 {

--- a/Shared/AgValoniaGPS.Views/Localization/Strings.resx
+++ b/Shared/AgValoniaGPS.Views/Localization/Strings.resx
@@ -483,6 +483,27 @@
   <data xml:space="preserve" name="ViewSettings">
     <value>View Settings</value>
   </data>
+  <data xml:space="preserve" name="NetworkIo">
+    <value>Network IO</value>
+  </data>
+  <data xml:space="preserve" name="Modules">
+    <value>Modules</value>
+  </data>
+  <data xml:space="preserve" name="ScanModules">
+    <value>Scan for Modules</value>
+  </data>
+  <data xml:space="preserve" name="ModuleSubnet">
+    <value>Subnet</value>
+  </data>
+  <data xml:space="preserve" name="HostIps">
+    <value>Host IPs</value>
+  </data>
+  <data xml:space="preserve" name="SendSubnetToModules">
+    <value>Send Subnet to Modules</value>
+  </data>
+  <data xml:space="preserve" name="Ntrip">
+    <value>NTRIP</value>
+  </data>
   <data xml:space="preserve" name="ScreenAndAlerts">
     <value>Screen &amp; Alerts</value>
   </data>

--- a/Tests/AgValoniaGPS.Services.Tests/ModuleNetworkPgnTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/ModuleNetworkPgnTests.cs
@@ -1,0 +1,109 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2026 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using AgValoniaGPS.Services.AutoSteer;
+
+namespace AgValoniaGPS.Services.Tests;
+
+/// <summary>
+/// Byte-exact parity with AgIO's module-network PGNs (FormUDP.cs /
+/// UDP.designer.cs) so the existing AiO board install base responds correctly.
+/// </summary>
+[TestFixture]
+public class ModuleNetworkPgnTests
+{
+    // ===== PGN 202 — scan request =====
+
+    [Test]
+    public void BuildScanRequest_MatchesAgIoBytesExactly()
+    {
+        // AgIO FormUDP.cs:137 — { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 }
+        var expected = new byte[] { 0x80, 0x81, 0x7F, 202, 3, 202, 202, 5, 0x47 };
+        Assert.That(PgnBuilder.BuildScanRequest(), Is.EqualTo(expected));
+    }
+
+    // ===== PGN 201 — set subnet =====
+
+    [Test]
+    public void BuildSubnetChange_MatchesAgIoLayout_WithGivenOctets()
+    {
+        // AgIO FormUDP.cs:19 — { 0x80,0x81,0x7F,201,5,201,201, o1,o2,o3, 0x47 }
+        var pgn = PgnBuilder.BuildSubnetChange(192, 168, 5);
+        var expected = new byte[] { 0x80, 0x81, 0x7F, 201, 5, 201, 201, 192, 168, 5, 0x47 };
+        Assert.That(pgn, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BuildSubnetChange_OnlyOctets7To9Vary()
+    {
+        var a = PgnBuilder.BuildSubnetChange(10, 0, 0);
+        var b = PgnBuilder.BuildSubnetChange(172, 16, 9);
+
+        // Magic/header/crc bytes are identical; only [7..9] differ.
+        Assert.That(a[7], Is.EqualTo(10));
+        Assert.That(a[8], Is.EqualTo(0));
+        Assert.That(a[9], Is.EqualTo(0));
+        Assert.That(b[7], Is.EqualTo(172));
+        Assert.That(b[8], Is.EqualTo(16));
+        Assert.That(b[9], Is.EqualTo(9));
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (i is 7 or 8 or 9) continue;
+            Assert.That(a[i], Is.EqualTo(b[i]), $"byte {i} should be constant");
+        }
+    }
+
+    // ===== PGN 203 — scan reply parse =====
+
+    [Test]
+    public void TryParseScanReply_ExtractsModuleIpAndSubnet()
+    {
+        // module id 126 (steer), IP 192.168.5.126, subnet 192.168.5
+        var reply = new byte[] { 0x80, 0x81, 126, 203, 7, 192, 168, 5, 126, 192, 168, 5, 0x17 };
+
+        Assert.That(PgnBuilder.TryParseScanReply(reply, out var id, out var ip, out var subnet), Is.True);
+        Assert.That(id, Is.EqualTo(126));
+        Assert.That(ip, Is.EqualTo("192.168.5.126"));
+        Assert.That(subnet, Is.EqualTo("192.168.5"));
+    }
+
+    [TestCase((byte)126, "192.168.5.126")]
+    [TestCase((byte)123, "192.168.5.123")]
+    [TestCase((byte)121, "192.168.5.121")]
+    [TestCase((byte)120, "192.168.5.124")]
+    public void TryParseScanReply_HandlesEachModuleId(byte moduleId, string lastOctetIp)
+    {
+        var parts = lastOctetIp.Split('.');
+        var reply = new byte[]
+        {
+            0x80, 0x81, moduleId, 203, 7,
+            byte.Parse(parts[0]), byte.Parse(parts[1]), byte.Parse(parts[2]), byte.Parse(parts[3]),
+            byte.Parse(parts[0]), byte.Parse(parts[1]), byte.Parse(parts[2]), 0x00
+        };
+
+        Assert.That(PgnBuilder.TryParseScanReply(reply, out var id, out var ip, out _), Is.True);
+        Assert.That(id, Is.EqualTo(moduleId));
+        Assert.That(ip, Is.EqualTo(lastOctetIp));
+    }
+
+    [Test]
+    public void TryParseScanReply_RejectsWrongPgnOrShortPacket()
+    {
+        // wrong PGN (200, not 203)
+        var notReply = new byte[] { 0x80, 0x81, 126, 200, 3, 56, 0, 0, 0x47 };
+        Assert.That(PgnBuilder.TryParseScanReply(notReply, out _, out _, out _), Is.False);
+
+        // too short
+        var tooShort = new byte[] { 0x80, 0x81, 126, 203, 7 };
+        Assert.That(PgnBuilder.TryParseScanReply(tooShort, out _, out _, out _), Is.False);
+
+        // bad header
+        var badHeader = new byte[] { 0x00, 0x81, 126, 203, 7, 1, 2, 3, 4, 1, 2, 3, 0 };
+        Assert.That(PgnBuilder.TryParseScanReply(badHeader, out _, out _, out _), Is.False);
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 27
+#define VERSION_PATCH 28
 
-#define VERSION "26.5.27"
+#define VERSION "26.5.28"
 #define VERSION_DATE "2026-05-29"


### PR DESCRIPTION
A left-nav **Network IO** fly-out combining NTRIP with an expanded module config/readout, porting AgIO's `FormUDP` network behaviour so the **existing AiO board install base works unchanged**. Plan: `Plans/NETWORK_IO_PLAN.md`.

## Protocol (byte-exact with `AgOpen_Snapshot/AgIO`)
- `PgnNumbers`: `SCAN_REQUEST=202`, `SET_SUBNET=201`.
- `PgnBuilder`: `BuildScanRequest()` / `BuildSubnetChange(o1,o2,o3)` / `TryParseScanReply()` — pure, **9 new unit tests**.
- `UdpCommunicationService`: parses inbound **PGN 203** → per-module IP + subnet (incl. GPS); `ScanModules()` (202) and `SetModuleSubnet()` (201) broadcast to `255.255.255.255:8888` **per up-NIC** (reaches modules on any subnet); re-arms discovery after a subnet change; `GetLocalIpAddresses()`. Replicates AgIO's hardcoded `0x47`.
- `ConnectionState`: `GpsIpAddress`, `ModuleSubnet`.

## UI / VM
- **Module table** with a per-module **present checkbox** (persistent `ConnectionConfig.IsXConfigured`) and a **3-state dot** = configured AND responding; **Scan**; global **Set-Subnet** (confirmation); **Host IPs** list; **NTRIP** status + Profiles.
- New nav button (vector network glyph). Panel sized to the nav height with spaced sections.
- `ModulePresenceToColorConverter`; checkboxes persist on user change (guarded against initial load).

## NTRIP
- **Default profile auto-connects at startup** so corrections flow before a field is opened; field-load keeps an already-connected same-caster session.
- NTRIP entry moved from File Menu into the Network IO panel.
- Profile editor compacted (inline User/Pass/Port/Mount) with **Back/Close/Save**; Profiles dialog gets a **Back** (to Network IO).

Build clean; **1363 tests pass**. v26.5.28.

> Reviewer note: scan/subnet verified by unit tests + build; the live PGN 202/203/201 round-trip and the post-subnet-change re-lock need a real-hardware pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)