### PR TITLE
UI: fixed-width Speed + Heading readouts so the strip doesn't twitch

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingReadout.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingReadout.axaml
@@ -36,6 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Text="{Binding Heading, StringFormat='{}{0:000.0}°'}"
                    Foreground="#E91E90"
                    FontSize="26" FontWeight="Bold"
+                   Width="94" TextAlignment="Center"
                    HorizontalAlignment="Center"/>
         <TextBlock Text="HDG"
                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
@@ -205,9 +205,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <!-- Large Speed slot — AgOpen-style. Value tracks the user's
                  metric/imperial preference. Units sit small beside it. -->
             <StackPanel Spacing="0" VerticalAlignment="Center" Margin="6,0,0,0">
+                <!-- Fixed width + centred text so the number's changing digits
+                     don't shift the strip layout to its right. -->
                 <TextBlock Text="{Binding SpeedLargeValue, StringFormat='{}{0:F1}'}"
                            Foreground="#E67E22"
                            FontSize="26" FontWeight="Bold"
+                           Width="66" TextAlignment="Center"
                            HorizontalAlignment="Center"/>
                 <!-- Unit below the number to match the heading readout's layout. -->
                 <TextBlock Text="{Binding SpeedLargeUnit}"


### PR DESCRIPTION
The large **Speed** value (`F1`) and **Heading** readout changed pixel width as their digits changed — even the heading's zero-padded `000.0°` varies in a proportional font (a "1" is narrower than a "0") — which shifted the right side of the status strip on every update.

Both number TextBlocks now reserve a **constant width with centred text**:
- Speed → `Width="66"`
- Heading → `Width="94"`

The digits just re-centre within their box, so nothing to the right moves.

XAML-only (`StatusBarPanel.axaml`, `HeadingReadout.axaml`). Build clean; tests pass. v26.5.29.

> Shares v26.5.29 with in-flight PRs #453 / #454 — last to merge needs a trivial `version.h` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)