### PR TITLE
Hard-boundary U-turns: keep the implement clear of fences/obstacles

### DIFF
--- a/Shared/AgValoniaGPS.Models/BoundaryPolygon.cs
+++ b/Shared/AgValoniaGPS.Models/BoundaryPolygon.cs
@@ -181,6 +181,14 @@ public class BoundaryPolygon
     public bool IsDriveThrough { get; set; } = false;
 
     /// <summary>
+    /// Hard boundary: there are obstacles/objects (fence, building, trees) right
+    /// at this edge, so the implement's swept path must not cross it during a
+    /// U-turn. Soft boundaries (default) allow the implement to swing close, as
+    /// today. Used by the U-turn clearance check to keep the implement clear.
+    /// </summary>
+    public bool IsHard { get; set; } = false;
+
+    /// <summary>
     /// Area in square meters (calculated from points)
     /// </summary>
     public double AreaSquareMeters

--- a/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
+++ b/Shared/AgValoniaGPS.Models/Configuration/ToolConfig.cs
@@ -70,6 +70,18 @@ public class ToolConfig : ObservableObject
         set => SetProperty(ref _hitchLength, Math.Max(0, value));
     }
 
+    // Fore-aft length of the implement body, from its attachment (hitch for rigid
+    // tools, tool pivot for trailing) to the rearmost point. Used by the hard-
+    // boundary U-turn clearance check so a long mounted implement's rear corners
+    // don't swing into a fence. 0 = unspecified (clearance falls back to the
+    // working-width line only).
+    private double _length;
+    public double Length
+    {
+        get => _length;
+        set => SetProperty(ref _length, Math.Max(0, value));
+    }
+
     // Distance from hitch to trailing tool, measured behind the hitch.
     // Convention: positive = tool is behind hitch (the only physically valid direction
     // for a trailing implement). Sign-agnostic at runtime; legacy profiles with

--- a/Shared/AgValoniaGPS.Models/GeoJson/GeoJsonModels.cs
+++ b/Shared/AgValoniaGPS.Models/GeoJson/GeoJsonModels.cs
@@ -92,6 +92,7 @@ public static class FieldPropertyKeys
     public const string NudgeDistance = "nudgeDistance";
     public const string IsVisible = "isVisible";
     public const string IsDriveThrough = "isDriveThrough";
+    public const string IsHard = "isHard";
     public const string OriginLatitude = "originLatitude";
     public const string OriginLongitude = "originLongitude";
     public const string Convergence = "convergence";

--- a/Shared/AgValoniaGPS.Models/Guidance/TurnClearance.cs
+++ b/Shared/AgValoniaGPS.Models/Guidance/TurnClearance.cs
@@ -1,0 +1,106 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Tool;
+
+namespace AgValoniaGPS.Models.Guidance
+{
+    /// <summary>
+    /// Pure check of whether an implement's swept path stays clear of a hard
+    /// boundary by a required margin. Used by the U-turn clearance loop to decide
+    /// whether a candidate turn keeps the implement off a fence/obstacle, and by
+    /// how much it intrudes (so the turn can be shifted away the right amount).
+    /// </summary>
+    public static class TurnClearance
+    {
+        /// <summary>Which side of the polygon the implement must stay on.</summary>
+        public enum KeepSide
+        {
+            /// <summary>Outer field boundary — implement must stay inside it.</summary>
+            Inside,
+            /// <summary>Inner exclusion/obstacle — implement must stay outside it.</summary>
+            Outside
+        }
+
+        /// <param name="IsClear">True when every tested point holds the margin.</param>
+        /// <param name="MaxIntrusion">
+        /// Worst violation in metres: &gt; 0 means the implement is that far inside
+        /// the margin (shift the turn away by at least this much); ≤ 0 means clear.
+        /// </param>
+        public readonly record struct ClearanceResult(bool IsClear, double MaxIntrusion);
+
+        /// <summary>
+        /// Evaluates the implement body footprint (all four corner rails) of a
+        /// swept path against a hard polygon.
+        /// </summary>
+        public static ClearanceResult Evaluate(ImplementSweptPathResult swept,
+            IReadOnlyList<Vec2> polygon, KeepSide keep, double margin)
+            => Evaluate(EnumerateCorners(swept), polygon, keep, margin);
+
+        /// <summary>
+        /// Evaluates an arbitrary set of implement points against a hard polygon.
+        /// </summary>
+        public static ClearanceResult Evaluate(IEnumerable<Vec3> implementPoints,
+            IReadOnlyList<Vec2> polygon, KeepSide keep, double margin)
+        {
+            if (polygon == null || polygon.Count < 3)
+                return new ClearanceResult(true, double.NegativeInfinity);
+
+            double maxIntrusion = double.NegativeInfinity;
+            bool any = false;
+
+            foreach (var p in implementPoints)
+            {
+                any = true;
+                var pt = new Vec2(p.Easting, p.Northing);
+                bool inside = GeometryMath.IsPointInPolygon(polygon, pt);
+                double edge = MinEdgeDistance(polygon, pt);
+
+                // Intrusion = how far past the required margin on the allowed side.
+                double intrusion = keep == KeepSide.Inside
+                    ? (inside ? margin - edge : margin + edge)
+                    : (inside ? margin + edge : margin - edge);
+
+                if (intrusion > maxIntrusion) maxIntrusion = intrusion;
+            }
+
+            if (!any) return new ClearanceResult(true, double.NegativeInfinity);
+            return new ClearanceResult(maxIntrusion <= 0.0, maxIntrusion);
+        }
+
+        private static IEnumerable<Vec3> EnumerateCorners(ImplementSweptPathResult s)
+        {
+            foreach (var p in s.FrontLeft) yield return p;
+            foreach (var p in s.FrontRight) yield return p;
+            foreach (var p in s.RearLeft) yield return p;
+            foreach (var p in s.RearRight) yield return p;
+        }
+
+        private static double MinEdgeDistance(IReadOnlyList<Vec2> poly, Vec2 pt)
+        {
+            double min = double.MaxValue;
+            int n = poly.Count;
+            for (int i = 0, j = n - 1; i < n; j = i++)
+            {
+                double d = GeometryMath.PointToSegmentDistance(pt, poly[j], poly[i]);
+                if (d < min) min = d;
+            }
+            return min;
+        }
+    }
+}

