### PR TITLE
UI: Back/Close navigation chains + menu-system style standardization

### DIFF
--- a/Plans/MENU_STYLE_STANDARDIZATION_PLAN.md
+++ b/Plans/MENU_STYLE_STANDARDIZATION_PLAN.md
@@ -1,0 +1,104 @@
+# Menu System Style Standardization
+
+## Context
+
+After the `feature/nav-back-close-chains` rollout, the menu system's **chrome is
+consistent** but **buttons and colors have drifted**. An audit (3-way sweep of every
+panel/dialog) found the cards/headers are uniform and 100% theme-driven, while the
+drift lives in (a) per-dialog button styles that are each re-declared locally, (b)
+~280 hardcoded hex colors that should be a handful of named brushes, and (c) a
+card/header background **inversion** between the two base controls. Goal: one shared
+style vocabulary so every menu panel/dialog reads as the same app, and theme/accent
+changes happen in one place.
+
+Do this in its own branch off `develop`. Mechanical but broad (touches most dialogs).
+
+## Current state (from audit)
+
+**Strong commonality (keep as the baseline):**
+- All 7 fly-outs use `Controls/FloatingPanel.axaml` — ChromeMedium card / AltHigh
+  header / `=` glyph + `X` / CornerRadius 12 / 1px BaseLow border / 8px padding.
+- All converted chain dialogs wrap in `Controls/DialogChrome.axaml` — Back · Title ·
+  Close header, CornerRadius 12.
+- Both base controls are already fully `DynamicResource`-driven.
+
+**Drift to fix (ranked by visibility):**
+1. **Card/header inversion:** `FloatingPanel` = ChromeMedium card / AltHigh header;
+   `DialogChrome` = the reverse (AltHigh card / ChromeMedium header). Pick ONE
+   convention and apply to both.
+2. **Primary-button color scatter:** majority use `SystemControlHighlightAccentBrush`,
+   but `#27AE60` (imports, Field Builder), `#3498DB` (ImportTracks), `#9B59B6`
+   (AgShare Download), multi-color (Log Viewer) all deviate. Cancel/secondary is
+   sometimes gray, sometimes `#C0392B`, sometimes no hover.
+3. **Per-dialog button styles:** `DialogButton`/`CancelButton`/`OkButton`/`DangerButton`
+   /`ToolbarButton`/`TestButton` are redeclared in nearly every dialog's local
+   `<UserControl.Styles>` instead of being shared.
+4. **~280 hardcoded hex colors** → should be named brushes:
+   `#E74C3C` danger (55×), `#4A9A7E` status-green (36×, Screen&Alerts + Network IO),
+   `#27AE60` success (29×), `#80000000` modal backdrop (22×), `#1ABC9C` info/teal
+   (18×), `#2980B9` primary-blue/hover (14×), plus `#C0392B`/`#2ECC71`/`#E67E22`.
+5. **Two structural one-offs:** `RecordedPathDialogPanel` is a hand-built Border
+   imitating FloatingPanel (convert to a real `FloatingPanel`); `HelpDialogPanel` and
+   `BugReportDialogPanel` reference `ModernButton`, a class defined only inside
+   FloatingPanel — likely unresolved in those dialogs (verify + fix).
+
+## Approach
+
+### 1. Add semantic brushes + shared button styles to `SharedResources.axaml`
+File: `Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml` (already has the
+`ThemeDictionaries` with `ToggleOn/OffBrush`). Add to BOTH Light and Dark variants:
+- `PrimaryButtonBrush` (← `SystemControlHighlightAccentBrush` value), `PrimaryButtonHoverBrush` (#2980B9)
+- `SuccessButtonBrush` (#27AE60) / `SuccessButtonHoverBrush` (#2ECC71)
+- `DangerButtonBrush` (#E74C3C) / `DangerButtonHoverBrush` (#C0392B)
+- `StatusOkBrush` (#4A9A7E)  — the Screen&Alerts/Network IO status green
+- `InfoAccentBrush` (#1ABC9C)
+- `ModalBackdropBrush` (#80000000)  — for any remaining darkening backdrops
+
+Then add **app-wide `Button` style classes** (in a shared styles file included by each
+platform's `App.axaml`, or in `SharedResources.axaml` as styles): `Button.DialogButton`
+(primary), `Button.CancelButton`, `Button.OkButton` (success), `Button.DangerButton`,
+`Button.ToolbarButton` — each bound to the new brushes. Mirror the existing dialog
+definitions (CornerRadius 6, Padding 16,10, FontSize 14, SemiBold) so it's a drop-in.
+
+### 2. Reconcile the card/header convention
+Decide one: recommend `DialogChrome`'s look (AltHigh card + ChromeMedium header) as the
+standard since dialogs hold forms/lists that need card contrast, and update
+`FloatingPanel.axaml` to match (swap its card/header brushes) — OR vice-versa. One-line
+brush swaps in the two control axaml files; verify both light/dark.
+
+### 3. Strip per-dialog redefinitions + hardcoded hex
+For each dialog under `Controls/Dialogs/` that locally defines `DialogButton`/etc.:
+delete the local `<Style Selector="Button...">` blocks and the hardcoded button
+backgrounds, relying on the shared classes/brushes. Replace primary actions with
+`Classes="DialogButton"`, confirms with `OkButton`, deletes with `DangerButton`.
+Representative files: NtripProfiles/Editor, NewField, FromExisting, Kml/IsoXml import,
+AgShare Upload/Download/Settings, StartWorkSession, ResumeJob, FieldBuilder,
+LogViewer, Hotkey, ImportTracks (drop its `#3498DB`).
+
+### 4. Fix the two structural one-offs
+- Convert `RecordedPathDialogPanel.axaml` to a real `FloatingPanel` (PanelContent =
+  its tab/record/playback body) like the Offset Fix conversion already done.
+- In `HelpDialogPanel`/`BugReportDialogPanel`, replace `ModernButton` with the shared
+  `DialogButton`/`CancelButton` (confirm whether `ModernButton` resolves there first).
+
+## Files
+- `Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml` — new brushes (Light+Dark) + shared button styles.
+- `Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml` and `DialogChrome.axaml` — reconcile card/header brushes.
+- ~20 dialogs under `Shared/AgValoniaGPS.Views/Controls/Dialogs/` — strip local styles/hex, use shared classes.
+- `RecordedPathDialogPanel.axaml(.cs)` — convert to FloatingPanel.
+- Hardcoded `#4A9A7E`/status colors in `ScreenAlertsPanel.axaml`, `NetworkIoPanel.axaml` → `StatusOkBrush`.
+
+## Verification
+1. `dotnet build Platforms/AgValoniaGPS.Desktop/...` clean; `dotnet test Tests/AgValoniaGPS.UI.Tests/` (147 pass).
+2. Run Desktop; open every fly-out and a dialog from each chain in BOTH day and night
+   mode (toggle theme) — confirm cards/headers/buttons read identically and there's no
+   stray accent color. Charts + tool overlays included.
+3. Grep that the hardcoded hex set (`#27AE60`, `#E74C3C`, `#3498DB`, `#9B59B6`,
+   `#4A9A7E`, `#2980B9`) no longer appears in `Controls/Dialogs` button backgrounds.
+
+## Notes
+- Cross-platform: `SharedResources.axaml` is included by each platform `App.axaml` — no
+  per-platform edits beyond confirming the include is present.
+- Keep gauge/indicator colors (`#E91E90`, `#FFE000`, `#3FD0F0`, roll gauge) as-is —
+  those are data-viz, out of scope.
+- Audit detail lives in memory `project_nav_back_close_chains.md`.

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -148,10 +148,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Canvas.Left="300" Canvas.Top="20"
                                             DataContext="{Binding}"/>
                     <panels:HeadingChartPanel x:Name="HeadingChartPanel"
-                                              Canvas.Left="300" Canvas.Top="250"
+                                              Canvas.Left="300" Canvas.Top="285"
                                               DataContext="{Binding}"/>
                     <panels:XTEChartPanel x:Name="XTEChartPanel"
-                                          Canvas.Left="300" Canvas.Top="480"
+                                          Canvas.Left="300" Canvas.Top="550"
                                           DataContext="{Binding}"/>
                     <dialogs:RecordedPathDialogPanel x:Name="RecordedPathPanel"
                                                       Canvas.Left="150" Canvas.Top="20"

--- a/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.Android/Views/MainView.axaml
@@ -148,10 +148,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Canvas.Left="300" Canvas.Top="20"
                                             DataContext="{Binding}"/>
                     <panels:HeadingChartPanel x:Name="HeadingChartPanel"
-                                              Canvas.Left="300" Canvas.Top="285"
+                                              Canvas.Left="300" Canvas.Top="230"
                                               DataContext="{Binding}"/>
                     <panels:XTEChartPanel x:Name="XTEChartPanel"
-                                          Canvas.Left="300" Canvas.Top="550"
+                                          Canvas.Left="300" Canvas.Top="440"
                                           DataContext="{Binding}"/>
                     <dialogs:RecordedPathDialogPanel x:Name="RecordedPathPanel"
                                                       Canvas.Left="150" Canvas.Top="20"

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -195,10 +195,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Canvas.Left="400" Canvas.Top="20"
                                     DataContext="{Binding}"/>
             <panels:HeadingChartPanel x:Name="HeadingChartPanel"
-                                      Canvas.Left="400" Canvas.Top="285"
+                                      Canvas.Left="400" Canvas.Top="230"
                                       DataContext="{Binding}"/>
             <panels:XTEChartPanel x:Name="XTEChartPanel"
-                                  Canvas.Left="400" Canvas.Top="550"
+                                  Canvas.Left="400" Canvas.Top="440"
                                   DataContext="{Binding}"/>
             <dialogs:RecordedPathDialogPanel x:Name="RecordedPathPanel"
                                               Canvas.Left="200" Canvas.Top="20"

--- a/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
+++ b/Platforms/AgValoniaGPS.Desktop/Views/MainWindow.axaml
@@ -195,10 +195,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     Canvas.Left="400" Canvas.Top="20"
                                     DataContext="{Binding}"/>
             <panels:HeadingChartPanel x:Name="HeadingChartPanel"
-                                      Canvas.Left="400" Canvas.Top="250"
+                                      Canvas.Left="400" Canvas.Top="285"
                                       DataContext="{Binding}"/>
             <panels:XTEChartPanel x:Name="XTEChartPanel"
-                                  Canvas.Left="400" Canvas.Top="480"
+                                  Canvas.Left="400" Canvas.Top="550"
                                   DataContext="{Binding}"/>
             <dialogs:RecordedPathDialogPanel x:Name="RecordedPathPanel"
                                               Canvas.Left="200" Canvas.Top="20"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -148,10 +148,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Canvas.Left="300" Canvas.Top="20"
                                             DataContext="{Binding}"/>
                     <panels:HeadingChartPanel x:Name="HeadingChartPanel"
-                                              Canvas.Left="300" Canvas.Top="250"
+                                              Canvas.Left="300" Canvas.Top="285"
                                               DataContext="{Binding}"/>
                     <panels:XTEChartPanel x:Name="XTEChartPanel"
-                                          Canvas.Left="300" Canvas.Top="480"
+                                          Canvas.Left="300" Canvas.Top="550"
                                           DataContext="{Binding}"/>
                     <dialogs:RecordedPathDialogPanel x:Name="RecordedPathPanel"
                                                       Canvas.Left="150" Canvas.Top="20"

--- a/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
+++ b/Platforms/AgValoniaGPS.iOS/Views/MainView.axaml
@@ -148,10 +148,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Canvas.Left="300" Canvas.Top="20"
                                             DataContext="{Binding}"/>
                     <panels:HeadingChartPanel x:Name="HeadingChartPanel"
-                                              Canvas.Left="300" Canvas.Top="285"
+                                              Canvas.Left="300" Canvas.Top="230"
                                               DataContext="{Binding}"/>
                     <panels:XTEChartPanel x:Name="XTEChartPanel"
-                                          Canvas.Left="300" Canvas.Top="550"
+                                          Canvas.Left="300" Canvas.Top="440"
                                           DataContext="{Binding}"/>
                     <dialogs:RecordedPathDialogPanel x:Name="RecordedPathPanel"
                                                       Canvas.Left="150" Canvas.Top="20"

--- a/Shared/AgValoniaGPS.Models/State/UIState.cs
+++ b/Shared/AgValoniaGPS.Models/State/UIState.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AgValoniaGPS.Models.State;
@@ -25,6 +26,11 @@ namespace AgValoniaGPS.Models.State;
 /// </summary>
 public class UIState : ObservableObject
 {
+    // Back-stack of parent dialogs in the current navigation chain. Only the
+    // chain dialog layers live here; the chain's originating left-nav fly-out is
+    // tracked separately in the ViewModel (it is not a DialogType).
+    private readonly Stack<DialogType> _dialogStack = new();
+
     // Active dialog (only one modal at a time)
     private DialogType _activeDialog = DialogType.None;
     public DialogType ActiveDialog
@@ -193,8 +199,37 @@ public class UIState : ObservableObject
         ActiveDialog = dialog;
     }
 
+    /// <summary>
+    /// Push the current dialog (if any) onto the back-stack and show the next one.
+    /// Use for chain navigation so <see cref="GoBack"/> can return to the parent.
+    /// </summary>
+    public void PushDialog(DialogType dialog)
+    {
+        if (_activeDialog != DialogType.None)
+            _dialogStack.Push(_activeDialog);
+        ActiveDialog = dialog;
+    }
+
+    /// <summary>
+    /// Pop back to the previous dialog in the chain. Returns true if a parent
+    /// dialog was surfaced; false if the stack was empty (the caller then reopens
+    /// the originating fly-out).
+    /// </summary>
+    public bool GoBack()
+    {
+        if (_dialogStack.Count > 0)
+        {
+            ActiveDialog = _dialogStack.Pop();
+            return true;
+        }
+        ActiveDialog = DialogType.None;
+        SelectedItem = null;
+        return false;
+    }
+
     public void CloseDialog()
     {
+        _dialogStack.Clear();
         ActiveDialog = DialogType.None;
         SelectedItem = null;
     }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
@@ -158,7 +158,7 @@ public partial class MainViewModel
         // AgShare Dialogs
         ShowAgShareDownloadDialogCommand = new RelayCommand(() =>
         {
-            State.UI.ShowDialog(DialogType.AgShareDownload);
+            OpenChainDialog(DialogType.AgShareDownload);
         });
 
         CancelAgShareDownloadDialogCommand = new RelayCommand(() =>
@@ -168,7 +168,7 @@ public partial class MainViewModel
 
         ShowAgShareUploadDialogCommand = new RelayCommand(() =>
         {
-            State.UI.ShowDialog(DialogType.AgShareUpload);
+            OpenChainDialog(DialogType.AgShareUpload);
         });
 
         CancelAgShareUploadDialogCommand = new RelayCommand(() =>
@@ -182,7 +182,7 @@ public partial class MainViewModel
             AgShareSettingsServerUrl = ConfigStore.Connections.AgShareServer;
             AgShareSettingsApiKey = ConfigStore.Connections.AgShareApiKey;
             AgShareSettingsEnabled = ConfigStore.Connections.AgShareEnabled;
-            State.UI.ShowDialog(DialogType.AgShareSettings);
+            OpenChainDialog(DialogType.AgShareSettings);
         });
 
         CancelAgShareSettingsDialogCommand = new RelayCommand(() =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
@@ -214,7 +214,7 @@ public partial class MainViewModel
                 StatusMessage = "Open a field first";
                 return;
             }
-            State.UI.ShowDialog(DialogType.FieldBuilder);
+            OpenChainDialog(DialogType.FieldBuilder);
             UpdateHeadlandPreview();
         });
 
@@ -315,7 +315,7 @@ public partial class MainViewModel
         // Headland Dialog - now opens Field Builder
         ShowHeadlandDialogCommand = new RelayCommand(() =>
         {
-            State.UI.ShowDialog(DialogType.FieldBuilder);
+            OpenChainDialog(DialogType.FieldBuilder);
             UpdateHeadlandPreview();
         });
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -55,7 +55,7 @@ public partial class MainViewModel
                 confirmWithOption: (title, msg, checkboxLabel, defaultChecked, action) =>
                     ShowConfirmationDialog(title, msg, checkboxLabel, defaultChecked, action));
             StartWorkSessionDialogVm.Refresh();
-            State.UI.ShowDialog(DialogType.StartWorkSession);
+            OpenChainDialog(DialogType.StartWorkSession);
         });
 
         CancelStartWorkSessionDialogCommand = new RelayCommand(() =>
@@ -73,7 +73,7 @@ public partial class MainViewModel
                 openFieldResumingJob: (path, name, taskName) =>
                     _ = OpenFieldResumingJobAsync(path, name, taskName));
             ResumeJobDialogVm.Refresh();
-            State.UI.ShowDialog(DialogType.ResumeJob);
+            OpenChainDialog(DialogType.ResumeJob);
         });
 
         CancelResumeJobDialogCommand = new RelayCommand(() =>
@@ -190,7 +190,7 @@ public partial class MainViewModel
             NewFieldLatitude = Latitude != 0 ? Latitude : 40.7128;
             NewFieldLongitude = Longitude != 0 ? Longitude : -74.0060;
             NewFieldName = string.Empty;
-            State.UI.ShowDialog(DialogType.NewField);
+            OpenChainDialog(DialogType.NewField);
         });
 
         CancelNewFieldDialogCommand = new RelayCommand(() =>
@@ -310,7 +310,7 @@ public partial class MainViewModel
                 FromExistingSelectedField = AvailableFields[0];
             }
 
-            State.UI.ShowDialog(DialogType.FromExistingField);
+            OpenChainDialog(DialogType.FromExistingField);
         });
 
         CancelFromExistingFieldDialogCommand = new RelayCommand(() =>
@@ -479,7 +479,7 @@ public partial class MainViewModel
                 SelectedKmlFile = AvailableKmlFiles[0];
             }
 
-            State.UI.ShowDialog(DialogType.KmlImport);
+            OpenChainDialog(DialogType.KmlImport);
         });
 
         CancelKmlImportDialogCommand = new RelayCommand(() =>
@@ -631,7 +631,7 @@ public partial class MainViewModel
                 SelectedIsoXmlFile = AvailableIsoXmlFiles[0];
             }
 
-            State.UI.ShowDialog(DialogType.IsoXmlImport);
+            OpenChainDialog(DialogType.IsoXmlImport);
         });
 
         CancelIsoXmlImportDialogCommand = new RelayCommand(() =>
@@ -783,7 +783,7 @@ public partial class MainViewModel
                     ShowConfirmationDialog(title, msg, checkboxLabel, defaultChecked, action),
                 nearbyMaxKm: 0.5);
             StartWorkSessionDialogVm.Refresh();
-            State.UI.ShowDialog(DialogType.StartWorkSession);
+            OpenChainDialog(DialogType.StartWorkSession);
         });
 
         ResumeFieldCommand = new AsyncRelayCommand(async () =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Hotkeys.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Hotkeys.cs
@@ -48,8 +48,7 @@ public partial class MainViewModel
     {
         ShowHotkeyConfigDialogCommand = new RelayCommand(() =>
         {
-            IsFileMenuPanelVisible = false;
-            State.UI.ShowDialog(DialogType.HotkeyConfig);
+            OpenChainDialog(DialogType.HotkeyConfig);
         });
 
         CloseHotkeyConfigDialogCommand = new RelayCommand(() =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Navigation.cs
@@ -34,6 +34,10 @@ public partial class MainViewModel
         {
             if (e.Current != Models.State.DialogType.None)
                 CloseAllNavFlyouts();
+            // Re-evaluate whether a confirmation can offer a Back-to-fly-out button
+            // (it depends on which fly-out, if any, was just closed).
+            if (e.Current == Models.State.DialogType.Confirmation)
+                OnPropertyChanged(nameof(IsConfirmationBackVisible));
         };
 
         // Panel toggle commands. Only one left-nav fly-out is open at a time:
@@ -97,6 +101,20 @@ public partial class MainViewModel
         // The fly-out close (X) is a pure close, not a toggle: a toggle would
         // re-open the panel because the bubbling item-close already shut it.
         CloseAllNavFlyoutsCommand = new RelayCommand(CloseAllNavFlyouts);
+
+        // Back from a Field Tools tool overlay (boundary recording, recorded path,
+        // offset-fix pad): close the overlays and reopen the Field Tools fly-out.
+        // These are bool-visibility panels, not DialogType dialogs, so they use
+        // this dedicated command rather than the dialog back-stack.
+        BackToFieldToolsCommand = new RelayCommand(() =>
+        {
+            IsBoundaryPanelVisible = false;
+            IsRecordedPathPanelVisible = false;
+            State.UI.IsOffsetFixPanelVisible = false;
+            // Route through the chain Back path so Field Tools reopens where the
+            // chain currently is (flagged reopen) rather than snapping home.
+            ReopenFlyout(NavFlyout.FieldTools);
+        });
 
         ToggleAutoTrackCommand = new RelayCommand(() =>
         {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Ntrip.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Ntrip.cs
@@ -32,34 +32,19 @@ public partial class MainViewModel
 {
     private void InitializeNtripCommands()
     {
+        // First level of the chain: opens from the Network IO fly-out, which the
+        // shared chain navigation records so Back can reopen it.
         ShowNtripProfilesDialogCommand = new RelayCommand(() =>
         {
             RefreshNtripProfiles();
-            State.UI.ShowDialog(DialogType.NtripProfiles);
-        });
-
-        CloseNtripProfilesDialogCommand = new RelayCommand(() =>
-        {
-            State.UI.CloseDialog();
-            SelectedNtripProfile = null;
-        });
-
-        // Back: dismiss the dialog and reopen the Network IO panel it was
-        // launched from (CloseDialog fires DialogChanged with Current=None, so
-        // it does NOT re-close the fly-out we open here).
-        BackFromNtripProfilesCommand = new RelayCommand(() =>
-        {
-            State.UI.CloseDialog();
-            SelectedNtripProfile = null;
-            CloseAllNavFlyouts();
-            IsNetworkIoPanelVisible = true;
+            OpenChainDialog(DialogType.NtripProfiles);
         });
 
         AddNtripProfileCommand = new RelayCommand(() =>
         {
             EditingNtripProfile = _ntripProfileService.CreateNewProfile("New Profile");
             PopulateAvailableFieldsForProfile(EditingNtripProfile);
-            State.UI.ShowDialog(DialogType.NtripProfileEditor);
+            PushChainDialog(DialogType.NtripProfileEditor);
         });
 
         EditNtripProfileCommand = new RelayCommand(() =>
@@ -81,7 +66,7 @@ public partial class MainViewModel
                     FilePath = SelectedNtripProfile.FilePath
                 };
                 PopulateAvailableFieldsForProfile(EditingNtripProfile);
-                State.UI.ShowDialog(DialogType.NtripProfileEditor);
+                PushChainDialog(DialogType.NtripProfileEditor);
             }
         });
 
@@ -126,7 +111,7 @@ public partial class MainViewModel
                 RefreshNtripProfiles();
                 EditingNtripProfile = null;
                 AvailableFieldsForProfile.Clear();
-                State.UI.ShowDialog(DialogType.NtripProfiles);
+                NavigateBack(); // pop the editor back to the profiles list
                 StatusMessage = "NTRIP profile saved";
             }
         });
@@ -136,7 +121,7 @@ public partial class MainViewModel
             EditingNtripProfile = null;
             AvailableFieldsForProfile.Clear();
             NtripTestStatus = string.Empty;
-            State.UI.ShowDialog(DialogType.NtripProfiles);
+            NavigateBack(); // pop the editor back to the profiles list
         });
 
         TestNtripConnectionCommand = new AsyncRelayCommand(async () =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -47,7 +47,7 @@ public partial class MainViewModel
                 ConfigurationViewModel = new ConfigurationViewModel(_configurationService);
             }
             RefreshAppDirectories();
