### PR TITLE
Status strip: widen field/job line so the job name isn't clipped

### DIFF
--- a/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml
@@ -71,7 +71,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <!-- Two-line text stack: Fix/Age on top, rotating field info on the
              bottom. Width fixed so the live readouts to the right don't
              reflow when the rotating line changes pages. -->
-        <Grid Grid.Column="1" RowDefinitions="Auto,Auto" Margin="6,0,12,0" Width="350"
+        <Grid Grid.Column="1" RowDefinitions="Auto,Auto" Margin="6,0,12,0" Width="520"
               VerticalAlignment="Center">
             <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6">
                 <!-- Fix dot + RTK label form one tap target that toggles the


### PR DESCRIPTION
The top status strip's two-line text column is a fixed width (so the live readouts to its right don't reflow as the rotating line cycles pages). At 350px the rotating `Field: … Job: …` line clipped the job name — noticeable on the tablets during verification.

Widen that column to 520px so the full job name shows; ellipsis remains as the safety net for very long names.

`Shared/AgValoniaGPS.Views/Controls/Panels/StatusBarPanel.axaml` — 1 line.

Verified on both the Android tablet and the physical iPad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)