--- a/Shared/AgValoniaGPS.Models/Tool/ImplementSweptPath.cs
+++ b/Shared/AgValoniaGPS.Models/Tool/ImplementSweptPath.cs
@@ -1,0 +1,233 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using AgValoniaGPS.Models.Base;
+
+namespace AgValoniaGPS.Models.Tool
+{
+    /// <summary>How the implement is attached to the vehicle.</summary>
+    public enum ToolMount
+    {
+        /// <summary>Rigidly attached ahead of the pivot (follows vehicle heading).</summary>
+        FrontFixed,
+        /// <summary>Rigidly attached behind the pivot (follows vehicle heading).</summary>
+        RearFixed,
+        /// <summary>Trails behind on a hitch; swings during turns (off-tracking).</summary>
+        Trailing,
+        /// <summary>Tow-between-tractor: two-stage trailing (tank then tool).</summary>
+        TBT
+    }
+
+    /// <summary>
+    /// Pure implement geometry needed to reproduce <c>ToolPositionService</c>'s
+    /// kinematics without depending on <c>ConfigurationStore</c>. Distances in metres.
+    /// </summary>
+    /// <param name="Mount">Attachment type.</param>
+    /// <param name="Width">Implement working width.</param>
+    /// <param name="Offset">Lateral offset of the tool centre (right positive).</param>
+    /// <param name="VehicleHitchLength">Axle → tractor hitch pin (used by Trailing/TBT).</param>
+    /// <param name="ToolHitchLength">Axle → implement working centre (used by rigid tools).</param>
+    /// <param name="TrailingHitchLength">Hitch → tool pivot, along the tool.</param>
+    /// <param name="TrailingToolToPivotLength">Tool pivot → tool working centre.</param>
+    /// <param name="TankTrailingHitchLength">Hitch → tank pivot (TBT only).</param>
+    /// <param name="Length">
+    /// Fore-aft length of the implement body, from its attachment to the
+    /// rearmost point. The attachment is the rigid hitch (fixed tools) or the
+    /// tool pivot (trailing/TBT, so the drawbar <see cref="TrailingHitchLength"/>
+    /// is counted separately). 0 collapses the body to the working-centre line
+    /// (legacy behaviour).
+    /// </param>
+    public readonly record struct ToolGeometry(
+        ToolMount Mount,
+        double Width,
+        double Offset,
+        double VehicleHitchLength,
+        double ToolHitchLength,
+        double TrailingHitchLength,
+        double TrailingToolToPivotLength,
+        double TankTrailingHitchLength,
+        double Length = 0.0);
+
+    /// <summary>
+    /// The implement's swept path along a candidate vehicle-pivot trajectory.
+    /// <see cref="ToolCenter"/> + <see cref="LeftEdge"/>/<see cref="RightEdge"/>
+    /// are the working-centre line and its rails (for coverage). The four
+    /// corner rails (<see cref="FrontLeft"/>, <see cref="FrontRight"/>,
+    /// <see cref="RearLeft"/>, <see cref="RearRight"/>) trace the physical body
+    /// footprint when <c>ToolGeometry.Length &gt; 0</c> — the rear-outer corner
+    /// is the worst case for hard-boundary clearance. All lists align 1:1 with
+    /// the input pivot path.
+    /// </summary>
+    public sealed class ImplementSweptPathResult
+    {
+        public List<Vec3> ToolCenter { get; } = new();
+        public List<Vec3> LeftEdge { get; } = new();
+        public List<Vec3> RightEdge { get; } = new();
+
+        public List<Vec3> FrontLeft { get; } = new();
+        public List<Vec3> FrontRight { get; } = new();
+        public List<Vec3> RearLeft { get; } = new();
+        public List<Vec3> RearRight { get; } = new();
+    }
+
+    /// <summary>
+    /// Reproduces <c>ToolPositionService</c>'s tractor/implement kinematics as a
+    /// pure function so a *candidate* turn path can be evaluated offline: given
+    /// the vehicle pivot trajectory, returns where the implement edges sweep.
+    ///
+    /// Heading convention matches the rest of the guidance code:
+    /// <c>heading = atan2(easting-delta, northing-delta)</c> (clockwise from north),
+    /// positions advance by <c>sin(heading)</c> east / <c>cos(heading)</c> north.
+    ///
+    /// Trailing/TBT use Torriem's algorithm (tool heading = direction from the
+    /// trailed pivot toward its tow point), seeded aligned behind the first pose
+    /// — appropriate for a turn that begins after driving straight. The live
+    /// service's startup-snap, GPS-jump and jackknife guards are intentionally
+    /// omitted: a generated turn path is smooth and glitch-free.
+    /// </summary>
+    public static class ImplementSweptPath
+    {
+        private const double TwoPi = Math.PI * 2.0;
+        private const double Eps = 1e-9;
+
+        public static ImplementSweptPathResult Compute(IReadOnlyList<Vec3> pivotPath, ToolGeometry geom)
+        {
+            var result = new ImplementSweptPathResult();
+            int n = pivotPath?.Count ?? 0;
+            if (n == 0) return result;
+
+            double halfWidth = geom.Width / 2.0;
+
+            // Hitch distance + sign: rigid tools measure axle→implement centre,
+            // trailing/TBT measure axle→tractor pin. Behind for everything except
+            // a front-fixed tool.
+            bool rigid = geom.Mount == ToolMount.FrontFixed || geom.Mount == ToolMount.RearFixed;
+            double hitchDistance = Math.Abs(rigid ? geom.ToolHitchLength : geom.VehicleHitchLength);
+            if (geom.Mount != ToolMount.FrontFixed) hitchDistance = -hitchDistance;
+
+            Vec3 lastToolPivot = default;
+            Vec3 lastTank = default;
+            bool seeded = false;
+
+            for (int i = 0; i < n; i++)
+            {
+                Vec3 pivot = pivotPath![i];
+                double heading = HeadingAt(pivotPath, i);
+                double sinH = Math.Sin(heading), cosH = Math.Cos(heading);
+
+                Vec3 hitch = new Vec3(
+                    pivot.Easting + sinH * hitchDistance,
+                    pivot.Northing + cosH * hitchDistance,
+                    heading);
+
+                double toolHeading;
+                Vec3 toolCenter;
+                Vec3 attachment;   // implement's attachment: hitch (rigid) or tool pivot (trailed)
+
+                switch (geom.Mount)
+                {
+                    case ToolMount.Trailing:
+                    {
+                        if (!seeded) { lastToolPivot = Behind(hitch, heading, geom.TrailingHitchLength); seeded = true; }
+                        toolHeading = DirectionFrom(lastToolPivot, hitch, heading);
+                        attachment = Behind(hitch, toolHeading, geom.TrailingHitchLength);
+                        toolCenter = Behind(hitch, toolHeading, geom.TrailingHitchLength - geom.TrailingToolToPivotLength);
+                        lastToolPivot = attachment;
+                        break;
+                    }
+                    case ToolMount.TBT:
+                    {
+                        if (!seeded)
+                        {
+                            lastTank = Behind(hitch, heading, geom.TankTrailingHitchLength);
+                            lastToolPivot = Behind(lastTank, heading, geom.TrailingHitchLength);
+                            seeded = true;
+                        }
+                        double tankHeading = DirectionFrom(lastTank, hitch, heading);
+                        Vec3 tank = Behind(hitch, tankHeading, geom.TankTrailingHitchLength);
+                        toolHeading = DirectionFrom(lastToolPivot, tank, tankHeading);
+                        attachment = Behind(tank, toolHeading, geom.TrailingHitchLength);
+                        toolCenter = Behind(tank, toolHeading, geom.TrailingHitchLength - geom.TrailingToolToPivotLength);
+                        lastTank = tank;
+                        lastToolPivot = attachment;
+                        break;
+                    }
+                    case ToolMount.FrontFixed:
+                    case ToolMount.RearFixed:
+                    default:
+                        toolHeading = heading;
+                        attachment = hitch;
+                        toolCenter = hitch;
+                        break;
+                }
+
+                // Lateral offset, perpendicular to the tool (right positive). Shifts
+                // the whole implement (working line and body) by the same amount.
+                double perpH = toolHeading + Math.PI / 2.0;
+                double sp = Math.Sin(perpH), cp = Math.Cos(perpH);
+                double offE = sp * geom.Offset, offN = cp * geom.Offset;
+
+                toolCenter = new Vec3(toolCenter.Easting + offE, toolCenter.Northing + offN, toolHeading);
+
+                result.ToolCenter.Add(toolCenter);
+                result.LeftEdge.Add(new Vec3(toolCenter.Easting - sp * halfWidth, toolCenter.Northing - cp * halfWidth, toolHeading));
+                result.RightEdge.Add(new Vec3(toolCenter.Easting + sp * halfWidth, toolCenter.Northing + cp * halfWidth, toolHeading));
+
+                // Physical body footprint: a rectangle from the attachment to the
+                // rearmost point (forward for a front-mounted tool), full width.
+                var front = new Vec3(attachment.Easting + offE, attachment.Northing + offN, toolHeading);
+                double bodyDist = (geom.Mount == ToolMount.FrontFixed) ? -geom.Length : geom.Length;
+                var rear = Behind(front, toolHeading, bodyDist);
+
+                result.FrontLeft.Add(new Vec3(front.Easting - sp * halfWidth, front.Northing - cp * halfWidth, toolHeading));
+                result.FrontRight.Add(new Vec3(front.Easting + sp * halfWidth, front.Northing + cp * halfWidth, toolHeading));
+                result.RearLeft.Add(new Vec3(rear.Easting - sp * halfWidth, rear.Northing - cp * halfWidth, toolHeading));
+                result.RearRight.Add(new Vec3(rear.Easting + sp * halfWidth, rear.Northing + cp * halfWidth, toolHeading));
+            }
+
+            return result;
+        }
+
+        /// <summary>Heading from the path tangent (forward diff; backward at the last point).</summary>
+        private static double HeadingAt(IReadOnlyList<Vec3> path, int i)
+        {
+            int a = i, b = i + 1;
+            if (b >= path.Count) { a = i - 1; b = i; }
+            if (a < 0) return path[i].Heading;
+
+            double dx = path[b].Easting - path[a].Easting;
+            double dy = path[b].Northing - path[a].Northing;
+            if (Math.Abs(dx) < Eps && Math.Abs(dy) < Eps) return path[i].Heading;
+            return Normalize(Math.Atan2(dx, dy));
+        }
+
+        /// <summary>Torriem heading: direction from a trailed point toward its tow point.</summary>
+        private static double DirectionFrom(Vec3 from, Vec3 to, double fallback)
+        {
+            double dx = to.Easting - from.Easting;
+            double dy = to.Northing - from.Northing;
+            if (Math.Abs(dx) < Eps && Math.Abs(dy) < Eps) return fallback;
+            return Normalize(Math.Atan2(dx, dy));
+        }
+
+        private static Vec3 Behind(Vec3 from, double heading, double dist) =>
+            new Vec3(from.Easting - Math.Sin(heading) * dist, from.Northing - Math.Cos(heading) * dist, heading);
+
+        private static double Normalize(double a) => a < 0 ? a + TwoPi : a;
+    }
+}

--- a/Shared/AgValoniaGPS.Services/BoundaryFileService.cs
+++ b/Shared/AgValoniaGPS.Services/BoundaryFileService.cs
@@ -149,6 +149,14 @@ public class BoundaryFileService
 
         if (line == null) return null;
 