-            State.UI.ShowDialog(Models.State.DialogType.AppSettings);
+            OpenChainDialog(Models.State.DialogType.AppSettings);
         });
 
         CloseAppSettingsDialogCommand = new RelayCommand(() =>
@@ -57,7 +57,7 @@ public partial class MainViewModel
 
         ShowAboutDialogCommand = new RelayCommand(() =>
         {
-            State.UI.ShowDialog(Models.State.DialogType.About);
+            OpenChainDialog(Models.State.DialogType.About);
         });
 
         CloseAboutDialogCommand = new RelayCommand(() =>
@@ -83,9 +83,15 @@ public partial class MainViewModel
         ShowLogViewerDialogCommand = new RelayCommand(() =>
         {
             RefreshLogEntries();
-            _logStoreSubscribed = true;
-            LogStore.Instance.LogAdded += OnLogStoreUpdated;
-            State.UI.ShowDialog(Models.State.DialogType.LogViewer);
+            // Guard against a double subscription: with the chain model the dialog
+            // can be dismissed via Back/Close (cleanup runs on hide), so only wire
+            // the LogStore handler when not already subscribed.
+            if (!_logStoreSubscribed)
+            {
+                LogStore.Instance.LogAdded += OnLogStoreUpdated;
+                _logStoreSubscribed = true;
+            }
+            OpenChainDialog(Models.State.DialogType.LogViewer);
         });
 
         CloseLogViewerDialogCommand = new RelayCommand(() =>
@@ -133,7 +139,7 @@ public partial class MainViewModel
         ShowViewSettingsDialogCommand = new RelayCommand(() =>
         {
             RefreshSettingsTree();
-            State.UI.ShowDialog(Models.State.DialogType.ViewSettings);
+            OpenChainDialog(Models.State.DialogType.ViewSettings);
         });
 
         CloseViewSettingsDialogCommand = new RelayCommand(() =>
@@ -144,7 +150,7 @@ public partial class MainViewModel
         // Help (#16)
         ShowHelpDialogCommand = new RelayCommand(() =>
         {
-            State.UI.ShowDialog(Models.State.DialogType.Help);
+            OpenChainDialog(Models.State.DialogType.Help);
         });
 
         CloseHelpDialogCommand = new RelayCommand(() =>
@@ -155,7 +161,7 @@ public partial class MainViewModel
         // Language Selection (#40)
         ShowLanguageDialogCommand = new RelayCommand(() =>
         {
-            State.UI.ShowDialog(Models.State.DialogType.Language);
+            OpenChainDialog(Models.State.DialogType.Language);
         });
 
         CloseLanguageDialogCommand = new RelayCommand(() =>
@@ -235,7 +241,7 @@ public partial class MainViewModel
                 StatusMessage = $"Bug report capture failed: {ex.Message}";
             }
 
-            State.UI.ShowDialog(Models.State.DialogType.BugReport);
+            OpenChainDialog(Models.State.DialogType.BugReport);
         });
 
         CloseBugReportDialogCommand = new RelayCommand(() =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -1239,7 +1239,7 @@ public partial class MainViewModel
 
         // Field Builder dialog
         ShowFieldBuilderCommand = new RelayCommand(() =>
-            State.UI.ShowDialog(Models.State.DialogType.FieldBuilder));
+            OpenChainDialog(Models.State.DialogType.FieldBuilder));
 
         CloseFieldBuilderCommand = new RelayCommand(() =>
             State.UI.CloseDialog());

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Navigation.Chain.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Navigation.Chain.cs
@@ -51,6 +51,13 @@ public partial class MainViewModel
     // once the dialog back-stack is exhausted.
     private NavFlyout _chainOriginFlyout = NavFlyout.None;
 
+    // The fly-out most recently closed by CloseAllNavFlyouts. Menu fly-outs close
+    // themselves on item-click (CloseOnItemClick) BEFORE the item's command runs,
+    // so by the time OpenChainDialog reads CurrentFlyout() the fly-out is already
+    // gone. This remembers it so the origin can still be captured. Consumed (set
+    // to None) by OpenChainDialog so it can't go stale across unrelated opens.
+    private NavFlyout _lastClosedFlyout = NavFlyout.None;
+
     private void InitializeChainNavigationCommands()
     {
         NavBackCommand = new RelayCommand(NavigateBack);
@@ -63,7 +70,14 @@ public partial class MainViewModel
     /// </summary>
     private void OpenChainDialog(DialogType dialog)
     {
-        _chainOriginFlyout = CurrentFlyout();
+        // Prefer a still-open fly-out; fall back to the one just closed by an
+        // item-click. Consume the fallback so a later non-fly-out open (e.g. a
+        // hotkey) doesn't inherit a stale origin.
+        var origin = CurrentFlyout();
+        if (origin == NavFlyout.None)
+            origin = _lastClosedFlyout;
+        _chainOriginFlyout = origin;
+        _lastClosedFlyout = NavFlyout.None;
         State.UI.PushDialog(dialog);
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Navigation.Chain.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Navigation.Chain.cs
@@ -58,11 +58,42 @@ public partial class MainViewModel
     // to None) by OpenChainDialog so it can't go stale across unrelated opens.
     private NavFlyout _lastClosedFlyout = NavFlyout.None;
 
+    // True only while a fly-out is being reopened by Back (not a fresh nav-button
+    // open). The left-nav reads this to reopen the fly-out at the chain's current
+    // location (where panels were dragged) instead of snapping it home — so backing
+    // out to a sibling keeps the chain where you left it rather than chasing it
+    // back to the top-left.
+    private bool _flyoutReopenFromBack;
+    public bool IsFlyoutReopenFromBack => _flyoutReopenFromBack;
+
     private void InitializeChainNavigationCommands()
     {
         NavBackCommand = new RelayCommand(NavigateBack);
         NavCloseChainCommand = new RelayCommand(CloseChain);
+
+        // Back from a confirmation that was launched by a fly-out item (e.g. Field
+        // Tools → Delete Applied Area): dismiss the confirmation without running its
+        // action and reopen the originating fly-out. Only shown when the confirmation
+        // has no parent dialog to fall back to (see IsConfirmationBackVisible).
+        BackFromConfirmationCommand = new RelayCommand(() =>
+        {
+            _confirmationDialogCallback = null;
+            _confirmationDialogCheckboxCallback = null;
+            _previousDialogBeforeConfirmation = DialogType.None;
+            var flyout = _lastClosedFlyout;
+            State.UI.CloseDialog();
+            ReopenFlyout(flyout);
+            _lastClosedFlyout = NavFlyout.None;
+        });
     }
+
+    /// <summary>
+    /// True when the active confirmation was raised directly from a left-nav
+    /// fly-out item (no parent dialog) so a Back button can return to that fly-out.
+    /// </summary>
+    public bool IsConfirmationBackVisible =>
+        _previousDialogBeforeConfirmation == DialogType.None
+        && _lastClosedFlyout != NavFlyout.None;
 
     /// <summary>
     /// Open the FIRST dialog of a chain from the currently-open fly-out. Records
@@ -125,6 +156,21 @@ public partial class MainViewModel
 
     /// <summary>Reopen a specific left-nav fly-out (all others stay closed).</summary>
     private void ReopenFlyout(NavFlyout flyout)
+    {
+        // Flag the reopen as a Back so the left-nav places the fly-out at the
+        // chain's current location rather than resetting it to home.
+        _flyoutReopenFromBack = true;
+        try
+        {
+            ReopenFlyoutCore(flyout);
+        }
+        finally
+        {
+            _flyoutReopenFromBack = false;
+        }
+    }
+
+    private void ReopenFlyoutCore(NavFlyout flyout)
     {
         switch (flyout)
         {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Navigation.Chain.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Navigation.Chain.cs
@@ -1,0 +1,127 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using AgValoniaGPS.Models.State;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AgValoniaGPS.ViewModels;
+
+/// <summary>
+/// Shared chain navigation for the left-nav fly-out → dialog → dialog chains.
+///
+/// Model: only one panel is visible at a time. Opening the next panel closes the
+/// current one; <b>Back</b> closes the current one and reopens the previous;
+/// <b>Close</b> dismisses the whole chain back to the map.
+///
+/// The dialog layers live on <see cref="UIState"/>'s back-stack
+/// (<see cref="UIState.PushDialog"/> / <see cref="UIState.GoBack"/>). The bottom of
+/// every chain is a left-nav fly-out, which is plain VM bool state (not a
+/// <see cref="DialogType"/>), so the originating fly-out is tracked here and
+/// reopened when Back unwinds past the first dialog.
+/// </summary>
+public partial class MainViewModel
+{
+    /// <summary>The left-nav fly-outs that can originate a dialog chain.</summary>
+    private enum NavFlyout
+    {
+        None,
+        ScreenAlerts,
+        FileMenu,
+        Tools,
+        Configuration,
+        FieldOperations,
+        FieldTools,
+        NetworkIo,
+    }
+
+    // Which fly-out the current chain was launched from, so Back can reopen it
+    // once the dialog back-stack is exhausted.
+    private NavFlyout _chainOriginFlyout = NavFlyout.None;
+
+    private void InitializeChainNavigationCommands()
+    {
+        NavBackCommand = new RelayCommand(NavigateBack);
+        NavCloseChainCommand = new RelayCommand(CloseChain);
+    }
+
+    /// <summary>
+    /// Open the FIRST dialog of a chain from the currently-open fly-out. Records
+    /// the origin fly-out (which the existing DialogChanged handler then closes).
+    /// </summary>
+    private void OpenChainDialog(DialogType dialog)
+    {
+        _chainOriginFlyout = CurrentFlyout();
+        State.UI.PushDialog(dialog);
+    }
+
+    /// <summary>
+    /// Open a DEEPER dialog within the chain — the current dialog is pushed onto
+    /// the back-stack so Back returns to it.
+    /// </summary>
+    private void PushChainDialog(DialogType dialog) => State.UI.PushDialog(dialog);
+
+    /// <summary>
+    /// Back: close the current panel and reopen the previous one. Pops to the
+    /// parent dialog if there is one; otherwise reopens the originating fly-out.
+    /// </summary>
+    private void NavigateBack()
+    {
+        if (!State.UI.GoBack())
+        {
+            // Stack exhausted — we were at the first dialog; reopen its fly-out.
+            ReopenFlyout(_chainOriginFlyout);
+            _chainOriginFlyout = NavFlyout.None;
+        }
+    }
+
+    /// <summary>
+    /// Close: dismiss the whole chain back to the map (no fly-out reopened).
+    /// </summary>
+    private void CloseChain()
+    {
+        State.UI.CloseDialog();
+        _chainOriginFlyout = NavFlyout.None;
+    }
+
+    /// <summary>Identify which left-nav fly-out is currently open (if any).</summary>
+    private NavFlyout CurrentFlyout()
+    {
+        if (IsScreenAlertsPanelVisible) return NavFlyout.ScreenAlerts;
+        if (IsFileMenuPanelVisible) return NavFlyout.FileMenu;
+        if (IsToolsPanelVisible) return NavFlyout.Tools;
+        if (IsConfigurationPanelVisible) return NavFlyout.Configuration;
+        if (IsFieldOperationsPanelVisible) return NavFlyout.FieldOperations;
+        if (IsFieldToolsPanelVisible) return NavFlyout.FieldTools;
+        if (IsNetworkIoPanelVisible) return NavFlyout.NetworkIo;
+        return NavFlyout.None;
+    }
+
+    /// <summary>Reopen a specific left-nav fly-out (all others stay closed).</summary>
+    private void ReopenFlyout(NavFlyout flyout)
+    {
+        switch (flyout)
+        {
+            case NavFlyout.ScreenAlerts: IsScreenAlertsPanelVisible = true; break;
+            case NavFlyout.FileMenu: IsFileMenuPanelVisible = true; break;
+            case NavFlyout.Tools: IsToolsPanelVisible = true; break;
+            case NavFlyout.Configuration: IsConfigurationPanelVisible = true; break;
+            case NavFlyout.FieldOperations: IsFieldOperationsPanelVisible = true; break;
+            case NavFlyout.FieldTools: IsFieldToolsPanelVisible = true; break;
+            case NavFlyout.NetworkIo: IsNetworkIoPanelVisible = true; break;
+            // NavFlyout.None: nothing to reopen (chain was opened programmatically).
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.TrackManagement.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.TrackManagement.cs
@@ -161,7 +161,7 @@ public partial class MainViewModel
                 return;
             }
 
-            State.UI.ShowDialog(DialogType.ImportTracks);
+            OpenChainDialog(DialogType.ImportTracks);
         });
 
         ImportTracksFromFieldCommand = new RelayCommand<string>(fieldName =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -130,6 +130,12 @@ public partial class MainViewModel
     /// </summary>
     public void CloseAllNavFlyouts()
     {
+        // Remember which fly-out we're closing so a chain dialog launched by the
+        // same item-click can still capture it as its origin (see OpenChainDialog).
+        var open = CurrentFlyout();
+        if (open != NavFlyout.None)
+            _lastClosedFlyout = open;
+
         IsScreenAlertsPanelVisible = false;
         IsFileMenuPanelVisible = false;
         IsToolsPanelVisible = false;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -508,6 +508,7 @@ public partial class MainViewModel : ObservableObject
         _simulatorTimer.Tick += OnSimulatorTick;
 
         // Initialize commands (split into partial class files for organization)
+        InitializeChainNavigationCommands();
         InitializeNavigationCommands();
         InitializeSimulatorCommands();
         InitializeConfigurationCommands();
@@ -2380,10 +2381,13 @@ public partial class MainViewModel : ObservableObject
     /// </summary>
     public ObservableCollection<FieldAssociationItem> AvailableFieldsForProfile { get; } = new();
 
+    // Shared chain navigation (Back / Close) for every fly-out → dialog chain.
+    // See MainViewModel.Navigation.Chain.cs.
+    public ICommand? NavBackCommand { get; private set; }
+    public ICommand? NavCloseChainCommand { get; private set; }
+
     // NTRIP Profiles commands
     public ICommand? ShowNtripProfilesDialogCommand { get; private set; }
-    public ICommand? CloseNtripProfilesDialogCommand { get; private set; }
-    public ICommand? BackFromNtripProfilesCommand { get; private set; }
     public ICommand? AddNtripProfileCommand { get; private set; }
     public ICommand? EditNtripProfileCommand { get; private set; }
     public ICommand? DeleteNtripProfileCommand { get; private set; }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -2386,6 +2386,12 @@ public partial class MainViewModel : ObservableObject
     public ICommand? NavBackCommand { get; private set; }
     public ICommand? NavCloseChainCommand { get; private set; }
 
+    // Back from a Field Tools tool overlay to the Field Tools fly-out.
+    public ICommand? BackToFieldToolsCommand { get; private set; }
+
+    // Back from a fly-out-launched confirmation to its originating fly-out.
+    public ICommand? BackFromConfirmationCommand { get; private set; }
+
     // NTRIP Profiles commands
     public ICommand? ShowNtripProfilesDialogCommand { get; private set; }
     public ICommand? AddNtripProfileCommand { get; private set; }

--- a/Shared/AgValoniaGPS.Views/Controls/ChainPanelAnchor.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/ChainPanelAnchor.cs
@@ -1,0 +1,36 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using Avalonia;
+
+namespace AgValoniaGPS.Views.Controls;
+
+/// <summary>
+/// Shared upper-left position (in window / TopLevel coordinates) of the currently
+/// active panel in a left-nav → dialog chain.
+///
+/// A panel publishes its position here whenever it is shown or dragged; the next
+/// panel in the chain reads it on open so it appears with its upper-left corner
+/// aligned over the panel that launched it — even if that panel was dragged away
+/// from home. The chain root (a left-nav fly-out) resets to its home position on
+/// open and republishes, so a freshly opened chain starts at home rather than
+/// chasing a stale position.
+/// </summary>
+public static class ChainPanelAnchor
+{
+    /// <summary>Upper-left of the active chain panel, or null if none captured.</summary>
+    public static Point? Current { get; set; }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/ChainPanelAnchor.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/ChainPanelAnchor.cs
@@ -15,6 +15,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.VisualTree;
 
 namespace AgValoniaGPS.Views.Controls;
 
@@ -33,4 +36,29 @@ public static class ChainPanelAnchor
 {
     /// <summary>Upper-left of the active chain panel, or null if none captured.</summary>
     public static Point? Current { get; set; }
+
+    /// <summary>
+    /// Position a tool overlay so its upper-left lands at the current chain anchor
+    /// (over the fly-out that launched it). Handles both Canvas-hosted overlays
+    /// (boundary recording, recorded path) and alignment/Panel-hosted ones
+    /// (offset-fix pad). No-op when no anchor has been captured.
+    /// </summary>
+    public static void PositionAtAnchor(Control panel)
+    {
+        if (Current is not { } anchor) return;
+        var top = TopLevel.GetTopLevel(panel);
+        if (top is null || panel.Parent is not Visual parent) return;
+        var origin = parent.TranslatePoint(new Point(0, 0), top) ?? default;
+        if (parent is Canvas)
+        {
+            Canvas.SetLeft(panel, anchor.X - origin.X);
+            Canvas.SetTop(panel, anchor.Y - origin.Y);
+        }
+        else
+        {
+            panel.HorizontalAlignment = HorizontalAlignment.Left;
+            panel.VerticalAlignment = VerticalAlignment.Top;
+            panel.Margin = new Thickness(anchor.X - origin.X, anchor.Y - origin.Y, 0, 0);
+        }
+    }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/DialogChrome.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogChrome.axaml
@@ -1,0 +1,93 @@
+<!--
+AgValoniaGPS
+Copyright (C) 2024-2025 AgValoniaGPS Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:AgValoniaGPS.Views.Controls"
+             x:Class="AgValoniaGPS.Views.Controls.DialogChrome"
+             HorizontalAlignment="Left" VerticalAlignment="Top"
+             Margin="90,8,0,0">
+
+    <UserControl.Styles>
+        <!-- Header chrome button (Back / Close): flat, square, hover-lit.
+             Matches the FloatingPanel header close button so fly-outs and
+             dialogs read as the same control family. -->
+        <Style Selector="Button.ChromeButton">
+            <Setter Property="Width" Value="28"/>
+            <Setter Property="Height" Value="28"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+            <Setter Property="FontSize" Value="18"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button.ChromeButton:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+        </Style>
+    </UserControl.Styles>
+
+    <!-- Rounded card; clip so the header background respects the corners. The
+         card uses AltHigh (matching the app's dialogs) so ChromeMedium fields and
+         lists inside keep their contrast; the header bar takes the distinct
+         ChromeMedium shade. The template is wrapped in an explicit
+         UserControl.Content so the [Content] PanelContent property is reserved
+         for the consumer's dialog body (same pattern as FloatingPanel). -->
+  <UserControl.Content>
+    <Border x:Name="Card"
+            Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="1"
+            CornerRadius="12"
+            ClipToBounds="True">
+        <DockPanel LastChildFill="True">
+
+            <!-- Header bar (also the drag handle): Back · Title · Close -->
+            <Grid x:Name="DragHandle" DockPanel.Dock="Top" ColumnDefinitions="Auto,*,Auto" Height="40"
+                  Cursor="SizeAll" ToolTip.Tip="Drag to move"
+                  Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
+                <Button Grid.Column="0" Classes="ChromeButton" Content="&#x2190;"
+                        Margin="8,0,0,0"
+                        ToolTip.Tip="Back"
+                        IsVisible="{Binding ShowBackButton, RelativeSource={RelativeSource AncestorType=local:DialogChrome}}"
+                        Command="{Binding BackCommand, RelativeSource={RelativeSource AncestorType=local:DialogChrome}}"/>
+
+                <TextBlock Grid.Column="1"
+                           Text="{Binding Title, RelativeSource={RelativeSource AncestorType=local:DialogChrome}}"
+                           FontSize="16" FontWeight="Bold"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+
+                <Button Grid.Column="2" Classes="ChromeButton" Content="&#x2715;"
+                        Margin="0,0,8,0"
+                        ToolTip.Tip="Close"
+                        Command="{Binding CloseCommand, RelativeSource={RelativeSource AncestorType=local:DialogChrome}}"/>
+            </Grid>
+
+            <Separator DockPanel.Dock="Top" Height="1"
+                       Background="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
+
+            <!-- Dialog body -->
+            <ContentPresenter Margin="16"
+                              Content="{Binding PanelContent, RelativeSource={RelativeSource AncestorType=local:DialogChrome}}"/>
+        </DockPanel>
+    </Border>
+  </UserControl.Content>
+</UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/DialogChrome.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogChrome.axaml.cs
@@ -1,0 +1,229 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Linq;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Metadata;
+using Avalonia.Reactive;
+using Avalonia.VisualTree;
+using AgValoniaGPS.Views.Controls.Panels;
+
+namespace AgValoniaGPS.Views.Controls;
+
+/// <summary>
+/// Standard chrome for a chain dialog: a draggable header bar with a Back button
+/// (left), title (center) and Close button (right), wrapping the dialog body in a
+/// rounded card. Visual sibling of <see cref="FloatingPanel"/> so fly-outs and
+/// dialogs share one look and feel.
+///
+/// Non-modal: the host renders no darkening backdrop, so the map stays visible and
+/// clickable behind it, and the header can be dragged to move the card aside for a
+/// peek at the map. The card re-centers each time it is shown. Back/Close bind to
+/// the shared chain-navigation commands (NavBackCommand / NavCloseChainCommand).
+/// </summary>
+public partial class DialogChrome : UserControl
+{
+    private readonly TranslateTransform _drag = new();
+    private bool _isDragging;
+    private Point _lastScreenPoint;
+    private IDisposable? _hostVisibilitySub;
+
+    public static readonly StyledProperty<string> TitleProperty =
+        AvaloniaProperty.Register<DialogChrome, string>(nameof(Title), "");
+
+    public string Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public static readonly StyledProperty<bool> ShowBackButtonProperty =
+        AvaloniaProperty.Register<DialogChrome, bool>(nameof(ShowBackButton), true);
+
+    public bool ShowBackButton
+    {
+        get => GetValue(ShowBackButtonProperty);
+        set => SetValue(ShowBackButtonProperty, value);
+    }
+
+    public static readonly StyledProperty<ICommand?> BackCommandProperty =
+        AvaloniaProperty.Register<DialogChrome, ICommand?>(nameof(BackCommand));
+
+    public ICommand? BackCommand
+    {
+        get => GetValue(BackCommandProperty);
+        set => SetValue(BackCommandProperty, value);
+    }
+
+    public static readonly StyledProperty<ICommand?> CloseCommandProperty =
+        AvaloniaProperty.Register<DialogChrome, ICommand?>(nameof(CloseCommand));
+
+    public ICommand? CloseCommand
+    {
+        get => GetValue(CloseCommandProperty);
+        set => SetValue(CloseCommandProperty, value);
+    }
+
+    // The dialog body — default [Content] property so panels nest naturally.
+    public static readonly StyledProperty<object?> PanelContentProperty =
+        AvaloniaProperty.Register<DialogChrome, object?>(nameof(PanelContent));
+
+    [Content]
+    public object? PanelContent
+    {
+        get => GetValue(PanelContentProperty);
+        set => SetValue(PanelContentProperty, value);
+    }
+
+    public DialogChrome()
+    {
+        InitializeComponent();
+
+        // Translate the whole control (not the inner card) so the dragged-away
+        // portion isn't clipped by the card's own bounds. The control is centered
+        // in a full-window Grid that does not clip, so it moves freely.
+        RenderTransform = _drag;
+
+        var handle = this.FindControl<Grid>("DragHandle");
+        if (handle != null)
+        {
+            handle.PointerPressed += Handle_PointerPressed;
+            handle.PointerMoved += Handle_PointerMoved;
+            handle.PointerReleased += Handle_PointerReleased;
+        }
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        // The hosting dialog panel toggles its own IsVisible (bound to the dialog
+        // flag). Re-center the card each time it is shown, so a panel always opens
+        // at its home location rather than wherever it was last dragged.
+        _hostVisibilitySub?.Dispose();
+        var host = this.FindAncestorOfType<UserControl>();
+        if (host != null)
+        {
+            _hostVisibilitySub = host.GetObservable(Visual.IsVisibleProperty)
+                .Subscribe(new AnonymousObserver<bool>(visible =>
+                {
+                    if (visible)
+                    {
+                        _drag.X = 0;
+                        _drag.Y = 0;
+                        PositionAtChainAnchor();
+                    }
+                }));
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        _hostVisibilitySub?.Dispose();
+        _hostVisibilitySub = null;
+    }
+
+    /// <summary>
+    /// Open with the dialog's upper-left aligned over the chain anchor — i.e. over
+    /// the panel that launched it, at that panel's current position. Falls back to
+    /// the fly-out's home position (nav top + 90) if no anchor was captured. After
+    /// positioning, republish the anchor so the next panel in the chain stacks on
+    /// top of this one.
+    /// </summary>
+    private void PositionAtChainAnchor()
+    {
+        var top = TopLevel.GetTopLevel(this);
+        if (top == null || this.Parent is not Visual parent) return;
+        var parentOrigin = parent.TranslatePoint(new Point(0, 0), top) ?? default;
+
+        var anchor = ChainPanelAnchor.Current
+                     ?? NavFlyoutHome(top)
+                     ?? new Point(parentOrigin.X + Margin.Left, parentOrigin.Y + Margin.Top);
+
+        Margin = new Thickness(anchor.X - parentOrigin.X, anchor.Y - parentOrigin.Y, 0, 0);
+        ChainPanelAnchor.Current = anchor;
+    }
+
+    /// <summary>Window-space upper-left of a left-nav fly-out at its home position
+    /// (the nav panel's on-screen origin plus the fly-out's Canvas.Left of 90).</summary>
+    private static Point? NavFlyoutHome(Visual top)
+    {
+        var nav = top.GetVisualDescendants().OfType<LeftNavigationPanel>().FirstOrDefault();
+        return nav?.TranslatePoint(new Point(90, 0), top);
+    }
+
+    /// <summary>Publish this dialog's current on-screen upper-left (Margin + drag)
+    /// so a child panel opens aligned over it.</summary>
+    private void PublishAnchor()
+    {
+        var top = TopLevel.GetTopLevel(this);
+        if (top != null && this.Parent is Visual parent &&
+            parent.TranslatePoint(new Point(0, 0), top) is { } o)
+        {
+            ChainPanelAnchor.Current =
+                new Point(o.X + Margin.Left + _drag.X, o.Y + Margin.Top + _drag.Y);
+        }
+    }
+
+    private void Handle_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is Grid handle)
+        {
+            _isDragging = false;
+            var root = this.VisualRoot as Visual;
+            _lastScreenPoint = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            e.Pointer.Capture(handle);
+        }
+    }
+
+    private void Handle_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            var root = this.VisualRoot as Visual;
+            var current = root != null ? e.GetPosition(root) : e.GetPosition(this);
+            var dx = current.X - _lastScreenPoint.X;
+            var dy = current.Y - _lastScreenPoint.Y;
+
+            if (!_isDragging && (dx * dx + dy * dy) > 25.0)
+                _isDragging = true;
+
+            if (_isDragging)
+            {
+                _drag.X += dx;
+                _drag.Y += dy;
+                _lastScreenPoint = current;
+                PublishAnchor();
+            }
+            e.Handled = true;
+        }
+    }
+
+    private void Handle_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (sender is Grid handle && e.Pointer.Captured == handle)
+        {
+            _isDragging = false;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Views/Controls/DialogChrome.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/DialogChrome.axaml.cs
@@ -64,6 +64,18 @@ public partial class DialogChrome : UserControl
         set => SetValue(ShowBackButtonProperty, value);
     }
 
+    // When true (default) the panel opens at the chain anchor and is header-draggable.
+    // Set false for full-screen workspace dialogs (Field Builder, Vehicle Config,
+    // AutoSteer) that fill their parent — there is no position to anchor or drag.
+    public static readonly StyledProperty<bool> AnchoredProperty =
+        AvaloniaProperty.Register<DialogChrome, bool>(nameof(Anchored), true);
+
+    public bool Anchored
+    {
+        get => GetValue(AnchoredProperty);
+        set => SetValue(AnchoredProperty, value);
+    }
+
     public static readonly StyledProperty<ICommand?> BackCommandProperty =
         AvaloniaProperty.Register<DialogChrome, ICommand?>(nameof(BackCommand));
 
@@ -150,6 +162,7 @@ public partial class DialogChrome : UserControl
     /// </summary>
     private void PositionAtChainAnchor()
     {
+        if (!Anchored) return; // full-screen workspaces fill their parent
         var top = TopLevel.GetTopLevel(this);
         if (top == null || this.Parent is not Visual parent) return;
         var parentOrigin = parent.TranslatePoint(new Point(0, 0), top) ?? default;
@@ -185,6 +198,7 @@ public partial class DialogChrome : UserControl
 
     private void Handle_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (!Anchored) return; // full-screen workspaces don't drag
         if (sender is Grid handle)
         {
             _isDragging = false;

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml
@@ -13,6 +13,7 @@ the Free Software Foundation, either version 3 of the License, or
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="400"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.AboutDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -20,10 +21,11 @@ the Free Software Foundation, either version 3 of the License, or
              IsHitTestVisible="{Binding State.UI.IsAboutDialogVisible}">
 
     <Grid>
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="24"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
+        <controls:DialogChrome Title="{loc:Localize About}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 MinWidth="420" MaxWidth="550">
             <StackPanel Spacing="12">
                 <TextBlock Text="{loc:Localize Agvaloniagps}" FontSize="22" FontWeight="Bold"
@@ -59,12 +61,7 @@ the Free Software Foundation, either version 3 of the License, or
                                Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontSize="12"/>
                 </StackPanel>
 
-                <Button Content="{loc:Localize Close}" Margin="0,8,0,0"
-                        Command="{Binding CloseAboutDialogCommand}"
-                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                        HorizontalAlignment="Stretch" Height="44" FontSize="16" FontWeight="Bold"
-                        HorizontalContentAlignment="Center" CornerRadius="6"/>
             </StackPanel>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AboutDialogPanel.axaml.cs
@@ -33,7 +33,7 @@ public partial class AboutDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CloseAboutDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
@@ -27,12 +27,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              IsHitTestVisible="{Binding State.UI.IsAgShareDownloadDialogVisible}">
 
     <UserControl.Styles>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="Bold"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
         <Style Selector="CheckBox">
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
@@ -78,9 +72,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <StackPanel Grid.Row="2" Margin="0,10" Spacing="10">
                     <StackPanel Orientation="Horizontal" Spacing="10">
                         <Button Content="{loc:Localize Refresh}" Click="Refresh_Click"
-                                Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
+                                Classes="SecondaryButton"/>
                         <Button x:Name="BtnDownloadAll" Content="{loc:Localize DownloadAll}" Click="DownloadAll_Click"
-                                Background="#9B59B6" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="10,5" CornerRadius="4"/>
+                                Classes="DialogButton"/>
                     </StackPanel>
                     <CheckBox x:Name="ForceOverwriteCheckBox" Content="{loc:Localize ForceOverwriteExistingFields}"/>
                 </StackPanel>
@@ -97,8 +91,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Download (Back/Close live in the header chrome). -->
                 <Button Grid.Row="4" x:Name="BtnDownload" Content="{loc:Localize DownloadSelected}"
-                        Classes="DialogButton" IsEnabled="False" HorizontalAlignment="Right" Margin="0,10,0,0"
-                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                        Classes="OkButton" IsEnabled="False" HorizontalAlignment="Right" Margin="0,10,0,0"
                         Click="Download_Click"/>
             </Grid>
         </controls:DialogChrome>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:local="clr-namespace:AgValoniaGPS.Views.Controls.Dialogs;assembly=AgValoniaGPS.Views"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.AgShareDownloadDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsAgShareDownloadDialogVisible}"
@@ -38,18 +39,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog Content -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
+        <controls:DialogChrome Title="{loc:Localize DownloadFromAgshare}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 MinWidth="400" MaxWidth="500" MaxHeight="600">
             <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
-                <!-- Header -->
-                <TextBlock Grid.Row="0" Text="{loc:Localize DownloadFromAgshare}"
-                           FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                           HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
                 <!-- Field List -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6"
@@ -99,17 +95,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                HorizontalAlignment="Center" Margin="0,5"/>
                 </StackPanel>
 
-                <!-- Action Buttons -->
-                <Grid Grid.Row="4" ColumnDefinitions="*,Auto,Auto" Margin="0,10,0,0">
-                    <Button Grid.Column="1" x:Name="BtnDownload" Content="{loc:Localize DownloadSelected}"
-                            Classes="DialogButton" IsEnabled="False"
-                            Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                            Click="Download_Click" Margin="0,0,10,0"/>
-                    <Button Grid.Column="2" Content="{loc:Localize Cancel}" Classes="DialogButton"
-                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                            Click="Cancel_Click"/>
-                </Grid>
+                <!-- Download (Back/Close live in the header chrome). -->
+                <Button Grid.Row="4" x:Name="BtnDownload" Content="{loc:Localize DownloadSelected}"
+                        Classes="DialogButton" IsEnabled="False" HorizontalAlignment="Right" Margin="0,10,0,0"
+                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                        Click="Download_Click"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareDownloadDialogPanel.axaml.cs
@@ -259,7 +259,7 @@ public partial class AgShareDownloadDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CancelAgShareDownloadDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
@@ -48,39 +48,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="MinHeight" Value="40"/>
         </Style>
         <Style Selector="Border.InputField.Selected">
-            <Setter Property="BorderBrush" Value="#1ABC9C"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource InfoAccentBrush}"/>
             <Setter Property="BorderThickness" Value="2"/>
-        </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="24,12"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-        </Style>
-        <Style Selector="Button.TestButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,8"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="4"/>
-        </Style>
-        <Style Selector="Button.TestButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -123,7 +92,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Test Connection & Enable -->
                 <Grid Grid.Row="3" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,8">
-                    <Button Grid.Column="0" Classes="TestButton" Click="TestConnection_Click">
+                    <Button Grid.Column="0" Classes="SecondaryButton" Click="TestConnection_Click">
                         <TextBlock Text="{loc:Localize TestConnection}"/>
                     </Button>
                     <TextBlock x:Name="ConnectionStatusLabel" Grid.Column="1"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml
@@ -84,33 +84,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
-    <!-- Semi-transparent overlay background -->
     <Grid>
-        <!-- Backdrop that dims the rest of the UI -->
-        <Border Background="#80000000" IsHitTestVisible="True"
-                PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel positioned near top for mobile -->
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="12"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="1"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Top"
-                Margin="0,20,0,0"
-                MinWidth="380"
-                MaxWidth="420"
-                Padding="16">
-            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-                <!-- Title -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,12">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AgShare.png" Width="24" Height="24" Margin="0,0,8,0"/>
-                    <TextBlock Text="{loc:Localize AgshareSettings}"
-                               FontSize="18"
-                               FontWeight="Bold"
-                               Foreground="#1ABC9C"
-                               VerticalAlignment="Center"/>
-                </StackPanel>
+        <controls:DialogChrome Title="{loc:Localize AgshareSettings}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MinWidth="380" MaxWidth="420">
+            <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
 
                 <!-- Server URL Field -->
                 <StackPanel Grid.Row="1" Margin="0,0,0,8">
@@ -162,22 +143,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     MaxLength="200"
                                                     Margin="0,0,0,12"/>
 
-                <!-- Buttons -->
-                <Grid Grid.Row="5" ColumnDefinitions="*,*" Margin="0,4,0,0">
-                    <Button Grid.Column="0"
-                            Classes="DialogButton CancelButton"
-                            Content="{loc:Localize Cancel}"
-                            HorizontalAlignment="Stretch"
-                            Click="Cancel_Click"
-                            Margin="0,0,6,0"/>
-                    <Button Grid.Column="1"
-                            Classes="DialogButton"
-                            Content="{loc:Localize Save}"
-                            HorizontalAlignment="Stretch"
-                            Click="Save_Click"
-                            Margin="6,0,0,0"/>
-                </Grid>
+                <!-- Save (Back/Close live in the header chrome). -->
+                <Button Grid.Row="5" Classes="DialogButton"
+                        Content="{loc:Localize Save}" HorizontalAlignment="Right" Margin="0,4,0,0"
+                        Click="Save_Click"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareSettingsDialogPanel.axaml.cs
@@ -195,7 +195,7 @@ public partial class AgShareSettingsDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CancelAgShareSettingsDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
@@ -27,12 +27,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              IsHitTestVisible="{Binding State.UI.IsAgShareUploadDialogVisible}">
 
     <UserControl.Styles>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="Bold"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
         <Style Selector="CheckBox">
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         </Style>
@@ -100,8 +94,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Upload (Back/Close live in the header chrome). -->
                 <Button Grid.Row="4" x:Name="BtnUpload" Content="{loc:Localize Upload}"
-                        Classes="DialogButton" IsEnabled="False" HorizontalAlignment="Right" Margin="0,10,0,0"
-                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                        Classes="OkButton" IsEnabled="False" HorizontalAlignment="Right" Margin="0,10,0,0"
                         Click="Upload_Click"/>
             </Grid>
         </controls:DialogChrome>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml
@@ -20,6 +20,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:local="clr-namespace:AgValoniaGPS.Views.Controls.Dialogs;assembly=AgValoniaGPS.Views"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.AgShareUploadDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsAgShareUploadDialogVisible}"
@@ -38,18 +39,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog Content -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
+        <controls:DialogChrome Title="{loc:Localize UploadToAgshare}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 MinWidth="400" MaxWidth="500" MaxHeight="600">
             <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
-                <!-- Header -->
-                <TextBlock Grid.Row="0" Text="{loc:Localize UploadToAgshare}"
-                           FontSize="20" FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                           HorizontalAlignment="Center" Margin="0,0,0,15"/>
 
                 <!-- Field List -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6"
@@ -102,17 +98,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                HorizontalAlignment="Center" Margin="0,5"/>
                 </StackPanel>
 
-                <!-- Action Buttons -->
-                <Grid Grid.Row="4" ColumnDefinitions="*,Auto,Auto" Margin="0,10,0,0">
-                    <Button Grid.Column="1" x:Name="BtnUpload" Content="{loc:Localize Upload}"
-                            Classes="DialogButton" IsEnabled="False"
-                            Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                            Click="Upload_Click" Margin="0,0,10,0"/>
-                    <Button Grid.Column="2" Content="{loc:Localize Cancel}" Classes="DialogButton"
-                            Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                            Click="Cancel_Click"/>
-                </Grid>
+                <!-- Upload (Back/Close live in the header chrome). -->
+                <Button Grid.Row="4" x:Name="BtnUpload" Content="{loc:Localize Upload}"
+                        Classes="DialogButton" IsEnabled="False" HorizontalAlignment="Right" Margin="0,10,0,0"
+                        Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                        Click="Upload_Click"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AgShareUploadDialogPanel.axaml.cs
@@ -406,7 +406,7 @@ public partial class AgShareUploadDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CancelAgShareUploadDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
@@ -14,6 +14,7 @@ the Free Software Foundation, either version 3 of the License, or
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:conv="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="560"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.AppSettingsDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -59,25 +60,18 @@ the Free Software Foundation, either version 3 of the License, or
         </Style>
     </UserControl.Styles>
 
-    <!-- Full screen modal overlay -->
     <Grid>
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="8" Width="560" Height="560"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="1" BoxShadow="0 8 32 #80000000">
-            <Grid RowDefinitions="Auto,Auto,*,Auto">
-                <!-- Header -->
-                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,8">
-                    <TextBlock Text="App Settings" FontSize="18" FontWeight="Bold"
-                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                </Border>
+        <controls:DialogChrome Title="App Settings"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                Width="560" Height="560">
+            <Grid RowDefinitions="Auto,*">
 
                 <!-- Set-once system preferences (Units | System on one row). Display,
                      sounds, on-screen buttons and messages now live in Screen & Alerts. -->
-                <Grid Grid.Row="1" Margin="24,16" ColumnDefinitions="Auto,Auto,*"
+                <Grid Grid.Row="0" Margin="8,8,8,12" ColumnDefinitions="Auto,Auto,*"
                       DataContext="{Binding ConfigurationViewModel}" x:DataType="vm:ConfigurationViewModel">
                             <!-- Units -->
                             <StackPanel Grid.Column="0" Spacing="8" VerticalAlignment="Top">
@@ -143,7 +137,7 @@ the Free Software Foundation, either version 3 of the License, or
 
                 <!-- App Directories (folded in). Scroll lives inside this list,
                      not the whole panel, so Units/System stay fixed above. -->
-                <Grid Grid.Row="2" Margin="24,0,24,8" RowDefinitions="Auto,*">
+                <Grid Grid.Row="1" Margin="8,0,8,8" RowDefinitions="Auto,*">
                     <TextBlock Grid.Row="0" Text="{loc:Localize AppDirectories}" Classes="AppGroupHeader"/>
                     <ScrollViewer Grid.Row="1">
                         <ItemsControl ItemsSource="{Binding AppDirectories}">
@@ -164,19 +158,7 @@ the Free Software Foundation, either version 3 of the License, or
                     </ScrollViewer>
                 </Grid>
 
-                <!-- Footer -->
-                <Border Grid.Row="3" Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Padding="16,12">
-                    <Grid ColumnDefinitions="*,Auto">
-                        <Button Grid.Column="1" Width="48" Height="48" Background="#4A9A7E" CornerRadius="24"
-                                Command="{Binding CloseAppSettingsDialogCommand}"
-                                ToolTip.Tip="Close">
-                            <TextBlock Text="✓" FontSize="24" FontWeight="Bold"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Button>
-                    </Grid>
-                </Border>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml
@@ -50,7 +50,7 @@ the Free Software Foundation, either version 3 of the License, or
         <Style Selector="TextBlock.AppGroupHeader">
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Foreground" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="Margin" Value="0,0,0,10"/>
         </Style>
         <Style Selector="Border.VRule">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AppSettingsDialogPanel.axaml.cs
@@ -19,7 +19,7 @@ public partial class AppSettingsDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CloseAppSettingsDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/AutoSteerConfigPanel.axaml
@@ -55,7 +55,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.TappableValue:pointerover">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource StatusOkBrush}"/>
         </Style>
 
         <!-- Toggle Button -->
@@ -109,7 +109,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <!-- Full screen modal overlay -->
-    <Grid Background="#80000000">
+    <Grid Background="{DynamicResource ModalBackdropBrush}">
         <!-- Main dialog container -->
         <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 CornerRadius="8"
@@ -166,17 +166,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Pure Pursuit Controls -->
                                             <StackPanel Spacing="12" IsVisible="{Binding !AutoSteer.IsStanleyMode}">
                                                 <!-- Algorithm Label -->
-                                                <TextBlock Text="{loc:Localize PurePursuit}" FontSize="18" FontWeight="Bold" Foreground="#4A9A7E"
+                                                <TextBlock Text="{loc:Localize PurePursuit}" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"
                                                            HorizontalAlignment="Center"/>
 
                                                 <!-- Steer Response -->
                                                 <Border Classes="ParamCard">
                                                     <StackPanel Spacing="8">
                                                         <Grid ColumnDefinitions="Auto,*,Auto">
-                                                            <TextBlock Text="{loc:Localize Fast}" Foreground="#4A9A7E" FontSize="12"/>
+                                                            <TextBlock Text="{loc:Localize Fast}" Foreground="{DynamicResource StatusOkBrush}" FontSize="12"/>
                                                             <TextBlock Grid.Column="1" Text="{loc:Localize SteerResponse}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                        HorizontalAlignment="Center" FontWeight="SemiBold"/>
-                                                            <TextBlock Grid.Column="2" Text="{loc:Localize Slow}" Foreground="#E74C3C" FontSize="12"/>
+                                                            <TextBlock Grid.Column="2" Text="{loc:Localize Slow}" Foreground="{DynamicResource DangerButtonBrush}" FontSize="12"/>
                                                         </Grid>
                                                         <Grid ColumnDefinitions="Auto,*">
                                                             <Button Classes="TappableValue" Command="{Binding EditSteerResponseCommand}"
@@ -290,10 +290,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8" HorizontalAlignment="Center">
                                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
-                                                        <TextBlock Text="{loc:Localize }" Foreground="#4A9A7E"/>
+                                                        <TextBlock Text="{loc:Localize }" Foreground="{DynamicResource StatusOkBrush}"/>
                                                         <TextBlock Text="{Binding AutoSteer.WasOffset}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                    FontWeight="Bold" FontSize="18"/>
-                                                        <TextBlock Text="{loc:Localize lt}" Foreground="#4A9A7E"/>
+                                                        <TextBlock Text="{loc:Localize lt}" Foreground="{DynamicResource StatusOkBrush}"/>
                                                     </StackPanel>
                                                     <TextBlock Text="{loc:Localize WasZero}" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}" HorizontalAlignment="Center"/>
                                                     <Button Content="{loc:Localize ZeroWas}" Command="{Binding ZeroWasCommand}"
@@ -439,7 +439,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     <!-- Tab 4 Content: Gain -->
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="{loc:Localize Gain}" FontSize="18" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize Gain}" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Proportional Gain -->
@@ -587,7 +587,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Turn Sensor -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
-                                                    <TextBlock Text="{loc:Localize TurnSensor}" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
+                                                    <TextBlock Text="{loc:Localize TurnSensor}" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
@@ -615,7 +615,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Pressure Turn -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
-                                                    <TextBlock Text="{loc:Localize PressureTurn}" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
+                                                    <TextBlock Text="{loc:Localize PressureTurn}" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
@@ -650,7 +650,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <!-- Current Turn -->
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="8">
-                                                    <TextBlock Text="{loc:Localize CurrentTurn}" FontSize="14" FontWeight="Bold" Foreground="#4A9A7E"/>
+                                                    <TextBlock Text="{loc:Localize CurrentTurn}" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"/>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Border Grid.Column="0" CornerRadius="4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
                                                                 Margin="0,0,8,0"
@@ -693,7 +693,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="8">
-                                            <TextBlock Text="{loc:Localize HardwareConfig}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize HardwareConfig}" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Toggle buttons for hardware settings -->
@@ -806,7 +806,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="{loc:Localize SteeringAlgorithm}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize SteeringAlgorithm}" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Stanley/Pure toggle -->
@@ -816,7 +816,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <Grid ColumnDefinitions="*,Auto">
                                                         <TextBlock Text="{loc:Localize Algorithm}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                                         <Grid Grid.Column="1">
-                                                            <TextBlock Text="{loc:Localize Stanley}" Foreground="#4A9A7E" FontWeight="Bold"
+                                                            <TextBlock Text="{loc:Localize Stanley}" Foreground="{DynamicResource StatusOkBrush}" FontWeight="Bold"
                                                                        IsVisible="{Binding AutoSteer.IsStanleyMode}"/>
                                                             <TextBlock Text="{loc:Localize PurePursuit}" Foreground="{DynamicResource SystemControlHighlightAccentBrush}" FontWeight="Bold"
                                                                        IsVisible="{Binding !AutoSteer.IsStanleyMode}"/>
@@ -829,10 +829,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             <Border Classes="ParamCard">
                                                 <StackPanel Spacing="4">
                                                     <Grid ColumnDefinitions="Auto,*,Auto">
-                                                        <TextBlock Text="{loc:Localize Out}" Foreground="#E74C3C" FontSize="11"/>
+                                                        <TextBlock Text="{loc:Localize Out}" Foreground="{DynamicResource DangerButtonBrush}" FontSize="11"/>
                                                         <TextBlock Grid.Column="1" Text="{loc:Localize UTurnCompensation}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                                    HorizontalAlignment="Center" FontWeight="SemiBold"/>
-                                                        <TextBlock Grid.Column="2" Text="{loc:Localize In}" Foreground="#4A9A7E" FontSize="11"/>
+                                                        <TextBlock Grid.Column="2" Text="{loc:Localize In}" Foreground="{DynamicResource StatusOkBrush}" FontSize="11"/>
                                                     </Grid>
                                                     <Grid ColumnDefinitions="Auto,*">
                                                         <Button Classes="TappableValue" Command="{Binding EditUTurnCompensationCommand}">
@@ -870,9 +870,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                                     <Grid ColumnDefinitions="*,Auto">
                                                         <TextBlock Text="{loc:Localize SteerInReverse}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                                                         <Grid Grid.Column="1">
-                                                            <TextBlock Text="{loc:Localize On2}" Foreground="#4A9A7E" FontWeight="Bold"
+                                                            <TextBlock Text="{loc:Localize On2}" Foreground="{DynamicResource StatusOkBrush}" FontWeight="Bold"
                                                                        IsVisible="{Binding AutoSteer.SteerInReverse}"/>
-                                                            <TextBlock Text="{loc:Localize Off2}" Foreground="#E74C3C" FontWeight="Bold"
+                                                            <TextBlock Text="{loc:Localize Off2}" Foreground="{DynamicResource DangerButtonBrush}" FontWeight="Bold"
                                                                        IsVisible="{Binding !AutoSteer.SteerInReverse}"/>
                                                         </Grid>
                                                     </Grid>
@@ -890,7 +890,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="{loc:Localize SpeedLimits}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize SpeedLimits}" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Speed Settings -->
@@ -955,7 +955,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                     </TabItem.Header>
                                     <ScrollViewer Padding="8">
                                         <StackPanel Spacing="12">
-                                            <TextBlock Text="{loc:Localize DisplaySettings}" FontSize="16" FontWeight="Bold" Foreground="#4A9A7E"
+                                            <TextBlock Text="{loc:Localize DisplaySettings}" FontSize="16" FontWeight="Bold" Foreground="{DynamicResource StatusOkBrush}"
                                                        HorizontalAlignment="Center"/>
 
                                             <!-- Numeric inputs row 1: Line Width & Nudge Distance -->
@@ -1143,7 +1143,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             <StackPanel Orientation="Horizontal" Width="80">
                                 <TextBlock Text="{loc:Localize Err}" Classes="StatusLabel" VerticalAlignment="Center" Width="30"/>
                                 <TextBlock Text="{Binding SteerError, StringFormat='{}{0:F1}°'}"
-                                           Foreground="#E74C3C" FontWeight="Bold" FontSize="14"
+                                           Foreground="{DynamicResource DangerButtonBrush}" FontWeight="Bold" FontSize="14"
                                            VerticalAlignment="Center" Width="50" TextAlignment="Right"/>
                             </StackPanel>
                         </StackPanel>
@@ -1225,7 +1225,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12" Padding="24"
                     Width="320"
                     HorizontalAlignment="Center" VerticalAlignment="Center"
-                    BorderBrush="#E74C3C" BorderThickness="2">
+                    BorderBrush="{DynamicResource DangerButtonBrush}" BorderThickness="2">
                 <StackPanel Spacing="16">
                     <!-- Warning Icon and Title -->
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BoundaryMapDialogPanel.axaml
@@ -43,14 +43,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ToolButton:pressed">
-            <Setter Property="Background" Value="#1ABC9C"/>
+            <Setter Property="Background" Value="{DynamicResource InfoAccentBrush}"/>
         </Style>
         <Style Selector="Button.ToolButton.active">
-            <Setter Property="Background" Value="#1ABC9C"/>
+            <Setter Property="Background" Value="{DynamicResource InfoAccentBrush}"/>
         </Style>
 
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#C0392B"/>
+            <Setter Property="Background" Value="{DynamicResource DangerButtonHoverBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="MinWidth" Value="80"/>
@@ -59,11 +59,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#E74C3C"/>
+            <Setter Property="Background" Value="{DynamicResource DangerButtonBrush}"/>
         </Style>
 
         <Style Selector="Button.OkButton">
-            <Setter Property="Background" Value="#27AE60"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="MinWidth" Value="80"/>
@@ -72,7 +72,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.OkButton:pointerover">
-            <Setter Property="Background" Value="#2ECC71"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonHoverBrush}"/>
         </Style>
         <Style Selector="Button.OkButton:disabled">
             <Setter Property="Opacity" Value="0.5"/>
@@ -85,7 +85,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid>
         <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel - full screen with margin for touch targets -->
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
@@ -99,7 +99,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Grid.Column="0">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="24" Height="24"/>
-                                <TextBlock Text="{loc:Localize DrawFieldBoundary}" Foreground="#1ABC9C" FontWeight="Bold" FontSize="18"/>
+                                <TextBlock Text="{loc:Localize DrawFieldBoundary}" Foreground="{DynamicResource InfoAccentBrush}" FontWeight="Bold" FontSize="18"/>
                                 <Border Background="#F5F54D" CornerRadius="4" Padding="6,2" VerticalAlignment="Center"
                                         IsVisible="{Binding IsInnerBoundaryMode}">
                                     <TextBlock Text="INNER" FontSize="12" FontWeight="Bold" Foreground="#333333"/>
@@ -110,7 +110,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
                             <TextBlock x:Name="PointCountLabel" Text="{Binding BoundaryMapPointCount, StringFormat='Points: {0}'}"
-                                       Foreground="#1ABC9C" FontSize="14"
+                                       Foreground="{DynamicResource InfoAccentBrush}" FontSize="14"
                                        FontWeight="Bold" VerticalAlignment="Center"/>
                             <TextBlock x:Name="CoordinateLabel" Text="{Binding BoundaryMapCoordinateText}"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12"
@@ -123,7 +123,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <mapsui:MapControl x:Name="MapControl" Grid.Row="1"/>
 
                 <!-- Bottom toolbar -->
-                <Border Grid.Row="1" Background="#80000000" Padding="10"
+                <Border Grid.Row="1" Background="{DynamicResource ModalBackdropBrush}" Padding="10"
                         VerticalAlignment="Top" HorizontalAlignment="Left"
                         CornerRadius="0,0,8,0" Margin="0">
                     <StackPanel Orientation="Horizontal" Spacing="8">

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml
@@ -1,23 +1,20 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.BugReportDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsBugReportDialogVisible}"
              IsHitTestVisible="{Binding State.UI.IsBugReportDialogVisible}">
 
-    <!-- Semi-transparent backdrop -->
-    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="12" Padding="24"
-                MaxWidth="520" MaxHeight="680"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
-                BoxShadow="0 4 16 #40000000"
-                PointerPressed="Body_PointerPressed">
+    <Grid>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
+        <controls:DialogChrome Title="Report a Bug"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MaxWidth="520" MaxHeight="680">
             <StackPanel Spacing="12">
-                <TextBlock Text="Report a Bug" FontSize="22" FontWeight="Bold"
-                           HorizontalAlignment="Center"/>
 
                 <!-- What gets captured -->
                 <TextBlock TextWrapping="Wrap" FontSize="12"
@@ -83,17 +80,12 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <!-- Buttons -->
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="12" Margin="0,8,0,0">
-                    <Button Content="Submit Report" Classes="ModernButton"
-                            MinWidth="140" MinHeight="40"
-                            Command="{Binding SubmitBugReportCommand}"
-                            IsEnabled="{Binding BugReportTitle.Length}"/>
-                    <Button Content="Cancel" Classes="ModernButton"
-                            MinWidth="100" MinHeight="40"
-                            Command="{Binding CloseBugReportDialogCommand}"/>
-                </StackPanel>
+                <!-- Submit (Back/Close live in the header chrome). -->
+                <Button Content="Submit Report" Classes="ModernButton"
+                        HorizontalAlignment="Center" MinWidth="140" MinHeight="40" Margin="0,8,0,0"
+                        Command="{Binding SubmitBugReportCommand}"
+                        IsEnabled="{Binding BugReportTitle.Length}"/>
             </StackPanel>
-        </Border>
-    </Border>
+        </controls:DialogChrome>
+    </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/BugReportDialogPanel.axaml.cs
@@ -24,7 +24,7 @@ public partial class BugReportDialogPanel : UserControl
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
-            vm.CloseBugReportDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
     }
 
     // Stop pointer events on the dialog body chrome from bubbling up to

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/MachineModuleSubTab.axaml
@@ -72,7 +72,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="TextBlock.SectionHeader">
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Foreground" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
         </Style>
     </UserControl.Styles>
@@ -158,7 +158,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Text="Send + Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                         <TextBlock Text="&#x2699;" FontSize="18" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" VerticalAlignment="Center"/>
-                        <TextBlock Text="&#x2192;" FontSize="18" Foreground="#4A9A7E" VerticalAlignment="Center"/>
+                        <TextBlock Text="&#x2192;" FontSize="18" Foreground="{DynamicResource StatusOkBrush}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
             </StackPanel>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/PinConfigSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/MachineSubTabs/PinConfigSubTab.axaml
@@ -27,7 +27,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <UserControl.Styles>
         <!-- Pin Label -->
         <Style Selector="TextBlock.PinLabel">
-            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Foreground" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="FontSize" Value="11"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="HorizontalAlignment" Value="Center"/>
@@ -214,7 +214,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Upload Button -->
                 <Button Grid.Column="1" Classes="ActionButton" Command="{Binding UploadPinConfigCommand}" Margin="8,0,0,0">
-                    <TextBlock Text="&#x2191;" FontSize="20" Foreground="#4A9A7E"/>
+                    <TextBlock Text="&#x2191;" FontSize="20" Foreground="{DynamicResource StatusOkBrush}"/>
                 </Button>
 
                 <!-- Send + Save -->
@@ -222,7 +222,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Text="Send + Save" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold" VerticalAlignment="Center"/>
                         <TextBlock Text="&#x2699;" FontSize="18" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" VerticalAlignment="Center"/>
-                        <TextBlock Text="&#x2192;" FontSize="18" Foreground="#4A9A7E" VerticalAlignment="Center"/>
+                        <TextBlock Text="&#x2192;" FontSize="18" Foreground="{DynamicResource StatusOkBrush}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/GpsSubTab.axaml
@@ -40,7 +40,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Border.AntennaCard.Selected">
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
 
@@ -48,7 +48,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="TextBlock.SectionHeader">
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Foreground" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
         </Style>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/SourcesSubTabs/RollSubTab.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="TextBlock.SectionHeader">
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Foreground" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="Margin" Value="0,16,0,8"/>
         </Style>
 
@@ -45,7 +45,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Action Button Style -->
         <Style Selector="Button.ActionButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="CornerRadius" Value="4"/>
             <Setter Property="Padding" Value="16,8"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolSectionsSubTab.axaml
@@ -51,7 +51,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="Button.SectionWidthBtn:pointerover">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource StatusOkBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTypeSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolTypeSubTab.axaml
@@ -51,7 +51,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
         <Style Selector="RadioButton.TypeCard:checked /template/ Border#PART_Border">
             <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="BorderBrush" Value="#4A9A7E"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource StatusOkBrush}"/>
         </Style>
     </UserControl.Styles>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/VehicleConfigTab.axaml
@@ -214,7 +214,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
 
                     <!-- Selection display -->
-                    <Border Background="#4A9A7E" CornerRadius="8" Padding="16,12"
+                    <Border Background="{DynamicResource StatusOkBrush}" CornerRadius="8" Padding="16,12"
                             HorizontalAlignment="Center" Margin="0,24,0,0">
                         <TextBlock Text="{Binding Vehicle.VehicleTypeDisplayName, StringFormat='Selected: {0}'}"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold" FontSize="16"/>
@@ -314,7 +314,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                 Command="{Binding SetAntennaOffsetLeftCommand}">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AntennaLeftOffset.png" Stretch="Uniform"/>
                         </Button>
-                        <Button Width="50" Height="36" Padding="4" Background="#4A9A7E" ToolTip.Tip="Antenna on Centerline"
+                        <Button Width="50" Height="36" Padding="4" Background="{DynamicResource StatusOkBrush}" ToolTip.Tip="Antenna on Centerline"
                                 Command="{Binding SetAntennaOffsetCenterCommand}">
                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AntennaNoOffset.png" Stretch="Uniform"/>
                         </Button>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfigurationDialog.axaml
@@ -100,7 +100,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Resources>
 
     <!-- Full screen modal overlay -->
-    <Grid Background="#80000000">
+    <Grid Background="{DynamicResource ModalBackdropBrush}">
         <!-- Main dialog container - fixed size to prevent resizing on tab switch -->
         <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                 CornerRadius="8"
@@ -266,13 +266,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                             <!-- Action Buttons -->
                             <Grid Grid.Row="3" ColumnDefinitions="*,*" ColumnSpacing="8">
-                                <Button Grid.Column="0" Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                <Button Grid.Column="0" Background="{DynamicResource DangerButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding CancelNumericInputCommand}"
                                         HorizontalContentAlignment="Center">
                                     <TextBlock Text="{loc:Localize Cancel}"/>
                                 </Button>
-                                <Button Grid.Column="1" Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                <Button Grid.Column="1" Background="{DynamicResource StatusOkBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding ConfirmNumericInputCommand}"
                                         HorizontalContentAlignment="Center">
@@ -402,13 +402,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                             <!-- Action Buttons -->
                             <Grid Grid.Row="3" ColumnDefinitions="*,*" ColumnSpacing="8">
-                                <Button Grid.Column="0" Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                <Button Grid.Column="0" Background="{DynamicResource DangerButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding CancelTextInputCommand}"
                                         HorizontalContentAlignment="Center">
                                     <TextBlock Text="{loc:Localize Cancel}"/>
                                 </Button>
-                                <Button Grid.Column="1" Background="#4A9A7E" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                <Button Grid.Column="1" Background="{DynamicResource StatusOkBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                         FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                         Command="{Binding ConfirmTextInputCommand}"
                                         HorizontalContentAlignment="Center">
@@ -486,7 +486,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             </UniformGrid>
 
                             <!-- Cancel Button -->
-                            <Button Grid.Row="2" Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            <Button Grid.Row="2" Background="{DynamicResource DangerButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                     FontSize="16" FontWeight="Bold" CornerRadius="8" Height="48"
                                     Command="{Binding CancelColorPickerCommand}"
                                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center">
@@ -519,7 +519,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                         <!-- Apply button (checkmark) -->
                         <Button Grid.Column="5" Width="48" Height="48"
-                                Background="#4A9A7E" CornerRadius="24"
+                                Background="{DynamicResource StatusOkBrush}" CornerRadius="24"
                                 Command="{Binding ApplyCommand}"
                                 ToolTip.Tip="Apply and Close">
                             <TextBlock Text="✓" FontSize="24" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="Bold"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
@@ -37,9 +37,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="320" MaxWidth="400">
             <StackPanel Spacing="16">
-                <!-- Title -->
-                <TextBlock Text="{Binding ConfirmationDialogTitle}" FontSize="20" FontWeight="Bold"
-                           Foreground="#E74C3C" HorizontalAlignment="Center"/>
+                <!-- Title, with an optional Back arrow when the confirmation was
+                     raised from a fly-out item (e.g. Field Tools → Delete Applied
+                     Area) so it can return to that fly-out instead of the map. -->
+                <Grid ColumnDefinitions="Auto,*,Auto">
+                    <Button Grid.Column="0" Content="&#x2190;" Width="28" Height="28" Padding="0"
+                            Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            FontSize="18" BorderThickness="0" Cursor="Hand" ToolTip.Tip="Back"
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                            IsVisible="{Binding IsConfirmationBackVisible}"
+                            Command="{Binding BackFromConfirmationCommand}"/>
+                    <TextBlock Grid.Column="1" Text="{Binding ConfirmationDialogTitle}" FontSize="20" FontWeight="Bold"
+                               Foreground="#E74C3C" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    <Border Grid.Column="2" Width="28"/>
+                </Grid>
 
                 <!-- Message -->
                 <TextBlock Text="{Binding ConfirmationDialogMessage}" FontSize="14"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ConfirmationDialogPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Full screen overlay with backdrop -->
     <Grid>
         <!-- Semi-transparent backdrop - clicking dismisses (cancels) -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
@@ -48,7 +48,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             IsVisible="{Binding IsConfirmationBackVisible}"
                             Command="{Binding BackFromConfirmationCommand}"/>
                     <TextBlock Grid.Column="1" Text="{Binding ConfirmationDialogTitle}" FontSize="20" FontWeight="Bold"
-                               Foreground="#E74C3C" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                               Foreground="{DynamicResource DangerButtonBrush}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     <Border Grid.Column="2" Width="28"/>
                 </Grid>
 
@@ -78,7 +78,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Padding="0" CornerRadius="6"/>
                     <Button Grid.Column="1" Content="{loc:Localize Yes}" Margin="8,0,0,0"
                             Command="{Binding ConfirmConfirmationDialogCommand}"
-                            Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Background="{DynamicResource DangerButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="50" FontSize="18" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Padding="0" CornerRadius="6"/>
@@ -97,7 +97,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Padding="4" CornerRadius="6"/>
                     <Button Grid.Column="1" Content="{Binding ConfirmationDialogConfirmLabel}" Margin="8,0,0,0"
                             Command="{Binding ConfirmConfirmationDialogCommand}"
-                            Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Background="{DynamicResource DangerButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="50" FontSize="16" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                             Padding="4" CornerRadius="6"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/DrawABDialogPanel.axaml
@@ -42,11 +42,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ModeButton:pressed">
-            <Setter Property="Background" Value="#1ABC9C"/>
+            <Setter Property="Background" Value="{DynamicResource InfoAccentBrush}"/>
         </Style>
 
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#C0392B"/>
+            <Setter Property="Background" Value="{DynamicResource DangerButtonHoverBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
@@ -56,13 +56,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#E74C3C"/>
+            <Setter Property="Background" Value="{DynamicResource DangerButtonBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <Grid>
         <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Draw AB panel - centered -->
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ErrorDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ErrorDialogPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Full screen overlay with backdrop -->
     <Grid>
         <!-- Semi-transparent backdrop - clicking dismisses -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
@@ -39,7 +39,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <StackPanel Spacing="16">
                 <!-- Title -->
                 <TextBlock Text="{Binding ErrorDialogTitle}" FontSize="20" FontWeight="Bold"
-                           Foreground="#E74C3C" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource DangerButtonBrush}" HorizontalAlignment="Center"/>
 
                 <!-- Message -->
                 <TextBlock Text="{Binding ErrorDialogMessage}" FontSize="14"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
@@ -9,6 +9,7 @@ Licensed under GNU GPL v3.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              xmlns:converters="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.FieldBuilderDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -45,30 +46,18 @@ Licensed under GNU GPL v3.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog - full screen -->
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="0" Padding="16"
-                HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+        <!-- Full-screen workspace: Anchored=False so DialogChrome fills the parent
+             and skips the drag/anchor behaviour; just supplies the Back/Close header. -->
+        <controls:DialogChrome Title="Field Builder" Anchored="False"
+                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}">
             <Panel>
-            <Grid RowDefinitions="Auto,*">
-                <!-- Header -->
-                <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,8">
-                    <TextBlock Text="Field Builder" FontSize="24" FontWeight="Bold"
-                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                    <Button Grid.Column="1" Width="44" Height="44" Padding="0"
-                            Background="#C0392B" Foreground="White" CornerRadius="8"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            Cursor="Hand" Command="{Binding CloseFieldBuilderCommand}">
-                        <TextBlock Text="X" FontSize="20" FontWeight="Bold"
-                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                    </Button>
-                </Grid>
-
+            <Grid>
                 <!-- Main: Visualizer + Right Panel -->
-                <Grid Grid.Row="1" ColumnDefinitions="*,340" ColumnSpacing="12">
+                <Grid ColumnDefinitions="*,340" ColumnSpacing="12">
 
                     <!-- LEFT: Boundary/Track Visualizer -->
                     <Border Grid.Column="0" CornerRadius="8" ClipToBounds="True"
@@ -755,6 +744,6 @@ Licensed under GNU GPL v3.
                 </Border>
             </Border>
             </Panel>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml
@@ -31,7 +31,7 @@ Licensed under GNU GPL v3.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
         </Style>
         <Style Selector="Button.ActionBtn">
-            <Setter Property="Background" Value="#27AE60"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonBrush}"/>
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="CornerRadius" Value="6"/>
             <Setter Property="Padding" Value="12,8"/>
