### PR TITLE
CI: upload signed Android APK instead of unsigned

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -215,13 +215,17 @@ jobs:
 
       - name: Find and rename APK
         run: |
-          APK=$(find publish/android -name "*.apk" | head -1)
-          if [ -n "$APK" ]; then
-            cp "$APK" AgValoniaGPS-Android.apk
-          else
-            echo "No APK found!"
+          # dotnet publish emits BOTH an unsigned (com.*.apk) and a signed
+          # (com.*-Signed.apk) APK. Only the signed one is installable, so
+          # select it explicitly — never fall back to the unsigned APK.
+          APK=$(find publish/android -name "*-Signed.apk" | head -1)
+          if [ -z "$APK" ]; then
+            echo "::error::No signed APK found in publish/android. Available APKs:"
+            find publish/android -name "*.apk"
             exit 1
           fi
+          echo "Selected signed APK: $APK"
+          cp "$APK" AgValoniaGPS-Android.apk
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem
Last night's nightly (`nightly-20260604`) shipped an **unsigned** Android APK. Verified against the actual release asset:

```
$ apksigner verify AgValoniaGPS-Android.apk
DOES NOT VERIFY
ERROR: Missing META-INF/MANIFEST.MF
```

Android refuses to install an unsigned package, so beta testers cannot sideload it regardless of "unknown sources" settings.

## Root cause
`dotnet publish` emits **two** APKs:
- `com.agvaloniaagps.android.apk` (unsigned)
- `com.agvaloniaagps.android-Signed.apk` (signed, installable)

The "Find and rename APK" step picked one with `find ... | head -1`, which returns whichever the filesystem lists first — on the runner that was the unsigned APK. The signed APK was built correctly; CI just selected the wrong file.

## Fix
Select `*-Signed.apk` explicitly, and **fail the build** if no signed APK exists so a non-installable APK can never silently ship again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)