+        // AgValonia-specific hard-boundary marker (optional, labeled).
+        if (line.Trim().Equals("hard", StringComparison.OrdinalIgnoreCase))
+        {
+            polygon.IsHard = true;
+            line = reader.ReadLine();
+            if (line == null) return null;
+        }
+
         // Read point count
         if (!int.TryParse(line.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int count))
         {
@@ -223,6 +231,11 @@ public class BoundaryFileService
     {
         // Write isDriveThru flag
         writer.WriteLine(polygon.IsDriveThrough.ToString());
+
+        // AgValonia-specific: hard boundary marker (labeled so it can't be confused
+        // with the bool/count lines and stays compatible with AgOpen import).
+        if (polygon.IsHard)
+            writer.WriteLine("hard");
 
         // Write point count
         writer.WriteLine(polygon.Points.Count.ToString(CultureInfo.InvariantCulture));

--- a/Shared/AgValoniaGPS.Services/GeoJson/GeoJsonFieldService.cs
+++ b/Shared/AgValoniaGPS.Services/GeoJson/GeoJsonFieldService.cs
@@ -155,6 +155,8 @@ public class GeoJsonFieldService
             {
                 case FeatureRoles.OuterBoundary:
                     boundary.OuterBoundary = ReadBoundaryPolygon(geo, feature);
+                    if (boundary.OuterBoundary != null)
+                        boundary.OuterBoundary.IsHard = GetBoolProp(feature, FieldPropertyKeys.IsHard);
                     break;
 
                 case FeatureRoles.InnerBoundary:
@@ -162,6 +164,7 @@ public class GeoJsonFieldService
                     if (inner != null)
                     {
                         inner.IsDriveThrough = GetBoolProp(feature, FieldPropertyKeys.IsDriveThrough);
+                        inner.IsHard = GetBoolProp(feature, FieldPropertyKeys.IsHard);
                         boundary.InnerBoundaries.Add(inner);
                     }
                     break;
@@ -229,6 +232,7 @@ public class GeoJsonFieldService
             {
                 [FieldPropertyKeys.Role] = role,
                 [FieldPropertyKeys.IsDriveThrough] = polygon.IsDriveThrough,
+                [FieldPropertyKeys.IsHard] = polygon.IsHard,
                 [FieldPropertyKeys.AreaHectares] = polygon.AreaHectares,
             }
         };

--- a/Shared/AgValoniaGPS.Services/Profile/ToolProfileJsonService.cs
+++ b/Shared/AgValoniaGPS.Services/Profile/ToolProfileJsonService.cs
@@ -122,6 +122,7 @@ public static class ToolProfileJsonService
                 Overlap = store.Tool.Overlap,
                 Offset = store.Tool.Offset,
                 HitchLength = store.Tool.HitchLength,
+                Length = store.Tool.Length,
                 TrailingHitchLength = store.Tool.TrailingHitchLength,
                 TankTrailingHitchLength = store.Tool.TankTrailingHitchLength,
                 TrailingToolToPivotLength = store.Tool.TrailingToolToPivotLength,
@@ -171,6 +172,7 @@ public static class ToolProfileJsonService
         store.Tool.Overlap = dto.Tool?.Overlap ?? 0.0;
         store.Tool.Offset = dto.Tool?.Offset ?? 0.0;
         store.Tool.HitchLength = dto.Tool?.HitchLength ?? 1.8;
+        store.Tool.Length = dto.Tool?.Length ?? 0.0;
         // Legacy AOG sign convention used negative TrailingHitchLength; canonicalize.
         store.Tool.TrailingHitchLength = Math.Abs(dto.Tool?.TrailingHitchLength ?? 2.5);
         store.Tool.TankTrailingHitchLength = dto.Tool?.TankTrailingHitchLength ?? 3.0;
@@ -257,6 +259,7 @@ public static class ToolProfileJsonService
         public double Overlap { get; set; }
         public double Offset { get; set; }
         public double HitchLength { get; set; }
+        public double Length { get; set; }
         public double TrailingHitchLength { get; set; }
         public double TankTrailingHitchLength { get; set; }
         public double TrailingToolToPivotLength { get; set; }

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -24,6 +24,7 @@ using AgValoniaGPS.Models.Configuration;
 using AgValoniaGPS.Models.Guidance;
 using AgValoniaGPS.Models.Pipeline;
 using AgValoniaGPS.Models.State;
+using AgValoniaGPS.Models.Tool;
 using AgValoniaGPS.Models.YouTurn;
 
 using Microsoft.Extensions.Logging;
@@ -44,7 +45,15 @@ public partial class YouTurnCreationService
     /// is true when the primary Dubins-based algorithm returned a spiral or failed outright
     /// and the simple geometric fallback was substituted.
     /// </summary>
-    public readonly record struct TurnPathResult(List<Vec3>? Path, bool UsedFallback);
+    public readonly record struct TurnPathResult(List<Vec3>? Path, bool UsedFallback)
+    {
+        /// <summary>
+        /// True when no forward turn could keep the implement clear of a hard
+        /// boundary, so <see cref="Path"/> is null and the turn must not be
+        /// auto-engaged — the operator should be warned to take over.
+        /// </summary>
+        public bool ClearanceBlocked { get; init; }
+    }
 
     /// <summary>
     /// Maps the persisted <see cref="GuidanceConfig.UTurnStyle"/> integer onto the
@@ -83,70 +92,153 @@ public partial class YouTurnCreationService
         _logger.LogDebug("[YouTurn] Creating turn: direction={Dir}, sameWay={SameWay}, pathsAway={Away}",
             turnLeft ? "LEFT" : "RIGHT", guidance.IsHeadingSameWay, guidance.HowManyPathsAway);
 
-        var input = BuildCreationInput(
-            currentPosition, selectedTrack, headingRadians, abHeading, turnLeft,
-            boundary, headlandLine, guidance, turn, uTurnSkipRows, headlandCalculatedWidth);
-
-        if (input == null)
-        {
-            _logger.LogWarning("[YouTurn] Failed to build creation input - no boundary available?");
-            return new TurnPathResult(null, false);
-        }
-
-        var output = CreateTurn(input);
         var config = ConfigurationStore.Instance;
 
-        if (output.Success && output.TurnPath != null && output.TurnPath.Count > 10)
+        // Hard outer boundary: the implement's swept path (including a long
+        // mounted tool's rear corners) must stay clear of the fence/obstacle
+        // edge. When set, we shift the turn inward and regenerate until the
+        // implement clears, or give up and refuse to auto-engage.
+        bool hardOuter = boundary?.OuterBoundary?.IsHard == true && boundary.OuterBoundary.IsValid;
+        var outerPolygon = hardOuter
+            ? boundary!.OuterBoundary!.Points.Select(p => new Vec2(p.Easting, p.Northing)).ToList()
+            : null;
+        ToolGeometry toolGeom = hardOuter ? BuildToolGeometry(config) : default;
+        double clearanceMargin = Math.Max(0.0, config.Guidance.UTurnDistanceFromBoundary);
+
+        const double SetbackStep = 0.5;
+        const double MaxExtraSetback = 30.0;
+        double extraSetback = 0.0;
+
+        while (true)
         {
-            var path = output.TurnPath;
+            var input = BuildCreationInput(
+                currentPosition, selectedTrack, headingRadians, abHeading, turnLeft,
+                boundary, headlandLine, guidance, turn, uTurnSkipRows, headlandCalculatedWidth,
+                extraSetback);
 
-            // Spiral / pretzel guard. The original check summed |ΔHeading| per step and
-            // rejected anything > 1.5π (270°) — but a legit Dubins RLR/LRL arc-arc-arc
-            // solution can accumulate 300°+ of absolute turning while ending at the correct
-            // 180° reversal. That false-rejected valid paths (#289 F2) and dropped the run
-            // to the less-optimal simple fallback.
-            //
-            // New guard:
-            //   - Primary check: start-to-end heading delta should be ~π (180°) for a U-turn.
-            //   - Secondary safety: cumulative |ΔHeading| capped at 4π (720°) to still catch
-            //     actual infinite-loop spirals, without rejecting loopy-but-valid paths.
-            double netHeadingChange = path[^1].Heading - path[0].Heading;
-            while (netHeadingChange > Math.PI) netHeadingChange -= 2 * Math.PI;
-            while (netHeadingChange < -Math.PI) netHeadingChange += 2 * Math.PI;
-
-            double totalHeadingChange = 0;
-            for (int i = 1; i < path.Count; i++)
+            if (input == null)
             {
-                double delta = path[i].Heading - path[i - 1].Heading;
-                while (delta > Math.PI) delta -= 2 * Math.PI;
-                while (delta < -Math.PI) delta += 2 * Math.PI;
-                totalHeadingChange += Math.Abs(delta);
+                _logger.LogWarning("[YouTurn] Failed to build creation input - no boundary available?");
+                return new TurnPathResult(null, false);
             }
 
-            // ~π expected for U-turn; tolerate ±30° slack to account for approach angle.
-            bool netIsUTurnLike = Math.Abs(Math.Abs(netHeadingChange) - Math.PI) < Math.PI / 6.0;
-            bool cumulativeRunaway = totalHeadingChange > Math.PI * 4.0;
+            var output = CreateTurn(input);
 
-            if (!netIsUTurnLike || cumulativeRunaway)
+            if (output.Success && output.TurnPath != null && output.TurnPath.Count > 10)
             {
-                _logger.LogWarning("[YouTurn] Service path rejected: net={Net:F0}° cumulative={Cum:F0}° - using simple fallback",
-                    netHeadingChange * 180 / Math.PI, totalHeadingChange * 180 / Math.PI);
-                var fallback = SimpleFallback(currentPosition, abHeading, turnLeft, boundary,
-                    guidance, turn, uTurnSkipRows, headlandDistance);
-                return new TurnPathResult(fallback.Count > 10 ? fallback : null, UsedFallback: true);
+                var path = output.TurnPath;
+
+                // Spiral / pretzel guard. The original check summed |ΔHeading| per step and
+                // rejected anything > 1.5π (270°) — but a legit Dubins RLR/LRL arc-arc-arc
+                // solution can accumulate 300°+ of absolute turning while ending at the correct
+                // 180° reversal. That false-rejected valid paths (#289 F2) and dropped the run
+                // to the less-optimal simple fallback.
+                //
+                // New guard:
+                //   - Primary check: start-to-end heading delta should be ~π (180°) for a U-turn.
+                //   - Secondary safety: cumulative |ΔHeading| capped at 4π (720°) to still catch
+                //     actual infinite-loop spirals, without rejecting loopy-but-valid paths.
+                double netHeadingChange = path[^1].Heading - path[0].Heading;
+                while (netHeadingChange > Math.PI) netHeadingChange -= 2 * Math.PI;
+                while (netHeadingChange < -Math.PI) netHeadingChange += 2 * Math.PI;
+
+                double totalHeadingChange = 0;
+                for (int i = 1; i < path.Count; i++)
+                {
+                    double delta = path[i].Heading - path[i - 1].Heading;
+                    while (delta > Math.PI) delta -= 2 * Math.PI;
+                    while (delta < -Math.PI) delta += 2 * Math.PI;
+                    totalHeadingChange += Math.Abs(delta);
+                }
+
+                // ~π expected for U-turn; tolerate ±30° slack to account for approach angle.
+                bool netIsUTurnLike = Math.Abs(Math.Abs(netHeadingChange) - Math.PI) < Math.PI / 6.0;
+                bool cumulativeRunaway = totalHeadingChange > Math.PI * 4.0;
+
+                if (!netIsUTurnLike || cumulativeRunaway)
+                {
+                    if (hardOuter)
+                    {
+                        _logger.LogWarning("[YouTurn] Turn near hard boundary was malformed; not engaging.");
+                        return new TurnPathResult(null, UsedFallback: false) { ClearanceBlocked = true };
+                    }
+                    _logger.LogWarning("[YouTurn] Service path rejected: net={Net:F0}° cumulative={Cum:F0}° - using simple fallback",
+                        netHeadingChange * 180 / Math.PI, totalHeadingChange * 180 / Math.PI);
+                    var fallback = SimpleFallback(currentPosition, abHeading, turnLeft, boundary,
+                        guidance, turn, uTurnSkipRows, headlandDistance);
+                    return new TurnPathResult(fallback.Count > 10 ? fallback : null, UsedFallback: true);
+                }
+
+                TurnPathSmoothing.Smooth(path, config.Guidance.UTurnSmoothing);
+
+                // Implement clearance against the hard outer boundary, checked on
+                // the final (smoothed) path that will actually be driven.
+                if (hardOuter)
+                {
+                    var swept = ImplementSweptPath.Compute(path, toolGeom);
+                    var clearance = TurnClearance.Evaluate(swept, outerPolygon!,
+                        TurnClearance.KeepSide.Inside, clearanceMargin);
+
+                    if (!clearance.IsClear)
+                    {
+                        extraSetback += Math.Max(SetbackStep, clearance.MaxIntrusion);
+                        if (extraSetback <= MaxExtraSetback)
+                        {
+                            _logger.LogDebug("[YouTurn] Implement intrudes hard boundary by {I:F2}m; shifting turn inward (setback {S:F2}m) and retrying",
+                                clearance.MaxIntrusion, extraSetback);
+                            continue;
+                        }
+
+                        _logger.LogWarning("[YouTurn] No forward turn keeps the implement clear of the hard boundary (intrusion {I:F2}m); not engaging.",
+                            clearance.MaxIntrusion);
+                        return new TurnPathResult(null, UsedFallback: false) { ClearanceBlocked = true };
+                    }
+                }
+
+                _logger.LogDebug("[YouTurn] Path created with {Count} points, net={Net:F0}° cumulative={Cum:F0}° (setback {S:F2}m)",
+                    path.Count, netHeadingChange * 180 / Math.PI, totalHeadingChange * 180 / Math.PI, extraSetback);
+                return new TurnPathResult(path, UsedFallback: false);
             }
 
-            TurnPathSmoothing.Smooth(path, config.Guidance.UTurnSmoothing);
-            _logger.LogDebug("[YouTurn] Path created with {Count} points, net={Net:F0}° cumulative={Cum:F0}°",
-                path.Count, netHeadingChange * 180 / Math.PI, totalHeadingChange * 180 / Math.PI);
-            return new TurnPathResult(path, UsedFallback: false);
+            // Creation failed outright.
+            if (hardOuter)
+            {
+                _logger.LogWarning("[YouTurn] Turn creation failed near a hard boundary ({Reason}); not engaging.",
+                    output.FailureReason ?? "unknown");
+                return new TurnPathResult(null, UsedFallback: false) { ClearanceBlocked = true };
+            }
+
+            _logger.LogWarning("[YouTurn] Service failed: {Reason} - using simple fallback",
+                output.FailureReason ?? "unknown");
+            var fallbackPath = SimpleFallback(currentPosition, abHeading, turnLeft, boundary,
+                guidance, turn, uTurnSkipRows, headlandDistance);
+            return new TurnPathResult(fallbackPath.Count > 10 ? fallbackPath : null, UsedFallback: true);
         }
+    }
 
-        _logger.LogWarning("[YouTurn] Service failed: {Reason} - using simple fallback",
-            output.FailureReason ?? "unknown");
-        var fallbackPath = SimpleFallback(currentPosition, abHeading, turnLeft, boundary,
-            guidance, turn, uTurnSkipRows, headlandDistance);
-        return new TurnPathResult(fallbackPath.Count > 10 ? fallbackPath : null, UsedFallback: true);
+    /// <summary>
+    /// Maps the runtime tool/vehicle config onto the pure <see cref="ToolGeometry"/>
+    /// used by the implement swept-path clearance check.
+    /// </summary>
+    private static ToolGeometry BuildToolGeometry(ConfigurationStore config)
+    {
+        var tool = config.Tool;
+        ToolMount mount =
+            tool.IsToolFrontFixed ? ToolMount.FrontFixed :
+            tool.IsToolTBT ? ToolMount.TBT :
+            tool.IsToolTrailing ? ToolMount.Trailing :
+            ToolMount.RearFixed; // rear-fixed is the default
+
+        return new ToolGeometry(
+            Mount: mount,
+            Width: tool.Width,
+            Offset: tool.Offset,
+            VehicleHitchLength: config.Vehicle.HitchLength,
+            ToolHitchLength: tool.HitchLength,
+            TrailingHitchLength: tool.TrailingHitchLength,
+            TrailingToolToPivotLength: tool.TrailingToolToPivotLength,
+            TankTrailingHitchLength: tool.TankTrailingHitchLength,
+            Length: tool.Length);
     }
 
     // ── Input builder ───────────────────────────────────────────────────
@@ -162,7 +254,8 @@ public partial class YouTurnCreationService
         GuidanceWorkingState guidance,
         YouTurnWorkingState turn,
         int uTurnSkipRows,
-        double headlandCalculatedWidth)
+        double headlandCalculatedWidth,
+        double extraInwardSetback = 0.0)
     {
         if (boundary?.OuterBoundary == null || !boundary.OuterBoundary.IsValid)
         {
@@ -182,7 +275,9 @@ public partial class YouTurnCreationService
         //  > 0: turn stays that far inside the field
         //  = 0: turn may touch the outer boundary
         //  < 0: turn may extend past the outer boundary
-        double distanceFromBoundary = config.Guidance.UTurnDistanceFromBoundary;
+        // Base setback, plus any extra the clearance loop asked for to pull the
+        // turn further inside a hard boundary.
+        double distanceFromBoundary = config.Guidance.UTurnDistanceFromBoundary + extraInwardSetback;
         List<Vec2>? turnBoundaryVec2;
         if (distanceFromBoundary > 0.1)
             turnBoundaryVec2 = _polygonOffsetService.CreateInwardOffset(outerPoints, distanceFromBoundary);

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -105,6 +105,14 @@ public partial class YouTurnCreationService
         ToolGeometry toolGeom = hardOuter ? BuildToolGeometry(config) : default;
         double clearanceMargin = Math.Max(0.0, config.Guidance.UTurnDistanceFromBoundary);
 
+        // Diagnostic (#hard-boundary): one line per turn build so we can see whether
+        // the clearance path is actually armed at runtime and with what geometry.
+        _logger.LogWarning(
+            "[YouTurn][HardBoundary] hardOuter={Hard} isHard={IsHard} validOuter={Valid} width={W:F1} rearFixed={RF} trailing={TR} tbt={TBT} frontFixed={FF} length={L:F1} margin={M:F1}",
+            hardOuter, boundary?.OuterBoundary?.IsHard, boundary?.OuterBoundary?.IsValid,
+            config.Tool.Width, config.Tool.IsToolRearFixed, config.Tool.IsToolTrailing,
+            config.Tool.IsToolTBT, config.Tool.IsToolFrontFixed, config.Tool.Length, clearanceMargin);
+
         const double SetbackStep = 0.5;
         const double MaxExtraSetback = 30.0;
         double extraSetback = 0.0;

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -201,6 +201,11 @@ public partial class YouTurnCreationService
                             clearance.MaxIntrusion);
                         return new TurnPathResult(null, UsedFallback: false) { ClearanceBlocked = true };
                     }