@@ -41,7 +41,7 @@ Licensed under GNU GPL v3.
             <Setter Property="HorizontalAlignment" Value="Stretch"/>
         </Style>
         <Style Selector="Button.ActionBtn:pointerover">
-            <Setter Property="Background" Value="#2ECC71"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonHoverBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -201,7 +201,7 @@ Licensed under GNU GPL v3.
                                                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                                                            VerticalAlignment="Center"/>
                                                 <TextBlock Grid.Column="2" Text="{Binding Offset, StringFormat='{}{0:F1}m'}" FontSize="12"
-                                                           Foreground="#1ABC9C" VerticalAlignment="Center"/>
+                                                           Foreground="{DynamicResource InfoAccentBrush}" VerticalAlignment="Center"/>
                                             </Grid>
                                         </DataTemplate>
                                     </ListBox.ItemTemplate>
@@ -254,7 +254,7 @@ Licensed under GNU GPL v3.
                                     </StackPanel>
                                     <StackPanel Spacing="2">
                                         <Button Width="56" Height="56" CornerRadius="8" Cursor="Hand" Padding="0"
-                                                Background="#C0392B" BorderThickness="0"
+                                                Background="{DynamicResource DangerButtonHoverBrush}" BorderThickness="0"
                                                 ToolTip.Tip="Delete Selected" Click="DeleteHeadlandSegment_Click">
                                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Trash.png"
                                                    Width="36" Height="36" Stretch="Uniform"/>
