### PR TITLE
CI: sign Android APK with a stable release keystore

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -243,7 +243,7 @@ jobs:
         run: |
           APK=$(find publish/android -type f -name "*-Signed.apk" | head -1)
           if [ -n "$APK" ]; then
-            cp "$APK" AgValoniaGPS-Android.apk
+            cp "$APK" AgValoniaGPS-Android-Signed.apk
           else
             echo "No signed APK found!"
             exit 1
@@ -253,7 +253,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: AgValoniaGPS-Android
-          path: AgValoniaGPS-Android.apk
+          path: AgValoniaGPS-Android-Signed.apk
           retention-days: 30
 
   # Build iOS (simulator .app bundle)
@@ -388,7 +388,7 @@ jobs:
             | macOS x64 (Intel) | `AgValoniaGPS-macOS-x64.zip` |
             | Linux x64 | `AgValoniaGPS-Linux-x64.zip` |
             | Linux ARM64 | `AgValoniaGPS-Linux-ARM64.zip` |
-            | Android | `AgValoniaGPS-Android.apk` |
+            | Android | `AgValoniaGPS-Android-Signed.apk` |
             | iOS Simulator (ARM64) | `AgValoniaGPS-iOS-Simulator.zip` |
 
             ### Installation Notes
@@ -429,7 +429,7 @@ jobs:
             | macOS x64 (Intel) | `AgValoniaGPS-macOS-x64.zip` |
             | Linux x64 | `AgValoniaGPS-Linux-x64.zip` |
             | Linux ARM64 | `AgValoniaGPS-Linux-ARM64.zip` |
-            | Android | `AgValoniaGPS-Android.apk` |
+            | Android | `AgValoniaGPS-Android-Signed.apk` |
             | iOS Simulator (ARM64) | `AgValoniaGPS-iOS-Simulator.zip` |
 
             ### Installation Notes

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -206,12 +206,38 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore Platforms/AgValoniaGPS.Android/AgValoniaGPS.Android.csproj
 
-      - name: Build Android APK
+      - name: Decode signing keystore
+        id: keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
-          dotnet publish Platforms/AgValoniaGPS.Android/AgValoniaGPS.Android.csproj \
-            -c Release \
-            -f net10.0-android \
-            -o publish/android
+          if [ -n "$KEYSTORE_B64" ]; then
+            echo "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/agvalonia-release.keystore"
+            echo "path=$RUNNER_TEMP/agvalonia-release.keystore" >> "$GITHUB_OUTPUT"
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "Using committed release keystore for a stable signing identity."
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::ANDROID_KEYSTORE_BASE64 secret not set — falling back to the runner's ephemeral debug key. The resulting APK will NOT update over installs signed by a different build."
+          fi
+
+      - name: Build Android APK
+        env:
+          # Read by AndroidSigning*Pass=env: below (keeps secrets off the command line)
+          KS_PASS: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+        run: |
+          ARGS=(publish Platforms/AgValoniaGPS.Android/AgValoniaGPS.Android.csproj
+                -c Release
+                -f net10.0-android
+                -o publish/android)
+          if [ "${{ steps.keystore.outputs.present }}" = "true" ]; then
+            ARGS+=(-p:AndroidKeyStore=true
+                   "-p:AndroidSigningKeyStore=${{ steps.keystore.outputs.path }}"
+                   -p:AndroidSigningKeyAlias=agvalonia
+                   -p:AndroidSigningStorePass=env:KS_PASS
+                   -p:AndroidSigningKeyPass=env:KS_PASS)
+          fi
+          dotnet "${ARGS[@]}"
 
       - name: Find and rename APK
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ pat.local
 
 # LSP / tooling per-csproj cache
 *.lscache
+
+# Android signing keystores — NEVER commit. Supplied to CI via secrets.
+*.keystore
+*.jks


### PR DESCRIPTION
## Problem
Tonight's nightly (`nightly-20260605`) *is* signed (the #462 selection fix worked), but it's signed with the **runner's auto-generated debug keystore**. GitHub-hosted runners are ephemeral, so **every nightly is signed with a different key**.

Consequence for beta testers:
- Installing a new nightly over a previously-installed copy fails with `INSTALL_FAILED_UPDATE_INCOMPATIBLE` → *"App not installed"* (looks like a broken/unsigned APK, but it's a key mismatch).
- Every update requires uninstall → reinstall, losing app data.

Verified locally — three builds, three different signing certs:
| APK | Cert SHA-256 |
|---|---|
| nightly-20260605 (CI debug key) | `d74fe918…` |
| local Desktop build (my debug key) | `04c8a1e2…` |
| nightly-20260604 | unsigned |

## Fix
Sign with a **committed release keystore** supplied via repo secrets, so every build shares one stable signing identity and nightly→nightly updates install in place.

- New `Decode signing keystore` step base64-decodes `ANDROID_KEYSTORE_BASE64` to a temp file.
- Build step passes `AndroidSigningKeyStore` + alias `agvalonia`, with passwords via `AndroidSigning*Pass=env:` to keep them off the command line.
- Falls back to debug signing **with a loud warning** when the secret is absent (fork PRs), so those builds still succeed.

## Required repo secrets (maintainer action)
This PR is inert until these are added:
- `ANDROID_KEYSTORE_BASE64` — base64 of the release keystore (alias `agvalonia`)
- `ANDROID_KEYSTORE_PASSWORD` — store/key password

Generation + `gh secret set` commands are documented in the PR thread / handoff.

> ⚠️ One-time break: testers must uninstall the current debug-key build once before installing the first keystore-signed nightly. After that, updates are seamless forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)