+
+                    // Cleared. MaxIntrusion <= 0; the worst implement point sits
+                    // (margin - MaxIntrusion) m inside the fence — log the achieved gap.
+                    _logger.LogDebug("[YouTurn][HardBoundary] CLEARED: nearest implement point {C:F2}m inside fence (margin {M:F2}m, setback {S:F2}m)",
+                        clearanceMargin - clearance.MaxIntrusion, clearanceMargin, extraSetback);
                 }
 
                 _logger.LogDebug("[YouTurn] Path created with {Count} points, net={Net:F0}° cumulative={Cum:F0}° (setback {S:F2}m)",

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -241,6 +241,28 @@ public partial class YouTurnCreationService
             Length: tool.Length);
     }
 
+    /// <summary>
+    /// True when the implement swept along <paramref name="path"/> stays clear of a
+    /// hard outer boundary by the configured margin — or when there is no hard
+    /// boundary (in which case it is always "clear"). <paramref name="intrusion"/>
+    /// is how far the worst implement point pushes past the margin (&gt; 0 = violated).
+    /// </summary>
+    private static bool ImplementClearsHardBoundary(
+        IReadOnlyList<Vec3> path, Boundary? boundary, ConfigurationStore config, out double intrusion)
+    {
+        intrusion = 0.0;
+        if (boundary?.OuterBoundary == null || !boundary.OuterBoundary.IsValid
+            || !boundary.OuterBoundary.IsHard || path == null || path.Count < 2)
+            return true;
+
+        var outerPolygon = boundary.OuterBoundary.Points.Select(p => new Vec2(p.Easting, p.Northing)).ToList();
+        var swept = ImplementSweptPath.Compute(path, BuildToolGeometry(config));
+        double margin = Math.Max(0.0, config.Guidance.UTurnDistanceFromBoundary);
+        var clearance = TurnClearance.Evaluate(swept, outerPolygon, TurnClearance.KeepSide.Inside, margin);
+        intrusion = clearance.MaxIntrusion;
+        return clearance.IsClear;
+    }
+
     // ── Input builder ───────────────────────────────────────────────────
 
     private YouTurnCreationInput? BuildCreationInput(
@@ -849,6 +871,16 @@ public partial class YouTurnCreationService
         }
 
         TurnPathSmoothing.Smooth(path, config.Guidance.UTurnSmoothing);
+
+        // Hard boundary: a manual arc is anchored at the tractor, so it can't be
+        // shifted inward — if the implement would swing into the fence, refuse it.
+        if (!ImplementClearsHardBoundary(path, boundary, config, out double intrusion))
+        {
+            _logger.LogWarning("[ManualYouTurn] Implement would swing into hard boundary (intrusion {I:F2}m) — refusing",
+                intrusion);
+            path.Clear();
+            return path;
+        }
 
         _logger.LogDebug("[ManualYouTurn] Arc path: {Count} points, radius={Rad:F1}m, offset={Off:F1}m, turnLeft={Left}",
             path.Count, turnRadius, turnOffset, turnLeft);

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -105,13 +105,13 @@ public partial class YouTurnCreationService
         ToolGeometry toolGeom = hardOuter ? BuildToolGeometry(config) : default;
         double clearanceMargin = Math.Max(0.0, config.Guidance.UTurnDistanceFromBoundary);
 
-        // Diagnostic (#hard-boundary): one line per turn build so we can see whether
-        // the clearance path is actually armed at runtime and with what geometry.
-        _logger.LogWarning(
-            "[YouTurn][HardBoundary] hardOuter={Hard} isHard={IsHard} validOuter={Valid} width={W:F1} rearFixed={RF} trailing={TR} tbt={TBT} frontFixed={FF} length={L:F1} margin={M:F1}",
+        // Diagnostic: one line per turn build to see whether the clearance path is
+        // armed at runtime and with what geometry (note actualWidth vs storedWidth).
+        _logger.LogDebug(
+            "[YouTurn][HardBoundary] hardOuter={Hard} isHard={IsHard} validOuter={Valid} actualWidth={AW:F1} storedWidth={W:F1} rearFixed={RF} trailing={TR} length={L:F1} margin={M:F1}",
             hardOuter, boundary?.OuterBoundary?.IsHard, boundary?.OuterBoundary?.IsValid,
-            config.Tool.Width, config.Tool.IsToolRearFixed, config.Tool.IsToolTrailing,
-            config.Tool.IsToolTBT, config.Tool.IsToolFrontFixed, config.Tool.Length, clearanceMargin);
+            config.ActualToolWidth, config.Tool.Width, config.Tool.IsToolRearFixed,
+            config.Tool.IsToolTrailing, config.Tool.Length, clearanceMargin);
 
         const double SetbackStep = 0.5;
         const double MaxExtraSetback = 30.0;
@@ -239,7 +239,9 @@ public partial class YouTurnCreationService
 
         return new ToolGeometry(
             Mount: mount,
-            Width: tool.Width,
+            // Real implement width comes from the active sections (ActualToolWidth),
+            // not Tool.Width — the latter is a stored fallback (often the 6 m default).
+            Width: config.ActualToolWidth,
             Offset: tool.Offset,
             VehicleHitchLength: config.Vehicle.HitchLength,
             ToolHitchLength: tool.HitchLength,

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
@@ -630,6 +630,9 @@ public sealed class YouTurnStateMachine
             guidance, turn,
             ctx.UTurnSkipRows, ctx.HeadlandCalculatedWidth, ctx.HeadlandDistance);
 
+        if (result.ClearanceBlocked && effects.StatusMessage == null)
+            effects.StatusMessage = "U-turn blocked: implement would swing into a hard boundary — take over manually.";
+
         if (result.Path == null) return;
 
         turn.TurnPath = result.Path;

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
@@ -473,7 +473,7 @@ public sealed class YouTurnStateMachine
         }
         else
         {
-            effects.StatusMessage = "Not enough room — turn would leave the field";
+            effects.StatusMessage = "Not enough room — turn would put the tool past the boundary";
         }
 
         return effects;

--- a/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/ConfigurationViewModel.cs
@@ -912,6 +912,7 @@ public partial class ConfigurationViewModel : ObservableObject
     public ICommand EditToolOverlapCommand { get; private set; } = null!;
     public ICommand EditToolOffsetCommand { get; private set; } = null!;
     public ICommand EditToolHitchLengthCommand { get; private set; } = null!;