@@ -339,7 +339,7 @@ Licensed under GNU GPL v3.
                                     </StackPanel>
                                     <StackPanel Spacing="2">
                                         <Button Width="56" Height="56" CornerRadius="8" Cursor="Hand" Padding="0"
-                                                Background="#C0392B" BorderThickness="0"
+                                                Background="{DynamicResource DangerButtonHoverBrush}" BorderThickness="0"
                                                 ToolTip.Tip="Delete Selected" Click="DeleteTramSystem_Click">
                                             <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Trash.png"
                                                    Width="36" Height="36" Stretch="Uniform"/>
@@ -475,7 +475,7 @@ Licensed under GNU GPL v3.
 
                                 <StackPanel Spacing="2" HorizontalAlignment="Center" Margin="0,6,0,0">
                                     <Button Width="56" Height="56" CornerRadius="8" Cursor="Hand" Padding="0"
-                                            Background="#27AE60" BorderThickness="0"
+                                            Background="{DynamicResource SuccessButtonBrush}" BorderThickness="0"
                                             Click="TramSystemEditDone_Click">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png"
                                                Width="36" Height="36" Stretch="Uniform"/>
@@ -607,7 +607,7 @@ Licensed under GNU GPL v3.
                             <TextBlock x:Name="DrawInstructionText" Text="" FontSize="14" TextWrapping="Wrap"
                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
                             <TextBlock x:Name="DrawPointCountText" Text="Points: 0" FontSize="14" FontWeight="Bold"
-                                       Foreground="#1ABC9C"/>
+                                       Foreground="{DynamicResource InfoAccentBrush}"/>
 
                             <!-- Heading input for A+ Line -->
                             <StackPanel x:Name="HeadingInputPanel" IsVisible="False" Orientation="Horizontal"
@@ -639,13 +639,13 @@ Licensed under GNU GPL v3.
                                                Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
                                 </StackPanel>
                                 <TextBlock x:Name="ToolWidthResultText" Text="" FontSize="14" HorizontalAlignment="Center"
