### PR TITLE
UI: roll gauge — centre pivot, spread arcs, 1-decimal readout

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/RollGaugeReadout.axaml
@@ -35,47 +35,51 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     -->
     <Grid Width="200" Height="80">
 
-        <!-- Left pink arc + four outward ticks. -->
+        <!-- Left pink arc + four outward ticks. Spread out (centre x=70). -->
         <Path Stroke="#E91E90" StrokeThickness="2.5" StrokeLineCap="Round"
-              Data="M 80,12 A 22,28 0 0 0 80,68
-                    M 69,20 L 61,20
-                    M 62,30 L 54,30
-                    M 58,40 L 50,40
-                    M 62,50 L 54,50
-                    M 69,60 L 61,60"/>
+              Data="M 70,12 A 22,28 0 0 0 70,68
+                    M 59,20 L 51,20
+                    M 52,30 L 44,30
+                    M 48,40 L 40,40
+                    M 52,50 L 44,50
+                    M 59,60 L 51,60"/>
 
-        <!-- Right pink arc + four outward ticks, mirrored. -->
+        <!-- Right pink arc + four outward ticks, mirrored (centre x=130). -->
         <Path Stroke="#E91E90" StrokeThickness="2.5" StrokeLineCap="Round"
-              Data="M 120,12 A 22,28 0 0 1 120,68
-                    M 131,20 L 139,20
-                    M 138,30 L 146,30
-                    M 142,40 L 150,40
-                    M 138,50 L 146,50
-                    M 131,60 L 139,60"/>
+              Data="M 130,12 A 22,28 0 0 1 130,68
+                    M 141,20 L 149,20
+                    M 148,30 L 156,30
+                    M 152,40 L 160,40
+                    M 148,50 L 156,50
+                    M 141,60 L 149,60"/>
 
-        <!-- Tilting green horizon line through the centre. Extends 2 px past
-             each arc's outermost point (left arc leftmost x=58, right arc
-             rightmost x=142) so it visibly bisects both arcs. Rotates around
-             centre. -->
-        <Line StartPoint="56,40" EndPoint="144,40"
-              Stroke="#2ECC71" StrokeThickness="4" StrokeLineCap="Round"
-              RenderTransformOrigin="0.5,0.5">
-            <Line.RenderTransform>
-                <RotateTransform Angle="{Binding RollDegrees}"/>
-            </Line.RenderTransform>
-        </Line>
+        <!-- Tilting green horizon bar. A centred Rectangle (not a Line shape,
+             whose bounds make RenderTransformOrigin land off-centre) so it
+             reliably pivots about its own centre — the white dot at the gauge
+             centre. 100 wide -> ends sit just inside each arc's widest point. -->
+        <Rectangle Width="100" Height="4" Fill="#2ECC71"
+                   RadiusX="2" RadiusY="2"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   RenderTransformOrigin="0,0">
+            <Rectangle.RenderTransform>
+                <!-- Rotate about the bar's own centre (100 wide / 4 tall ->
+                     50,2) in explicit pixels, so the pivot is the white dot at
+                     the gauge centre regardless of how the origin is parsed. -->
+                <RotateTransform Angle="{Binding RollDegrees}" CenterX="50" CenterY="2"/>
+            </Rectangle.RenderTransform>
+        </Rectangle>
 
         <!-- Static centre dot — the level reference. -->
         <Ellipse Width="6" Height="6" Fill="White"
                  HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
-        <!-- Roll degrees, big and centred above the horizon line. -->
-        <TextBlock Text="{Binding RollDegrees, StringFormat='{}{0:F0}'}"
+        <!-- Roll degrees (3 digits + 1 decimal), centred above the horizon line. -->
+        <TextBlock Text="{Binding RollDegrees, StringFormat='{}{0:F1}'}"
                    Foreground="White"
-                   FontSize="32" FontWeight="Bold"
+                   FontSize="24" FontWeight="Bold"
                    HorizontalAlignment="Center"
                    VerticalAlignment="Center"
-                   Margin="0,0,0,28"/>
+                   Margin="0,0,0,24"/>
     </Grid>
 
 </UserControl>


### PR DESCRIPTION
Refinements to the status-strip roll gauge.

- **Pivots on the white centre dot.** The green horizon is now a centred `Rectangle` rotated about its own centre via explicit-pixel `CenterX/CenterY`. The previous `Line` + `RenderTransformOrigin="0.5,0.5"` was parsed as *half a pixel*, pinning the pivot to the bar's left end (over the left arc).
- **Arcs spread out** — centres moved x=80/120 → **70/130**, ticks shifted to match; the bar is sized (100 wide) to sit just inside each arc so the ends track them.
- **Readout = 1 decimal** (F1, e.g. `5.2` / `-12.3`), font **32 → 24**.

XAML-only (`RollGaugeReadout.axaml`). Build clean; tests pass. v26.5.29.

> Note: shares v26.5.29 with the in-flight App Settings PR #453 — whichever merges second will need a trivial `version.h` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)