+    public ICommand EditToolLengthCommand { get; private set; } = null!;
     public ICommand EditTrailingHitchLengthCommand { get; private set; } = null!;
     public ICommand EditTankHitchLengthCommand { get; private set; } = null!;
     public ICommand EditToolPivotCommand { get; private set; } = null!;
@@ -1208,6 +1209,11 @@ public partial class ConfigurationViewModel : ObservableObject
             ShowNumericInput("Working Center Distance", Tool.HitchLength,
                 v => Tool.HitchLength = v,
                 "m", integerOnly: false, allowNegative: true, min: -15, max: 15));
+
+        EditToolLengthCommand = new RelayCommand(() =>
+            ShowNumericInput("Implement Length", Tool.Length,
+                v => Tool.Length = v,
+                "m", integerOnly: false, allowNegative: false, min: 0, max: 30));
 
         EditTrailingHitchLengthCommand = new RelayCommand(() =>
             ShowNumericInput("Trailing Hitch Length", Tool.TrailingHitchLength,

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
@@ -777,5 +777,53 @@ public partial class MainViewModel
                 }
             }
         });
+
+        ToggleHardCommand = new RelayCommand(() =>
+        {
+            if (SelectedBoundaryIndex < 0)
+            {
+                StatusMessage = "Select a boundary first";
+                return;
+            }
+
+            if (string.IsNullOrEmpty(CurrentFieldName)) return;
+
+            var fieldPath = Path.Combine(_settingsService.Settings.FieldsDirectory, CurrentFieldName);
+            var boundary = _boundaryFileService.LoadBoundary(fieldPath);
+            if (boundary == null) return;
+
+            int currentIndex = 0;
+
+            if (boundary.OuterBoundary != null && boundary.OuterBoundary.IsValid)
+            {
+                if (currentIndex == SelectedBoundaryIndex)
+                {
+                    boundary.OuterBoundary.IsHard = !boundary.OuterBoundary.IsHard;
+                    _boundaryFileService.SaveBoundary(boundary, fieldPath);
+                    SetCurrentBoundary(boundary);
+                    RefreshBoundaryList();
+                    StatusMessage = $"Outer boundary hard: {(boundary.OuterBoundary.IsHard ? "On" : "Off")}";
+                    return;
+                }
+                currentIndex++;
+            }
+
+            for (int i = 0; i < boundary.InnerBoundaries.Count; i++)
+            {
+                if (boundary.InnerBoundaries[i].IsValid)
+                {
+                    if (currentIndex == SelectedBoundaryIndex)
+                    {
+                        boundary.InnerBoundaries[i].IsHard = !boundary.InnerBoundaries[i].IsHard;
+                        _boundaryFileService.SaveBoundary(boundary, fieldPath);
+                        SetCurrentBoundary(boundary);
+                        RefreshBoundaryList();
+                        StatusMessage = $"Inner {i + 1} hard: {(boundary.InnerBoundaries[i].IsHard ? "On" : "Off")}";
+                        return;
+                    }
+                    currentIndex++;
+                }
+            }
+        });
     }
 }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -3709,6 +3709,7 @@ public partial class MainViewModel : ObservableObject
     public ICommand? DriveAroundInnerBoundaryCommand { get; private set; }
     public ICommand? DrawMapInnerBoundaryCommand { get; private set; }
     public ICommand? ToggleDriveThroughCommand { get; private set; }
+    public ICommand? ToggleHardCommand { get; private set; }
     public ICommand? ToggleRecordingCommand { get; private set; }
     public ICommand? ToggleBoundaryLeftRightCommand { get; private set; }
     public ICommand? ToggleBoundaryAntennaToolCommand { get; private set; }
@@ -4070,7 +4071,8 @@ public partial class MainViewModel : ObservableObject
                 Index = index++,
                 BoundaryType = "Outer",
                 AreaAcres = boundary.OuterBoundary.AreaAcres,
-                IsDriveThrough = boundary.OuterBoundary.IsDriveThrough
+                IsDriveThrough = boundary.OuterBoundary.IsDriveThrough,
+                IsHard = boundary.OuterBoundary.IsHard
             });
         }
 
@@ -4085,7 +4087,8 @@ public partial class MainViewModel : ObservableObject
                     Index = index++,
                     BoundaryType = $"Inner {i + 1}",
                     AreaAcres = inner.AreaAcres,
-                    IsDriveThrough = inner.IsDriveThrough
+                    IsDriveThrough = inner.IsDriveThrough,
+                    IsHard = inner.IsHard
                 });
             }
         }
@@ -5866,8 +5869,10 @@ public class BoundaryListItem
     public string BoundaryType { get; set; } = string.Empty;
     public double AreaAcres { get; set; }
     public bool IsDriveThrough { get; set; }
+    public bool IsHard { get; set; }
     public string AreaDisplay => $"{AreaAcres:F2} Ac";
     public string DriveThruDisplay => IsDriveThrough ? "Yes" : "--";
+    public string HardDisplay => IsHard ? "Hard" : "Soft";
 }
 
 /// <summary>

--- a/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Dialogs/Configuration/ToolSubTabs/ToolHitchSubTab.axaml
@@ -120,6 +120,21 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Grid>
             </Border>
 
+            <!-- Implement Length (all tool types) - used by hard-boundary U-turn clearance -->
+            <Border Classes="SettingRow">
+                <Grid ColumnDefinitions="*,Auto">
+                    <StackPanel>
+                        <TextBlock Text="Implement Length" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" FontWeight="SemiBold"/>
+                        <TextBlock Text="Attachment to rearmost point. Keeps a long mounted tool's rear corners off a hard boundary in turns. 0 = unspecified."
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" FontSize="12" TextWrapping="Wrap"/>
+                    </StackPanel>
+                    <controls:EditableNumericField Grid.Column="1"
+                        Value="{Binding Tool.Length, Mode=TwoWay}"
+                        Unit="m" FormatString="F2"
+                        EditCommand="{Binding EditToolLengthCommand}"/>
+                </Grid>
+            </Border>
+
             <!-- Info box -->
             <Border Background="{DynamicResource InfoPanelBackgroundBrush}" CornerRadius="6" Padding="12" Margin="0,8,0,0">
                 <StackPanel Spacing="4">

--- a/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
+++ b/Shared/AgValoniaGPS.Views/Controls/Panels/BoundaryRecordingPanel.axaml
@@ -103,12 +103,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                 </Grid>
 
                 <!-- Column Headers -->
-                <Grid ColumnDefinitions="*,*,*" Background="{DynamicResource SystemControlHighlightAccentBrush}" Margin="4,0,4,0">
+                <Grid ColumnDefinitions="*,*,*,*" Background="{DynamicResource SystemControlHighlightAccentBrush}" Margin="4,0,4,0">
                     <TextBlock Grid.Column="0" Text="{loc:Localize Boundary}" HorizontalAlignment="Center"
                                FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     <TextBlock Grid.Column="1" Text="{loc:Localize Area}" HorizontalAlignment="Center"
                                FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                     <TextBlock Grid.Column="2" Text="{loc:Localize DriveThru}" HorizontalAlignment="Center"
+                               FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
+                    <TextBlock Grid.Column="3" Text="Hard" HorizontalAlignment="Center"
                                FontWeight="Bold" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                 </Grid>
 
@@ -120,7 +122,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                              BorderThickness="0">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
-                                <Grid ColumnDefinitions="*,*,*">
+                                <Grid ColumnDefinitions="*,*,*,*">
                                     <TextBlock Grid.Column="0" Text="{Binding BoundaryType}"
                                                HorizontalAlignment="Center" Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}" Padding="8,6"/>
                                     <TextBlock Grid.Column="1" Text="{Binding AreaDisplay}"
@@ -130,6 +132,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
                                             Foreground="{Binding IsDriveThrough, Converter={StaticResource BoolToColorConverter}}"
                                             Background="Transparent" BorderThickness="0" Cursor="Hand"
                                             Command="{Binding $parent[ListBox].((vm:MainViewModel)DataContext).ToggleDriveThroughCommand}"/>
+                                    <Button Grid.Column="3" Content="{Binding HardDisplay}"
+                                            HorizontalAlignment="Center" Padding="8,6"
+                                            Foreground="{Binding IsHard, Converter={StaticResource BoolToColorConverter}}"
+                                            Background="Transparent" BorderThickness="0" Cursor="Hand"
+                                            Command="{Binding $parent[ListBox].((vm:MainViewModel)DataContext).ToggleHardCommand}"/>
                                 </Grid>
                             </DataTemplate>
                         </ListBox.ItemTemplate>

