### PR TITLE
Add Sagitta U-turn style (smoother turns)

### DIFF
--- a/Shared/AgValoniaGPS.Models/YouTurn/SagittaTurnGeometry.cs
+++ b/Shared/AgValoniaGPS.Models/YouTurn/SagittaTurnGeometry.cs
@@ -1,0 +1,119 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+
+namespace AgValoniaGPS.Models.YouTurn
+{
+    /// <summary>
+    /// Pure geometry for Brian Tischler's "sagitta" U-turn (AOG dev-fork
+    /// CYouTurn.GetOffsetSemicirclePoints / AddCoordinatesToPath).
+    ///
+    /// A sagitta turn is a single offset arc with an optional short counter-arc
+    /// lead-in. The lead-in (curving the opposite way by the sagitta angle) makes
+    /// the path meet the crop row tangentially, eliminating the straight-leg→arc
+    /// curvature step that makes Omega turns feel sharp. The sagitta (extra arc
+    /// depth) lets the arc reach rows closer than twice the turn radius.
+    ///
+    /// Heading convention matches the rest of the guidance code:
+    /// <c>theta = atan2(easting, northing)</c> (clockwise from north).
+    /// </summary>
+    public static class SagittaTurnGeometry
+    {
+        private const double TwoPi = Math.PI * 2.0;
+
+        /// <summary>
+        /// Builds the sagitta offset arc starting at <paramref name="start"/>.
+        /// </summary>
+        /// <param name="start">Arc start point.</param>
+        /// <param name="theta">Start heading in radians.</param>
+        /// <param name="isTurningRight">True to curve right, false to curve left.</param>
+        /// <param name="turningRadius">Turn radius in metres (must be &gt; 0).</param>
+        /// <param name="offsetDistance">
+        /// Pullback from a full 2R semicircle, in metres. The arc lands
+        /// <c>2R - offsetDistance</c> sideways, so to land exactly on a row at
+        /// lateral distance <c>L</c> pass <c>offsetDistance = 2R - L</c>. 0 gives a
+        /// plain semicircle landing at 2R. Valid range [0, 2R].
+        /// </param>
+        /// <param name="angle">Main sweep angle in radians (Math.PI for a semicircle).</param>
+        public static List<Vec3> BuildOffsetArc(Vec3 start, double theta, bool isTurningRight,
+            double turningRadius, double offsetDistance, double angle)
+        {
+            var points = new List<Vec3> { start };
+            if (turningRadius <= 0) return points;
+
+            // Sagitta relation s = R(1 - cos θ)  ->  θ = acos(1 - s/R).
+            // The 0.5 factor splits the sagitta across the lead-in counter-arc.
+            double ratio = 1.0 - (offsetDistance * 0.5) / turningRadius;
+            if (ratio > 1.0) ratio = 1.0;
+            if (ratio < -1.0) ratio = -1.0;
+            double firstArcAngle = Math.Acos(ratio);
+
+            var pos = start;
+
+            if (offsetDistance > 0)
+            {
+                // Counter-arc lead-in: curve the opposite way to align the entry tangent.
+                AddArc(ref pos, ref theta, points, firstArcAngle * turningRadius, !isTurningRight, turningRadius);
+            }
+
+            // Main arc completes the turn; the extra firstArcAngle compensates for the lead-in.
+            double remainingAngle = angle + firstArcAngle;
+            AddArc(ref pos, ref theta, points, remainingAngle * turningRadius, isTurningRight, turningRadius);
+
+            return points;
+        }
+
+        /// <summary>
+        /// Appends points along a constant-radius arc of the given <paramref name="length"/>,
+        /// advancing <paramref name="pos"/> and <paramref name="theta"/> by reference.
+        /// </summary>
+        private static void AddArc(ref Vec3 pos, ref double theta, List<Vec3> path,
+            double length, bool isTurningRight, double turningRadius)
+        {
+            int segments = (int)Math.Ceiling(length / (turningRadius * 0.1));
+            if (segments < 1) segments = 1;
+
+            double dist = length / segments;
+            double turnParameter = (dist / turningRadius) * (isTurningRight ? 1.0 : -1.0);
+            double radius = isTurningRight ? turningRadius : -turningRadius;
+
+            double sinH = Math.Sin(theta);
+            double cosH = Math.Cos(theta);
+
+            for (int i = 0; i < segments; i++)
+            {
+                // Step to the arc centre, rotate the heading, step back out to the rim.
+                pos.Easting += cosH * radius;
+                pos.Northing -= sinH * radius;
+
+                theta += turnParameter;
+                theta %= TwoPi;
+
+                sinH = Math.Sin(theta);
+                cosH = Math.Cos(theta);
+
+                pos.Easting -= cosH * radius;
+                pos.Northing += sinH * radius;
+                pos.Heading = theta;
+
+                path.Add(pos);
+            }
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Models/YouTurn/YouTurnType.cs
+++ b/Shared/AgValoniaGPS.Models/YouTurn/YouTurnType.cs
@@ -31,7 +31,17 @@ namespace AgValoniaGPS.Models.YouTurn
         /// K-style turn.
         /// Creates a more squared-off turn pattern.
         /// </summary>
-        KStyle = 1
+        KStyle = 1,
+
+        /// <summary>
+        /// Sagitta turn (Brian Tischler's AOG dev-fork "sagitta" U-turn).
+        /// A single offset arc with a short counter-arc lead-in so the path
+        /// meets the crop row tangentially, eliminating the straight-leg→arc
+        /// curvature step that makes Omega turns feel sharp. The sagitta
+        /// (extra arc depth) lets it connect rows closer than twice the turn
+        /// radius without falling back to a teardrop.
+        /// </summary>
+        SagittaStyle = 2
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -47,6 +47,18 @@ public partial class YouTurnCreationService
     public readonly record struct TurnPathResult(List<Vec3>? Path, bool UsedFallback);
 
     /// <summary>
+    /// Maps the persisted <see cref="GuidanceConfig.UTurnStyle"/> integer onto the
+    /// creation <see cref="YouTurnType"/>. 0 = Omega/Wide (Albin), 1 = K-style,
+    /// 2 = Sagitta. Unknown values fall back to the Albin default.
+    /// </summary>
+    private static YouTurnType MapTurnStyle(int uTurnStyle) => uTurnStyle switch
+    {
+        (int)YouTurnType.KStyle => YouTurnType.KStyle,
+        (int)YouTurnType.SagittaStyle => YouTurnType.SagittaStyle,
+        _ => YouTurnType.AlbinStyle,
+    };
+
+    /// <summary>
     /// Build a complete U-turn path for the current vehicle state.
     /// The returned path is smoothed per <see cref="GuidanceConfig.UTurnSmoothing"/>.
     /// </summary>
@@ -208,7 +220,7 @@ public partial class YouTurnCreationService
 
         var input = new YouTurnCreationInput
         {
-            TurnType = YouTurnType.AlbinStyle,
+            TurnType = MapTurnStyle(config.Guidance.UTurnStyle),
             IsTurnLeft = turnLeft,
             GuidanceType = GuidanceLineType.ABLine,
             BoundaryTurnLines = boundaryTurnLines,

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.cs
@@ -150,7 +150,11 @@ namespace AgValoniaGPS.Services.YouTurn
 
         private bool CreateCurveTurn(YouTurnCreationInput input, double turnOffset)
         {
-            if (input.TurnType == YouTurnType.AlbinStyle)
+            if (input.TurnType == YouTurnType.SagittaStyle)
+            {
+                return CreateCurveSagittaTurn(input, turnOffset);
+            }
+            else if (input.TurnType == YouTurnType.AlbinStyle)
             {
                 // Omega (narrow) or Wide turn based on offset
                 if (turnOffset > (input.TurnRadius * 2.0))
@@ -381,6 +385,122 @@ namespace AgValoniaGPS.Services.YouTurn
                     youTurnPhase = 10;
                     return true;
             }
+            return true;
+        }
+
+        /// <summary>
+        /// Sagitta-style curve turn (Brian Tischler's AOG dev-fork geometry).
+        /// Mirrors the omega curve turn's single-call behaviour (find crossing,
+        /// build an arc that lands inside the boundary, snap to the turn line),
+        /// but replaces the Dubins constant-radius arc with a sagitta offset arc
+        /// (<see cref="GetOffsetSemicirclePoints"/>) so the path meets the row
+        /// tangentially instead of stepping curvature from 0 to 1/R.
+        /// </summary>
+        private bool CreateCurveSagittaTurn(YouTurnCreationInput input, double turnOffset)
+        {
+            // Keep from making turns constantly - wait 1.5 seconds
+            if (input.MakeUTurnCounter < 4)
+            {
+                youTurnPhase = 0;
+                return true;
+            }
+
+            // Check for valid track mode
+            if (input.TrackMode == 64 || input.TrackMode == 32) // waterPivot or bndCurve
+            {
+                youTurnPhase = 11; // Ignore
+                return false;
+            }
+
+            // A single sagitta semicircle of radius R reaches at most 2R sideways.
+            // Wider rows need straight connectors, so fall back to the omega turn.
+            if (Math.Abs(turnOffset) > input.TurnRadius * 2.0)
+            {
+                return CreateCurveOmegaTurn(input, turnOffset);
+            }
+
+            // Find the crossing point
+            if (!FindCurveTurnPoint(input, false))
+            {
+                FailCreate();
+                return false;
+            }
+
+            inClosestTurnPt = new TurnClosePoint(closestTurnPt);
+            ytList?.Clear();
+
+            int count = input.IsHeadingSameWay ? -1 : 1;
+            int curveIndex = inClosestTurnPt.CurveIndex;
+
+            // Pull the arc back from a full 2R semicircle so it lands exactly on the
+            // next row: landing lateral = 2R - pullback, hence pullback = 2R - turnOffset.
+            double sagittaPullback = input.TurnRadius * 2.0 - Math.Abs(turnOffset);
+            bool isTurningRight = !input.IsTurnLeft;
+
+            isOutOfBounds = true;
+            int stopIfWayOut = 0;
+            double head = 0;
+
+            // Walk the start index inward until the generated arc sits inside the turn area
+            while (isOutOfBounds)
+            {
+                stopIfWayOut++;
+                isOutOfBounds = false;
+
+                ytList.Clear();
+                curveIndex += count;
+
+                if (stopIfWayOut == 300 || curveIndex < 1 || curveIndex > (input.GuidancePoints.Count - 2))
+                {
+                    FailCreate();
+                    return false;
+                }
+
+                Vec3 currentPos = input.GuidancePoints[curveIndex];
+                if (!input.IsHeadingSameWay) currentPos.Heading += Math.PI;
+                if (currentPos.Heading >= TWO_PI) currentPos.Heading -= TWO_PI;
+                head = currentPos.Heading;
+
+                ytList = SagittaTurnGeometry.BuildOffsetArc(currentPos, head, isTurningRight, input.TurnRadius, sagittaPullback, Math.PI);
+                if (ytList.Count == 0)
+                {
+                    FailCreate();
+                    return false;
+                }
+
+                for (int i = 0; i < ytList.Count; i++)
+                {
+                    if (input.IsPointInsideTurnArea(ytList[i]) != 0)
+                    {
+                        isOutOfBounds = true;
+                        break;
+                    }
+                }
+            }
+            inClosestTurnPt.CurveIndex = curveIndex;
+
+            // Remove closely spaced points
+            int cnt = ytList.Count;
+            for (int i = 1; i < cnt - 2; i++)
+            {
+                if (DistanceSquared(ytList[i], ytList[i + 1]) < pointSpacing)
+                {
+                    ytList.RemoveAt(i + 1);
+                    i--;
+                    cnt = ytList.Count;
+                }
+            }
+
+            // Snap the turn to the turn line
+            ytList = MoveTurnInsideTurnLine(input, ytList, head, false, false);
+            if (ytList.Count == 0)
+            {
+                FailCreate();
+                return false;
+            }
+
+            isOutOfBounds = false;
+            youTurnPhase = 10;
             return true;
         }
 
@@ -909,7 +1029,11 @@ namespace AgValoniaGPS.Services.YouTurn
 
         private bool CreateABTurn(YouTurnCreationInput input, double turnOffset)
         {
-            if (input.TurnType == YouTurnType.AlbinStyle)
+            if (input.TurnType == YouTurnType.SagittaStyle)
+            {
+                return CreateABSagittaTurn(input, turnOffset);
+            }
+            else if (input.TurnType == YouTurnType.AlbinStyle)
             {
                 // Always use OmegaTurn - it uses Dubins paths which handle any turnOffset
                 // The wide turn multi-phase approach doesn't work with single-call pattern
@@ -1015,6 +1139,96 @@ namespace AgValoniaGPS.Services.YouTurn
             // Phase 1: Move turn inside boundary and add sequence lines
             ytList = MoveTurnInsideTurnLine(input, ytList, head, false, false);
 
+            if (ytList.Count == 0)
+            {
+                FailCreate();
+                return false;
+            }
+
+            isOutOfBounds = false;
+            youTurnPhase = 10;
+
+            // Add the entry and exit legs
+            if (!AddABSequenceLines(input))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Sagitta-style AB turn (Brian Tischler's AOG dev-fork geometry).
+        /// Mirrors <see cref="CreateABOmegaTurn"/> exactly (find turn point, snap
+        /// inside the turn line, add entry/exit legs) but builds the arc with the
+        /// sagitta offset construction instead of a Dubins constant-radius arc.
+        /// </summary>
+        private bool CreateABSagittaTurn(YouTurnCreationInput input, double turnOffset)
+        {
+            // Keep from making turns constantly
+            if (input.MakeUTurnCounter < 4)
+            {
+                youTurnPhase = 0;
+                return true;
+            }
+
+            // A single sagitta semicircle of radius R reaches at most 2R sideways.
+            // Wider rows need straight connectors, so fall back to the omega turn.
+            if (Math.Abs(turnOffset) > input.TurnRadius * 2.0)
+            {
+                return CreateABOmegaTurn(input, turnOffset);
+            }
+
+            double head = input.ABHeading;
+            if (!input.IsHeadingSameWay) head += Math.PI;
+            if (head >= TWO_PI) head -= TWO_PI;
+
+            // Find turn point where the current AB track crosses the turn boundary
+            Vec3 onPurePoint = new Vec3(input.ABReferencePoint.Easting, input.ABReferencePoint.Northing, head);
+            FindABTurnPoint(input, onPurePoint);
+
+            if (closestTurnPt.TurnLineIndex == -1)
+            {
+                _logger.LogDebug("Sagitta FindABTurnPoint failed: no intersection. RefPoint=({E}, {N}), head={Head}°",
+                    onPurePoint.Easting, onPurePoint.Northing, head * 180 / Math.PI);
+                FailCreate();
+                return false;
+            }
+
+            inClosestTurnPt = new TurnClosePoint(closestTurnPt);
+
+            Vec3 start = inClosestTurnPt.ClosePt;
+            start.Heading = head;
+
+            // Pull the arc back from a full 2R semicircle so it lands exactly on the
+            // next row: landing lateral = 2R - pullback, hence pullback = 2R - turnOffset.
+            double sagittaPullback = input.TurnRadius * 2.0 - Math.Abs(turnOffset);
+            bool isTurningRight = !input.IsTurnLeft;
+
+            // Generate the sagitta arc
+            ytList = SagittaTurnGeometry.BuildOffsetArc(start, head, isTurningRight, input.TurnRadius, sagittaPullback, Math.PI);
+            isOutOfBounds = true;
+
+            if (ytList.Count == 0)
+            {
+                FailCreate();
+                return false;
+            }
+
+            // Clean up closely spaced points
+            int cnt = ytList.Count;
+            for (int i = 1; i < cnt - 2; i++)
+            {
+                if (DistanceSquared(ytList[i], ytList[i + 1]) < pointSpacing)
+                {
+                    ytList.RemoveAt(i + 1);
+                    i--;
+                    cnt = ytList.Count;
+                }
+            }
+
+            // Move turn inside boundary
+            ytList = MoveTurnInsideTurnLine(input, ytList, head, false, false);
             if (ytList.Count == 0)
             {
                 FailCreate();

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -23,6 +23,7 @@ using System.Windows.Input;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Base;
 using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.YouTurn;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Services.Interfaces;
 using CommunityToolkit.Mvvm.Input;
@@ -964,6 +965,16 @@ public partial class ConfigurationViewModel : ObservableObject
     public ICommand EditUTurnSkipWidthCommand { get; private set; } = null!;
     public ICommand EditUTurnSmoothingCommand { get; private set; } = null!;
 
+    // U-Turn style selector (0 = Omega/Albin, 2 = Sagitta)
+    public ICommand SetOmegaTurnStyleCommand { get; private set; } = null!;
+    public ICommand SetSagittaTurnStyleCommand { get; private set; } = null!;
+
+    /// <summary>True when the active U-turn style is Omega (or any non-Sagitta style).</summary>
+    public bool IsOmegaTurnStyle => Guidance.UTurnStyle != (int)YouTurnType.SagittaStyle;
+
+    /// <summary>True when the active U-turn style is Sagitta.</summary>
+    public bool IsSagittaTurnStyle => Guidance.UTurnStyle == (int)YouTurnType.SagittaStyle;
+
     // GPS Tab Commands
     public ICommand SetSingleGpsCommand { get; private set; } = null!;
     public ICommand SetDualGpsCommand { get; private set; } = null!;
@@ -1385,6 +1396,21 @@ public partial class ConfigurationViewModel : ObservableObject
             ShowNumericInput("Smoothing", Guidance.UTurnSmoothing,
                 v => Guidance.UTurnSmoothing = (int)v,
                 "", integerOnly: true, allowNegative: false, min: 1, max: 50));
+
+        SetOmegaTurnStyleCommand = new RelayCommand(() => SetTurnStyle((int)YouTurnType.AlbinStyle));
+        SetSagittaTurnStyleCommand = new RelayCommand(() => SetTurnStyle((int)YouTurnType.SagittaStyle));
+    }
+
+    /// <summary>
+    /// Sets the persisted U-turn style, persists the change, and refreshes the
+    /// selector's bound state so the cards re-highlight.
+    /// </summary>
+    private void SetTurnStyle(int style)
+    {
+        Guidance.UTurnStyle = style;
+        Config.MarkChanged();
+        OnPropertyChanged(nameof(IsOmegaTurnStyle));
+        OnPropertyChanged(nameof(IsSagittaTurnStyle));
     }
 
     private void InitializeGpsEditCommands()

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml
@@ -32,6 +32,23 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="12"/>
         </Style>
+
+        <!-- Turn-style selector card -->
+        <Style Selector="Border.StyleCard">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Padding" Value="12,8"/>
+            <Setter Property="BorderThickness" Value="2"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </Style>
+        <Style Selector="Border.StyleCard:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
+        </Style>
+        <Style Selector="Border.StyleCard.Selected">
+            <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundListLowBrush}"/>
+        </Style>
     </UserControl.Styles>
 
     <Grid RowDefinitions="Auto,*">
@@ -39,6 +56,42 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
         <TextBlock Text="U-Turn Settings" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Margin="16,12,16,8"/>
 
         <ScrollViewer Grid.Row="1">
+          <StackPanel Spacing="4">
+
+            <!-- Turn Style Selector -->
+            <Border Classes="ParamCard" Margin="16,0,16,4">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="Turn Style" FontWeight="SemiBold"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                    <Grid ColumnDefinitions="*,*">
+                        <!-- Omega -->
+                        <Border Grid.Column="0" Classes="StyleCard" Margin="0,0,4,0"
+                                Classes.Selected="{Binding IsOmegaTurnStyle}"
+                                PointerPressed="OnOmegaTurnStylePressed">
+                            <StackPanel Spacing="2">
+                                <TextBlock Text="Omega" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                <TextBlock Text="Tight constant-radius semicircle. Sharper leg-to-arc transition."
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                                           FontSize="11" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                        <!-- Sagitta -->
+                        <Border Grid.Column="1" Classes="StyleCard" Margin="4,0,0,0"
+                                Classes.Selected="{Binding IsSagittaTurnStyle}"
+                                PointerPressed="OnSagittaTurnStylePressed">
+                            <StackPanel Spacing="2">
+                                <TextBlock Text="Sagitta" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                                <TextBlock Text="Smoother offset arc with tangential entry. Gentler on the operator."
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}"
+                                           FontSize="11" TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
             <!-- 3-Column Layout matching AgOpenGPS -->
             <Grid ColumnDefinitions="*,*,*" Margin="12,8,12,16">
 
@@ -120,6 +173,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </StackPanel>
 
             </Grid>
+          </StackPanel>
         </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml.cs
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/UTurnConfigTab.axaml.cs
@@ -15,6 +15,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using Avalonia.Controls;
+using Avalonia.Input;
+using AgValoniaGPS.ViewModels;
 
 namespace AgValoniaGPS.Views.Controls.Dialogs.Configuration;
 
@@ -23,5 +25,17 @@ public partial class UTurnConfigTab : UserControl
     public UTurnConfigTab()
     {
         InitializeComponent();
+    }
+
+    private void OnOmegaTurnStylePressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is ConfigurationViewModel vm)
+            vm.SetOmegaTurnStyleCommand.Execute(null);
+    }
+
+    private void OnSagittaTurnStylePressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is ConfigurationViewModel vm)
+            vm.SetSagittaTurnStyleCommand.Execute(null);
     }
 }