-                                           Foreground="#1ABC9C"/>
+                                           Foreground="{DynamicResource InfoAccentBrush}"/>
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center" Margin="0,8,0,0">
                                 <StackPanel x:Name="CreateABBtnPanel" Spacing="2" IsVisible="False">
                                     <Button x:Name="CreateABBtn" Width="56" Height="56" CornerRadius="8" Cursor="Hand" Padding="0"
-                                            Background="#27AE60" BorderThickness="0" Click="CreateAB_Click">
+                                            Background="{DynamicResource SuccessButtonBrush}" BorderThickness="0" Click="CreateAB_Click">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png"
                                                Width="36" Height="36" Stretch="Uniform"/>
                                     </Button>
@@ -654,7 +654,7 @@ Licensed under GNU GPL v3.
                                 </StackPanel>
                                 <StackPanel x:Name="FinishDrawBtnPanel" Spacing="2" IsVisible="False">
                                     <Button x:Name="FinishDrawBtn" Width="56" Height="56" CornerRadius="8" Cursor="Hand" Padding="0"
-                                            Background="#27AE60" BorderThickness="0" Click="FinishDraw_Click">
+                                            Background="{DynamicResource SuccessButtonBrush}" BorderThickness="0" Click="FinishDraw_Click">
                                         <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/OK64.png"
                                                Width="36" Height="36" Stretch="Uniform"/>
                                     </Button>
@@ -679,7 +679,7 @@ Licensed under GNU GPL v3.
                                                Width="36" Height="36" Stretch="Uniform"/>
                                     </Button>
                                     <TextBlock Text="Cancel" FontSize="12" HorizontalAlignment="Center"
-                                               Foreground="#E74C3C"/>
+                                               Foreground="{DynamicResource DangerButtonBrush}"/>
                                 </StackPanel>
                             </StackPanel>
 
@@ -698,7 +698,7 @@ Licensed under GNU GPL v3.
                         BoxShadow="0 8 32 #80000000">
                     <StackPanel Spacing="12">
                         <TextBlock x:Name="InlineConfirmTitle" FontSize="18" FontWeight="Bold"
-                                   Foreground="#E74C3C"/>
+                                   Foreground="{DynamicResource DangerButtonBrush}"/>
                         <TextBlock x:Name="InlineConfirmMessage" FontSize="14" TextWrapping="Wrap"
                                    Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                         <Grid ColumnDefinitions="*,*" ColumnSpacing="8" Margin="0,8,0,0">
@@ -708,7 +708,7 @@ Licensed under GNU GPL v3.
                                     CornerRadius="6" BorderThickness="0" Cursor="Hand"
                                     Click="InlineConfirmNo_Click"/>
                             <Button Grid.Column="1" Content="Yes" HorizontalAlignment="Stretch" Height="40"
-                                    Background="#E74C3C" Foreground="White"
+                                    Background="{DynamicResource DangerButtonBrush}" Foreground="White"
                                     CornerRadius="6" BorderThickness="0" Cursor="Hand"
                                     Click="InlineConfirmYes_Click"/>
                         </Grid>
@@ -736,7 +736,7 @@ Licensed under GNU GPL v3.
                                     CornerRadius="6" BorderThickness="0" Cursor="Hand"
                                     Click="RenameCancel_Click"/>
                             <Button Grid.Column="1" Content="Rename" HorizontalAlignment="Stretch" Height="40"
-                                    Background="#27AE60" Foreground="White"
+                                    Background="{DynamicResource SuccessButtonBrush}" Foreground="White"
                                     CornerRadius="6" BorderThickness="0" Cursor="Hand"
                                     Click="RenameConfirm_Click"/>
                         </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldBuilderDialogPanel.axaml.cs
@@ -146,7 +146,7 @@ public partial class FieldBuilderDialogPanel : UserControl
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (DataContext is MainViewModel vm)
-            vm.State.UI.CloseDialog();
+            vm.NavCloseChainCommand?.Execute(null);
     }
 
     private void AddTrackBtn_Click(object? sender, RoutedEventArgs e)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FieldSelectionDialogPanel.axaml
@@ -34,31 +34,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.DangerButton">
-            <Setter Property="Background" Value="#E74C3C"/>
-        </Style>
-        <Style Selector="Button.DangerButton:pointerover">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
@@ -81,7 +56,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Semi-transparent overlay background -->
     <Grid>
         <!-- Backdrop that dims the rest of the UI -->
-        <Border Background="#80000000" IsHitTestVisible="True"
+        <Border Background="{DynamicResource ModalBackdropBrush}" IsHitTestVisible="True"
                 PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagByLatLonDialogPanel.axaml
@@ -20,7 +20,7 @@ the Free Software Foundation, either version 3 of the License, or
              IsHitTestVisible="{Binding State.UI.IsFlagByLatLonDialogVisible}">
 
     <Grid>
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                 CornerRadius="12" Padding="24"
@@ -59,7 +59,7 @@ the Free Software Foundation, either version 3 of the License, or
 
                 <!-- Error message -->
                 <TextBlock Text="{Binding FlagByLatLonError}"
-                           Foreground="#E74C3C" FontSize="12"
+                           Foreground="{DynamicResource DangerButtonBrush}" FontSize="12"
                            IsVisible="{Binding FlagByLatLonError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                            HorizontalAlignment="Center"/>
 
@@ -74,7 +74,7 @@ the Free Software Foundation, either version 3 of the License, or
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="2" Content="{loc:Localize PlaceFlag}"
                             Command="{Binding PlaceFlagByLatLonCommand}"
-                            Background="#27AE60" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Background="{DynamicResource SuccessButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
                             HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagListDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FlagListDialogPanel.axaml
@@ -24,7 +24,7 @@ the Free Software Foundation, either version 3 of the License, or
 
     <Grid>
         <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
         <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
@@ -35,31 +35,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#E74C3C"/>
-        </Style>
-        <Style Selector="Button.OkButton">
-            <Setter Property="Background" Value="#27AE60"/>
-        </Style>
-        <Style Selector="Button.OkButton:pointerover">
-            <Setter Property="Background" Value="#2ECC71"/>
-        </Style>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
@@ -73,13 +48,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ToolButton:pressed">
-            <Setter Property="Background" Value="#1ABC9C"/>
+            <Setter Property="Background" Value="{DynamicResource InfoAccentBrush}"/>
         </Style>
         <Style Selector="Button.ToggleOn">
-            <Setter Property="Background" Value="#27AE60"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonBrush}"/>
         </Style>
         <Style Selector="Button.ToggleOn:pointerover">
-            <Setter Property="Background" Value="#2ECC71"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonHoverBrush}"/>
         </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
@@ -137,9 +112,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <!-- Column Headers -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8">
                     <Grid ColumnDefinitions="*,80,80">
-                        <TextBlock Grid.Column="0" Text="{loc:Localize FieldName}" Foreground="#E74C3C" FontWeight="Bold" FontSize="14"/>
-                        <TextBlock Grid.Column="1" Text="{loc:Localize Distance}" Foreground="#E74C3C" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
-                        <TextBlock Grid.Column="2" Text="{loc:Localize AreaHa}" Foreground="#E74C3C" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="0" Text="{loc:Localize FieldName}" Foreground="{DynamicResource DangerButtonBrush}" FontWeight="Bold" FontSize="14"/>
+                        <TextBlock Grid.Column="1" Text="{loc:Localize Distance}" Foreground="{DynamicResource DangerButtonBrush}" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
+                        <TextBlock Grid.Column="2" Text="{loc:Localize AreaHa}" Foreground="{DynamicResource DangerButtonBrush}" FontWeight="Bold" FontSize="14" TextAlignment="Right"/>
                     </Grid>
                 </Border>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml
@@ -22,6 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.FromExistingFieldDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsFromExistingFieldDialogVisible}"
@@ -125,21 +126,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                MaxWidth="650"
-                MaxHeight="550"
-                Margin="20"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                BoxShadow="0 8 32 #40000000">
-            <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto" Margin="20">
-                <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize CreateFieldFromExisting}"/>
+        <controls:DialogChrome Title="{loc:Localize CreateFieldFromExisting}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MaxWidth="650" MaxHeight="550">
+            <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto">
 
                 <!-- Column Headers -->
                 <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8">
@@ -251,17 +244,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </Button>
                 </Grid>
 
-                <!-- Action Buttons -->
-                <Grid Grid.Row="5" ColumnDefinitions="*,Auto,Auto" Margin="0,16,0,0">
-                    <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
-                            MinWidth="80" MinHeight="44"
-                            Command="{Binding CancelFromExistingFieldDialogCommand}"/>
-                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="{loc:Localize Create}"
-                            MinWidth="80" MinHeight="44" Margin="12,0,0,0"
-                            Command="{Binding ConfirmFromExistingFieldDialogCommand}"/>
-                </Grid>
+                <!-- Create (Back/Close live in the header chrome). -->
+                <Button Grid.Row="5" Classes="DialogButton OkButton" Content="{loc:Localize Create}"
+                        MinWidth="80" MinHeight="44" HorizontalAlignment="Right" Margin="0,16,0,0"
+                        Command="{Binding ConfirmFromExistingFieldDialogCommand}"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/FromExistingFieldDialogPanel.axaml.cs
@@ -31,7 +31,7 @@ public partial class FromExistingFieldDialogPanel : UserControl
         // Cancel the dialog when clicking/tapping the backdrop
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CancelFromExistingFieldDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
         e.Handled = true;
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml
@@ -1,23 +1,20 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.HelpDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsHelpDialogVisible}"
              IsHitTestVisible="{Binding State.UI.IsHelpDialogVisible}">
 
-    <!-- Semi-transparent backdrop -->
-    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="12" Padding="24"
-                MaxWidth="420"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
-                BoxShadow="0 4 16 #40000000">
+    <Grid>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
+        <controls:DialogChrome Title="Help"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MaxWidth="420">
             <StackPanel Spacing="16">
-                <TextBlock Text="Help" FontSize="22" FontWeight="Bold"
-                           HorizontalAlignment="Center"/>
-
                 <TextBlock Text="AgValoniaGPS - Agricultural GPS Guidance"
                            FontSize="14" HorizontalAlignment="Center"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
@@ -53,10 +50,7 @@
                     </Button>
                 </StackPanel>
 
-                <Button Content="Close" Classes="ModernButton"
-                        HorizontalAlignment="Center" MinWidth="120"
-                        Command="{Binding CloseHelpDialogCommand}"/>
             </StackPanel>
-        </Border>
-    </Border>
+        </controls:DialogChrome>
+    </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HelpDialogPanel.axaml.cs
@@ -33,7 +33,7 @@ public partial class HelpDialogPanel : UserControl
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
-            vm.CloseHelpDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
     }
 
     private static void OpenUrl(string url)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="600"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.HotkeyConfigDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -48,18 +49,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Centered dialog -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
+        <controls:DialogChrome Title="{loc:Localize HotkeyConfiguration}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 MinWidth="420" MaxWidth="520" MaxHeight="650">
             <StackPanel Spacing="12">
-                <!-- Title -->
-                <TextBlock Text="{loc:Localize HotkeyConfiguration}" FontSize="20" FontWeight="Bold"
-                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" HorizontalAlignment="Center"/>
-
                 <TextBlock Text="{loc:Localize ClickAKeyButtonThenPressANewKeyToReassign}"
                            FontSize="12" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" HorizontalAlignment="Center"
                            TextWrapping="Wrap" TextAlignment="Center"/>
@@ -75,20 +71,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <Separator Height="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="0,4"/>
 
-                <!-- Bottom buttons -->
-                <Grid ColumnDefinitions="*,Auto,Auto">
-                    <Button Grid.Column="1" Content="{loc:Localize ResetDefaults}" Margin="0,0,8,0"
-                            Command="{Binding ResetHotkeysToDefaultCommand}"
-                            Background="#E67E22" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                            Width="130" Height="40" FontSize="14"
-                            HorizontalContentAlignment="Center" CornerRadius="6"/>
-                    <Button Grid.Column="2" Content="{loc:Localize OK}"
-                            Command="{Binding CloseHotkeyConfigDialogCommand}"
-                            Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                            Width="80" Height="40" FontSize="16" FontWeight="Bold"
-                            HorizontalContentAlignment="Center" CornerRadius="6"/>
-                </Grid>
+                <!-- Reset (Back/Close are in the header chrome; edits save on close). -->
+                <Button Content="{loc:Localize ResetDefaults}" HorizontalAlignment="Right"
+                        Command="{Binding ResetHotkeysToDefaultCommand}"
+                        Background="#E67E22" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                        Width="130" Height="40" FontSize="14"
+                        HorizontalContentAlignment="Center" CornerRadius="6"/>
             </StackPanel>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/HotkeyConfigDialogPanel.axaml.cs
@@ -232,11 +232,20 @@ public partial class HotkeyConfigDialogPanel : UserControl
         return null;
     }
 
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        // Persist hotkey edits (and clear the pending reassignment) whenever the
+        // dialog is dismissed by ANY means — Back, Close, or backdrop — not just
+        // an OK button. Tied to visibility so changes are never lost on Back.
+        if (change.Property == IsVisibleProperty && !change.GetNewValue<bool>())
+        {
+            _vm?.CloseHotkeyConfigDialogCommand?.Execute(null);
+        }
+    }
+
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (_vm != null)
-        {
-            _vm.CloseHotkeyConfigDialogCommand?.Execute(null);
-        }
+        _vm?.NavCloseChainCommand?.Execute(null);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml
@@ -30,29 +30,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#3498DB"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
-        </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="#3498DB"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#5D6D7E"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#4A5A6A"/>
         </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="350"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.ImportTracksDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -73,31 +74,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel -->
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="12"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="1"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                MinWidth="380"
-                MaxWidth="480"
-                MaxHeight="420"
-                Padding="16">
-            <Grid RowDefinitions="Auto,Auto,*,Auto">
-                <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize ImportTracksFromField}"/>
+        <controls:DialogChrome Title="{loc:Localize ImportTracksFromField}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MinWidth="380" MaxWidth="480" MaxHeight="420">
+            <Grid RowDefinitions="Auto,*">
 
                 <!-- Description -->
-                <TextBlock Grid.Row="1" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,0,0,8"
+                <TextBlock Grid.Row="0" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="13" Margin="0,0,0,8"
                            TextWrapping="Wrap"
                            Text="{loc:Localize SelectAFieldToImportItsTracksIntoTheCurrentField}"/>
 
                 <!-- Field list -->
-                <ScrollViewer Grid.Row="2" MinHeight="150" MaxHeight="250">
+                <ScrollViewer Grid.Row="1" MinHeight="150" MaxHeight="250">
                     <ItemsControl x:Name="FieldsListBox"
                                   ItemsSource="{Binding ImportFieldsList}">
                         <ItemsControl.ItemTemplate>
@@ -112,13 +103,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </ItemsControl>
                 </ScrollViewer>
 
-                <!-- Buttons -->
-                <Grid Grid.Row="3" ColumnDefinitions="*,Auto" Margin="0,12,0,0">
-                    <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
-                            Command="{Binding CloseImportTracksDialogCommand}"/>
-                </Grid>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ImportTracksDialogPanel.axaml.cs
@@ -30,7 +30,7 @@ public partial class ImportTracksDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.State.UI.CloseDialog();
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
@@ -30,35 +30,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#E67E22"/>
+            <Setter Property="Foreground" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
             <Setter Property="FontSize" Value="20"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
-        </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#E74C3C"/>
-        </Style>
-        <Style Selector="Button.OkButton">
-            <Setter Property="Background" Value="#27AE60"/>
-        </Style>
-        <Style Selector="Button.OkButton:pointerover">
-            <Setter Property="Background" Value="#2ECC71"/>
         </Style>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml
@@ -22,6 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.IsoXmlImportDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsIsoXmlImportDialogVisible}"
@@ -116,24 +117,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                MaxWidth="500"
-                MaxHeight="480"
-                Margin="20"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                BoxShadow="0 8 32 #40000000">
-            <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto" Margin="20">
-                <!-- Header -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="10">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/Boundary.png" Width="24" Height="24"/>
-                    <TextBlock Classes="Header" Text="{loc:Localize ImportFieldFromIsoXml}"/>
-                </StackPanel>
+        <controls:DialogChrome Title="{loc:Localize ImportFieldFromIsoXml}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MaxWidth="500" MaxHeight="480">
+            <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto">
 
                 <!-- Info text -->
                 <TextBlock Grid.Row="1" Text="{loc:Localize PlaceIsoXmlFoldersContainingTaskdataxmlInDocumentsAgvaloniagpsImport}"
@@ -191,17 +181,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
                 </Grid>
 
-                <!-- Action Buttons -->
-                <Grid Grid.Row="5" ColumnDefinitions="*,Auto,Auto" Margin="0,16,0,0">
-                    <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
-                            MinWidth="80" MinHeight="44"
-                            Command="{Binding CancelIsoXmlImportDialogCommand}"/>
-                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="{loc:Localize Import}"
-                            MinWidth="80" MinHeight="44" Margin="12,0,0,0"
-                            Command="{Binding ConfirmIsoXmlImportDialogCommand}"/>
-                </Grid>
+                <!-- Import (Back/Close live in the header chrome). -->
+                <Button Grid.Row="5" Classes="DialogButton OkButton" Content="{loc:Localize Import}"
+                        MinWidth="80" MinHeight="44" HorizontalAlignment="Right" Margin="0,16,0,0"
+                        Command="{Binding ConfirmIsoXmlImportDialogCommand}"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/IsoXmlImportDialogPanel.axaml.cs
@@ -30,7 +30,7 @@ public partial class IsoXmlImportDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CancelIsoXmlImportDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
         e.Handled = true;
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
@@ -22,6 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.KmlImportDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsKmlImportDialogVisible}"
@@ -116,24 +117,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                MaxWidth="550"
-                MaxHeight="550"
-                Margin="20"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                BoxShadow="0 8 32 #40000000">
-            <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto" Margin="20">
-                <!-- Header -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="10">
-                    <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/GoogleEarth.png" Width="24" Height="24"/>
-                    <TextBlock Classes="Header" Text="{loc:Localize ImportFieldFromKml}"/>
-                </StackPanel>
+        <controls:DialogChrome Title="{loc:Localize ImportFieldFromKml}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MaxWidth="550" MaxHeight="550">
+            <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto">
 
                 <!-- Info text -->
                 <TextBlock Grid.Row="1" Text="{loc:Localize PlaceKmlFilesInDocumentsAgvaloniagpsImport}"
@@ -210,17 +200,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                     </StackPanel>
                 </Grid>
 
-                <!-- Action Buttons -->
-                <Grid Grid.Row="6" ColumnDefinitions="*,Auto,Auto" Margin="0,16,0,0">
-                    <Border Grid.Column="0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="{loc:Localize Cancel}"
-                            MinWidth="80" MinHeight="44"
-                            Command="{Binding CancelKmlImportDialogCommand}"/>
-                    <Button Grid.Column="2" Classes="DialogButton OkButton" Content="{loc:Localize Import}"
-                            MinWidth="80" MinHeight="44" Margin="12,0,0,0"
-                            Command="{Binding ConfirmKmlImportDialogCommand}"/>
-                </Grid>
+                <!-- Import (Back/Close live in the header chrome). -->
+                <Button Grid.Row="6" Classes="DialogButton OkButton" Content="{loc:Localize Import}"
+                        MinWidth="80" MinHeight="44" HorizontalAlignment="Right" Margin="0,16,0,0"
+                        Command="{Binding ConfirmKmlImportDialogCommand}"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml
@@ -30,35 +30,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="TextBlock.Header">
-            <Setter Property="Foreground" Value="#1ABC9C"/>
+            <Setter Property="Foreground" Value="{DynamicResource InfoAccentBrush}"/>
             <Setter Property="FontSize" Value="20"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
-        </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#E74C3C"/>
-        </Style>
-        <Style Selector="Button.OkButton">
-            <Setter Property="Background" Value="#27AE60"/>
-        </Style>
-        <Style Selector="Button.OkButton:pointerover">
-            <Setter Property="Background" Value="#2ECC71"/>
         </Style>
         <Style Selector="Button.ToolButton">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
@@ -152,7 +127,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         <StackPanel Orientation="Horizontal" Spacing="20">
                             <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13">
                                 <Run Text="Points: " Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
-                                <Run Text="{Binding KmlBoundaryPointCount}" Foreground="#1ABC9C"/>
+                                <Run Text="{Binding KmlBoundaryPointCount}" Foreground="{DynamicResource InfoAccentBrush}"/>
                             </TextBlock>
                             <TextBlock Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="13">
                                 <Run Text="Lat: " Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/KmlImportDialogPanel.axaml.cs
@@ -30,7 +30,7 @@ public partial class KmlImportDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CancelKmlImportDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
         e.Handled = true;
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml
@@ -2,31 +2,22 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.LanguageDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsLanguageDialogVisible}"
              IsHitTestVisible="{Binding State.UI.IsLanguageDialogVisible}">
 
-    <!-- Semi-transparent backdrop -->
-    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
-        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                CornerRadius="12" Padding="20"
-                MaxWidth="400" MaxHeight="600"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
-                BoxShadow="0 4 16 #40000000">
+    <Grid>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-            <StackPanel Spacing="12">
-                <TextBlock Text="{loc:Localize SelectLanguage}" FontSize="20" FontWeight="Bold"
-                           HorizontalAlignment="Center"/>
-
-                <ScrollViewer MaxHeight="450">
-                    <ItemsControl x:Name="LanguageList"/>
-                </ScrollViewer>
-
-                <Button Content="{loc:Localize Cancel}" Classes="ModernButton"
-                        HorizontalAlignment="Center" MinWidth="120"
-                        Command="{Binding CloseLanguageDialogCommand}"/>
-            </StackPanel>
-        </Border>
-    </Border>
+        <controls:DialogChrome Title="{loc:Localize SelectLanguage}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MaxWidth="400" MaxHeight="600">
+            <ScrollViewer MaxHeight="450">
+                <ItemsControl x:Name="LanguageList"/>
+            </ScrollViewer>
+        </controls:DialogChrome>
+    </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LanguageDialogPanel.axaml.cs
@@ -98,6 +98,6 @@ public partial class LanguageDialogPanel : UserControl
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
-            vm.CloseLanguageDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LoadVehicleToolDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LoadVehicleToolDialogPanel.axaml
@@ -34,28 +34,6 @@ Licensed under GNU GPL v3. See LICENSE.md.
             <Setter Property="FontSize" Value="19"/>
             <Setter Property="Margin" Value="0,0,0,8"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="18,12"/>
-            <Setter Property="FontSize" Value="16"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.DangerButton">
-            <Setter Property="Background" Value="#E74C3C"/>
-        </Style>
-        <Style Selector="Button.DangerButton:pointerover">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
@@ -75,7 +53,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#27AE60"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonBrush}"/>
         </Style>
         <Style Selector="Border.PreviewBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
@@ -86,7 +64,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
     </UserControl.Styles>
 
     <Grid>
-        <Border Background="#80000000" IsHitTestVisible="True"
+        <Border Background="{DynamicResource ModalBackdropBrush}" IsHitTestVisible="True"
                 PointerPressed="Backdrop_PointerPressed"/>
 
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
@@ -36,13 +36,13 @@ the Free Software Foundation, either version 3 of the License, or
                                 Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Debug"/>
                         <Button Content="{loc:Localize Info}" Padding="10,4" CornerRadius="4"
-                                Background="#2980B9" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
+                                Background="{DynamicResource PrimaryButtonHoverBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Information"/>
                         <Button Content="{loc:Localize Warning}" Padding="10,4" CornerRadius="4"
                                 Background="#F39C12" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Warning"/>
                         <Button Content="{loc:Localize Error}" Padding="10,4" CornerRadius="4"
-                                Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
+                                Background="{DynamicResource DangerButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
                                 Command="{Binding SetLogFilterCommand}" CommandParameter="Error"/>
                         <Border Width="1" Background="{DynamicResource SystemControlForegroundBaseLowBrush}" Margin="4,0"/>
                         <Button Content="{loc:Localize Clear}" Padding="10,4" CornerRadius="4"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml
@@ -14,6 +14,7 @@ the Free Software Foundation, either version 3 of the License, or
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:logging="clr-namespace:AgValoniaGPS.Services.Logging;assembly=AgValoniaGPS.Services"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.LogViewerDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -21,20 +22,15 @@ the Free Software Foundation, either version 3 of the License, or
              IsHitTestVisible="{Binding State.UI.IsLogViewerDialogVisible}">
 
     <Grid>
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="0"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
+        <controls:DialogChrome Title="{loc:Localize ApplicationLog}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 Width="750" Height="520">
-            <Grid RowDefinitions="Auto,Auto,*,Auto">
-                <!-- Header -->
-                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12,12,0,0" Padding="16,12">
-                    <TextBlock Text="{loc:Localize ApplicationLog}" FontSize="18" FontWeight="Bold"
-                               Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
-                </Border>
-
+            <Grid RowDefinitions="Auto,*">
                 <!-- Filter bar -->
-                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundListLowBrush}" Padding="12,8">
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundListLowBrush}" Padding="12,8">
                     <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
                         <Button Content="{loc:Localize Debug}" Padding="10,4" CornerRadius="4"
                                 Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="12"
@@ -56,7 +52,7 @@ the Free Software Foundation, either version 3 of the License, or
                 </Border>
 
                 <!-- Log entries list (non-virtualizing for headless rendering) -->
-                <Border Grid.Row="2" Margin="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4">
+                <Border Grid.Row="1" Margin="0,8,0,0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4">
                     <ScrollViewer>
                         <ItemsControl ItemsSource="{Binding FilteredLogEntries}">
                             <ItemsControl.ItemTemplate>
@@ -82,13 +78,7 @@ the Free Software Foundation, either version 3 of the License, or
                     </ScrollViewer>
                 </Border>
 
-                <!-- Close button -->
-                <Button Grid.Row="3" Content="{loc:Localize Close}" Margin="16,4,16,12"
-                        Command="{Binding CloseLogViewerDialogCommand}"
-                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                        HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
-                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/LogViewerDialogPanel.axaml.cs
@@ -6,6 +6,7 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 
@@ -18,11 +19,22 @@ public partial class LogViewerDialogPanel : UserControl
         InitializeComponent();
     }
 
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
-        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+        base.OnPropertyChanged(change);
+        // Run the viewer's cleanup (unsubscribe from LogStore) whenever the dialog
+        // is dismissed by ANY means — Back, Close, or backdrop — not just a Close
+        // button. Tied to visibility so the LogStore subscription can't leak.
+        if (change.Property == IsVisibleProperty && !change.GetNewValue<bool>() &&
+            DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
             vm.CloseLogViewerDialogCommand?.Execute(null);
         }
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+            vm.NavCloseChainCommand?.Execute(null);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
@@ -29,38 +29,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              IsHitTestVisible="{Binding State.UI.IsNewFieldDialogVisible}">
 
     <UserControl.Styles>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="16"/>
-            <Setter Property="MinWidth" Value="100"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pressed">
-            <Setter Property="Background" Value="#1F6391"/>
-        </Style>
-
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="16"/>
-            <Setter Property="MinWidth" Value="100"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pressed">
-            <Setter Property="Background" Value="#6B7B7C"/>
-        </Style>
-
         <Style Selector="TextBox.DialogInput">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml
@@ -22,6 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.NewFieldDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsNewFieldDialogVisible}"
@@ -88,30 +89,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     </UserControl.Styles>
 
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                MaxWidth="450"
-                MaxHeight="380"
-                Margin="20"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                BoxShadow="0 8 32 #40000000">
-            <Grid RowDefinitions="Auto,*,Auto" Margin="24">
-                <!-- Header -->
-                <StackPanel Grid.Row="0" Spacing="6" Margin="0,0,0,20">
-                    <TextBlock Text="{loc:Localize CreateNewField}"
-                               FontSize="24"
-                               FontWeight="Bold"
-                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                    <TextBlock Text="{loc:Localize EnterFieldNameOriginWillBeSetToCurrentGpsPosition}"
-                               Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
-                               FontSize="14"
-                               TextWrapping="Wrap"/>
-                </StackPanel>
+        <controls:DialogChrome Title="{loc:Localize CreateNewField}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MaxWidth="450" MaxHeight="380">
+            <Grid RowDefinitions="Auto,*,Auto">
+                <!-- Subtitle -->
+                <TextBlock Grid.Row="0" Text="{loc:Localize EnterFieldNameOriginWillBeSetToCurrentGpsPosition}"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                           FontSize="14" TextWrapping="Wrap" Margin="0,0,0,16"/>
 
                 <!-- Form -->
                 <StackPanel Grid.Row="1" Spacing="16">
@@ -159,20 +147,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                TextWrapping="Wrap"/>
                 </StackPanel>
 
-                <!-- Buttons -->
-                <StackPanel Grid.Row="2"
-                            Orientation="Horizontal"
-                            HorizontalAlignment="Right"
-                            Spacing="12"
-                            Margin="0,24,0,0">
-                    <Button Classes="CancelButton"
-                            Content="{loc:Localize Cancel}"
-                            Command="{Binding CancelNewFieldDialogCommand}"/>
-                    <Button Classes="DialogButton"
-                            Content="{loc:Localize Create}"
-                            Command="{Binding ConfirmNewFieldDialogCommand}"/>
-                </StackPanel>
+                <!-- Create (Back/Close live in the header chrome). -->
+                <Button Grid.Row="2" Classes="DialogButton"
+                        Content="{loc:Localize Create}" HorizontalAlignment="Right" Margin="0,24,0,0"
+                        Command="{Binding ConfirmNewFieldDialogCommand}"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NewFieldDialogPanel.axaml.cs
@@ -31,7 +31,7 @@ public partial class NewFieldDialogPanel : UserControl
         // Clicking backdrop cancels the dialog
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CancelNewFieldDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
@@ -52,31 +52,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="TextBox:focus">
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.TestButton">
-            <Setter Property="Background" Value="#27AE60"/>
-        </Style>
-        <Style Selector="Button.TestButton:pointerover">
-            <Setter Property="Background" Value="#219A52"/>
-        </Style>
         <Style Selector="CheckBox">
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="FontSize" Value="14"/>
@@ -137,7 +112,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Test Connection -->
                 <Grid ColumnDefinitions="Auto,*">
-                    <Button Grid.Column="0" Classes="DialogButton TestButton" Content="{loc:Localize TestConnection}"
+                    <Button Grid.Column="0" Classes="SecondaryButton" Content="{loc:Localize TestConnection}"
                             Command="{Binding TestNtripConnectionCommand}"
                             IsEnabled="{Binding !IsTestingNtripConnection}"/>
                     <TextBlock Grid.Column="1" Text="{Binding NtripTestStatus}"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml
@@ -22,6 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:ntrip="clr-namespace:AgValoniaGPS.Models.Ntrip;assembly=AgValoniaGPS.Models"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="650"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.NtripProfileEditorPanel"
              x:DataType="vm:MainViewModel"
@@ -82,23 +83,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
+    <!-- Non-modal: fully transparent light-dismiss scrim — map shows through, an
+         outside tap closes the chain. Drag the header to move the editor aside. -->
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="1"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
+        <!-- Dialog panel: standardized chrome supplies the Back/Title/Close header.
+             Back keeps the editor's field-cleanup (CancelNtripProfileEditCommand,
+             which ends in NavigateBack); Close exits the whole chain. -->
+        <controls:DialogChrome
+                Title="{loc:Localize EditNtripProfile}"
+                BackCommand="{Binding CancelNtripProfileEditCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 MinWidth="420"
-                MaxWidth="500"
-                Padding="20">
+                MaxWidth="500">
             <StackPanel Spacing="8">
-                <!-- Header -->
-                <TextBlock Classes="Header" Text="{loc:Localize EditNtripProfile}" Margin="0,0,0,4"/>
 
                 <!-- Profile Name (label inline to save vertical space) -->
                 <Grid ColumnDefinitions="62,*">
@@ -175,16 +174,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <CheckBox IsChecked="{Binding EditingNtripProfile.IsDefault, FallbackValue=False}"
                           Content="{loc:Localize SetAsDefaultProfileForFieldsWithoutSpecificAssociation}"/>
 
-                <!-- Action Buttons: Back (to profile list) · Close (dismiss) · Save -->
-                <Grid ColumnDefinitions="Auto,Auto,*,Auto" Margin="0,6,0,0">
-                    <Button Grid.Column="0" Classes="DialogButton CancelButton" Content="Back"
-                            Command="{Binding CancelNtripProfileEditCommand}" Margin="0,0,8,0"/>
-                    <Button Grid.Column="1" Classes="DialogButton CancelButton" Content="Close"
-                            Command="{Binding CloseNtripProfilesDialogCommand}"/>
-                    <Button Grid.Column="3" Classes="DialogButton" Content="{loc:Localize SaveProfile}"
-                            Command="{Binding SaveNtripProfileCommand}"/>
-                </Grid>
+                <!-- Primary action; Back/Close are in the header chrome above. -->
+                <Button HorizontalAlignment="Right" Classes="DialogButton" Margin="0,6,0,0"
+                        Content="{loc:Localize SaveProfile}"
+                        Command="{Binding SaveNtripProfileCommand}"/>
             </StackPanel>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfileEditorPanel.axaml.cs
@@ -28,6 +28,8 @@ public partial class NtripProfileEditorPanel : UserControl
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        // Don't close on backdrop click - user must use Cancel or Save
+        // Light-dismiss: an outside tap closes the whole chain back to the map.
+        if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
+            vm.NavCloseChainCommand?.Execute(null);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
@@ -36,44 +36,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.DangerButton">
-            <Setter Property="Background" Value="#E74C3C"/>
-        </Style>
-        <Style Selector="Button.DangerButton:pointerover">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
-        <Style Selector="Button.ToolbarButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Width" Value="48"/>
-            <Setter Property="Height" Value="48"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.ToolbarButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-        </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml
@@ -22,6 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
              xmlns:ntrip="clr-namespace:AgValoniaGPS.Models.Ntrip;assembly=AgValoniaGPS.Models"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="550" d:DesignHeight="450"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.NtripProfilesDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -92,27 +93,27 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         </Style>
     </UserControl.Styles>
 
+    <!-- Non-modal: a fully transparent light-dismiss scrim (not a darkening
+         backdrop) lets the map show through while still catching an outside tap
+         to close the chain — matching the left-nav fly-outs. Drag the header to
+         move the card aside for a wider peek. -->
     <Grid>
-        <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <!-- Dialog panel -->
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="1"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
+        <!-- Dialog panel: standardized Back/Title/Close chrome. Back is at the
+             bottom of the dialog stack, so it reopens the Network IO fly-out;
+             Close exits the whole chain to the map. Drag the header to peek. -->
+        <controls:DialogChrome
+                Title="{loc:Localize NtripProfiles}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 MinWidth="480"
                 MaxWidth="600"
-                MaxHeight="550"
-                Padding="16">
-            <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
-                <!-- Header -->
-                <TextBlock Grid.Row="0" Classes="Header" Text="{loc:Localize NtripProfiles}"/>
+                MaxHeight="550">
+            <Grid RowDefinitions="Auto,Auto,*">
 
                 <!-- Toolbar -->
-                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="4" Margin="0,0,0,12">
+                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="6" Padding="4" Margin="0,0,0,12">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <!-- Add Profile -->
                         <Button Classes="ToolbarButton" ToolTip.Tip="Add New Profile"
@@ -147,7 +148,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Border>
 
                 <!-- Column Headers -->
-                <Border Grid.Row="2" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="4,4,0,0" Padding="12,8" Margin="0,0,0,0">
                     <Grid ColumnDefinitions="*,150,60">
                         <TextBlock Grid.Column="0" Text="{loc:Localize ProfileName}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
                         <TextBlock Grid.Column="1" Text="{loc:Localize Caster}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontWeight="SemiBold"/>
@@ -157,7 +158,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
                 <!-- Profiles ListBox -->
                 <ListBox x:Name="ProfilesListBox"
-                         Grid.Row="3"
+                         Grid.Row="2"
                          SelectionMode="Single"
                          MinHeight="200"
                          MaxHeight="350"
@@ -180,17 +181,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
-
-                <!-- Action Buttons: Back (to Network IO) · Close (dismiss) -->
-                <Grid Grid.Row="4" ColumnDefinitions="Auto,*,Auto" Margin="0,12,0,0">
-                    <Button Grid.Column="0" Classes="DialogButton CancelButton" Content="Back"
-                            Command="{Binding BackFromNtripProfilesCommand}"/>
-
-                    <!-- Close Button -->
-                    <Button Grid.Column="2" Classes="DialogButton CancelButton" Content="{loc:Localize Close}"
-                            Command="{Binding CloseNtripProfilesDialogCommand}"/>
-                </Grid>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NtripProfilesDialogPanel.axaml.cs
@@ -28,10 +28,8 @@ public partial class NtripProfilesDialogPanel : UserControl
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        // Close dialog when clicking the backdrop
+        // Light-dismiss: an outside tap closes the whole chain back to the map.
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
-        {
-            vm.State.UI.CloseDialog();
-        }
+            vm.NavCloseChainCommand?.Execute(null);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/NumericInputDialogPanel.axaml
@@ -36,7 +36,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <!-- Full screen overlay with backdrop -->
     <Grid>
         <!-- Semi-transparent backdrop - clicking dismisses -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Centered dialog -->
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="16"
@@ -45,7 +45,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <StackPanel Spacing="12">
                 <!-- Title -->
                 <TextBlock Text="{Binding NumericInputDialogTitle}" FontSize="18" FontWeight="Bold"
-                           Foreground="#1ABC9C" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource InfoAccentBrush}" HorizontalAlignment="Center"/>
 
                 <!-- Current Value Display (shown with on-screen keyboard) -->
                 <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="12,8"
@@ -76,12 +76,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 <Grid ColumnDefinitions="*,*" Margin="0,8,0,0">
                     <Button Grid.Column="0" Content="{loc:Localize Cancel}" Margin="0,0,4,0"
                             Command="{Binding CancelNumericInputDialogCommand}"