--- a/Tests/AgValoniaGPS.Models.Tests/ImplementSweptPathTests.cs
+++ b/Tests/AgValoniaGPS.Models.Tests/ImplementSweptPathTests.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Tool;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Models.Tests;
+
+[TestFixture]
+public class ImplementSweptPathTests
+{
+    // ---- helpers --------------------------------------------------------
+
+    private static ToolGeometry Geom(ToolMount mount, double width = 4.0, double offset = 0.0,
+        double vehicleHitch = 1.0, double toolHitch = 2.0,
+        double trailingHitch = 3.0, double toolToPivot = 0.0, double tankHitch = 2.5,
+        double length = 0.0)
+        => new(mount, width, offset, vehicleHitch, toolHitch, trailingHitch, toolToPivot, tankHitch, length);
+
+    /// <summary>Straight path heading north (E=0), points 0.5 m apart.</summary>
+    private static List<Vec3> StraightNorth(int count = 40, double spacing = 0.5)
+    {
+        var p = new List<Vec3>();
+        for (int i = 0; i < count; i++) p.Add(new Vec3(0, i * spacing, 0));
+        return p;
+    }
+
+    /// <summary>Arc turning left (CCW) of given radius, centre on the +E side... </summary>
+    private static List<Vec3> LeftArc(double radius, double sweep, int count)
+    {
+        // Start at origin heading north; left turn => centre at (-radius, 0).
+        var p = new List<Vec3>();
+        double cx = -radius, cy = 0;
+        for (int i = 0; i < count; i++)
+        {
+            double a = sweep * i / (count - 1);            // 0..sweep
+            // position rotates CCW about centre starting from origin
+            double e = cx + radius * Math.Cos(a);
+            double n = cy + radius * Math.Sin(a);
+            p.Add(new Vec3(e, n, 0));
+        }
+        return p;
+    }
+
+    /// <summary>Arc turning right (CW) of given radius, centre on the +E side.</summary>
+    private static List<Vec3> RightArc(double radius, double sweep, int count)
+    {
+        // Start at origin heading north; right turn => centre at (+radius, 0).
+        var p = new List<Vec3>();
+        for (int i = 0; i < count; i++)
+        {
+            double a = sweep * i / (count - 1);            // 0..sweep
+            double e = radius - radius * Math.Cos(a);      // mirror of LeftArc about the N axis
+            double n = radius * Math.Sin(a);
+            p.Add(new Vec3(e, n, 0));
+        }
+        return p;
+    }
+
+    private static double Dist(Vec3 a, Vec3 b)
+        => Math.Sqrt((a.Easting - b.Easting) * (a.Easting - b.Easting) + (a.Northing - b.Northing) * (a.Northing - b.Northing));
+
+    // ---- tests ----------------------------------------------------------
+
+    [Test]
+    public void EmptyPath_ReturnsEmptyResult()
+    {
+        var r = ImplementSweptPath.Compute(new List<Vec3>(), Geom(ToolMount.RearFixed));
+        Assert.That(r.ToolCenter, Is.Empty);
+        Assert.That(r.LeftEdge, Is.Empty);
+        Assert.That(r.RightEdge, Is.Empty);
+    }
+
+    [Test]
+    public void EdgeSeparation_EqualsWidth()
+    {
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 6.0));
+        int mid = r.ToolCenter.Count / 2;
+        Assert.That(Dist(r.LeftEdge[mid], r.RightEdge[mid]), Is.EqualTo(6.0).Within(1e-6));
+    }
+
+    [Test]
+    public void RearFixed_Straight_ToolSitsBehindByHitch_EdgesSquare()
+    {
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 4.0, toolHitch: 2.0));
+        int mid = r.ToolCenter.Count / 2;
+
+        // Heading north: tool centre is hitch (behind pivot by 2 m), E stays 0.
+        Assert.That(r.ToolCenter[mid].Easting, Is.EqualTo(0.0).Within(1e-6));
+        Assert.That(r.ToolCenter[mid].Northing, Is.EqualTo(path[mid].Northing - 2.0).Within(1e-6));
+        // Edges straddle in E by ±halfWidth.
+        Assert.That(r.LeftEdge[mid].Easting, Is.EqualTo(-2.0).Within(1e-6));
+        Assert.That(r.RightEdge[mid].Easting, Is.EqualTo(+2.0).Within(1e-6));
+    }
+
+    [Test]
+    public void FrontFixed_Straight_ToolSitsAheadByHitch()
+    {
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.FrontFixed, toolHitch: 2.0));
+        int mid = r.ToolCenter.Count / 2;
+        Assert.That(r.ToolCenter[mid].Northing, Is.EqualTo(path[mid].Northing + 2.0).Within(1e-6));
+    }
+
+    [Test]
+    public void Trailing_Straight_NoOffTracking_EdgesSquare()
+    {
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.Trailing, width: 4.0));
+        int last = r.ToolCenter.Count - 1;
+
+        // On a straight line the trailed tool aligns directly behind: E ≈ 0.
+        Assert.That(r.ToolCenter[last].Easting, Is.EqualTo(0.0).Within(1e-6));
+        Assert.That(r.LeftEdge[last].Easting, Is.EqualTo(-2.0).Within(1e-6));
+        Assert.That(r.RightEdge[last].Easting, Is.EqualTo(+2.0).Within(1e-6));
+    }
+
+    [Test]
+    public void Offset_ShiftsToolCentreRight()
+    {
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 4.0, offset: 1.0));
+        int mid = r.ToolCenter.Count / 2;
+        Assert.That(r.ToolCenter[mid].Easting, Is.EqualTo(1.0).Within(1e-6));
+        Assert.That(r.LeftEdge[mid].Easting, Is.EqualTo(-1.0).Within(1e-6));
+        Assert.That(r.RightEdge[mid].Easting, Is.EqualTo(3.0).Within(1e-6));
+    }
+
+    [Test]
+    public void LeftOffset_ShiftsToolCentreLeft()
+    {
+        // Mirror of the right-offset case: a negative offset shifts the tool left (-E heading north).
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 4.0, offset: -1.0));
+        int mid = r.ToolCenter.Count / 2;
+        Assert.That(r.ToolCenter[mid].Easting, Is.EqualTo(-1.0).Within(1e-6));
+        Assert.That(r.LeftEdge[mid].Easting, Is.EqualTo(-3.0).Within(1e-6));
+        Assert.That(r.RightEdge[mid].Easting, Is.EqualTo(1.0).Within(1e-6));
+    }
+
+    [Test]
+    public void Offset_OnTurn_ChangesOuterEdgeReach()
+    {
+        // On a left turn the right edge is the outer one. An offset toward the
+        // outside (right, +) must make that outer edge reach further; an offset
+        // toward the inside (left, -) must pull it in. This is what the clearance
+        // engine relies on for offset implements near a hard boundary.
+        double radius = 10.0;
+        var path = LeftArc(radius, Math.PI / 2.0, 120);
+        var centre = new Vec3(-radius, 0, 0);
+
+        double OuterReach(double offset)
+        {
+            var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 4.0, offset: offset));
+            int last = r.RightEdge.Count - 1;        // right = outer on a left turn
+            return Dist(r.RightEdge[last], centre);
+        }
+
+        double outward = OuterReach(1.0);
+        double none = OuterReach(0.0);
+        double inward = OuterReach(-1.0);
+
+        Assert.That(outward, Is.GreaterThan(none), "offset toward outside should widen the outer reach");
+        Assert.That(none, Is.GreaterThan(inward), "offset toward inside should reduce the outer reach");
+        // The shift should be ~the offset magnitude (radial on a circular arc).
+        Assert.That(outward - none, Is.EqualTo(1.0).Within(0.05));
+    }
+
+    [Test]
+    public void Trailing_OnLeftTurn_ToolOffTracksToTheInside()
+    {
+        // Quarter-circle left turn, radius 10. The trailed tool should cut to the
+        // inside of the turn: its pivot/centre radius from the turn centre is
+        // smaller than the vehicle pivot radius (10).
+        double radius = 10.0;
+        var path = LeftArc(radius, Math.PI / 2.0, 120);
+        var centre = new Vec3(-radius, 0, 0);
+
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.Trailing, width: 4.0,
+            vehicleHitch: 1.0, trailingHitch: 4.0));
+
+        int last = r.ToolCenter.Count - 1;
+        double toolRadius = Dist(r.ToolCenter[last], centre);
+        Assert.That(toolRadius, Is.LessThan(radius - 0.5),
+            "trailing tool should off-track to the inside of the turn");
+    }
+
+    [Test]
+    public void Trailing_OnLeftTurn_OuterEdgeSweepsWiderThanInnerEdge()
+    {
+        // The outer (right, for a left turn) edge should trace a larger radius
+        // than the inner (left) edge — this wide swing is what catches a fence.
+        double radius = 10.0;
+        var path = LeftArc(radius, Math.PI / 2.0, 120);
+        var centre = new Vec3(-radius, 0, 0);
+
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.Trailing, width: 6.0,
+            vehicleHitch: 1.0, trailingHitch: 4.0));
+        int last = r.ToolCenter.Count - 1;
+
+        double outerR = Dist(r.RightEdge[last], centre); // right = outside on a left turn
+        double innerR = Dist(r.LeftEdge[last], centre);
+        Assert.That(outerR, Is.GreaterThan(innerR), "outer edge should sweep wider than inner edge");
+    }
+
+    [Test]
+    public void Trailing_OnRightTurn_ToolOffTracksToTheInside()
+    {
+        // Mirror of the left-turn case: right turn => inside is the +E side,
+        // centre at (+radius, 0). Trailed tool should cut inside (smaller radius).
+        double radius = 10.0;
+        var path = RightArc(radius, Math.PI / 2.0, 120);
+        var centre = new Vec3(radius, 0, 0);
+
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.Trailing, width: 4.0,
+            vehicleHitch: 1.0, trailingHitch: 4.0));
+
+        int last = r.ToolCenter.Count - 1;
+        double toolRadius = Dist(r.ToolCenter[last], centre);
+        Assert.That(toolRadius, Is.LessThan(radius - 0.5),
+            "trailing tool should off-track to the inside of a right turn too");
+    }
+
+    [Test]
+    public void Trailing_OnRightTurn_OuterEdgeSweepsWiderThanInnerEdge()
+    {
+        // On a right turn the LEFT edge is on the outside, so it should sweep wider.
+        double radius = 10.0;
+        var path = RightArc(radius, Math.PI / 2.0, 120);
+        var centre = new Vec3(radius, 0, 0);
+
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.Trailing, width: 6.0,
+            vehicleHitch: 1.0, trailingHitch: 4.0));
+        int last = r.ToolCenter.Count - 1;
+
+        double outerR = Dist(r.LeftEdge[last], centre);  // left = outside on a right turn
+        double innerR = Dist(r.RightEdge[last], centre);
+        Assert.That(outerR, Is.GreaterThan(innerR), "outer (left) edge should sweep wider on a right turn");
+    }
+
+    [Test]
+    public void OffTracking_IsSymmetric_LeftVsRight()
+    {
+        // The amount the tool cuts inside must be the same magnitude for a left
+        // and a right turn of equal radius — no left/right bias in the kinematics.
+        double radius = 10.0;
+        var left = ImplementSweptPath.Compute(LeftArc(radius, Math.PI / 2.0, 120),
+            Geom(ToolMount.Trailing, width: 4.0, vehicleHitch: 1.0, trailingHitch: 4.0));
+        var right = ImplementSweptPath.Compute(RightArc(radius, Math.PI / 2.0, 120),
+            Geom(ToolMount.Trailing, width: 4.0, vehicleHitch: 1.0, trailingHitch: 4.0));
+
+        int last = left.ToolCenter.Count - 1;
+        double leftCut = radius - Dist(left.ToolCenter[last], new Vec3(-radius, 0, 0));
+        double rightCut = radius - Dist(right.ToolCenter[last], new Vec3(radius, 0, 0));
+        Assert.That(rightCut, Is.EqualTo(leftCut).Within(1e-6), "off-tracking must be left/right symmetric");
+    }
+
+    [Test]
+    public void Length_Zero_CollapsesFootprintToWorkingLine()
+    {
+        // Legacy behaviour: with Length 0 the body corners sit on the working edges.
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 4.0, length: 0.0));
+        int mid = r.ToolCenter.Count / 2;
+        Assert.That(Dist(r.FrontLeft[mid], r.RearLeft[mid]), Is.EqualTo(0.0).Within(1e-9));
+        Assert.That(Dist(r.RearLeft[mid], r.LeftEdge[mid]), Is.EqualTo(0.0).Within(1e-9));
+    }
+
+    [Test]
+    public void RearFixed_Straight_RearCornersAreLengthBehindFront()
+    {
+        var path = StraightNorth();
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 4.0, toolHitch: 2.0, length: 5.0));
+        int mid = r.ToolCenter.Count / 2;
+
+        // Heading north: front corners at the hitch (N-2), rear corners 5 m further back.
+        Assert.That(r.FrontLeft[mid].Northing, Is.EqualTo(path[mid].Northing - 2.0).Within(1e-6));
+        Assert.That(r.RearLeft[mid].Northing, Is.EqualTo(path[mid].Northing - 2.0 - 5.0).Within(1e-6));
+        Assert.That(Dist(r.FrontLeft[mid], r.RearLeft[mid]), Is.EqualTo(5.0).Within(1e-6));
+        // Rear corners straddle by full width.
+        Assert.That(Dist(r.RearLeft[mid], r.RearRight[mid]), Is.EqualTo(4.0).Within(1e-6));
+    }
+
+    [Test]
+    public void MountedTool_OnTurn_RearOuterCornerSwingsWidestAndGrowsWithLength()
+    {
+        // The fence-catcher: a rigid rear-mounted implement (bush hog) rotates with
+        // the tractor, so its rear-outer corner sweeps the widest arc — and wider
+        // the longer the implement. Left turn => right side is outer.
+        double radius = 10.0;
+        var path = LeftArc(radius, Math.PI / 2.0, 120);
+        var centre = new Vec3(-radius, 0, 0);
+
+        double RearOuterReach(double length)
+        {
+            var r = ImplementSweptPath.Compute(path,
+                Geom(ToolMount.RearFixed, width: 4.0, toolHitch: 2.0, length: length));
+            int last = r.RearRight.Count - 1;          // rear-right = rear-outer on a left turn
+            return Dist(r.RearRight[last], centre);
+        }
+
+        var rShort = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, width: 4.0, length: 0.0));
+        int last = rShort.RearRight.Count - 1;
+        double frontOuter = Dist(rShort.FrontRight[last], centre);
+
+        double reach3 = RearOuterReach(3.0);
+        double reach6 = RearOuterReach(6.0);
+
+        Assert.That(reach3, Is.GreaterThan(frontOuter), "rear-outer corner should swing wider than the front");
+        Assert.That(reach6, Is.GreaterThan(reach3), "a longer implement should swing its rear corner wider");
+    }
+
+    [Test]
+    public void FootprintCorners_AlignWithInputPath()
+    {
+        var path = StraightNorth(25);
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.RearFixed, length: 5.0));
+        Assert.That(r.FrontLeft.Count, Is.EqualTo(path.Count));
+        Assert.That(r.FrontRight.Count, Is.EqualTo(path.Count));
+        Assert.That(r.RearLeft.Count, Is.EqualTo(path.Count));
+        Assert.That(r.RearRight.Count, Is.EqualTo(path.Count));
+    }
+
+    [Test]
+    public void IndicesAlignWithInputPath()
+    {
+        var path = StraightNorth(25);
+        var r = ImplementSweptPath.Compute(path, Geom(ToolMount.Trailing));
+        Assert.That(r.ToolCenter.Count, Is.EqualTo(path.Count));
+        Assert.That(r.LeftEdge.Count, Is.EqualTo(path.Count));
+        Assert.That(r.RightEdge.Count, Is.EqualTo(path.Count));
+    }
+}