--- a/Tests/AgValoniaGPS.Models.Tests/SagittaTurnGeometryTests.cs
+++ b/Tests/AgValoniaGPS.Models.Tests/SagittaTurnGeometryTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.YouTurn;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Models.Tests;
+
+[TestFixture]
+public class SagittaTurnGeometryTests
+{
+    private const double R = 5.0;
+
+    private static double MaxStep(IReadOnlyList<Vec3> path)
+    {
+        double max = 0;
+        for (int i = 1; i < path.Count; i++)
+        {
+            double d = GeometryMath.Distance(path[i - 1], path[i]);
+            if (d > max) max = d;
+        }
+        return max;
+    }
+
+    [Test]
+    public void PlainSemicircle_NoSagitta_LandsTwoRadiiAcross()
+    {
+        // Heading north (theta = 0), turning right, no sagitta -> a clean semicircle.
+        var start = new Vec3(0, 0, 0);
+        var path = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, isTurningRight: true,
+            turningRadius: R, offsetDistance: 0.0, angle: Math.PI);
+
+        Assert.That(path.Count, Is.GreaterThan(2));
+
+        var end = path[^1];
+        // A 180° turn of radius R offsets laterally by 2R and returns to the start's along-track line.
+        Assert.That(end.Easting, Is.EqualTo(2 * R).Within(0.05), "lateral offset should be 2R");
+        Assert.That(end.Northing, Is.EqualTo(0.0).Within(0.05), "should return to the start along-track line");
+    }
+
+    [Test]
+    public void PlainSemicircle_ReversesHeadingByPi()
+    {
+        var start = new Vec3(0, 0, 0);
+        var path = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, isTurningRight: true,
+            turningRadius: R, offsetDistance: 0.0, angle: Math.PI);
+
+        double endHeading = path[^1].Heading;
+        // Heading should have advanced ~PI (mod 2π).
+        double delta = Math.Abs(endHeading - Math.PI);
+        Assert.That(delta, Is.LessThan(0.02), $"end heading {endHeading} should be ~PI");
+    }
+
+    [TestCase(3.0)]
+    [TestCase(5.0)]
+    [TestCase(8.0)]
+    [TestCase(10.0)]
+    public void Sagitta_LandsExactlyOnTargetRow(double targetLateral)
+    {
+        // To land at lateral L, pass pullback = 2R - L. The arc must end at E≈L
+        // with heading reversed by π so the exit leg lies on the next track.
+        var start = new Vec3(0, 0, 0);
+        double pullback = 2 * R - targetLateral;
+        var path = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, isTurningRight: true,
+            turningRadius: R, offsetDistance: pullback, angle: Math.PI);
+
+        var end = path[^1];
+        Assert.That(end.Easting, Is.EqualTo(targetLateral).Within(0.05),
+            "landing lateral should equal the target row offset");
+        Assert.That(end.Heading, Is.EqualTo(Math.PI).Within(0.02),
+            "exit heading should be reversed (parallel to the track)");
+    }
+
+    [Test]
+    public void Sagitta_AddsCounterArc_StartingTheOppositeWay()
+    {
+        // With a sagitta, the path must begin with a short counter-arc: for a
+        // right turn heading north, the very first move bends LEFT (easting < 0)
+        // before the main arc sweeps right.
+        var start = new Vec3(0, 0, 0);
+        double offset = R; // tight row -> meaningful sagitta
+        var path = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, isTurningRight: true,
+            turningRadius: R, offsetDistance: offset, angle: Math.PI);
+
+        Assert.That(path.Count, Is.GreaterThan(4));
+        Assert.That(path[1].Easting, Is.LessThan(0.0),
+            "first point of a sagitta right-turn should bend left (counter-arc lead-in)");
+    }
+
+    [Test]
+    public void Sagitta_NoSagitta_HaveDifferentPaths()
+    {
+        var start = new Vec3(0, 0, 0);
+        var plain = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, true, R, 0.0, Math.PI);
+        var sagitta = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, true, R, R, Math.PI);
+
+        Assert.That(sagitta.Count, Is.GreaterThan(plain.Count),
+            "the counter-arc lead-in should add points");
+    }
+
+    [Test]
+    public void LeftAndRight_AreMirrored()
+    {
+        var start = new Vec3(0, 0, 0);
+        var right = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, isTurningRight: true, R, 0.0, Math.PI);
+        var left = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, isTurningRight: false, R, 0.0, Math.PI);
+
+        Assert.That(right[^1].Easting, Is.EqualTo(+2 * R).Within(0.05));
+        Assert.That(left[^1].Easting, Is.EqualTo(-2 * R).Within(0.05));
+    }
+
+    [Test]
+    public void Points_AreFinelySpaced_NoLargeGaps()
+    {
+        var start = new Vec3(0, 0, 0);
+        var path = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, true, R, R, Math.PI);
+
+        // Segment sizing is radius * 0.1, so steps should stay well under ~0.6 m for R=5.
+        Assert.That(MaxStep(path), Is.LessThan(R * 0.15));
+    }
+
+    [Test]
+    public void ZeroRadius_DoesNotThrow_ReturnsStartOnly()
+    {
+        var start = new Vec3(1, 2, 0);
+        var path = SagittaTurnGeometry.BuildOffsetArc(start, 0.0, true, 0.0, 0.0, Math.PI);
+        Assert.That(path.Count, Is.EqualTo(1));
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 40
+#define VERSION_PATCH 41
 
-#define VERSION "26.5.40"
-#define VERSION_DATE "2026-06-01"
+#define VERSION "26.5.41"
+#define VERSION_DATE "2026-06-06"


### PR DESCRIPTION
## What
Adds a selectable third U-turn style alongside Omega/Wide: the **Sagitta** turn from Brian Tischler's AOG dev-fork ("Twol"). Omega stays the default — this is opt-in.

## Why
An Omega turn has a curvature discontinuity: curvature steps from 0 (straight leg) to 1/R (arc) instantly, which throws the operator sideways, and the constant-radius arc holds a constant lateral acceleration the whole way around (feels harsh). A sagitta turn builds a single offset arc with a short **counter-arc lead-in** so the path meets the crop row tangentially — no leg→arc step — for a smoother turn in the seat.

## How
- **Models**: `YouTurnType.SagittaStyle`; new pure `SagittaTurnGeometry.BuildOffsetArc()` (counter-arc + main arc + sagitta math). Landing lateral = `2R − pullback`, so `pullback = 2R − turnOffset` lands the arc exactly on the next row with heading reversed (parallel to the track).
- **Services**: `CreateCurveSagittaTurn` + `CreateABSagittaTurn` mirror the omega methods but swap the Dubins arc for the sagitta arc, reusing the existing trim / `MoveTurnInsideTurnLine` / sequence-line / smoothing stages. Falls back to omega when `turnOffset > 2R` (a single radius-R semicircle can't reach wider rows). Orchestration now maps `GuidanceConfig.UTurnStyle → TurnType` instead of hardcoding Omega.
- **UI**: "Turn Style" selector (Omega vs Sagitta) on the U-Turn config tab, using the `Classes.Selected` + `PointerPressed` idiom; persists via `Config.MarkChanged()`.

## Testing
- 11 `SagittaTurnGeometry` unit tests, including a parametrized landing-on-row contract test (`Sagitta_LandsExactlyOnTargetRow`).
- Full suite green: Models 120 / Services 893 / UI 147, zero regressions.
- Verified in the simulator: exit leg lines up with the next track.

## Notes
- A first version overshot the row because the sagitta pullback was halved (Brian clips the arc against the next curve; our AB path extends a straight leg, so the overshoot showed). Fixed to the full `2R − turnOffset` and confirmed by simulation + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)