-                            Background="#E74C3C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Background="{DynamicResource DangerButtonBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="16"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                     <Button Grid.Column="1" Content="{loc:Localize OK}" Margin="4,0,0,0"
                             Command="{Binding ConfirmNumericInputDialogCommand}"
-                            Background="#1ABC9C" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                            Background="{DynamicResource InfoAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             HorizontalAlignment="Stretch" Height="44" FontSize="16"
                             HorizontalContentAlignment="Center" CornerRadius="6"/>
                 </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml
@@ -2,29 +2,21 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.OffsetFixDialogPanel"
              x:DataType="vm:MainViewModel"
              IsVisible="{Binding State.UI.IsOffsetFixPanelVisible}"
              IsHitTestVisible="{Binding State.UI.IsOffsetFixPanelVisible}">
 
-    <!-- Floating non-modal panel - user can interact with map behind it -->
-    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-            CornerRadius="12" Padding="16"
-            Width="280"
-            HorizontalAlignment="Right" VerticalAlignment="Top"
-            Margin="0,60,16,0"
-            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+    <!-- Floating non-modal panel styled like the other tool overlays (FloatingPanel
+         supplies the draggable header with Back · Title · Close). -->
+    <controls:FloatingPanel x:Name="FP"
+                            Width="280"
+                            Title="{loc:Localize GpsOffsetFix}"
+                            BackCommand="{Binding BackToFieldToolsCommand}"
+                            CloseCommand="{Binding CloseOffsetFixDialogCommand}">
+      <controls:FloatingPanel.PanelContent>
         <StackPanel Spacing="8">
-            <!-- Header with close button -->
-            <Grid ColumnDefinitions="*,Auto">
-                <TextBlock Text="{loc:Localize GpsOffsetFix}" FontSize="16" FontWeight="Bold"
-                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                <Button Grid.Column="1" Content="X" Width="28" Height="28"
-                        Command="{Binding CloseOffsetFixDialogCommand}"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                        FontSize="14" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                        Padding="0" CornerRadius="4"/>
-            </Grid>
 
             <!-- D-pad layout (compact) -->
             <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,*,*"
@@ -79,5 +71,6 @@
                        Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                        HorizontalAlignment="Center"/>
         </StackPanel>
-    </Border>
+      </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/OffsetFixDialogPanel.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 
 namespace AgValoniaGPS.Views.Controls.Dialogs;
@@ -7,5 +8,21 @@ public partial class OffsetFixDialogPanel : UserControl
     public OffsetFixDialogPanel()
     {
         InitializeComponent();
+
+        // Hosted in a Panel (DialogOverlayHost), not a Canvas, so move the whole
+        // control via its Margin when the FloatingPanel header is dragged.
+        var fp = this.FindControl<AgValoniaGPS.Views.Controls.FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (_, delta) =>
+                Margin = new Thickness(Margin.Left + delta.X, Margin.Top + delta.Y,
+                                       Margin.Right, Margin.Bottom);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        // Open over the fly-out that launched it (the chain anchor).
+        if (change.Property == IsVisibleProperty && change.GetNewValue<bool>())
+            AgValoniaGPS.Views.Controls.ChainPanelAnchor.PositionAtAnchor(this);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/QuickABSelectorPanel.axaml
@@ -42,11 +42,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
         </Style>
         <Style Selector="Button.ModeButton:pressed">
-            <Setter Property="Background" Value="#1ABC9C"/>
+            <Setter Property="Background" Value="{DynamicResource InfoAccentBrush}"/>
         </Style>
 
         <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="#C0392B"/>
+            <Setter Property="Background" Value="{DynamicResource DangerButtonHoverBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
@@ -56,13 +56,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="Cursor" Value="Hand"/>
         </Style>
         <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="#E74C3C"/>
+            <Setter Property="Background" Value="{DynamicResource DangerButtonBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <Grid>
         <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Compact selector panel - centered -->
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml
@@ -5,11 +5,10 @@ Licensed under GNU GPL v3.
 -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:loc="clr-namespace:AgValoniaGPS.Views.Localization;assembly=AgValoniaGPS.Views"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              xmlns:converters="clr-namespace:AgValoniaGPS.Views.Converters;assembly=AgValoniaGPS.Views"
-             mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.RecordedPathDialogPanel"
              x:DataType="vm:MainViewModel"
              x:Name="RecPathRoot"
@@ -44,27 +43,16 @@ Licensed under GNU GPL v3.
         </Style>
     </UserControl.Styles>
 
-    <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-            CornerRadius="12" Padding="12" MinWidth="340"
-            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+    <!-- Non-modal draggable tool overlay. FloatingPanel supplies the shared
+         Back · Title · Close header (same control family as the other tool
+         fly-outs); the record/playback body is the PanelContent. -->
+    <controls:FloatingPanel x:Name="FP"
+                            MinWidth="340"
+                            Title="Recorded Path"
+                            BackCommand="{Binding BackToFieldToolsCommand}"
+                            CloseCommand="{Binding CloseRecordedPathDialogCommand}">
+      <controls:FloatingPanel.PanelContent>
         <StackPanel Spacing="8">
-            <!-- Drag Handle Header -->
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,Auto,*,Auto" Height="28"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand"
-                  ToolTip.Tip="Drag to move">
-                <Button Grid.Column="0" Content="&#x2190;" Width="24" Height="24" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                        FontSize="16" Cursor="Hand" ToolTip.Tip="Back"
-                        Command="{Binding BackToFieldToolsCommand}" Margin="4,0,2,0"/>
-                <TextBlock Grid.Column="1" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                           FontSize="18" FontWeight="Bold" VerticalAlignment="Center" Margin="4,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="2" Text="Recorded Path"
-                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                           FontSize="14" FontWeight="Bold" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="3" Content="X" Width="22" Height="22" Padding="0" BorderThickness="0"
-                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                        FontSize="14" Cursor="Hand" Command="{Binding CloseRecordedPathDialogCommand}" Margin="4,0,4,0"/>
-            </Grid>
 
             <!-- Tab selector: active tab gets accent background -->
             <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
@@ -120,12 +108,12 @@ Licensed under GNU GPL v3.
                     <TextBox Text="{Binding RecordedPathName}" Watermark="RecPath name..." FontSize="14"/>
                     <Button Classes="RPWide" Content="Save" ClickMode="Press"
                             Command="{Binding SaveNamedRecordedPathCommand}"
-                            Background="#27AE60" Foreground="White" FontWeight="Bold"/>
+                            Background="{DynamicResource SuccessButtonBrush}" Foreground="White" FontWeight="Bold"/>
                 </StackPanel>
 
                 <TextBlock Text="Open a field to enable recording."
                            FontSize="12" TextWrapping="Wrap" IsVisible="{Binding !IsFieldOpen}"
-                           Foreground="#E74C3C"/>
+                           Foreground="{DynamicResource DangerButtonBrush}"/>
                 <TextBlock Text="Drive your route, then press Stop to save."
                            FontSize="12" TextWrapping="Wrap" IsVisible="{Binding IsFieldOpen}"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
@@ -192,6 +180,8 @@ Licensed under GNU GPL v3.
                 <TextBlock Text="{Binding RecordedPathInfo}" FontSize="12" TextWrapping="Wrap"
                            Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"/>
             </StackPanel>
+
         </StackPanel>
-    </Border>
+      </controls:FloatingPanel.PanelContent>
+    </controls:FloatingPanel>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml
@@ -49,15 +49,19 @@ Licensed under GNU GPL v3.
             BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
         <StackPanel Spacing="8">
             <!-- Drag Handle Header -->
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="28"
+            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,Auto,*,Auto" Height="28"
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Cursor="Hand"
                   ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                           FontSize="18" FontWeight="Bold" VerticalAlignment="Center" Margin="8,0,8,0" IsHitTestVisible="False"/>
-                <TextBlock Grid.Column="1" Text="Recorded Path"
+                <Button Grid.Column="0" Content="&#x2190;" Width="24" Height="24" Padding="0" BorderThickness="0"
+                        Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                        FontSize="16" Cursor="Hand" ToolTip.Tip="Back"
+                        Command="{Binding BackToFieldToolsCommand}" Margin="4,0,2,0"/>
+                <TextBlock Grid.Column="1" Text="=" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                           FontSize="18" FontWeight="Bold" VerticalAlignment="Center" Margin="4,0,8,0" IsHitTestVisible="False"/>
+                <TextBlock Grid.Column="2" Text="Recorded Path"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            FontSize="14" FontWeight="Bold" VerticalAlignment="Center" IsHitTestVisible="False"/>
-                <Button Grid.Column="2" Content="X" Width="22" Height="22" Padding="0" BorderThickness="0"
+                <Button Grid.Column="3" Content="X" Width="22" Height="22" Padding="0" BorderThickness="0"
                         Background="Transparent" Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                         FontSize="14" Cursor="Hand" Command="{Binding CloseRecordedPathDialogCommand}" Margin="4,0,4,0"/>
             </Grid>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml.cs
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2025 AgValoniaGPS Contributors
 // Licensed under GNU GPL v3.
 
+using Avalonia;
 using Avalonia.Controls;
 
 namespace AgValoniaGPS.Views.Controls.Dialogs;
@@ -11,5 +12,13 @@ public partial class RecordedPathDialogPanel : UserControl
     public RecordedPathDialogPanel()
     {
         InitializeComponent();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        // Open over the fly-out that launched it (the chain anchor).
+        if (change.Property == IsVisibleProperty && change.GetNewValue<bool>())
+            AgValoniaGPS.Views.Controls.ChainPanelAnchor.PositionAtAnchor(this);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/RecordedPathDialogPanel.axaml.cs
@@ -12,6 +12,15 @@ public partial class RecordedPathDialogPanel : UserControl
     public RecordedPathDialogPanel()
     {
         InitializeComponent();
+
+        // Hosted in a Panel (DialogOverlayHost), not a Canvas, so move the whole
+        // control via its Margin when the FloatingPanel header is dragged
+        // (same pattern as OffsetFixDialogPanel).
+        var fp = this.FindControl<AgValoniaGPS.Views.Controls.FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (_, delta) =>
+                Margin = new Thickness(Margin.Left + delta.X, Margin.Top + delta.Y,
+                                       Margin.Right, Margin.Bottom);
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ResumeJobDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ResumeJobDialogPanel.axaml
@@ -9,6 +9,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.ResumeJobDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -72,22 +73,14 @@ Licensed under GNU GPL v3. See LICENSE.md.
     </UserControl.Styles>
 
     <Grid>
-        <Border Background="#80000000" IsHitTestVisible="True"
-                PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="1"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                MinWidth="540"
-                MaxWidth="720"
-                MaxHeight="600"
-                Padding="20"
-                DataContext="{Binding ResumeJobDialogVm}">
-            <Grid RowDefinitions="Auto,*,Auto,Auto">
-                <TextBlock Grid.Row="0" Classes="Header" Text="Resume Job"/>
+        <controls:DialogChrome Title="Resume Job"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MinWidth="540" MaxWidth="720" MaxHeight="600">
+            <Grid RowDefinitions="Auto,*,Auto,Auto"
+                  DataContext="{Binding ResumeJobDialogVm}">
 
                 <ListBox Grid.Row="1" x:Name="JobsListBox"
                          ItemsSource="{Binding Jobs}"
@@ -122,17 +115,12 @@ Licensed under GNU GPL v3. See LICENSE.md.
                            IsVisible="{Binding StatusMessage, Converter={x:Static ObjectConverters.IsNotNull}}"
                            Margin="0,8,0,0"/>
 
-                <Grid Grid.Row="3" ColumnDefinitions="Auto,*,Auto" Margin="0,16,0,0">
-                    <Button Grid.Column="0" Classes="DialogButton CancelButton"
-                            Content="Cancel"
-                            Command="{Binding CancelCommand}"/>
-                    <Border Grid.Column="1"/>
-                    <Button Grid.Column="2" Classes="DialogButton"
-                            Content="Resume Selected Job"
-                            Command="{Binding ResumeJobCommand}"
-                            CommandParameter="{Binding SelectedJob}"/>
-                </Grid>
+                <!-- Resume (Back/Close live in the header chrome). -->
+                <Button Grid.Row="3" Classes="DialogButton" HorizontalAlignment="Right" Margin="0,16,0,0"
+                        Content="Resume Selected Job"
+                        Command="{Binding ResumeJobCommand}"
+                        CommandParameter="{Binding SelectedJob}"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ResumeJobDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ResumeJobDialogPanel.axaml
@@ -37,22 +37,6 @@ Licensed under GNU GPL v3. See LICENSE.md.
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="12,8"/>
-            <Setter Property="FontSize" Value="13"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
@@ -68,7 +52,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#27AE60"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -110,7 +94,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
 
                 <TextBlock Grid.Row="2"
                            Text="{Binding StatusMessage}"
-                           Foreground="#E74C3C"
+                           Foreground="{DynamicResource DangerButtonBrush}"
                            FontSize="12"
                            IsVisible="{Binding StatusMessage, Converter={x:Static ObjectConverters.IsNotNull}}"
                            Margin="0,8,0,0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ResumeJobDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ResumeJobDialogPanel.axaml.cs
@@ -18,10 +18,9 @@ public partial class ResumeJobDialogPanel : UserControl
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (DataContext is MainViewModel vm
-            && vm.CancelResumeJobDialogCommand?.CanExecute(null) == true)
+        if (DataContext is MainViewModel vm)
         {
-            vm.CancelResumeJobDialogCommand.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
         e.Handled = true;
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SimCoordsDialogPanel.axaml
@@ -53,34 +53,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="MinHeight" Value="48"/>
         </Style>
         <Style Selector="Border.InputField.Selected">
-            <Setter Property="BorderBrush" Value="#1ABC9C"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource InfoAccentBrush}"/>
             <Setter Property="BorderThickness" Value="2"/>
-        </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="24,12"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
         </Style>
     </UserControl.Styles>
 
     <!-- Semi-transparent overlay background -->
     <Grid>
         <!-- Backdrop that dims the rest of the UI -->
-        <Border Background="#80000000" IsHitTestVisible="True"
+        <Border Background="{DynamicResource ModalBackdropBrush}" IsHitTestVisible="True"
                 PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel positioned near top for mobile -->

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/SmartWasDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/SmartWasDialogPanel.axaml
@@ -7,7 +7,7 @@
              IsHitTestVisible="{Binding State.UI.IsSmartWasDialogVisible}">
 
     <!-- Semi-transparent backdrop -->
-    <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed">
+    <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed">
 
         <!-- Inner panel: switch DataContext to the SmartWasViewModel -->
         <Border DataContext="{Binding SmartWasViewModel}"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
@@ -9,6 +9,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.StartWorkSessionDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -90,26 +91,14 @@ Licensed under GNU GPL v3. See LICENSE.md.
     </UserControl.Styles>
 
     <Grid>
-        <Border Background="#80000000" IsHitTestVisible="True"
-                PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                CornerRadius="12"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
-                BorderThickness="1"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                MinWidth="960"
-                MaxWidth="1350"
-                MaxHeight="960"
-                Padding="30"
-                DataContext="{Binding StartWorkSessionDialogVm}">
-            <Grid RowDefinitions="Auto,*,Auto,Auto" ColumnDefinitions="*,16,1.5*">
-
-                <!-- Title row spans both columns -->
-                <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
-                           Classes="Header" Text="Start Work Session"
-                           FontSize="24" Margin="0,0,0,16"/>
+        <controls:DialogChrome Title="Start Work Session"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
+                MinWidth="960" MaxWidth="1350" MaxHeight="960">
+            <Grid RowDefinitions="Auto,*,Auto,Auto" ColumnDefinitions="*,16,1.5*"
+                  DataContext="{Binding StartWorkSessionDialogVm}">
 
                 <!-- LEFT: Fields list -->
                 <Grid Grid.Row="1" Grid.Column="0" RowDefinitions="Auto,Auto,*">
@@ -265,12 +254,6 @@ Licensed under GNU GPL v3. See LICENSE.md.
                 <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
                              Rows="1"
                              Margin="0,16,0,0">
-                    <Button Classes="DialogButton CancelButton"
-                            Content="Cancel"
-                            Command="{Binding CancelCommand}"
-                            HorizontalAlignment="Stretch"
-                            HorizontalContentAlignment="Center"
-                            Margin="0,0,6,0"/>
                     <Button Classes="DialogButton SecondaryButton"
                             Content="Open Field Only"
                             Command="{Binding OpenFieldOnlyCommand}"
@@ -305,6 +288,6 @@ Licensed under GNU GPL v3. See LICENSE.md.
                             Margin="6,0,0,0"/>
                 </UniformGrid>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml
@@ -40,33 +40,6 @@ Licensed under GNU GPL v3. See LICENSE.md.
             <Setter Property="FontSize" Value="15"/>
             <Setter Property="Margin" Value="0,8,0,2"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="18,12"/>
-            <Setter Property="FontSize" Value="16"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.SecondaryButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-        </Style>
-        <Style Selector="Button.DangerButton">
-            <Setter Property="Background" Value="#E74C3C"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-        </Style>
-        <Style Selector="Button.DangerButton:pointerover">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
@@ -86,7 +59,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
         </Style>
         <Style Selector="ListBoxItem:selected">
-            <Setter Property="Background" Value="#27AE60"/>
+            <Setter Property="Background" Value="{DynamicResource SuccessButtonBrush}"/>
         </Style>
     </UserControl.Styles>
 
@@ -241,7 +214,7 @@ Licensed under GNU GPL v3. See LICENSE.md.
                 <!-- Status / error message -->
                 <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3"
                            Text="{Binding StatusMessage}"
-                           Foreground="#E74C3C"
+                           Foreground="{DynamicResource DangerButtonBrush}"
                            FontSize="14"
                            IsVisible="{Binding StatusMessage, Converter={x:Static ObjectConverters.IsNotNull}}"
                            Margin="0,10,0,0"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/StartWorkSessionDialogPanel.axaml.cs
@@ -19,10 +19,9 @@ public partial class StartWorkSessionDialogPanel : UserControl
 
     private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (DataContext is MainViewModel vm
-            && vm.CancelStartWorkSessionDialogCommand?.CanExecute(null) == true)
+        if (DataContext is MainViewModel vm)
         {
-            vm.CancelStartWorkSessionDialogCommand.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
         e.Handled = true;
     }

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/TracksDialogPanel.axaml
@@ -36,44 +36,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="Margin" Value="0,0,0,12"/>
         </Style>
-        <Style Selector="Button.DialogButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="16,10"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.DialogButton:pointerover">
-            <Setter Property="Background" Value="#2980B9"/>
-        </Style>
-        <Style Selector="Button.CancelButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.CancelButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
-        </Style>
-        <Style Selector="Button.DangerButton">
-            <Setter Property="Background" Value="#E74C3C"/>
-        </Style>
-        <Style Selector="Button.DangerButton:pointerover">
-            <Setter Property="Background" Value="#C0392B"/>
-        </Style>
-        <Style Selector="Button.ToolbarButton">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Width" Value="48"/>
-            <Setter Property="Height" Value="48"/>
-            <Setter Property="Padding" Value="8"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="CornerRadius" Value="6"/>
-        </Style>
-        <Style Selector="Button.ToolbarButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
-        </Style>
         <Style Selector="ListBox">
             <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
@@ -95,7 +57,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid>
         <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
@@ -182,7 +144,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                         <TextBlock Grid.Column="1" Text="{Binding Name}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontSize="14"
                                                    VerticalAlignment="Center"/>
                                         <Panel Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                            <TextBlock Text="{loc:Localize Contour}" Foreground="#27AE60" FontSize="14" IsVisible="{Binding IsContour}"/>
+                                            <TextBlock Text="{loc:Localize Contour}" Foreground="{DynamicResource SuccessButtonBrush}" FontSize="14" IsVisible="{Binding IsContour}"/>
                                             <TextBlock Text="{loc:Localize Path}" Foreground="#8E44AD" FontSize="14" IsVisible="{Binding IsRecordedPath}"/>
                                             <TextBlock Text="{loc:Localize Curve}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding IsCurve}"/>
                                             <TextBlock Text="{loc:Localize Line}" Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="14" IsVisible="{Binding IsABLine}"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/TramSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/TramSettingsDialogPanel.axaml
@@ -17,7 +17,7 @@ Licensed under GNU GPL v3.
 
     <Grid>
         <!-- Semi-transparent backdrop -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <!-- Dialog panel -->
         <Border Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
@@ -107,7 +107,7 @@ Licensed under GNU GPL v3.
                 <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
                     <Button Grid.Column="1" Content="Build" Width="100" Height="40"
                             Command="{Binding BuildTramLinesCommand}"
-                            Background="#27AE60" Foreground="White" FontWeight="Bold"
+                            Background="{DynamicResource SuccessButtonBrush}" Foreground="White" FontWeight="Bold"
                             CornerRadius="6"/>
                     <Button Grid.Column="2" Content="Close" Width="100" Height="40"
                             Command="{Binding CloseTramSettingsCommand}"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/UnsavedCoveragePanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/UnsavedCoveragePanel.axaml
@@ -28,14 +28,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <Grid>
         <!-- Backdrop. Clicking it is the safe choice: cancel the close. -->
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="{DynamicResource ModalBackdropBrush}" PointerPressed="Backdrop_PointerPressed"/>
 
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="20"
                 HorizontalAlignment="Center" VerticalAlignment="Center"
                 MinWidth="360" MaxWidth="440">
             <StackPanel Spacing="16">
                 <TextBlock Text="Unsaved coverage" FontSize="20" FontWeight="Bold"
-                           Foreground="#E74C3C" HorizontalAlignment="Center"/>
+                           Foreground="{DynamicResource DangerButtonBrush}" HorizontalAlignment="Center"/>
 
                 <TextBlock Text="{Binding UnsavedCoverageMessage}" FontSize="14"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" TextWrapping="Wrap"
@@ -60,7 +60,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                             Padding="4,0" CornerRadius="6"/>
                     <Button Grid.Column="2" Content="Save to a job"
                             Command="{Binding SaveCoverageToJobCommand}"
-                            Background="#27AE60"
+                            Background="{DynamicResource SuccessButtonBrush}"
                             Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                             Height="50" FontSize="15" FontWeight="Bold"
                             HorizontalAlignment="Stretch"

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml
@@ -13,6 +13,7 @@ the Free Software Foundation, either version 3 of the License, or
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:AgValoniaGPS.ViewModels;assembly=AgValoniaGPS.ViewModels"
+             xmlns:controls="using:AgValoniaGPS.Views.Controls"
              mc:Ignorable="d" d:DesignWidth="700" d:DesignHeight="600"
              x:Class="AgValoniaGPS.Views.Controls.Dialogs.ViewSettingsDialogPanel"
              x:DataType="vm:MainViewModel"
@@ -20,24 +21,19 @@ the Free Software Foundation, either version 3 of the License, or
              IsHitTestVisible="{Binding State.UI.IsViewSettingsDialogVisible}">
 
     <Grid>
-        <Border Background="#80000000" PointerPressed="Backdrop_PointerPressed"/>
+        <Border Background="Transparent" PointerPressed="Backdrop_PointerPressed"/>
 
-        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}" CornerRadius="12" Padding="0"
-                HorizontalAlignment="Center" VerticalAlignment="Center"
+        <controls:DialogChrome Title="{loc:Localize AllSettings}"
+                BackCommand="{Binding NavBackCommand}"
+                CloseCommand="{Binding NavCloseChainCommand}"
                 Width="650" Height="520">
-            <Grid RowDefinitions="Auto,*,Auto">
-                <!-- Header -->
-                <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="12,12,0,0" Padding="16,12">
-                    <StackPanel Spacing="4" HorizontalAlignment="Center">
-                        <TextBlock Text="{loc:Localize AllSettings}" FontSize="18" FontWeight="Bold"
-                                   Foreground="{DynamicResource SystemControlHighlightAccentBrush}" HorizontalAlignment="Center"/>
-                        <TextBlock Text="{loc:Localize ReadOnlyViewOfCurrentConfigurationValues}"
-                                   FontSize="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" HorizontalAlignment="Center"/>
-                    </StackPanel>
-                </Border>
+            <Grid RowDefinitions="Auto,*">
+                <TextBlock Grid.Row="0" Text="{loc:Localize ReadOnlyViewOfCurrentConfigurationValues}"
+                           FontSize="11" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                           HorizontalAlignment="Center" Margin="0,0,0,8"/>
 
                 <!-- Settings tree -->
-                <Border Grid.Row="1" Margin="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4">
+                <Border Grid.Row="1" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" CornerRadius="6" Padding="4">
                     <ScrollViewer>
                         <ItemsControl ItemsSource="{Binding SettingsTree}">
                             <ItemsControl.ItemTemplate>
@@ -72,13 +68,7 @@ the Free Software Foundation, either version 3 of the License, or
                     </ScrollViewer>
                 </Border>
 
-                <!-- Close button -->
-                <Button Grid.Row="2" Content="{loc:Localize Close}" Margin="16,4,16,12"
-                        Command="{Binding CloseViewSettingsDialogCommand}"
-                        Background="{DynamicResource SystemControlHighlightAccentBrush}" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                        HorizontalAlignment="Stretch" Height="40" FontSize="14" FontWeight="Bold"
-                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center" CornerRadius="6"/>
             </Grid>
-        </Border>
+        </controls:DialogChrome>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/ViewSettingsDialogPanel.axaml.cs
@@ -22,7 +22,7 @@ public partial class ViewSettingsDialogPanel : UserControl
     {
         if (DataContext is AgValoniaGPS.ViewModels.MainViewModel vm)
         {
-            vm.CloseViewSettingsDialogCommand?.Execute(null);
+            vm.NavCloseChainCommand?.Execute(null);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml
@@ -24,7 +24,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
     <UserControl.Styles>
         <Style Selector="Border.FloatingPanelBorder">
-            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
             <Setter Property="CornerRadius" Value="12"/>
             <Setter Property="Padding" Value="8"/>
             <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}"/>
@@ -54,7 +54,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
             <!-- Title bar / drag handle -->
             <Grid x:Name="DragHandle" ColumnDefinitions="Auto,Auto,*,Auto" Height="32"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                  Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
                   Cursor="Hand" ToolTip.Tip="Drag to move">
                 <!-- Optional Back button (only when BackCommand is set). -->
                 <Button Grid.Column="0" Content="&#x2190;"

--- a/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml
@@ -53,20 +53,29 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <StackPanel Spacing="4">
 
             <!-- Title bar / drag handle -->
-            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,*,Auto" Height="32"
+            <Grid x:Name="DragHandle" ColumnDefinitions="Auto,Auto,*,Auto" Height="32"
                   Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
                   Cursor="Hand" ToolTip.Tip="Drag to move">
-                <TextBlock Grid.Column="0" Text="=" VerticalAlignment="Center"
+                <!-- Optional Back button (only when BackCommand is set). -->
+                <Button Grid.Column="0" Content="&#x2190;"
+                        Width="24" Height="24" Padding="0" BorderThickness="0"
+                        Background="Transparent" FontSize="18" Cursor="Hand"
+                        Margin="6,0,0,0"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        ToolTip.Tip="Back"
+                        IsVisible="{Binding BackCommand, Converter={x:Static ObjectConverters.IsNotNull}, RelativeSource={RelativeSource AncestorType=local:FloatingPanel}}"
+                        Command="{Binding BackCommand, RelativeSource={RelativeSource AncestorType=local:FloatingPanel}}"/>
+                <TextBlock Grid.Column="1" Text="=" VerticalAlignment="Center"
                            Margin="8,0" IsHitTestVisible="False"
                            Foreground="{DynamicResource SystemControlForegroundBaseLowBrush}"
                            FontSize="20" FontWeight="Bold"/>
-                <TextBlock Grid.Column="1"
+                <TextBlock Grid.Column="2"
                            Text="{Binding Title, RelativeSource={RelativeSource AncestorType=local:FloatingPanel}}"
                            FontWeight="Bold" VerticalAlignment="Center"
                            IsHitTestVisible="False"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                            FontSize="16"/>
-                <Button Grid.Column="2" Content="X"
+                <Button Grid.Column="3" Content="X"
                         Width="24" Height="24" Padding="0" BorderThickness="0"
                         Background="Transparent" FontSize="16" Cursor="Hand"
                         Margin="8,0"

--- a/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/FloatingPanel.axaml.cs
@@ -86,6 +86,18 @@ public partial class FloatingPanel : UserControl
         set => SetValue(CloseCommandProperty, value);
     }
 
+    // Optional Back Command. When set, a Back (←) button appears in the header,
+    // left of the title — used by Field Tools tool overlays to return to the
+    // Field Tools fly-out. Fly-out menus and charts leave this null (no Back).
+    public static readonly StyledProperty<ICommand?> BackCommandProperty =
+        AvaloniaProperty.Register<FloatingPanel, ICommand?>(nameof(BackCommand));
+
+    public ICommand? BackCommand
+    {
+        get => GetValue(BackCommandProperty);
+        set => SetValue(BackCommandProperty, value);
+    }
+
     // Menu items — default [Content] property
     public static readonly StyledProperty<IList<MenuButton>> MenuItemsProperty =
         AvaloniaProperty.Register<FloatingPanel, IList<MenuButton>>(nameof(MenuItems));

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
@@ -33,6 +33,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
     <controls:FloatingPanel x:Name="FP"
                             MinWidth="480"
                             Title="{Binding BoundaryRecordingHeaderText}"
+                            BackCommand="{Binding BackToFieldToolsCommand}"
                             CloseCommand="{Binding ToggleBoundaryPanelCommand}">
         <controls:FloatingPanel.PanelContent>
             <StackPanel Spacing="4">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml.cs
@@ -30,4 +30,13 @@ public partial class BoundaryRecordingPanel : UserControl
         if (fp != null)
             fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        // Open over the fly-out that launched it (the chain anchor) like a chain
+        // child, rather than at its fixed Canvas home.
+        if (change.Property == IsVisibleProperty && change.GetNewValue<bool>())
+            AgValoniaGPS.Views.Controls.ChainPanelAnchor.PositionAtAnchor(this);
+    }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/HeadingChartPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                           Title="{loc:Localize HeadingChart}"
                           CloseCommand="{Binding ToggleHeadingChartPanelCommand}">
     <controls:FloatingPanel.PanelContent>
-      <controls:ChartControl x:Name="HeadingChart" Height="192"/>
+      <controls:ChartControl x:Name="HeadingChart" Height="150"/>
     </controls:FloatingPanel.PanelContent>
   </controls:FloatingPanel>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
@@ -17,6 +17,9 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Reactive;
+using Avalonia.VisualTree;
+using AgValoniaGPS.Views.Controls;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
@@ -44,6 +47,23 @@ public partial class LeftNavigationPanel : UserControl
         var panel = this.FindControl<T>(controlName);
         if (panel == null) return;
 
+        // Remember the panel's home position (its XAML Canvas.Left/Top) and snap
+        // back to it each time the panel is shown, so a fly-out always reopens at
+        // home rather than wherever it was last dragged.
+        var homeLeft = Canvas.GetLeft(panel);
+        var homeTop = Canvas.GetTop(panel);
+        panel.GetObservable(Visual.IsVisibleProperty).Subscribe(new AnonymousObserver<bool>(visible =>
+        {
+            if (visible)
+            {
+                Canvas.SetLeft(panel, homeLeft);
+                Canvas.SetTop(panel, homeTop);
+                // This fly-out is the chain root; publish its home position so the
+                // first dialog opens aligned over it.
+                PublishFlyoutAnchor(panel);
+            }
+        }));
+
         // Use reflection to check for DragMoved event
         var dragMovedEvent = typeof(T).GetEvent("DragMoved");
         if (dragMovedEvent != null)
@@ -58,8 +78,28 @@ public partial class LeftNavigationPanel : UserControl
                     if (double.IsNaN(top)) top = 0;
                     Canvas.SetLeft(control, left + delta.X);
                     Canvas.SetTop(control, top + delta.Y);
+                    // Keep the chain anchor in sync so a child opens over the
+                    // dragged fly-out rather than at its old home.
+                    PublishFlyoutAnchor(control);
                 }
             }));