--- a/Tests/AgValoniaGPS.Models.Tests/TurnClearanceTests.cs
+++ b/Tests/AgValoniaGPS.Models.Tests/TurnClearanceTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Guidance;
+using AgValoniaGPS.Models.Tool;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Models.Tests;
+
+[TestFixture]
+public class TurnClearanceTests
+{
+    // 100 x 100 m square boundary.
+    private static List<Vec2> Square() => new()
+    {
+        new Vec2(0, 0), new Vec2(100, 0), new Vec2(100, 100), new Vec2(0, 100)
+    };
+
+    private static IEnumerable<Vec3> P(params (double e, double n)[] pts)
+    {
+        foreach (var (e, n) in pts) yield return new Vec3(e, n, 0);
+    }
+
+    [Test]
+    public void Inside_WellClear_IsClear()
+    {
+        var r = TurnClearance.Evaluate(P((50, 50)), Square(), TurnClearance.KeepSide.Inside, margin: 5);
+        Assert.That(r.IsClear, Is.True);
+        Assert.That(r.MaxIntrusion, Is.LessThan(0));
+    }
+
+    [Test]
+    public void Inside_PointOutsideBoundary_IsNotClear()
+    {
+        // 1 m outside the right edge, margin 5 -> intrusion = 5 + 1 = 6.
+        var r = TurnClearance.Evaluate(P((101, 50)), Square(), TurnClearance.KeepSide.Inside, margin: 5);
+        Assert.That(r.IsClear, Is.False);
+        Assert.That(r.MaxIntrusion, Is.EqualTo(6.0).Within(1e-6));
+    }
+
+    [Test]
+    public void Inside_WithinMarginOfEdge_IsNotClear()
+    {
+        // 2 m inside the top edge, margin 5 -> intrusion = 5 - 2 = 3.
+        var r = TurnClearance.Evaluate(P((50, 98)), Square(), TurnClearance.KeepSide.Inside, margin: 5);
+        Assert.That(r.IsClear, Is.False);
+        Assert.That(r.MaxIntrusion, Is.EqualTo(3.0).Within(1e-6));
+    }
+
+    [Test]
+    public void Outside_ExclusionFarAway_IsClear()
+    {
+        var r = TurnClearance.Evaluate(P((200, 200)), Square(), TurnClearance.KeepSide.Outside, margin: 5);
+        Assert.That(r.IsClear, Is.True);
+    }
+
+    [Test]
+    public void Outside_PointInsideExclusion_IsNotClear()
+    {
+        var r = TurnClearance.Evaluate(P((50, 50)), Square(), TurnClearance.KeepSide.Outside, margin: 5);
+        Assert.That(r.IsClear, Is.False);
+        Assert.That(r.MaxIntrusion, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void LargerMargin_ReducesClearance()
+    {
+        // 4 m inside the edge: clear at margin 2, not clear at margin 6.
+        var pts = P((50, 96));
+        var ok = TurnClearance.Evaluate(P((50, 96)), Square(), TurnClearance.KeepSide.Inside, margin: 2);
+        var bad = TurnClearance.Evaluate(P((50, 96)), Square(), TurnClearance.KeepSide.Inside, margin: 6);
+        Assert.That(ok.IsClear, Is.True);
+        Assert.That(bad.IsClear, Is.False);
+    }
+
+    [Test]
+    public void SweptFootprint_RearCornerPokingOut_IsNotClear()
+    {
+        // A short north path near the top edge; a long rear-fixed tool whose rear
+        // corners extend past the top boundary should be flagged.
+        var path = new List<Vec3>();
+        for (int i = 0; i < 10; i++) path.Add(new Vec3(50, 95 + i * 0.2, 0)); // ends ~96.8, heading north
+        var geom = new ToolGeometry(ToolMount.RearFixed, Width: 4, Offset: 0,
+            VehicleHitchLength: 0, ToolHitchLength: 0, TrailingHitchLength: 0,
+            TrailingToolToPivotLength: 0, TankTrailingHitchLength: 0, Length: 0);
+
+        // Front-fixed so the body extends NORTH (toward the top edge) past 100.
+        var frontGeom = geom with { Mount = ToolMount.FrontFixed, ToolHitchLength = 2, Length = 6 };
+        var swept = ImplementSweptPath.Compute(path, frontGeom);
+
+        var r = TurnClearance.Evaluate(swept, Square(), TurnClearance.KeepSide.Inside, margin: 0.5);
+        Assert.That(r.IsClear, Is.False, "rear/far corners extending past the boundary should not be clear");
+    }
+
+    [Test]
+    public void DegeneratePolygon_IsTreatedAsClear()
+    {
+        var r = TurnClearance.Evaluate(P((50, 50)), new List<Vec2> { new(0, 0), new(1, 1) },
+            TurnClearance.KeepSide.Inside, margin: 5);
+        Assert.That(r.IsClear, Is.True);
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/FileIOTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/FileIOTests.cs
@@ -201,6 +201,33 @@ public class FileIOTests
     }
 
     [Test]
+    public void Boundary_SaveAndLoad_IsHard_RoundTrip()
+    {
+        var service = new BoundaryFileService();
+        var outer = CreateSquarePolygon(0, 0, 200);
+        outer.IsHard = true;
+        var innerSoft = CreateSquarePolygon(50, 50, 30);
+        var innerHard = CreateSquarePolygon(120, 120, 20);
+        innerHard.IsHard = true;
+
+        var boundary = new Boundary
+        {
+            OuterBoundary = outer,
+            InnerBoundaries = new List<BoundaryPolygon> { innerSoft, innerHard }
+        };
+
+        service.SaveBoundary(boundary, _tempDir);
+        var loaded = service.LoadBoundary(_tempDir);
+
+        Assert.That(loaded.OuterBoundary!.IsHard, Is.True, "outer hard flag should persist");
+        Assert.That(loaded.InnerBoundaries[0].IsHard, Is.False, "soft inner stays soft");
+        Assert.That(loaded.InnerBoundaries[1].IsHard, Is.True, "hard inner flag should persist");
+        // Points must still round-trip (the hard marker must not corrupt parsing).
+        Assert.That(loaded.OuterBoundary.Points, Has.Count.EqualTo(4));
+        Assert.That(loaded.InnerBoundaries[1].Points, Has.Count.EqualTo(4));
+    }
+
+    [Test]
     public void Boundary_SaveAndLoad_WithInnerBoundaries_RoundTrip()
     {
         var service = new BoundaryFileService();

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurn/AutoTurnHardBoundaryTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurn/AutoTurnHardBoundaryTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.Pipeline;
+using AgValoniaGPS.Models.Tool;
+using AgValoniaGPS.Services.Geometry;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Services.Tests.YouTurn;
+
+/// <summary>
+/// Reproduces the field report: a 3-point mounted 16 m sprayer auto-turning
+/// next to a HARD outer boundary must not plot the implement through the fence.
+/// Calls the auto generator (CreateTurnPath) directly with the operator's rig.
+/// </summary>
+[TestFixture]
+public class AutoTurnHardBoundaryTests
+{
+    private YouTurnCreationService _creation = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var c = ConfigurationStore.Instance;
+        c.Tool.Width = 16;               // 16 m wide
+        c.Tool.Overlap = 0;
+        c.Tool.HitchLength = 4.5;        // working-centre distance
+        c.Tool.Length = 3.5;             // overall implement length
+        c.Tool.IsToolRearFixed = true;   // 3-point mounted
+        c.Tool.IsToolTrailing = false;
+        c.Tool.IsToolTBT = false;
+        c.Tool.IsToolFrontFixed = false;
+        c.NumSections = 1;
+        c.Tool.SetSectionWidth(0, 1600);
+        c.Guidance.UTurnDistanceFromBoundary = 1.0;
+        c.Guidance.UTurnRadius = 8.0;
+        c.Guidance.UTurnSmoothing = 3;
+
+        _creation = new YouTurnCreationService(
+            NullLogger<YouTurnCreationService>.Instance, new PolygonOffsetService());
+    }
+
+    private static Boundary Square(bool hard)
+    {
+        var pts = new List<Vec2> { new(-50, -50), new(50, -50), new(50, 50), new(-50, 50) };
+        return new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = pts.Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+                IsHard = hard
+            }
+        };
+    }
+
+    private static List<Vec3> HeadlandSquare() => new()
+    {
+        new(-40, -40, 0), new(40, -40, 0), new(40, 40, 0), new(-40, 40, 0)
+    };
+
+    private YouTurnCreationService.TurnPathResult Run(Boundary boundary)
+    {
+        var pos = new Position { Easting = 0, Northing = 38 }; // approaching north headland (y=40)
+        var track = Models.Track.Track.FromABLine("AB", new Vec3(0, -100, 0), new Vec3(0, 100, 0));
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = true, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        return _creation.CreateTurnPath(
+            pos, track, headingRadians: 0, abHeading: 0,
+            boundary, HeadlandSquare(), guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+    }
+
+    private static ToolGeometry Rig() => new(
+        ToolMount.RearFixed, Width: 16, Offset: 0,
+        VehicleHitchLength: ConfigurationStore.Instance.Vehicle.HitchLength,
+        ToolHitchLength: 4.5, TrailingHitchLength: 0, TrailingToolToPivotLength: 0,
+        TankTrailingHitchLength: 0, Length: 3.5);
+
+    [Test]
+    public void SoftBoundary_ProducesATurn_SoSetupIsValid()
+    {
+        var result = Run(Square(hard: false));
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10),
+            "soft boundary should yield a normal turn — confirms the test setup is valid");
+    }
+
+    [Test]
+    public void HardBoundary_ImplementNeverCrossesTheFence()
+    {
+        var outer = Square(hard: true);
+        var result = Run(outer);
+
+        // Acceptable outcomes: blocked (no path), OR a path whose implement
+        // footprint stays inside the fence. NOT acceptable: a plotted turn whose
+        // implement crosses the boundary.
+        if (result.Path == null)
+        {
+            Assert.That(result.ClearanceBlocked, Is.True, "no path should mean clearance-blocked");
+            return;
+        }
+
+        var poly = outer.OuterBoundary!.Points.Select(p => new Vec2(p.Easting, p.Northing)).ToList();
+        var swept = ImplementSweptPath.Compute(result.Path, Rig());
+
+        var corners = swept.FrontLeft.Concat(swept.FrontRight)
+            .Concat(swept.RearLeft).Concat(swept.RearRight);
+        foreach (var corner in corners)
+        {
+            bool inside = GeometryMath.IsPointInPolygon(poly, new Vec2(corner.Easting, corner.Northing));
+            Assert.That(inside, Is.True,
+                $"implement corner ({corner.Easting:F1},{corner.Northing:F1}) crossed the hard boundary");
+        }
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurn/AutoTurnHardBoundaryTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurn/AutoTurnHardBoundaryTests.cs
@@ -28,7 +28,11 @@ public class AutoTurnHardBoundaryTests
     {
         ConfigurationStore.SetInstance(new ConfigurationStore());
         var c = ConfigurationStore.Instance;
-        c.Tool.Width = 16;               // 16 m wide
+        // Deliberately leave the stored Tool.Width at the small default — the real
+        // 16 m width must come from the active sections (ActualToolWidth). This
+        // guards the bug where clearance used Tool.Width (6 m) and under-modelled
+        // the implement, letting a 16 m boom hit the fence.
+        c.Tool.Width = 6;
         c.Tool.Overlap = 0;
         c.Tool.HitchLength = 4.5;        // working-centre distance
         c.Tool.Length = 3.5;             // overall implement length
@@ -37,7 +41,7 @@ public class AutoTurnHardBoundaryTests
         c.Tool.IsToolTBT = false;
         c.Tool.IsToolFrontFixed = false;
         c.NumSections = 1;
-        c.Tool.SetSectionWidth(0, 1600);
+        c.Tool.SetSectionWidth(0, 1600); // 16 m via sections -> ActualToolWidth = 16
         c.Guidance.UTurnDistanceFromBoundary = 1.0;
         c.Guidance.UTurnRadius = 8.0;
         c.Guidance.UTurnSmoothing = 3;

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurn/ManualTurnHardBoundaryTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurn/ManualTurnHardBoundaryTests.cs
@@ -28,7 +28,9 @@ public class ManualTurnHardBoundaryTests
     {
         ConfigurationStore.SetInstance(new ConfigurationStore());
         var config = ConfigurationStore.Instance;
-        config.Tool.Width = 16;          // wide implement
+        config.Tool.Width = 16;          // stored width (fallback only)
+        config.NumSections = 1;
+        config.Tool.SetSectionWidth(0, 1600); // 16 m via sections -> ActualToolWidth = 16
         config.Tool.Overlap = 0;
         config.Tool.HitchLength = 2;
         config.Tool.IsToolRearFixed = true;

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurn/ManualTurnHardBoundaryTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurn/ManualTurnHardBoundaryTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.Pipeline;
+using AgValoniaGPS.Services.Geometry;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Services.Tests.YouTurn;
+
+/// <summary>
+/// Regression: a manual U-turn must not plot the implement through a HARD outer
+/// boundary. The manual arc generator (CreateManualArcPath) originally had no
+/// implement clearance — only an arc-endpoint-inside check — so a wide tool
+/// would swing past the fence even with the boundary marked hard.
+/// </summary>
+[TestFixture]
+public class ManualTurnHardBoundaryTests
+{
+    private YouTurnCreationService _creation = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var config = ConfigurationStore.Instance;
+        config.Tool.Width = 16;          // wide implement
+        config.Tool.Overlap = 0;
+        config.Tool.HitchLength = 2;
+        config.Tool.IsToolRearFixed = true;
+        config.Tool.IsToolTrailing = false;
+        config.Tool.IsToolTBT = false;
+        config.Tool.IsToolFrontFixed = false;
+        config.Guidance.UTurnDistanceFromBoundary = 1.0; // clearance margin
+
+        _creation = new YouTurnCreationService(
+            NullLogger<YouTurnCreationService>.Instance, new PolygonOffsetService());
+    }
+
+    // 100×100 m square boundary centred on origin (edges at ±50).
+    private static Boundary Square(bool hard)
+    {
+        var pts = new List<Vec2> { new(-50, -50), new(50, -50), new(50, 50), new(-50, 50) };
+        return new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = pts.Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+                IsHard = hard
+            }
+        };
+    }
+
+    private List<Vec3> ManualTurn(Boundary boundary, double startN)
+    {
+        var pos = new Position { Easting = 0, Northing = startN };
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = true };
+        // abHeading 0 = north; left turn. Radius = (16/2) = 8 m, so an arc started
+        // at N=45 sweeps the pivot to ~N=53 — past the +50 edge.
+        return _creation.CreateManualArcPath(pos, abHeading: 0, turnLeft: true,
+            boundary, guidance, uTurnSkipRows: 0);
+    }
+
+    [Test]
+    public void SoftBoundary_NearEdge_PlotsTurn()
+    {
+        var path = ManualTurn(Square(hard: false), startN: 45);
+        Assert.That(path.Count, Is.GreaterThan(2), "soft boundary should still plot the manual turn");
+    }
+
+    [Test]
+    public void HardBoundary_NearEdge_RefusesTurn()
+    {
+        var path = ManualTurn(Square(hard: true), startN: 45);
+        Assert.That(path.Count, Is.LessThanOrEqualTo(2),
+            "hard boundary must refuse a manual turn that swings the implement past the fence");
+    }
+
+    [Test]
+    public void HardBoundary_WellInside_StillPlotsTurn()
+    {
+        // Centred at origin: the whole turn + implement stays well inside ±50.
+        var path = ManualTurn(Square(hard: true), startN: 0);
+        Assert.That(path.Count, Is.GreaterThan(2),
+            "a clear turn far from the hard boundary must not be falsely refused");
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 42
+#define VERSION_PATCH 43
 
-#define VERSION "26.5.42"
+#define VERSION "26.5.43"
 #define VERSION_DATE "2026-06-06"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 41
+#define VERSION_PATCH 42
 
-#define VERSION "26.5.41"
+#define VERSION "26.5.42"
 #define VERSION_DATE "2026-06-06"

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 43
+#define VERSION_PATCH 44
 
-#define VERSION "26.5.43"
+#define VERSION "26.5.44"
 #define VERSION_DATE "2026-06-06"


### PR DESCRIPTION
## What
Adds the concept of **hard** vs **soft** boundaries. For a hard boundary (a fence/building/obstacle right at the edge), the U-turn is now generated so the **implement's swept path** — including a long mounted tool's rear corners — stays clear of it. Soft boundaries (default) behave exactly as before.

Neither AgOpen nor Brian's Twol model this (both check only the pivot path against a single inward-offset turn line), so this is net-new.

## Why
The old clearance check (`IsPointInsideTurnArea`) only tested the **tractor pivot path**. A wide or trailed implement — or a 15–20 ft 3-point bush hog whose rear corners swing wide in a turn — can cross the boundary even though the pivot stays inside.

## How
Built bottom-up as pure, tested units, then wired in:

1. **`ImplementSweptPath`** (pure) — reproduces `ToolPositionService` kinematics offline for a candidate path: trailing (Torriem)/TBT/fixed, lateral offset, and a fore-aft **`Length`** that builds the implement as a rectangle exposing the four body corners. *(18 tests: L/R turns symmetric, off-tracking, offsets, rear-corner swing grows with length.)*
2. **`BoundaryPolygon.IsHard`** + **`TurnClearance`** (pure) — tests the swept footprint against a hard polygon with a margin, returning `MaxIntrusion`. *(8 tests.)*
3. **Clearance engine** in `CreateTurnPath`: when the outer boundary is hard, generate → check implement clearance → if it intrudes, **shift the turn inward** (extra setback) and regenerate until clear; if nothing forward fits, **refuse to engage** (`ClearanceBlocked`) rather than backing. Reuses `UTurnDistanceFromBoundary` as the margin. Works for both omega and sagitta styles. Non-hard fields: unchanged (loop runs once).
4. **Plumbing**: `ToolConfig.Length` (+ tool-tab field), `IsHard` persisted in GeoJSON + legacy text (labeled line, AgOpen-safe), a **Hard toggle** in the boundary list (record + edit), and an operator warning on `ClearanceBlocked`.

## Scope / follow-ups
- This handles the **hard outer boundary** ("more to the inside" per the design discussion). Hard **inner** exclusions (obstacle in the field) reuse the same evaluator but need a different reposition strategy — a follow-up.
- Rigid-tool length references the working centre (`Tool.HitchLength`); if operators measure from the physical 3-point pin we can reconcile the small offset later.

## Testing
Models 146 / Services 894 / UI 147 — all green. New: 18 swept-path, 8 clearance, 1 boundary `IsHard` round-trip (existing round-trips prove backward compat). Full app builds (Desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)