### PR TITLE
fix: android upload signed apk

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -215,11 +215,11 @@ jobs:
 
       - name: Find and rename APK
         run: |
-          APK=$(find publish/android -name "*.apk" | head -1)
+          APK=$(find publish/android -type f -name "*-Signed.apk" | head -1)
           if [ -n "$APK" ]; then
             cp "$APK" AgValoniaGPS-Android.apk
           else
-            echo "No APK found!"
+            echo "No signed APK found!"
             exit 1
           fi
 


### PR DESCRIPTION
## What changed

Fixed Android release packaging to upload the signed APK instead of the unsigned APK.

## Related issue

Relates to nightly APK install failures from `nightly-20260602`.

## Pre-submit checklist

- [x] `dotnet build` succeeds with no errors
- [x] `dotnet test` passes
- [x] Tested on: Android APK publish output

## Screenshots

N/A - workflow-only change.