+        }
+    }
+
+    /// <summary>
+    /// Publish a fly-out's current on-screen upper-left to <see cref="ChainPanelAnchor"/>.
+    /// Computed from the host Canvas origin plus the panel's Canvas.Left/Top so it is
+    /// free of layout lag (the attached coords are already up to date during a drag).
+    /// </summary>
+    private static void PublishFlyoutAnchor(Control panel)
+    {
+        var top = TopLevel.GetTopLevel(panel);
+        if (top == null || panel.Parent is not Visual canvas) return;
+        if (canvas.TranslatePoint(new Point(0, 0), top) is { } origin)
+        {
+            var l = Canvas.GetLeft(panel); if (double.IsNaN(l)) l = 0;
+            var t = Canvas.GetTop(panel); if (double.IsNaN(t)) t = 0;
+            ChainPanelAnchor.Current = new Point(origin.X + l, origin.Y + t);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/LeftNavigationPanel.axaml.cs
@@ -38,31 +38,47 @@ public partial class LeftNavigationPanel : UserControl
         WireUpSubPanelDrag<ConfigurationPanel>("ConfigurationPanelControl");
         WireUpSubPanelDrag<FieldOperationsPanel>("FieldOperationsPanelControl");
         WireUpSubPanelDrag<FieldToolsPanel>("FieldToolsPanelControl");
-        WireUpSubPanelDrag<BoundaryRecordingPanel>("BoundaryRecordingPanelControl");
-        WireUpSubPanelDrag<BoundaryPlayerPanel>("BoundaryPlayerPanelControl");
+        // Boundary recording / player are independent tool overlays, not chain
+        // roots: they drag but stay out of the chain anchor so they don't corrupt
+        // where the menu chains open.
+        WireUpSubPanelDrag<BoundaryRecordingPanel>("BoundaryRecordingPanelControl", isChainRoot: false);
+        WireUpSubPanelDrag<BoundaryPlayerPanel>("BoundaryPlayerPanelControl", isChainRoot: false);
     }
 
-    private void WireUpSubPanelDrag<T>(string controlName) where T : UserControl
+    private void WireUpSubPanelDrag<T>(string controlName, bool isChainRoot = true) where T : UserControl
     {
         var panel = this.FindControl<T>(controlName);
         if (panel == null) return;
 
-        // Remember the panel's home position (its XAML Canvas.Left/Top) and snap
-        // back to it each time the panel is shown, so a fly-out always reopens at
-        // home rather than wherever it was last dragged.
-        var homeLeft = Canvas.GetLeft(panel);
-        var homeTop = Canvas.GetTop(panel);
-        panel.GetObservable(Visual.IsVisibleProperty).Subscribe(new AnonymousObserver<bool>(visible =>
+        if (isChainRoot)
         {
-            if (visible)
+            // Remember the panel's home position (its XAML Canvas.Left/Top) and snap
+            // back to it each time the panel is shown, so a fly-out always reopens at
+            // home rather than wherever it was last dragged.
+            var homeLeft = Canvas.GetLeft(panel);
+            var homeTop = Canvas.GetTop(panel);
+            panel.GetObservable(Visual.IsVisibleProperty).Subscribe(new AnonymousObserver<bool>(visible =>
             {
-                Canvas.SetLeft(panel, homeLeft);
-                Canvas.SetTop(panel, homeTop);
-                // This fly-out is the chain root; publish its home position so the
-                // first dialog opens aligned over it.
-                PublishFlyoutAnchor(panel);
-            }
-        }));
+                if (!visible) return;
+
+                var vm = this.DataContext as AgValoniaGPS.ViewModels.MainViewModel;
+                if (vm != null && vm.IsFlyoutReopenFromBack && ChainPanelAnchor.Current is { } anchor)
+                {
+                    // Reopened by Back: place the fly-out where the chain currently is
+                    // (where panels were dragged) and keep the anchor, so backing out
+                    // to a sibling opens it in the same spot rather than at home.
+                    PositionFlyoutAt(panel, anchor);
+                }
+                else
+                {
+                    // Fresh open: snap to home and publish it as the chain anchor so the
+                    // first dialog opens aligned over the fly-out.
+                    Canvas.SetLeft(panel, homeLeft);
+                    Canvas.SetTop(panel, homeTop);
+                    PublishFlyoutAnchor(panel);
+                }
+            }));
+        }
 
         // Use reflection to check for DragMoved event
         var dragMovedEvent = typeof(T).GetEvent("DragMoved");
@@ -79,8 +95,9 @@ public partial class LeftNavigationPanel : UserControl
                     Canvas.SetLeft(control, left + delta.X);
                     Canvas.SetTop(control, top + delta.Y);
                     // Keep the chain anchor in sync so a child opens over the
-                    // dragged fly-out rather than at its old home.
-                    PublishFlyoutAnchor(control);
+                    // dragged fly-out rather than at its old home (chain roots only).
+                    if (isChainRoot)
+                        PublishFlyoutAnchor(control);
                 }
             }));
         }
@@ -100,6 +117,21 @@ public partial class LeftNavigationPanel : UserControl
             var l = Canvas.GetLeft(panel); if (double.IsNaN(l)) l = 0;
             var t = Canvas.GetTop(panel); if (double.IsNaN(t)) t = 0;
             ChainPanelAnchor.Current = new Point(origin.X + l, origin.Y + t);
+        }
+    }
+
+    /// <summary>
+    /// Place a fly-out so its on-screen upper-left lands at the given window-space
+    /// point (the chain anchor), converting through the host Canvas origin.
+    /// </summary>
+    private static void PositionFlyoutAt(Control panel, Point windowPos)
+    {
+        var top = TopLevel.GetTopLevel(panel);
+        if (top == null || panel.Parent is not Visual canvas) return;
+        if (canvas.TranslatePoint(new Point(0, 0), top) is { } origin)
+        {
+            Canvas.SetLeft(panel, windowPos.X - origin.X);
+            Canvas.SetTop(panel, windowPos.Y - origin.Y);
         }
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="TextBlock.NioHeader">
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Foreground" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="Margin" Value="2,2,0,2"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/NetworkIoPanel.axaml.cs
@@ -3,14 +3,24 @@
 //
 // Licensed under GNU GPL v3. See LICENSE.md.
 
+using System;
+using Avalonia;
 using Avalonia.Controls;
+using AgValoniaGPS.Views.Controls;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class NetworkIoPanel : UserControl
 {
+    // Forwarded from the inner FloatingPanel so LeftNavigationPanel's
+    // WireUpSubPanelDrag can move this fly-out on the host Canvas.
+    public event EventHandler<Vector>? DragMoved;
+
     public NetworkIoPanel()
     {
         InitializeComponent();
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ScreenAlertsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ScreenAlertsPanel.axaml
@@ -73,7 +73,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Style Selector="TextBlock.SaGroupHeader">
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#4A9A7E"/>
+            <Setter Property="Foreground" Value="{DynamicResource StatusOkBrush}"/>
             <Setter Property="Margin" Value="2,4,0,2"/>
         </Style>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ScreenAlertsPanel.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ScreenAlertsPanel.axaml.cs
@@ -3,14 +3,24 @@
 //
 // Licensed under GNU GPL v3. See LICENSE.md.
 
+using System;
+using Avalonia;
 using Avalonia.Controls;
+using AgValoniaGPS.Views.Controls;
 
 namespace AgValoniaGPS.Views.Controls.Panels;
 
 public partial class ScreenAlertsPanel : UserControl
 {
+    // Forwarded from the inner FloatingPanel so LeftNavigationPanel's
+    // WireUpSubPanelDrag can move this fly-out on the host Canvas.
+    public event EventHandler<Vector>? DragMoved;
+
     public ScreenAlertsPanel()
     {
         InitializeComponent();
+        var fp = this.FindControl<FloatingPanel>("FP");
+        if (fp != null)
+            fp.DragMoved += (s, delta) => DragMoved?.Invoke(this, delta);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/SteerChartPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                           Title="{loc:Localize SteerChart}"
                           CloseCommand="{Binding ToggleSteerChartPanelCommand}">
     <controls:FloatingPanel.PanelContent>
-      <controls:ChartControl x:Name="SteerChart" Height="192"/>
+      <controls:ChartControl x:Name="SteerChart" Height="150"/>
     </controls:FloatingPanel.PanelContent>
   </controls:FloatingPanel>
 

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/ToolsPanel.axaml
@@ -28,26 +28,55 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
   <controls:FloatingPanel x:Name="FP"
                           Title="Tools"
                           CloseCommand="{Binding CloseAllNavFlyoutsCommand}">
-    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png"
-                         Text="{loc:Localize SteerWizard}"
-                         Command="{Binding ShowSteerWizardCommand}"/>
+    <!-- Explicit two-column layout so the three chart buttons all sit in the
+         right column (the default MenuItems UniformGrid auto-flows and would
+         split them across columns). -->
+    <controls:FloatingPanel.PanelContent>
+      <Grid ColumnDefinitions="*,*" ColumnSpacing="4">
+        <!-- Left: non-chart tools -->
+        <StackPanel Grid.Column="0" Spacing="4">
+          <Button Classes="ModernButton" Command="{Binding ShowSteerWizardCommand}">
+            <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+              <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/WizardWand.png" Width="28" Height="28"/>
+              <TextBlock Text="{loc:Localize SteerWizard}" VerticalAlignment="Center" FontSize="12"/>
+            </StackPanel>
+          </Button>
+          <Button Classes="ModernButton">
+            <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+              <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png" Width="28" Height="28"/>
+              <TextBlock Text="{loc:Localize LogViewer}" VerticalAlignment="Center" FontSize="12"/>
+            </StackPanel>
+          </Button>
+          <Button Classes="ModernButton">
+            <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+              <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesRoll.png" Width="28" Height="28"/>
+              <TextBlock Text="{loc:Localize RollCorrection}" VerticalAlignment="Center" FontSize="12"/>
+            </StackPanel>
+          </Button>
+        </StackPanel>
 
-    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/ABTracks.png"
-                         Text="{loc:Localize LogViewer}"/>
-
-    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/AutoSteerOn.png"
-                         Text="{loc:Localize SteerChart}"
-                         Command="{Binding ToggleSteerChartPanelCommand}"/>
-
-    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesHeading.png"
-                         Text="{loc:Localize HeadingChart}"
-                         Command="{Binding ToggleHeadingChartPanelCommand}"/>
-
-    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/AutoManualIsAuto.png"
-                         Text="{loc:Localize XteChart}"
-                         Command="{Binding ToggleXTEChartPanelCommand}"/>
-
-    <controls:MenuButton Icon="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesRoll.png"
-                         Text="{loc:Localize RollCorrection}"/>
+        <!-- Right: the three diagnostic charts -->
+        <StackPanel Grid.Column="1" Spacing="4">
+          <Button Classes="ModernButton" Command="{Binding ToggleSteerChartPanelCommand}">
+            <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+              <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoSteerOn.png" Width="28" Height="28"/>
+              <TextBlock Text="{loc:Localize SteerChart}" VerticalAlignment="Center" FontSize="12"/>
+            </StackPanel>
+          </Button>
+          <Button Classes="ModernButton" Command="{Binding ToggleHeadingChartPanelCommand}">
+            <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+              <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/ConS_SourcesHeading.png" Width="28" Height="28"/>
+              <TextBlock Text="{loc:Localize HeadingChart}" VerticalAlignment="Center" FontSize="12"/>
+            </StackPanel>
+          </Button>
+          <Button Classes="ModernButton" Command="{Binding ToggleXTEChartPanelCommand}">
+            <StackPanel Orientation="Horizontal" Spacing="6" IsHitTestVisible="False">
+              <Image Source="avares://AgValoniaGPS.Views/Assets/Icons/AutoManualIsAuto.png" Width="28" Height="28"/>
+              <TextBlock Text="{loc:Localize XteChart}" VerticalAlignment="Center" FontSize="12"/>
+            </StackPanel>
+          </Button>
+        </StackPanel>
+      </Grid>
+    </controls:FloatingPanel.PanelContent>
     </controls:FloatingPanel>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
@@ -27,7 +27,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
   <controls:FloatingPanel x:Name="FP"
                           Width="420"
-                          Title="{loc:Localize SteerChart}"
+                          Title="{loc:Localize XteChart}"
                           CloseCommand="{Binding ToggleXTEChartPanelCommand}">
     <controls:FloatingPanel.PanelContent>
       <controls:ChartControl x:Name="XTEChart" Height="192"/>

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/XTEChartPanel.axaml
@@ -30,7 +30,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                           Title="{loc:Localize XteChart}"
                           CloseCommand="{Binding ToggleXTEChartPanelCommand}">
     <controls:FloatingPanel.PanelContent>
-      <controls:ChartControl x:Name="XTEChart" Height="192"/>
+      <controls:ChartControl x:Name="XTEChart" Height="150"/>
     </controls:FloatingPanel.PanelContent>
   </controls:FloatingPanel>
 

--- a/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedResources.axaml
@@ -65,6 +65,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <SolidColorBrush x:Key="ToggleOffBrush" Color="#C2CBD4"/>
             <SolidColorBrush x:Key="ToggleOnBrush" Color="#44566A"/>
             <SolidColorBrush x:Key="ToggleOnForegroundBrush" Color="#F5F7FA"/>
+
+            <!-- Semantic button + status brushes (menu-system standardization).
+                 Primary buttons keep using the live theme accent
+                 (SystemControlHighlightAccentBrush) so it remains the single
+                 accent source; only the hover shade is named here. The success
+                 / danger colors are saturated brand colors (white text on fill)
+                 and are theme-independent, so the Light and Dark values match. -->
+            <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#2980B9"/>
+            <SolidColorBrush x:Key="SuccessButtonBrush" Color="#27AE60"/>
+            <SolidColorBrush x:Key="SuccessButtonHoverBrush" Color="#229954"/>
+            <SolidColorBrush x:Key="DangerButtonBrush" Color="#E74C3C"/>
+            <SolidColorBrush x:Key="DangerButtonHoverBrush" Color="#C0392B"/>
+            <SolidColorBrush x:Key="StatusOkBrush" Color="#4A9A7E"/>
+            <SolidColorBrush x:Key="InfoAccentBrush" Color="#1ABC9C"/>
+            <SolidColorBrush x:Key="ModalBackdropBrush" Color="#80000000"/>
         </ResourceDictionary>
         <!-- Dark: use dark blue-gray instead of pure black -->
         <ResourceDictionary x:Key="Dark">
@@ -89,6 +104,19 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <SolidColorBrush x:Key="ToggleOffBrush" Color="#515C6B"/>
             <SolidColorBrush x:Key="ToggleOnBrush" Color="#34495E"/>
             <SolidColorBrush x:Key="ToggleOnForegroundBrush" Color="#F5F7FA"/>
+
+            <!-- Semantic button + status brushes (menu-system standardization).
+                 Saturated brand colors match the Light variant (white text on
+                 the fill reads correctly in both themes); the primary hover is
+                 the same accent-darkened blue. -->
+            <SolidColorBrush x:Key="PrimaryButtonHoverBrush" Color="#2980B9"/>
+            <SolidColorBrush x:Key="SuccessButtonBrush" Color="#27AE60"/>
+            <SolidColorBrush x:Key="SuccessButtonHoverBrush" Color="#229954"/>
+            <SolidColorBrush x:Key="DangerButtonBrush" Color="#E74C3C"/>
+            <SolidColorBrush x:Key="DangerButtonHoverBrush" Color="#C0392B"/>
+            <SolidColorBrush x:Key="StatusOkBrush" Color="#4A9A7E"/>
+            <SolidColorBrush x:Key="InfoAccentBrush" Color="#1ABC9C"/>
+            <SolidColorBrush x:Key="ModalBackdropBrush" Color="#80000000"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 

--- a/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
+++ b/Shared/AgValoniaGPS.Views/Styles/SharedStyles.axaml
@@ -131,16 +131,123 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <Setter Property="Margin" Value="0,80,0,0"/>
     </Style>
 
-    <!-- Cancel Button Style (red) -->
-    <Style Selector="Button.CancelButton">
-        <Setter Property="Background" Value="#DD3333"/>
-        <Setter Property="Foreground" Value="White"/>
-        <Setter Property="Padding" Value="12,4"/>
-        <Setter Property="CornerRadius" Value="4"/>
+    <!-- ===== Dialog button family (menu-system standardization) =====
+         Shared across every dialog and fly-out so confirms, cancels, and
+         destructive actions read identically app-wide. Geometry is uniform
+         (CornerRadius 6 / Padding 16,10 / FontSize 14 / SemiBold). The modifier
+         classes (OkButton / DangerButton / DeleteButton / CancelButton) are
+         self-contained AND declared AFTER DialogButton, so when combined as
+         Classes="DialogButton CancelButton" the modifier's fill wins (Avalonia
+         resolves equal-specificity setters in document order). Primary uses the
+         live theme accent; hover/semantic colors come from the named brushes in
+         SharedResources.axaml. -->
+    <Style Selector="Button.DialogButton">
+        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAccentBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="16,10"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
+    </Style>
+    <Style Selector="Button.DialogButton:pointerover">
+        <Setter Property="Background" Value="{DynamicResource PrimaryButtonHoverBrush}"/>
+    </Style>
+    <Style Selector="Button.DialogButton:disabled">
+        <Setter Property="Opacity" Value="0.5"/>
+    </Style>
+
+    <!-- Success / confirm (green) -->
+    <Style Selector="Button.OkButton">
+        <Setter Property="Background" Value="{DynamicResource SuccessButtonBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="16,10"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
+    </Style>
+    <Style Selector="Button.OkButton:pointerover">
+        <Setter Property="Background" Value="{DynamicResource SuccessButtonHoverBrush}"/>
+    </Style>
+
+    <!-- Destructive, full size (red) -->
+    <Style Selector="Button.DangerButton">
+        <Setter Property="Background" Value="{DynamicResource DangerButtonBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="16,10"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
+    </Style>
+    <Style Selector="Button.DangerButton:pointerover">
+        <Setter Property="Background" Value="{DynamicResource DangerButtonHoverBrush}"/>
+    </Style>
+
+    <!-- Destructive, compact (inline list-row delete) -->
+    <Style Selector="Button.DeleteButton">
+        <Setter Property="Background" Value="{DynamicResource DangerButtonBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="12,8"/>
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
+    </Style>
+    <Style Selector="Button.DeleteButton:pointerover">
+        <Setter Property="Background" Value="{DynamicResource DangerButtonHoverBrush}"/>
+    </Style>
+
+    <!-- Secondary / cancel (neutral mid-gray, full size) -->
+    <Style Selector="Button.CancelButton">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="16,10"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
     </Style>
     <Style Selector="Button.CancelButton:pointerover">
-        <Setter Property="Background" Value="#EE4444"/>
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumBrush}"/>
+    </Style>
+
+    <!-- Secondary neutral action (lighter surface) — Refresh / Test / etc.
+         Visually a sibling of CancelButton; separate name so non-cancel
+         secondary actions don't read as "cancel". -->
+    <Style Selector="Button.SecondaryButton">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="16,10"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
+    </Style>
+    <Style Selector="Button.SecondaryButton:pointerover">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
+    </Style>
+
+    <!-- Square icon toolbar button (48x48) — list-row / header icon actions -->
+    <Style Selector="Button.ToolbarButton">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Width" Value="48"/>
+        <Setter Property="Height" Value="48"/>
+        <Setter Property="Padding" Value="8"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
+    </Style>
+    <Style Selector="Button.ToolbarButton:pointerover">
+        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseMediumLowBrush}"/>
     </Style>
 
     <!-- Zoom Button Style -->

--- a/Tests/AgValoniaGPS.UI.Tests/UIStateDialogTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/UIStateDialogTests.cs
@@ -76,4 +76,64 @@ public class UIStateDialogTests
         _ui.ShowDialog(DialogType.AppSettings);
         Assert.That(_ui.IsDialogOpen, Is.True);
     }
+
+    // --- Back-stack (chain navigation) ---
+
+    [Test]
+    public void PushDialog_StacksParentAndShowsChild()
+    {
+        _ui.PushDialog(DialogType.NtripProfiles);      // first level, nothing to stack
+        _ui.PushDialog(DialogType.NtripProfileEditor); // parent (Profiles) pushed
+
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.NtripProfileEditor));
+    }
+
+    [Test]
+    public void GoBack_PopsToParentDialog_ReturnsTrue()
+    {
+        _ui.PushDialog(DialogType.NtripProfiles);
+        _ui.PushDialog(DialogType.NtripProfileEditor);
+
+        var surfacedParent = _ui.GoBack();
+
+        Assert.That(surfacedParent, Is.True);
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.NtripProfiles));
+    }
+
+    [Test]
+    public void GoBack_AtBottomOfChain_ClosesAndReturnsFalse()
+    {
+        _ui.PushDialog(DialogType.NtripProfiles); // single level: stack empty
+
+        var surfacedParent = _ui.GoBack();
+
+        Assert.That(surfacedParent, Is.False);
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.None));
+    }
+
+    [Test]
+    public void GoBack_UnwindsFullChainOneLevelAtATime()
+    {
+        _ui.PushDialog(DialogType.NtripProfiles);
+        _ui.PushDialog(DialogType.NtripProfileEditor);
+
+        Assert.That(_ui.GoBack(), Is.True);   // -> Profiles
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.NtripProfiles));
+        Assert.That(_ui.GoBack(), Is.False);  // -> None (bottom)
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.None));
+    }
+
+    [Test]
+    public void CloseDialog_ClearsStack_SoBackDoesNotResurrectParents()
+    {
+        _ui.PushDialog(DialogType.NtripProfiles);
+        _ui.PushDialog(DialogType.NtripProfileEditor);
+
+        _ui.CloseDialog();                    // exit the whole chain
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.None));
+
+        var surfacedParent = _ui.GoBack();    // stack must be empty
+        Assert.That(surfacedParent, Is.False);
+        Assert.That(_ui.ActiveDialog, Is.EqualTo(DialogType.None));
+    }
 }

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 35
+#define VERSION_PATCH 36
 
-#define VERSION "26.5.35"
+#define VERSION "26.5.36"
 #define VERSION_DATE "2026-05-31"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 30
+#define VERSION_PATCH 31
 
-#define VERSION "26.5.30"
+#define VERSION "26.5.31"
 #define VERSION_DATE "2026-05-30"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 33
+#define VERSION_PATCH 34
 
-#define VERSION "26.5.33"
+#define VERSION "26.5.34"
 #define VERSION_DATE "2026-05-30"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 31
+#define VERSION_PATCH 32
 
-#define VERSION "26.5.31"
+#define VERSION "26.5.32"
 #define VERSION_DATE "2026-05-30"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 32
+#define VERSION_PATCH 33
 
-#define VERSION "26.5.32"
+#define VERSION "26.5.33"
 #define VERSION_DATE "2026-05-30"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 29
+#define VERSION_PATCH 30
 
-#define VERSION "26.5.29"
-#define VERSION_DATE "2026-05-29"
+#define VERSION "26.5.30"
+#define VERSION_DATE "2026-05-30"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 34
+#define VERSION_PATCH 35
 
-#define VERSION "26.5.34"
-#define VERSION_DATE "2026-05-30"
+#define VERSION "26.5.35"
+#define VERSION_DATE "2026-05-31"


### PR DESCRIPTION
## Summary

Two related UI workstreams, shipped together because the styling builds directly on the chain conversions (the chain work isn't on `develop` yet).

### Part 1 — Back/Close navigation chains (7 commits)
Converts the menu system to a generic Back/Close back-stack with non-modal, draggable chain panels:
- Generic Back/Close back-stack + non-modal draggable chain panels (NTRIP pilot)
- File Menu, Field Operations, and Field Tools chains converted to Back/Close non-modal panels
- `DialogChrome` gains full-screen `Anchored=False`
- Chain panels follow drag; Field Tools overlays + Delete-Area Back; chart de-overlap + XTE title fixes
- Menu-chain Back-origin fix

### Part 2 — Menu-system style standardization (1 commit)
After the chain rollout the chrome was consistent but buttons/colors had drifted. Consolidates per-dialog button styles and ~280 hardcoded hex colors into one shared vocabulary:
- `SharedResources.axaml` (Light+Dark): semantic brushes — `PrimaryButtonHoverBrush`, `Success`/`Danger` (+hover), `StatusOkBrush`, `InfoAccentBrush`, `ModalBackdropBrush`.
- `SharedStyles.axaml`: app-wide `Button` classes — `DialogButton` / `OkButton` / `DangerButton` / `DeleteButton` / `CancelButton` / `SecondaryButton` / `ToolbarButton`. Modifiers declared after `DialogButton` so combined `Classes` resolve correctly.
- `FloatingPanel`: AltHigh card + ChromeMedium header to match `DialogChrome` (fixes the inversion).
- ~19 dialogs: dropped local shared-button style blocks + hardcoded button hex, now inherit the shared classes/brushes (value-identical colors). Status green + modal backdrops routed to `StatusOkBrush`/`ModalBackdropBrush`.
- `RecordedPathDialogPanel`: converted hand-built Border to a real `FloatingPanel` (Back/Close header + `DragMoved` wiring); all record/playback bindings preserved.

Out-of-scope hex deliberately kept: `.cs` code-behind status colors, `ConverterParameter=#…|#…` literals, and track-type/data-viz indicators.

## Verification
- `dotnet build` clean.
- `dotnet test Tests/AgValoniaGPS.UI.Tests/` — 147/147 pass.
- Fly-outs and a dialog from each chain confirmed in day and night mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)