### PR TITLE
Unify U-turn generator for curved + straight tracks (v26.5.45)

### DIFF
--- a/Shared/AgValoniaGPS.Models/Guidance/CurveProcessing.cs
+++ b/Shared/AgValoniaGPS.Models/Guidance/CurveProcessing.cs
@@ -264,6 +264,73 @@ namespace AgValoniaGPS.Models.Guidance
         }
 
         /// <summary>
+        /// Extends a curve straight along its end tangents at both ends so it behaves like
+        /// an (effectively infinite) AB line near the field edges. Without this, an offset
+        /// curve stops "parallel to the end of the base track" — at the field boundary — so
+        /// U-turn geometry and the displayed guidance line never reach into the turn the way
+        /// a straight track does. Mirrors AgOpenGPS CABCurve.GetExtendedReferenceCurve.
+        /// </summary>
+        /// <param name="points">Curve points with headings (heading = atan2(dEasting, dNorthing)).</param>
+        /// <param name="lengthMeters">How far to extend past each end.</param>
+        /// <param name="spacing">Spacing between added extension points.</param>
+        public static List<Vec3> ExtendCurveEnds(IReadOnlyList<Vec3> points,
+            double lengthMeters = 200.0, double spacing = 1.0)
+        {
+            if (points == null || points.Count < 2 || lengthMeters <= 0 || spacing <= 0)
+                return points != null ? new List<Vec3>(points) : new List<Vec3>();
+
+            // Closed loops (boundary curves / water pivots) must not be extended.
+            var first = points[0];
+            var last = points[points.Count - 1];
+            double closeSq = (first.Easting - last.Easting) * (first.Easting - last.Easting)
+                + (first.Northing - last.Northing) * (first.Northing - last.Northing);
+            if (closeSq < 1.0)
+                return new List<Vec3>(points);
+
+            int steps = (int)(lengthMeters / spacing);
+            var extended = new List<Vec3>(points.Count + steps * 2);
+
+            // Extend along a SMOOTHED end direction measured from point POSITIONS over a span,
+            // not the single endpoint's stored heading. Recorded-curve endpoints frequently
+            // carry a noisy/abrupt last-point heading; extending along it sends the straight
+            // lead-in/out (and the U-turn entry/exit legs built on it) off at a wrong angle,
+            // ~20° from the curve's actual direction — the operator's "tractor points 20° off
+            // the entry leg and hunts" symptom.
+            int span = Math.Min(5, points.Count - 1);
+
+            // Lead-out direction: from points[N-1-span] toward points[N-1].
+            var outFrom = points[points.Count - 1 - span];
+            double outHead = Math.Atan2(last.Easting - outFrom.Easting, last.Northing - outFrom.Northing);
+            // Lead-in direction (pointing INTO the curve): from points[span] back toward points[0].
+            var inTo = points[span];
+            double inHead = Math.Atan2(inTo.Easting - first.Easting, inTo.Northing - first.Northing);
+
+            // Lead-in: walk backward from the first point (opposite the into-curve direction).
+            double sinH = Math.Sin(inHead), cosH = Math.Cos(inHead);
+            for (int i = steps; i >= 1; i--)
+            {
+                extended.Add(new Vec3(
+                    first.Easting - sinH * (i * spacing),
+                    first.Northing - cosH * (i * spacing),
+                    inHead));
+            }
+
+            extended.AddRange(points);
+
+            // Lead-out: walk forward from the last point along the smoothed end direction.
+            sinH = Math.Sin(outHead); cosH = Math.Cos(outHead);
+            for (int i = 1; i <= steps; i++)
+            {
+                extended.Add(new Vec3(
+                    last.Easting + sinH * (i * spacing),
+                    last.Northing + cosH * (i * spacing),
+                    outHead));
+            }
+
+            return extended;
+        }
+
+        /// <summary>
         /// Creates a clean offset curve and returns information about whether points were removed.
         /// Uses AgOpenGPS collision detection: if an offset point is within offset² distance
         /// of ANY original curve point, it indicates self-intersection and the point is skipped.

--- a/Shared/AgValoniaGPS.Models/YouTurn/YouTurnCreationInput.cs
+++ b/Shared/AgValoniaGPS.Models/YouTurn/YouTurnCreationInput.cs
@@ -52,6 +52,15 @@ namespace AgValoniaGPS.Models.YouTurn
         public int CurrentLocationIndex { get; set; }
 
         /// <summary>
+        /// For curves: the BASE (path 0) reference curve points with headings.
+        /// <see cref="GuidancePoints"/> is the current pass — this base track offset
+        /// by <see cref="HowManyPathsAway"/> — whereas the destination pass for the
+        /// exit leg is built by offsetting THIS reference curve (matches AgOpen's
+        /// CABCurve.BuildNewOffsetList, which always offsets the reference curve).
+        /// </summary>
+        public List<Vec3> ReferenceCurvePoints { get; set; } = new List<Vec3>();
+
+        /// <summary>
         /// For curves: Is vehicle heading same way as curve direction?
         /// For AB: Is vehicle heading same way as AB line direction?
         /// </summary>

--- a/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
+++ b/Shared/AgValoniaGPS.Services/Pipeline/GpsPipelineService.cs
@@ -823,13 +823,34 @@ public sealed class GpsPipelineService : IGpsPipelineService
             double widthMinusOverlap = config2.ActualToolWidth - config2.Tool.Overlap;
             double distAway = widthMinusOverlap * passNumber + nudgeOffset;
 
+            // Curve tracks: extend the displayed (magenta) line straight to the U-turn so
+            // there's no visible gap between the guidance line and the turn (the line the
+            // tractor follows, CalculateTrackGuidance, is extended the same way). No-op for
+            // closed loops.
+            bool extendDisp = track!.Points.Count > 2 && !track.IsClosed;
+
             if (Math.Abs(distAway) < 0.01)
             {
-                displayTrack = track;
+                if (extendDisp)
+                {
+                    // Pass 0: extended curve IS the reference line — leave baseTrack null so
+                    // it isn't drawn twice at the same position.
+                    displayTrack = new Models.Track.Track
+                    {
+                        Name = $"{track.Name} (path {passNumber})",
+                        Points = CurveProcessing.ExtendCurveEnds(track.Points),
+                        Type = track.Type, IsVisible = true, IsActive = true, IsClosed = track.IsClosed
+                    };
+                }
+                else
+                {
+                    displayTrack = track;
+                }
             }
             else
             {
-                var offsetPoints = CurveProcessing.CreateOffsetCurve(track!.Points, distAway);
+                var offsetPoints = CurveProcessing.CreateOffsetCurve(track.Points, distAway);
+                if (extendDisp) offsetPoints = CurveProcessing.ExtendCurveEnds(offsetPoints);
                 displayTrack = new Models.Track.Track
                 {
                     Name = $"{track.Name} (path {passNumber})",
@@ -1206,13 +1227,30 @@ public sealed class GpsPipelineService : IGpsPipelineService
         Models.Track.Track currentTrack;
         string? statusMessage = null;
 
+        // Curve tracks are extended along their (smoothed) end tangents so the STEERING
+        // line is the SAME extended curve the U-turn is built from. Otherwise the offset
+        // guidance line stops at the recorded curve's end and the tractor approaches at the
+        // curve's local heading, while the U-turn entry leg sits on the straight tangent
+        // extension — a heading step at the algorithm handoff (the entry "hunt"). Extending
+        // the steering line lets the tractor commit to the extension direction during the
+        // (smooth) approach instead. No-op for closed loops.
+        bool extendCurve = track.Points.Count > 2 && !track.IsClosed;
+
         if (Math.Abs(distAway) < 0.01)
         {
-            currentTrack = track;
+            currentTrack = extendCurve
+                ? new Models.Track.Track
+                {
+                    Name = $"{track.Name} (path {passNumber})",
+                    Points = CurveProcessing.ExtendCurveEnds(track.Points),
+                    Type = track.Type, IsVisible = true, IsActive = true, IsClosed = track.IsClosed
+                }
+                : track;
         }
         else
         {
             var (offsetPoints, percentRemoved) = CurveProcessing.CreateOffsetCurveWithInfo(track.Points, distAway);
+            if (extendCurve) offsetPoints = CurveProcessing.ExtendCurveEnds(offsetPoints);
 
             // Warn on tight curves
             if (percentRemoved > 10 && passNumber != _lastWarnedPathsAway)
@@ -1385,6 +1423,19 @@ public sealed class GpsPipelineService : IGpsPipelineService
         double headingRad = currentPosition.Heading * Math.PI / 180.0;
         double speedKmh = currentPosition.Speed * 3.6;
 
+        // Use the SAME speed-scaled look-ahead as track guidance (CalculateTrackGuidance).
+        // A fixed hold value here is smaller than the track follower's dynamic look-ahead
+        // while moving, so the goal point jumped CLOSER at the track→turn handoff — a sudden
+        // sharper steer that made the tractor hunt for ~½ s on entry (exit was gentler
+        // because the goal jumped farther). Matching them makes the handoff seamless.
+        double lookAhead = config.Guidance.GoalPointLookAheadHold;
+        if (speedKmh > 1)
+        {
+            lookAhead = Math.Max(
+                config.Guidance.MinLookAheadDistance,
+                config.Guidance.GoalPointLookAheadHold + (speedKmh * config.Guidance.GoalPointLookAheadMult * 0.1));
+        }
+
         var input = new YouTurnGuidanceInput
         {
             TurnPath = turnPath,
@@ -1393,7 +1444,7 @@ public sealed class GpsPipelineService : IGpsPipelineService
             Wheelbase = config.Vehicle.Wheelbase,
             MaxSteerAngle = config.Vehicle.MaxSteerAngle,
             UseStanley = false,
-            GoalPointDistance = config.Guidance.GoalPointLookAheadHold,
+            GoalPointDistance = lookAhead,
             UTurnCompensation = config.Guidance.UTurnCompensation,
             FixHeading = headingRad,
             AvgSpeed = speedKmh,

--- a/Shared/AgValoniaGPS.Services/Track/TrackGuidanceService.cs
+++ b/Shared/AgValoniaGPS.Services/Track/TrackGuidanceService.cs
@@ -758,10 +758,29 @@ public class TrackGuidanceService : ITrackGuidanceService
             }
             else
             {
-                // Stop at ends for open curves
+                // Open curve ran off the end. An AB line is just a 2-point curve, and the
+                // AB branch projects its goal point along the *infinite* line (so the tractor
+                // keeps following it past the field edge into the U-turn). Match that here:
+                // project the remaining look-ahead along the LAST segment's tangent instead
+                // of clamping at the endpoint. Clamping froze the goal at the last point, so
+                // the tractor reached it and spun 180° instead of driving on to the turn.
                 if (i < 0 || i >= count)
                 {
-                    return new Vec2(current.Easting, current.Northing);
+                    int lastIdx = i - direction;        // endpoint just consumed (== current)
+                    int prevIdx = lastIdx - direction;  // point before it → travel tangent
+                    if (prevIdx < 0 || prevIdx >= count)
+                        return new Vec2(current.Easting, current.Northing); // too few points
+
+                    double tx = points[lastIdx].Easting - points[prevIdx].Easting;
+                    double tz = points[lastIdx].Northing - points[prevIdx].Northing;
+                    double tlen = Math.Sqrt(tx * tx + tz * tz);
+                    if (tlen < 1e-6)
+                        return new Vec2(current.Easting, current.Northing);
+
+                    double remaining = goalDistance - distSoFar;
+                    return new Vec2(
+                        current.Easting + (tx / tlen) * remaining,
+                        current.Northing + (tz / tlen) * remaining);
                 }
             }
         }

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.Orchestration.cs
@@ -136,27 +136,44 @@ public partial class YouTurnCreationService
             {
                 var path = output.TurnPath;
 
-                // Spiral / pretzel guard. The original check summed |ΔHeading| per step and
-                // rejected anything > 1.5π (270°) — but a legit Dubins RLR/LRL arc-arc-arc
-                // solution can accumulate 300°+ of absolute turning while ending at the correct
-                // 180° reversal. That false-rejected valid paths (#289 F2) and dropped the run
-                // to the less-optimal simple fallback.
-                //
-                // New guard:
-                //   - Primary check: start-to-end heading delta should be ~π (180°) for a U-turn.
-                //   - Secondary safety: cumulative |ΔHeading| capped at 4π (720°) to still catch
-                //     actual infinite-loop spirals, without rejecting loopy-but-valid paths.
-                double netHeadingChange = path[^1].Heading - path[0].Heading;
-                while (netHeadingChange > Math.PI) netHeadingChange -= 2 * Math.PI;
-                while (netHeadingChange < -Math.PI) netHeadingChange += 2 * Math.PI;
+                // Smooth FIRST, then validate. The spiral/pretzel guard must judge the path
+                // that is actually driven, not raw construction artifacts: the curve generator
+                // can leave sub-metre folds at arc/leg seams that produce spurious 180° heading
+                // flips. Those inflate the cumulative-turn metric and false-reject a perfectly
+                // good curved U-turn (net 180°), dropping it to the straight fallback — the
+                // "south end misaligned" report. Smoothing removes the folds; a genuine spiral
+                // survives it.
+                TurnPathSmoothing.Smooth(path, config.Guidance.UTurnSmoothing);
 
-                double totalHeadingChange = 0;
+                // Measure turning from SEGMENT DIRECTIONS (positions), not the stored per-point
+                // headings — smoothing only moves positions (it preserves the stale headings),
+                // and the generator's recomputed headings are exactly what's noisy.
+                //   - Primary check: net start→end direction change should be ~π (180°).
+                //   - Secondary safety: cumulative |Δdir| capped at 4π (720°) to still catch
+                //     actual infinite-loop spirals, without rejecting loopy-but-valid paths.
+                var dirs = new List<double>(path.Count);
                 for (int i = 1; i < path.Count; i++)
                 {
-                    double delta = path[i].Heading - path[i - 1].Heading;
-                    while (delta > Math.PI) delta -= 2 * Math.PI;
-                    while (delta < -Math.PI) delta += 2 * Math.PI;
-                    totalHeadingChange += Math.Abs(delta);
+                    double de = path[i].Easting - path[i - 1].Easting;
+                    double dn = path[i].Northing - path[i - 1].Northing;
+                    if ((de * de + dn * dn) < 1e-4) continue; // skip near-duplicate points
+                    dirs.Add(Math.Atan2(de, dn));
+                }
+
+                double netHeadingChange = 0, totalHeadingChange = 0;
+                if (dirs.Count >= 2)
+                {
+                    netHeadingChange = dirs[^1] - dirs[0];
+                    while (netHeadingChange > Math.PI) netHeadingChange -= 2 * Math.PI;
+                    while (netHeadingChange < -Math.PI) netHeadingChange += 2 * Math.PI;
+
+                    for (int i = 1; i < dirs.Count; i++)
+                    {
+                        double delta = dirs[i] - dirs[i - 1];
+                        while (delta > Math.PI) delta -= 2 * Math.PI;
+                        while (delta < -Math.PI) delta += 2 * Math.PI;
+                        totalHeadingChange += Math.Abs(delta);
+                    }
                 }
 
                 // ~π expected for U-turn; tolerate ±30° slack to account for approach angle.
@@ -176,8 +193,6 @@ public partial class YouTurnCreationService
                         guidance, turn, uTurnSkipRows, headlandDistance);
                     return new TurnPathResult(fallback.Count > 10 ? fallback : null, UsedFallback: true);
                 }
-
-                TurnPathSmoothing.Smooth(path, config.Guidance.UTurnSmoothing);
 
                 // Implement clearance against the hard outer boundary, checked on
                 // the final (smoothed) path that will actually be driven.
@@ -350,16 +365,58 @@ public partial class YouTurnCreationService
 
         var pivotPosition = new Vec3(currentPosition.Easting, currentPosition.Northing, headingRadians);
 
+        // ONE turn generator. "An AB line is just a curve with 2 points": a 2-point AB
+        // line is densified into a straight poly-curve so it flows through the SAME
+        // curve-aware generator as recorded curves — there is no separate analytic AB path.
+        //
+        // CRITICAL: offset FIRST, then extend the OFFSET RESULT. The in-field portion of the
+        // U-turn's current pass must be byte-for-byte identical to the guidance line the
+        // tractor steers to (GpsPipelineService offsets the NON-extended track), so the
+        // track→turn handoff has zero lateral step. Extending the base BEFORE offsetting
+        // shifts the in-field offset points by up to ~1 m (different point set → different
+        // pruning/spacing) — that step is what made the tractor "get lost" entering the turn.
+        // The tangent extension is added on TOP only so FindCurveTurnPoint can see the curve
+        // cross the boundary (a bare offset curve stops at the field edge → generator fails →
+        // straight fallback).
+        List<Vec3> basePoints = track.Points.Count > 2
+            ? new List<Vec3>(track.Points)
+            : DensifyAbLine(track.Points);
+
+        double widthMinusOverlap = toolWidth - config.Tool.Overlap;
+        double offsetDistance = guidance.HowManyPathsAway * widthMinusOverlap + guidance.NudgeOffset;
+        List<Vec3> offsetCurve = Math.Abs(offsetDistance) < 0.01
+            ? new List<Vec3>(basePoints)
+            : CurveProcessing.CreateOffsetCurve(basePoints, offsetDistance);
+        List<Vec3> currentCurvePoints = CurveProcessing.ExtendCurveEnds(offsetCurve);
+
+        int currentLocationIndex = 0;
+        double minDistSq = double.MaxValue;
+        for (int i = 0; i < currentCurvePoints.Count; i++)
+        {
+            double dx = currentCurvePoints[i].Easting - pivotPosition.Easting;
+            double dy = currentCurvePoints[i].Northing - pivotPosition.Northing;
+            double distSq = dx * dx + dy * dy;
+            if (distSq < minDistSq) { minDistSq = distSq; currentLocationIndex = i; }
+        }
+
         var input = new YouTurnCreationInput
         {
             TurnType = MapTurnStyle(config.Guidance.UTurnStyle),
             IsTurnLeft = turnLeft,
-            GuidanceType = GuidanceLineType.ABLine,
+            // Always the unified curve generator (AB lines are densified 2-point curves).
+            GuidanceType = GuidanceLineType.Curve,
             BoundaryTurnLines = boundaryTurnLines,
             IsPointInsideTurnArea = isPointInsideTurnArea,
 
-            // Curves: use the heading at the point where the current offset track crosses the headland
-            // (not the vehicle's local heading).
+            // The single generator walks these points (the current offset pass).
+            GuidancePoints = currentCurvePoints,
+            CurrentLocationIndex = currentLocationIndex,
+            // Non-extended base; the destination (exit) curve is offset+extended from this in
+            // BuildNewOffsetCurveList so its in-field portion matches the next guidance line.
+            ReferenceCurvePoints = basePoints,
+
+            // Retained for diagnostics / reference-point helpers; the curve generator
+            // anchors on GuidancePoints, not these.
             ABHeading = track.Points.Count > 2
                 ? FindTrackHeadingAtHeadland(track, pivotPosition, headlandLine, guidance)
                 : abHeading,
@@ -377,7 +434,10 @@ public partial class YouTurnCreationService
             RowSkipsWidth = uTurnSkipRows,
             TurnStartOffset = 0,
             HowManyPathsAway = guidance.HowManyPathsAway,
-            NudgeDistance = 0.0,
+            // Carry the nudge so the destination offset curve (exit leg) lands on the
+            // nudged next pass, matching the current pass built above (and AgOpen, whose
+            // BuildNewOffsetList distAway includes track.nudgeDistance).
+            NudgeDistance = guidance.NudgeOffset,
             TrackMode = 0,
 
             MakeUTurnCounter = turn.YouTurnCounter + 10,
@@ -391,6 +451,35 @@ public partial class YouTurnCreationService
             toolWidth, totalHeadlandWidth, headlandWidthForTurn, turnBoundaryVec3.Count, headlandBoundaryVec3.Count);
 
         return input;
+    }
+
+    /// <summary>
+    /// Densifies a 2-point AB line into an evenly-spaced poly-curve (heading = A→B) so it
+    /// can flow through the unified curve turn generator. Without dense points,
+    /// FindCurveTurnPoint (which tests boundary crossing per point) could step over the
+    /// turn boundary in one long segment.
+    /// </summary>
+    private static List<Vec3> DensifyAbLine(IReadOnlyList<Vec3> ab)
+    {
+        var a = ab[0];
+        var b = ab[1];
+        double dE = b.Easting - a.Easting;
+        double dN = b.Northing - a.Northing;
+        double len = Math.Sqrt(dE * dE + dN * dN);
+        if (len < 0.01)
+            return new List<Vec3> { a, b };
+
+        double head = Math.Atan2(dE, dN);
+        if (head < 0) head += Math.PI * 2;
+
+        int n = Math.Max(2, (int)(len / 2.0)); // ~2 m spacing
+        var pts = new List<Vec3>(n + 1);
+        for (int i = 0; i <= n; i++)
+        {
+            double t = (double)i / n;
+            pts.Add(new Vec3(a.Easting + dE * t, a.Northing + dN * t, head));
+        }
+        return pts;
     }
 
     // ── Reference-point helpers ─────────────────────────────────────────

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnCreationService.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Guidance;
 using AgValoniaGPS.Models.YouTurn;
 using AgValoniaGPS.Services.Geometry;
 using AgValoniaGPS.Services.PathPlanning;
@@ -95,34 +96,31 @@ namespace AgValoniaGPS.Services.YouTurn
             isOutOfBounds = false;
             isOutSameCurve = false;
 
-            // Use pre-calculated TurnOffset if provided, otherwise calculate from RowSkipsWidth
+            // Lateral span of the arc = the pass spacing. NO ToolOffset compensation:
+            // AgOpenGPS shifts the arc by ±2*ToolOffset because its steering applies the
+            // implement offset to the pivot target, so the arc must pre-compensate. AgValonia
+            // steering never applies ToolOffset (it only positions sections in
+            // SectionControlService) — the guidance line IS the pivot path — so adding the
+            // shift here lands the arc end (and exit leg) 2*ToolOffset off the cyan/post-turn
+            // line the pivot actually follows, causing a lateral jump + wiggle on turn exit.
             double turnOffset;
             if (input.TurnOffset > 0)
             {
                 // Use the pre-calculated offset (matches cyan next-track line exactly)
-                turnOffset = input.TurnOffset + (input.IsTurnLeft ? -input.ToolOffset * 2.0 : input.ToolOffset * 2.0);
-                _logger.LogDebug("Using pre-calculated TurnOffset: {InputOffset}m -> turnOffset={TurnOffset}m", input.TurnOffset, turnOffset);
+                turnOffset = input.TurnOffset;
+                _logger.LogDebug("Using pre-calculated TurnOffset: {TurnOffset}m", turnOffset);
             }
             else
             {
                 // Fallback: calculate from RowSkipsWidth (skip=0 means 1 width, skip=1 means 2 widths, etc.)
-                turnOffset = (input.ToolWidth - input.ToolOverlap) * (input.RowSkipsWidth + 1)
-                    + (input.IsTurnLeft ? -input.ToolOffset * 2.0 : input.ToolOffset * 2.0);
-                _logger.LogDebug("Fallback: TurnOffset was {InputOffset}m, calculated turnOffset={TurnOffset}m from RowSkipsWidth={RowSkipsWidth}", input.TurnOffset, turnOffset, input.RowSkipsWidth);
+                turnOffset = (input.ToolWidth - input.ToolOverlap) * (input.RowSkipsWidth + 1);
+                _logger.LogDebug("Fallback turnOffset={TurnOffset}m from RowSkipsWidth={RowSkipsWidth}", turnOffset, input.RowSkipsWidth);
             }
             pointSpacing = input.TurnRadius * 0.1;
 
-            bool success = false;
-
-            // Route to appropriate turn creation method based on type and geometry
-            if (input.GuidanceType == GuidanceLineType.Curve)
-            {
-                success = CreateCurveTurn(input, turnOffset);
-            }
-            else // AB Line
-            {
-                success = CreateABTurn(input, turnOffset);
-            }
+            // ONE turn generator for every track. AB lines arrive here as densified 2-point
+            // curves (see BuildCreationInput), so there is no separate AB turn path.
+            bool success = CreateCurveTurn(input, turnOffset);
 
             // Package output
             if (success && ytList.Count > 0)
@@ -156,15 +154,11 @@ namespace AgValoniaGPS.Services.YouTurn
             }
             else if (input.TurnType == YouTurnType.AlbinStyle)
             {
-                // Omega (narrow) or Wide turn based on offset
-                if (turnOffset > (input.TurnRadius * 2.0))
-                {
-                    return CreateCurveWideTurn(input, turnOffset);
-                }
-                else
-                {
-                    return CreateCurveOmegaTurn(input, turnOffset);
-                }
+                // Always use the omega turn: it uses Dubins paths which handle any
+                // turnOffset, and it completes in a single call. The multi-phase wide
+                // turn can't finish under the single-call CreateTurn contract (same
+                // reason CreateABTurn always uses the omega path).
+                return CreateCurveOmegaTurn(input, turnOffset);
             }
             else // KStyle
             {
@@ -294,97 +288,149 @@ namespace AgValoniaGPS.Services.YouTurn
                         return false;
                     }
 
-                    youTurnPhase = 1;
-                    break;
-
-                case 1:
-                    // Build the next line to add sequencelines
-                    double widthMinusOverlap = input.ToolWidth - input.ToolOverlap;
-
-                    double distAway = widthMinusOverlap * (input.HowManyPathsAway +
-                        ((input.IsTurnLeft ^ input.IsHeadingSameWay) ? input.RowSkipsWidth : -input.RowSkipsWidth))
-                        + (input.IsHeadingSameWay ? input.ToolOffset : -input.ToolOffset) + input.NudgeDistance;
-
-                    distAway += (0.5 * widthMinusOverlap);
-
-                    // Create the next line
-                    nextCurve = BuildNewOffsetCurveList(input, distAway);
-
-                    // Get the index of the last yt point
-                    double dis = double.MaxValue;
-                    if (nextCurve.Count > 1)
-                    {
-                        for (int i = 1; i < nextCurve.Count; i++)
-                        {
-                            double newdis = Distance(nextCurve[i], ytList[ytList.Count - 1]);
-                            if (newdis < dis)
-                            {
-                                dis = newdis;
-                                if (input.IsHeadingSameWay) outClosestTurnPt.CurveIndex = i - 1;
-                                else outClosestTurnPt.CurveIndex = i;
-                            }
-                        }
-
-                        if (outClosestTurnPt.CurveIndex >= 0)
-                        {
-                            var outPt = outClosestTurnPt;
-                            outPt.ClosePt = nextCurve[outClosestTurnPt.CurveIndex];
-                            outClosestTurnPt = outPt;
-
-                            var inPt = inClosestTurnPt;
-                            inPt.ClosePt = input.GuidancePoints[inClosestTurnPt.CurveIndex];
-                            inClosestTurnPt = inPt;
-
-                            if (!AddCurveSequenceLines(input)) return false;
-                        }
-                    }
-
-                    // Fill in the gaps
-                    double distanc;
-                    int cnt4 = ytList.Count;
-                    for (int i = 1; i < cnt4 - 2; i++)
-                    {
-                        int j = i + 1;
-                        if (j == cnt4 - 1) continue;
-                        distanc = DistanceSquared(ytList[i], ytList[j]);
-                        if (distanc > 1)
-                        {
-                            Vec3 pointB = new Vec3((ytList[i].Easting + ytList[j].Easting) / 2.0,
-                                (ytList[i].Northing + ytList[j].Northing) / 2.0, ytList[i].Heading);
-
-                            ytList.Insert(j, pointB);
-                            cnt4 = ytList.Count;
-                            i--;
-                        }
-                    }
-
-                    // Calculate the new points headings based on fore and aft of point - smoother turns
-                    cnt4 = ytList.Count;
-                    Vec3[] arr = new Vec3[cnt4];
-                    cnt4 -= 2;
-                    ytList.CopyTo(arr);
-                    ytList.Clear();
-
-                    for (int i = 2; i < cnt4; i++)
-                    {
-                        Vec3 pt3 = arr[i];
-                        pt3.Heading = Math.Atan2(arr[i + 1].Easting - arr[i - 1].Easting,
-                            arr[i + 1].Northing - arr[i - 1].Northing);
-                        if (pt3.Heading < 0) pt3.Heading += TWO_PI;
-                        ytList.Add(pt3);
-                    }
-
-                    // Check too close
-                    if (Distance(ytList[0], input.PivotPosition) < 3)
-                    {
-                        FailCreate();
-                        return false;
-                    }
-
-                    isOutOfBounds = false;
-                    youTurnPhase = 10;
-                    return true;
+                    // CreateTurn is single-call (youTurnPhase resets to 0 each call), so the
+                    // arc-plus-legs must finish in one pass — add the curve-following entry/exit
+                    // legs inline here rather than relying on a second call into a (dead) case 1.
+                    return CompleteCurveTurn(input);
             }
+            return true;
+        }
+
+        /// <summary>
+        /// Finishes a curve turn whose arc is already snapped to the turn line: builds the
+        /// destination offset curve, splices on the curve-following entry/exit legs, fills
+        /// gaps and recomputes smoothed headings. Shared by the omega and sagitta curve
+        /// turns so both produce extension legs that follow the actual curved passes
+        /// (instead of overrunning the boundary with no legs).
+        /// </summary>
+        private bool CompleteCurveTurn(YouTurnCreationInput input)
+        {
+            // Where the track crosses the turn boundary — the "too late to turn?" reference.
+            // Captured BEFORE the re-anchor below overwrites inClosestTurnPt.ClosePt. The
+            // vehicle being within a few metres of THIS point means it has reached the
+            // headland and can't start the turn. (Measuring against the arc start or the
+            // entry-leg start instead spuriously rejects valid turns: in tight geometry the
+            // big arc must start deep in the field near the still-approaching vehicle, and
+            // the entry leg extends a UTurnExtension lead-in back toward it.)
+            Vec3 turnLineCrossing = inClosestTurnPt.ClosePt;
+
+            Vec3 arcStartPoint = ytList.Count > 0 ? ytList[0] : input.PivotPosition;
+
+            // Re-anchor the entry leg to where the arc was actually seated. The omega/sagitta
+            // arc is generated from a curve index walked INWARD until it fits the turn area,
+            // then MoveTurnInsideTurnLine shifts it back out to the turn line — so the stored
+            // inClosestTurnPt.CurveIndex now lags the real arc start, which would leave a
+            // corner-cut gap between the track and the turn. Snap it to the curve point
+            // nearest the seated arc start so the entry leg meets the arc cleanly.
+            if (ytList.Count > 0 && input.GuidancePoints.Count > 1)
+            {
+                double bestSq = double.MaxValue;
+                int bestIdx = inClosestTurnPt.CurveIndex;
+                for (int i = 0; i < input.GuidancePoints.Count; i++)
+                {
+                    double dSq = DistanceSquared(input.GuidancePoints[i], arcStartPoint);
+                    if (dSq < bestSq) { bestSq = dSq; bestIdx = i; }
+                }
+                inClosestTurnPt.CurveIndex = bestIdx;
+            }
+
+            // Build the destination curve (the cyan next-track line) the exit leg follows.
+            // Offset the BASE reference by the SAME formula every other consumer uses for a
+            // pass — current pass, displayed line, STEERING line
+            // (GpsPipelineService.CalculateTrackGuidance) and the pass driven after the turn:
+            //   widthMinusOverlap * pathsAway + nudge.
+            // One definition, no per-turn measurement, so the exit leg is byte-aligned with
+            // the cyan line and the line the tractor actually steers after completion.
+            //
+            // (Previously this measured SignedPerpDistanceToCurve(base, arcEnd) to be
+            // "heading-agnostic". But that projects the arc end onto the NEAREST raw base
+            // point's stored heading; when the recorded curve ends before the headland the arc
+            // seats on the tangent extension and a noisy end-point heading skewed the measured
+            // offset by metres, plotting the exit leg off the next pass the tractor drives.)
+            double widthMinusOverlap = input.ToolWidth - input.ToolOverlap;
+            int passDelta = (input.IsTurnLeft ^ input.IsHeadingSameWay)
+                ? (input.RowSkipsWidth + 1)
+                : -(input.RowSkipsWidth + 1);
+            double distAway = widthMinusOverlap * (input.HowManyPathsAway + passDelta) + input.NudgeDistance;
+
+            // Create the next line
+            nextCurve = BuildNewOffsetCurveList(input, distAway);
+
+            // Get the index of the last yt point
+            double dis = double.MaxValue;
+            if (nextCurve.Count > 1)
+            {
+                for (int i = 1; i < nextCurve.Count; i++)
+                {
+                    double newdis = Distance(nextCurve[i], ytList[ytList.Count - 1]);
+                    if (newdis < dis)
+                    {
+                        dis = newdis;
+                        if (input.IsHeadingSameWay) outClosestTurnPt.CurveIndex = i - 1;
+                        else outClosestTurnPt.CurveIndex = i;
+                    }
+                }
+
+                if (outClosestTurnPt.CurveIndex >= 0)
+                {
+                    var outPt = outClosestTurnPt;
+                    outPt.ClosePt = nextCurve[outClosestTurnPt.CurveIndex];
+                    outClosestTurnPt = outPt;
+
+                    var inPt = inClosestTurnPt;
+                    inPt.ClosePt = input.GuidancePoints[inClosestTurnPt.CurveIndex];
+                    inClosestTurnPt = inPt;
+
+                    if (!AddCurveSequenceLines(input)) return false;
+                }
+            }
+
+            // Fill in the gaps
+            double distanc;
+            int cnt4 = ytList.Count;
+            for (int i = 1; i < cnt4 - 2; i++)
+            {
+                int j = i + 1;
+                if (j == cnt4 - 1) continue;
+                distanc = DistanceSquared(ytList[i], ytList[j]);
+                if (distanc > 1)
+                {
+                    Vec3 pointB = new Vec3((ytList[i].Easting + ytList[j].Easting) / 2.0,
+                        (ytList[i].Northing + ytList[j].Northing) / 2.0, ytList[i].Heading);
+
+                    ytList.Insert(j, pointB);
+                    cnt4 = ytList.Count;
+                    i--;
+                }
+            }
+
+            // Calculate the new points headings based on fore and aft of point - smoother turns
+            cnt4 = ytList.Count;
+            Vec3[] arr = new Vec3[cnt4];
+            cnt4 -= 2;
+            ytList.CopyTo(arr);
+            ytList.Clear();
+
+            for (int i = 2; i < cnt4; i++)
+            {
+                Vec3 pt3 = arr[i];
+                pt3.Heading = Math.Atan2(arr[i + 1].Easting - arr[i - 1].Easting,
+                    arr[i + 1].Northing - arr[i - 1].Northing);
+                if (pt3.Heading < 0) pt3.Heading += TWO_PI;
+                ytList.Add(pt3);
+            }
+
+            // Too late to turn? Vehicle within a few metres of the turn-line crossing means
+            // it has reached the headland and can't start the turn (matches the analytic AB
+            // path's pivot-to-turn-line check, NOT pivot-to-path-start).
+            if (ytList.Count == 0 || Distance(turnLineCrossing, input.PivotPosition) < 3)
+            {
+                FailCreate();
+                return false;
+            }
+
+            isOutOfBounds = false;
+            youTurnPhase = 10;
             return true;
         }
 
@@ -499,9 +545,8 @@ namespace AgValoniaGPS.Services.YouTurn
                 return false;
             }
 
-            isOutOfBounds = false;
-            youTurnPhase = 10;
-            return true;
+            // Add the curve-following entry/exit legs (single-call: see CompleteCurveTurn).
+            return CompleteCurveTurn(input);
         }
 
         private bool CreateCurveWideTurn(YouTurnCreationInput input, double turnOffset)
@@ -1025,636 +1070,6 @@ namespace AgValoniaGPS.Services.YouTurn
 
         #endregion
 
-        #region AB Turn Creation
-
-        private bool CreateABTurn(YouTurnCreationInput input, double turnOffset)
-        {
-            if (input.TurnType == YouTurnType.SagittaStyle)
-            {
-                return CreateABSagittaTurn(input, turnOffset);
-            }
-            else if (input.TurnType == YouTurnType.AlbinStyle)
-            {
-                // Always use OmegaTurn - it uses Dubins paths which handle any turnOffset
-                // The wide turn multi-phase approach doesn't work with single-call pattern
-                return CreateABOmegaTurn(input, turnOffset);
-            }
-            else // KStyle
-            {
-                return CreateKStyleTurnAB(input, turnOffset);
-            }
-        }
-
-        private bool CreateABOmegaTurn(YouTurnCreationInput input, double turnOffset)
-        {
-            // Keep from making turns constantly
-            if (input.MakeUTurnCounter < 4)
-            {
-                youTurnPhase = 0;
-                return true;
-            }
-
-            double head = input.ABHeading;
-            if (!input.IsHeadingSameWay) head += Math.PI;
-            if (head >= TWO_PI) head -= TWO_PI;
-
-            // Phase 0: Find turn point and create Dubins path
-            // How far are we from any turn boundary
-            Vec3 onPurePoint = new Vec3(input.ABReferencePoint.Easting, input.ABReferencePoint.Northing, head);
-            FindABTurnPoint(input, onPurePoint);
-
-            // Or did we lose the turnLine
-            if (closestTurnPt.TurnLineIndex == -1)
-            {
-                _logger.LogDebug("FindABTurnPoint failed: no intersection found. RefPoint=({E}, {N}), head={Head}°, boundaryLines={Count}",
-                    onPurePoint.Easting, onPurePoint.Northing, head * 180 / Math.PI, input.BoundaryTurnLines.Count);
-                FailCreate();
-                return false;
-            }
-
-            inClosestTurnPt = new TurnClosePoint(closestTurnPt);
-
-            _dubinsService.TurningRadius = input.TurnRadius;
-
-            Vec3 start = inClosestTurnPt.ClosePt;
-            start.Heading = head;
-
-            Vec3 goal = start;
-
-            // Now we go the other way to turn round
-            double invertedHead = head - Math.PI;
-            if (invertedHead < 0) invertedHead += TWO_PI;
-            if (invertedHead > TWO_PI) invertedHead -= TWO_PI;
-
-            if (input.IsTurnLeft)
-            {
-                goal.Easting = goal.Easting + (Math.Cos(-invertedHead) * turnOffset);
-                goal.Northing = goal.Northing + (Math.Sin(-invertedHead) * turnOffset);
-            }
-            else
-            {
-                goal.Easting = goal.Easting - (Math.Cos(-invertedHead) * turnOffset);
-                goal.Northing = goal.Northing - (Math.Sin(-invertedHead) * turnOffset);
-            }
-
-            goal.Heading = invertedHead;
-
-            // Check if start and goal are in valid locations
-            int goalResult = input.IsPointInsideTurnArea(goal);
-
-            _logger.LogDebug("OmegaTurn: turnOffset={TurnOffset}m, skipRows={SkipRows}, goalResult={GoalResult}", turnOffset, input.RowSkipsWidth, goalResult);
-            _logger.LogDebug("Goal position: E={Easting}, N={Northing}", goal.Easting, goal.Northing);
-
-            // If goal is outside boundary (-1), log it but proceed.
-            // The goal being near the edge is OK - we'll check the arc path later.
-            if (goalResult == -1)
-            {
-                _logger.LogDebug("Goal at turnOffset={TurnOffset}m is near/outside boundary edge", turnOffset);
-            }
-
-            // Generate the turn points
-            ytList = _dubinsService.GeneratePath(start, goal);
-            isOutOfBounds = true;
-
-            if (ytList.Count == 0)
-            {
-                FailCreate();
-                return false;
-            }
-
-            // Clean up closely spaced points
-            double distance;
-            int cnt = ytList.Count;
-            for (int i = 1; i < cnt - 2; i++)
-            {
-                distance = DistanceSquared(ytList[i], ytList[i + 1]);
-                if (distance < pointSpacing)
-                {
-                    ytList.RemoveAt(i + 1);
-                    i--;
-                    cnt = ytList.Count;
-                }
-            }
-
-            // Phase 1: Move turn inside boundary and add sequence lines
-            ytList = MoveTurnInsideTurnLine(input, ytList, head, false, false);
-
-            if (ytList.Count == 0)
-            {
-                FailCreate();
-                return false;
-            }
-
-            isOutOfBounds = false;
-            youTurnPhase = 10;
-
-            // Add the entry and exit legs
-            if (!AddABSequenceLines(input))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Sagitta-style AB turn (Brian Tischler's AOG dev-fork geometry).
-        /// Mirrors <see cref="CreateABOmegaTurn"/> exactly (find turn point, snap
-        /// inside the turn line, add entry/exit legs) but builds the arc with the
-        /// sagitta offset construction instead of a Dubins constant-radius arc.
-        /// </summary>
-        private bool CreateABSagittaTurn(YouTurnCreationInput input, double turnOffset)
-        {
-            // Keep from making turns constantly
-            if (input.MakeUTurnCounter < 4)
-            {
-                youTurnPhase = 0;
-                return true;
-            }
-
-            // A single sagitta semicircle of radius R reaches at most 2R sideways.
-            // Wider rows need straight connectors, so fall back to the omega turn.
-            if (Math.Abs(turnOffset) > input.TurnRadius * 2.0)
-            {
-                return CreateABOmegaTurn(input, turnOffset);
-            }
-
-            double head = input.ABHeading;
-            if (!input.IsHeadingSameWay) head += Math.PI;
-            if (head >= TWO_PI) head -= TWO_PI;
-
-            // Find turn point where the current AB track crosses the turn boundary
-            Vec3 onPurePoint = new Vec3(input.ABReferencePoint.Easting, input.ABReferencePoint.Northing, head);
-            FindABTurnPoint(input, onPurePoint);
-
-            if (closestTurnPt.TurnLineIndex == -1)
-            {
-                _logger.LogDebug("Sagitta FindABTurnPoint failed: no intersection. RefPoint=({E}, {N}), head={Head}°",
-                    onPurePoint.Easting, onPurePoint.Northing, head * 180 / Math.PI);
-                FailCreate();
-                return false;
-            }
-
-            inClosestTurnPt = new TurnClosePoint(closestTurnPt);
-
-            Vec3 start = inClosestTurnPt.ClosePt;
-            start.Heading = head;
-
-            // Pull the arc back from a full 2R semicircle so it lands exactly on the
-            // next row: landing lateral = 2R - pullback, hence pullback = 2R - turnOffset.
-            double sagittaPullback = input.TurnRadius * 2.0 - Math.Abs(turnOffset);
-            bool isTurningRight = !input.IsTurnLeft;
-
-            // Generate the sagitta arc
-            ytList = SagittaTurnGeometry.BuildOffsetArc(start, head, isTurningRight, input.TurnRadius, sagittaPullback, Math.PI);
-            isOutOfBounds = true;
-
-            if (ytList.Count == 0)
-            {
-                FailCreate();
-                return false;
-            }
-
-            // Clean up closely spaced points
-            int cnt = ytList.Count;
-            for (int i = 1; i < cnt - 2; i++)
-            {
-                if (DistanceSquared(ytList[i], ytList[i + 1]) < pointSpacing)
-                {
-                    ytList.RemoveAt(i + 1);
-                    i--;
-                    cnt = ytList.Count;
-                }
-            }
-
-            // Move turn inside boundary
-            ytList = MoveTurnInsideTurnLine(input, ytList, head, false, false);
-            if (ytList.Count == 0)
-            {
-                FailCreate();
-                return false;
-            }
-
-            isOutOfBounds = false;
-            youTurnPhase = 10;
-
-            // Add the entry and exit legs
-            if (!AddABSequenceLines(input))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private bool CreateABWideTurn(YouTurnCreationInput input, double turnOffset)
-        {
-            // Keep from making turns constantly
-            if (input.MakeUTurnCounter < 4)
-            {
-                youTurnPhase = 0;
-                return true;
-            }
-
-            double head = input.ABHeading;
-            if (!input.IsHeadingSameWay) head += Math.PI;
-            if (head >= TWO_PI) head -= TWO_PI;
-
-            switch (youTurnPhase)
-            {
-                case 0:
-                    // Grab the pure pursuit point right on ABLine
-                    Vec3 onPurePoint = new Vec3(input.ABReferencePoint.Easting, input.ABReferencePoint.Northing, 0);
-
-                    // How far are we from any turn boundary
-                    FindABTurnPoint(input, onPurePoint);
-
-                    // Save a copy for first point
-                    inClosestTurnPt = new TurnClosePoint(closestTurnPt);
-                    startOfTurnPt = new TurnClosePoint(closestTurnPt);
-
-                    // Already no turnline
-                    if (inClosestTurnPt.TurnLineIndex == -1)
-                    {
-                        FailCreate();
-                        return false;
-                    }
-
-                    // Creates half a circle starting at the crossing point
-                    ytList.Clear();
-                    Vec3 currentPos = new Vec3(inClosestTurnPt.ClosePt.Easting, inClosestTurnPt.ClosePt.Northing, head);
-                    ytList.Add(currentPos);
-
-                    // Taken from Dubins
-                    while (Math.Abs(head - currentPos.Heading) < Math.PI)
-                    {
-                        // Update the position of the car
-                        currentPos.Easting += pointSpacing * Math.Sin(currentPos.Heading);
-                        currentPos.Northing += pointSpacing * Math.Cos(currentPos.Heading);
-
-                        // Which way are we turning?
-                        double turnParameter = input.IsTurnLeft ? -1.0 : 1.0;
-
-                        // Update the heading
-                        currentPos.Heading += (pointSpacing / input.TurnRadius) * turnParameter;
-
-                        // Add the new coordinate to the path
-                        ytList.Add(currentPos);
-                    }
-
-                    // Move the half circle to tangent the turnline
-                    isOutOfBounds = true;
-                    ytList = MoveTurnInsideTurnLine(input, ytList, head, true, false);
-
-                    // If it couldn't be done this will trigger
-                    if (ytList.Count == 0)
-                    {
-                        FailCreate();
-                        return false;
-                    }
-
-                    youTurnPhase = 1;
-                    return true;
-
-                case 1:
-                    // Build the next line to add sequencelines
-                    // Use the pre-calculated turnOffset instead of recalculating from RowSkipsWidth
-                    double widthMinusOverlap = input.ToolWidth - input.ToolOverlap;
-
-                    // distAway = offset from reference line to next track center
-                    // turnOffset is the perpendicular distance we need to move
-                    double distAway = widthMinusOverlap * input.HowManyPathsAway
-                        + ((input.IsTurnLeft ^ input.IsHeadingSameWay) ? -turnOffset : turnOffset)
-                        + (input.IsHeadingSameWay ? input.ToolOffset : -input.ToolOffset) + input.NudgeDistance;
-
-                    distAway += (0.5 * widthMinusOverlap);
-                    _logger.LogDebug("WideTurn case 1: turnOffset={TurnOffset}m, distAway={DistAway}m", turnOffset, distAway);
-
-                    nextCurve = BuildNewOffsetCurveList(input, distAway);
-
-                    // Going with or against boundary?
-                    bool isTurnLineSameWay = true;
-                    double headingDifference = Math.Abs(startOfTurnPt.ClosePt.Heading - ytList[ytList.Count - 1].Heading);
-                    if (headingDifference > PI_BY_2 && headingDifference < 3 * PI_BY_2) isTurnLineSameWay = false;
-
-                    if (!FindABOutTurnPoint(nextCurve, inClosestTurnPt, isTurnLineSameWay))
-                    {
-                        // Error
-                        FailCreate();
-                        return false;
-                    }
-                    outClosestTurnPt = new TurnClosePoint(closestTurnPt);
-
-                    Vec3 pointPos = new Vec3(outClosestTurnPt.ClosePt.Easting, outClosestTurnPt.ClosePt.Northing, 0);
-                    double headie;
-                    if (!isOutSameCurve)
-                    {
-                        headie = head;
-                    }
-                    else
-                    {
-                        headie = head + Math.PI;
-                        if (headie >= TWO_PI) headie -= TWO_PI;
-                    }
-                    pointPos.Heading = headie;
-
-                    // Step 3 create half circle in new list
-                    ytList2.Clear();
-                    ytList2.Add(pointPos);
-
-                    // Taken from Dubins
-                    while (Math.Abs(headie - pointPos.Heading) < Math.PI)
-                    {
-                        // Update the position of the car
-                        pointPos.Easting += pointSpacing * Math.Sin(pointPos.Heading);
-                        pointPos.Northing += pointSpacing * Math.Cos(pointPos.Heading);
-
-                        // Which way are we turning?
-                        double turnParameter = input.IsTurnLeft ? 1.0 : -1.0;
-
-                        // Update the heading
-                        pointPos.Heading += (pointSpacing / input.TurnRadius) * turnParameter;
-
-                        // Add the new coordinate to the path
-                        ytList2.Add(pointPos);
-                    }
-
-                    // Move the half circle to tangent the turnline
-                    isOutOfBounds = true;
-                    ytList2 = MoveTurnInsideTurnLine(input, ytList2, headie, true, true);
-
-                    if (ytList2.Count == 0)
-                    {
-                        FailCreate();
-                        return false;
-                    }
-
-                    youTurnPhase = 2;
-                    return true;
-
-                case 2:
-                    int cnt1 = ytList.Count;
-                    int cnt2 = ytList2.Count;
-
-                    // Find if the turn goes same way as turnline heading
-                    bool isFirstTurnLineSameWay = true;
-                    double firstHeadingDifference = Math.Abs(inClosestTurnPt.TurnLineHeading - ytList[ytList.Count - 1].Heading);
-
-                    if (firstHeadingDifference > PI_BY_2 && firstHeadingDifference < 3 * PI_BY_2) isFirstTurnLineSameWay = false;
-
-                    // Finds out start and goal point along the turnline
-                    FindInnerTurnPoints(ytList[cnt1 - 1], ytList[0].Heading, inClosestTurnPt, isFirstTurnLineSameWay);
-                    TurnClosePoint startClosestTurnPt = new TurnClosePoint(closestTurnPt);
-
-                    FindInnerTurnPoints(ytList2[cnt2 - 1], ytList2[0].Heading + Math.PI, outClosestTurnPt, !isFirstTurnLineSameWay);
-                    TurnClosePoint goalClosestTurnPt = new TurnClosePoint(closestTurnPt);
-
-                    // We have 2 different turnLine crossings
-                    if (startClosestTurnPt.TurnLineNum != goalClosestTurnPt.TurnLineNum)
-                    {
-                        FailCreate();
-                        return false;
-                    }
-
-                    // Segment index is the "A" of the segment. segmentIndex+1 would be the "B"
-                    // Is in and out on same segment? so only 1 segment
-                    if (startClosestTurnPt.TurnLineIndex == goalClosestTurnPt.TurnLineIndex)
-                    {
-                        for (int a = 0; a < cnt2; cnt2--)
-                        {
-                            ytList.Add(ytList2[cnt2 - 1]);
-                        }
-                    }
-                    else
-                    {
-                        // Multiple segments
-                        Vec3 tPoint = new Vec3();
-                        int turnCount = input.BoundaryTurnLines[startClosestTurnPt.TurnLineNum].Points.Count;
-
-                        // How many points from turnline do we add
-                        int loops = Math.Abs(startClosestTurnPt.TurnLineIndex - goalClosestTurnPt.TurnLineIndex);
-
-                        // Are we crossing a border?
-                        if (loops > (input.BoundaryTurnLines[startClosestTurnPt.TurnLineNum].Points.Count / 2))
-                        {
-                            if (startClosestTurnPt.TurnLineIndex < goalClosestTurnPt.TurnLineIndex)
-                            {
-                                loops = (turnCount - goalClosestTurnPt.TurnLineIndex) + startClosestTurnPt.TurnLineIndex;
-                            }
-                            else
-                            {
-                                loops = (turnCount - startClosestTurnPt.TurnLineIndex) + goalClosestTurnPt.TurnLineIndex;
-                            }
-                        }
-
-                        // CountExit up - start with B which is next A
-                        if (isFirstTurnLineSameWay)
-                        {
-                            for (int i = 0; i < loops; i++)
-                            {
-                                if ((startClosestTurnPt.TurnLineIndex + 1) >= turnCount) startClosestTurnPt.TurnLineIndex = -1;
-
-                                tPoint = input.BoundaryTurnLines[startClosestTurnPt.TurnLineNum].Points[startClosestTurnPt.TurnLineIndex + 1];
-                                startClosestTurnPt.TurnLineIndex++;
-                                if (startClosestTurnPt.TurnLineIndex >= turnCount)
-                                    startClosestTurnPt.TurnLineIndex = 0;
-                                ytList.Add(tPoint);
-                            }
-                        }
-                        else // CountExit down = start with A
-                        {
-                            for (int i = 0; i < loops; i++)
-                            {
-                                tPoint = input.BoundaryTurnLines[startClosestTurnPt.TurnLineNum].Points[startClosestTurnPt.TurnLineIndex];
-                                startClosestTurnPt.TurnLineIndex--;
-                                if (startClosestTurnPt.TurnLineIndex == -1)
-                                    startClosestTurnPt.TurnLineIndex = turnCount - 1;
-                                ytList.Add(tPoint);
-                            }
-                        }
-
-                        // Add the out from ytList2
-                        for (int a = 0; a < cnt2; cnt2--)
-                        {
-                            ytList.Add(ytList2[cnt2 - 1]);
-                        }
-                    }
-
-                    // Fill in the gaps
-                    double distance;
-
-                    int cnt = ytList.Count;
-                    for (int i = 1; i < cnt - 2; i++)
-                    {
-                        int j = i + 1;
-                        if (j == cnt - 1) continue;
-                        distance = DistanceSquared(ytList[i], ytList[j]);
-                        if (distance > 1)
-                        {
-                            Vec3 pointB = new Vec3((ytList[i].Easting + ytList[j].Easting) / 2.0,
-                                (ytList[i].Northing + ytList[j].Northing) / 2.0, ytList[i].Heading);
-
-                            ytList.Insert(j, pointB);
-                            cnt = ytList.Count;
-                            i--;
-                        }
-                    }
-
-                    // Calculate the new points headings based on fore and aft of point - smoother turns
-                    cnt = ytList.Count;
-                    Vec3[] arr = new Vec3[cnt];
-                    cnt -= 2;
-                    ytList.CopyTo(arr);
-                    ytList.Clear();
-
-                    for (int i = 2; i < cnt; i++)
-                    {
-                        Vec3 pt3 = arr[i];
-                        pt3.Heading = Math.Atan2(arr[i + 1].Easting - arr[i - 1].Easting,
-                            arr[i + 1].Northing - arr[i - 1].Northing);
-                        if (pt3.Heading < 0) pt3.Heading += TWO_PI;
-                        ytList.Add(pt3);
-                    }
-
-                    // Check too close
-                    if (Distance(ytList[0], input.PivotPosition) < 3)
-                    {
-                        FailCreate();
-                        return false;
-                    }
-
-                    // Are we continuing the same way?
-                    isOutOfBounds = false;
-                    youTurnPhase = 10;
-                    ytList2.Clear();
-
-                    if (!AddABSequenceLines(input)) return false;
-
-                    return true;
-            }
-
-            // Just in case
-            return true;
-        }
-
-        private bool CreateKStyleTurnAB(YouTurnCreationInput input, double turnOffset)
-        {
-            double pointSpacing = input.TurnRadius * 0.1;
-
-            int turnIndex = input.IsPointInsideTurnArea(input.PivotPosition);
-            if (input.MakeUTurnCounter < 4 || turnIndex != 0)
-            {
-                youTurnPhase = 0;
-                return true;
-            }
-
-            // Grab the pure pursuit point right on ABLine
-            Vec3 onPurePoint = new Vec3(input.ABReferencePoint.Easting, input.ABReferencePoint.Northing, 0);
-
-            // How far are we from any turn boundary
-            FindABTurnPoint(input, onPurePoint);
-
-            // Save a copy for first point
-            inClosestTurnPt = new TurnClosePoint(closestTurnPt);
-
-            // Already no turnline
-            if (inClosestTurnPt.TurnLineIndex == -1) return false;
-
-            double head = input.ABHeading;
-
-            if (!input.IsHeadingSameWay) head += Math.PI;
-            if (head >= TWO_PI) head -= TWO_PI;
-
-            // Distance to turnline from where we are
-            double turnDiagDistance = Distance(input.PivotPosition, closestTurnPt.ClosePt);
-
-            // Moves the point to the crossing with the turnline
-            double rEastYT = input.ABReferencePoint.Easting + (Math.Sin(head) * turnDiagDistance);
-            double rNorthYT = input.ABReferencePoint.Northing + (Math.Cos(head) * turnDiagDistance);
-
-            // Creates half a circle starting at the crossing point
-            ytList.Clear();
-            Vec3 currentPos = new Vec3(rEastYT, rNorthYT, head);
-            ytList.Add(currentPos);
-
-            // Make semi circle - not quite
-            while (Math.Abs(head - currentPos.Heading) < 2.2)
-            {
-                // Update the position of the car
-                currentPos.Easting += pointSpacing * Math.Sin(currentPos.Heading);
-                currentPos.Northing += pointSpacing * Math.Cos(currentPos.Heading);
-
-                // Which way are we turning?
-                double turnParameter = 1.0;
-
-                if (input.IsTurnLeft) turnParameter = -1.0;
-
-                // Update the heading
-                currentPos.Heading += (pointSpacing / input.TurnRadius) * turnParameter;
-
-                // Add the new coordinate to the path
-                ytList.Add(currentPos);
-            }
-
-            // Move the half circle to tangent the turnline
-            ytList = MoveTurnInsideTurnLine(input, ytList, head, false, false);
-
-            // If it couldn't be done this will trigger
-            if (ytList.Count < 5 || semiCircleIndex == -1)
-            {
-                FailCreate();
-                return false;
-            }
-
-            // Grab the vehicle widths and offsets: skip=0 means 1 width, skip=1 means 2 widths, etc.
-            double turnOffsetCalc = (input.ToolWidth - input.ToolOverlap) * (input.RowSkipsWidth + 1) + (input.IsTurnLeft ? input.ToolOffset : -input.ToolOffset);
-
-            // Add the tail to first turn
-            int count = ytList.Count;
-            head = ytList[count - 1].Heading;
-
-            Vec3 pt = new Vec3();
-            for (int i = 1; i <= (int)(3 * turnOffsetCalc); i++)
-            {
-                pt.Easting = ytList[count - 1].Easting + (Math.Sin(head) * i * 0.5);
-                pt.Northing = ytList[count - 1].Northing + (Math.Cos(head) * i * 0.5);
-                pt.Heading = 0;
-                ytList.Add(pt);
-            }
-
-            // Leading in line of turn
-            head = input.ABHeading;
-            if (input.IsHeadingSameWay) head += Math.PI;
-            if (head >= TWO_PI) head -= TWO_PI;
-
-            for (int a = 0; a < 8; a++)
-            {
-                pt.Easting = ytList[0].Easting + (Math.Sin(head) * 0.511);
-                pt.Northing = ytList[0].Northing + (Math.Cos(head) * 0.511);
-                pt.Heading = ytList[0].Heading;
-                ytList.Insert(0, pt);
-            }
-
-            // Calculate line headings
-            Vec3[] arr = new Vec3[ytList.Count];
-            ytList.CopyTo(arr);
-            ytList.Clear();
-
-            // Headings of line one
-            for (int i = 0; i < arr.Length - 1; i++)
-            {
-                arr[i].Heading = Math.Atan2(arr[i + 1].Easting - arr[i].Easting, arr[i + 1].Northing - arr[i].Northing);
-                if (arr[i].Heading < 0) arr[i].Heading += TWO_PI;
-                ytList.Add(arr[i]);
-            }
-
-            isOutOfBounds = false;
-            youTurnPhase = 10;
-
-            return true;
-        }
-
-        #endregion
 
         #region Helper Methods - Turn Point Finding
 
@@ -1695,9 +1110,16 @@ namespace AgValoniaGPS.Services.YouTurn
                 int turnIndex = input.IsPointInsideTurnArea(input.GuidancePoints[j]);
                 if (turnIndex != 0)
                 {
+                    // IsPointInsideTurnArea returns 0 = inside, non-zero = outside as a FLAG
+                    // (the AgValonia lambda returns 1), NOT a boundary index. The turn line to
+                    // intersect is the boundary the curve crossed; AgValonia models a single
+                    // turn boundary, so clamp into BoundaryTurnLines range — using the raw flag
+                    // as an index threw IndexOutOfRange (BoundaryTurnLines[1] with one entry).
+                    int boundaryIndex = Math.Min(turnIndex, input.BoundaryTurnLines.Count - 1);
+                    if (boundaryIndex < 0) boundaryIndex = 0;
                     closestTurnPt.CurveIndex = j - count;
-                    closestTurnPt.TurnLineNum = turnIndex;
-                    turnNum = turnIndex;
+                    closestTurnPt.TurnLineNum = boundaryIndex;
+                    turnNum = boundaryIndex;
                     break;
                 }
             }
@@ -1765,82 +1187,6 @@ namespace AgValoniaGPS.Services.YouTurn
             }
 
             return closestTurnPt.TurnLineIndex != -1 && closestTurnPt.CurveIndex != -1;
-        }
-
-        private void FindABTurnPoint(YouTurnCreationInput input, Vec3 fromPt)
-        {
-            double eP = fromPt.Easting;
-            double nP = fromPt.Northing;
-            double eAB, nAB;
-            turnClosestList?.Clear();
-
-            if (input.IsHeadingSameWay)
-            {
-                // Point B direction
-                eAB = input.ABReferencePoint.Easting + Math.Sin(input.ABHeading) * 1000;
-                nAB = input.ABReferencePoint.Northing + Math.Cos(input.ABHeading) * 1000;
-            }
-            else
-            {
-                // Point A direction
-                eAB = input.ABReferencePoint.Easting - Math.Sin(input.ABHeading) * 1000;
-                nAB = input.ABReferencePoint.Northing - Math.Cos(input.ABHeading) * 1000;
-            }
-
-            turnClosestList.Clear();
-
-            for (int j = 0; j < input.BoundaryTurnLines.Count; j++)
-            {
-                var pts = input.BoundaryTurnLines[j].Points;
-                // Check all segments including the closing segment from last point back to first
-                for (int i = 0; i < pts.Count; i++)
-                {
-                    int nextI = (i + 1) % pts.Count;  // Wrap around to close polygon
-                    int res = GetLineIntersection(
-                        pts[i].Easting,
-                        pts[i].Northing,
-                        pts[nextI].Easting,
-                        pts[nextI].Northing,
-                        eP, nP, eAB, nAB, ref iE, ref iN
-                    );
-
-                    if (res == 1)
-                    {
-                        var cClose = new TurnClosePoint();
-                        var closePt = cClose.ClosePt;
-                        closePt.Easting = iE;
-                        closePt.Northing = iN;
-
-                        double hed = Math.Atan2(pts[nextI].Easting - pts[i].Easting,
-                            pts[nextI].Northing - pts[i].Northing);
-                        if (hed < 0) hed += TWO_PI;
-                        closePt.Heading = hed;
-                        cClose.ClosePt = closePt;
-                        cClose.TurnLineNum = j;
-                        cClose.TurnLineIndex = i;
-
-                        turnClosestList.Add(new TurnClosePoint(cClose));
-                    }
-                }
-            }
-
-            // Determine closest point
-            double minDistance = double.MaxValue;
-
-            if (turnClosestList.Count > 0)
-            {
-                for (int i = 0; i < turnClosestList.Count; i++)
-                {
-                    double dist = ((fromPt.Easting - turnClosestList[i].ClosePt.Easting) * (fromPt.Easting - turnClosestList[i].ClosePt.Easting))
-                                    + ((fromPt.Northing - turnClosestList[i].ClosePt.Northing) * (fromPt.Northing - turnClosestList[i].ClosePt.Northing));
-
-                    if (minDistance >= dist)
-                    {
-                        minDistance = dist;
-                        closestTurnPt = new TurnClosePoint(turnClosestList[i]);
-                    }
-                }
-            }
         }
 
         private List<Vec3> MoveTurnInsideTurnLine(YouTurnCreationInput input, List<Vec3> uTurnList, double head, bool deleteSecondHalf, bool invertHeading)
@@ -1927,7 +1273,7 @@ namespace AgValoniaGPS.Services.YouTurn
 
         private bool AddCurveSequenceLines(YouTurnCreationInput input)
         {
-            // Calculate leg length - use direct LegLength if set, otherwise calculate
+            // Leg length in METRES (user's UTurnExtension, or a headland-derived default).
             double legLength;
             if (input.LegLength > 0)
             {
@@ -1936,153 +1282,80 @@ namespace AgValoniaGPS.Services.YouTurn
             else
             {
                 legLength = input.HeadlandWidth * input.YouTurnLegExtensionMultiplier;
-
                 double minLegLength = input.TurnRadius * 2.0;
                 if (legLength < minLegLength) legLength = minLegLength;
             }
 
-            // For curves, we add points from the curve itself
-            // Estimate how many curve points we need based on leg length and typical curve point spacing (~1m)
-            int numLegPoints = (int)(legLength / 1.0);
-            if (numLegPoints < 10) numLegPoints = 10;
-
             bool sameWay = input.IsHeadingSameWay;
-            int a = sameWay ? -1 : 1;
 
-            // Add entry leg points from the curve
-            for (int i = 0; i < numLegPoints; i++)
-            {
-                if (inClosestTurnPt.CurveIndex < 2 || inClosestTurnPt.CurveIndex > input.GuidancePoints.Count - 3)
-                {
-                    break;  // Stop if we run out of curve points
-                }
-                ytList.Insert(0, input.GuidancePoints[inClosestTurnPt.CurveIndex]);
-                inClosestTurnPt.CurveIndex += a;
-            }
+            // Entry leg: walk the current pass inward from the arc start for legLength METRES.
+            WalkLegByDistance(input.GuidancePoints, ytList[0], inClosestTurnPt.CurveIndex,
+                sameWay ? -1 : 1, legLength, insertFront: true);
 
-            if (isOutSameCurve) sameWay = !sameWay;
-            a = sameWay ? -1 : 1;
-
-            // Add exit leg points from the next curve
-            for (int i = 0; i < numLegPoints; i++)
-            {
-                if (outClosestTurnPt.CurveIndex < 2 || outClosestTurnPt.CurveIndex > nextCurve.Count - 3)
-                {
-                    break;  // Stop if we run out of curve points
-                }
-                ytList.Add(nextCurve[outClosestTurnPt.CurveIndex]);
-                outClosestTurnPt.CurveIndex += a;
-            }
+            // Exit leg: walk the destination pass outward from the arc end for legLength METRES.
+            bool outSameWay = isOutSameCurve ? !sameWay : sameWay;
+            WalkLegByDistance(nextCurve, ytList[ytList.Count - 1], outClosestTurnPt.CurveIndex,
+                outSameWay ? -1 : 1, legLength, insertFront: false);
 
             return true;
         }
 
-        private bool AddABSequenceLines(YouTurnCreationInput input)
+        /// <summary>
+        /// Appends/prepends points along <paramref name="points"/> starting at
+        /// <paramref name="start"/>/<paramref name="idx"/> until <paramref name="length"/>
+        /// METRES have been covered (interpolating the final point), then stops. Mirrors
+        /// AgOpen/Twol AddCurveSequenceLines: walks by accumulated DISTANCE, not a fixed point
+        /// count — so the leg is the right length regardless of curve point spacing (a 2 m
+        /// densified AB line and a 1 m curve both yield a legLength-metre leg). Stops cleanly
+        /// if it runs off the end rather than failing the whole turn.
+        /// </summary>
+        private void WalkLegByDistance(List<Vec3> points, Vec3 start, int idx, int step,
+            double length, bool insertFront)
         {
-            double inhead = input.ABHeading;
-            if (!input.IsHeadingSameWay) inhead += Math.PI;
-            if (inhead > TWO_PI) inhead -= TWO_PI;
-
-            // After a U-turn, exit direction is opposite to entry (180° turn)
-            // Unless isOutSameCurve, in which case we continue in same direction
-            double outhead = inhead + Math.PI;  // Default: opposite direction after U-turn
-            if (isOutSameCurve) outhead = inhead;  // Same direction if exiting same curve
-            if (outhead > TWO_PI) outhead -= TWO_PI;
-            if (outhead < 0) outhead += TWO_PI;
-
-            // Calculate leg length - use direct LegLength if set, otherwise calculate
-            double legLength;
-            if (input.LegLength > 0)
+            if (points == null || points.Count == 0) return;
+            double distSoFar = 0;
+            Vec3 point = start;
+            while (true)
             {
-                // User specified leg length directly (UTurnExtension setting)
-                legLength = input.LegLength;
-            }
-            else
-            {
-                // Fallback: calculate from headland width
-                legLength = input.HeadlandWidth * input.YouTurnLegExtensionMultiplier;
+                if (idx < 0 || idx >= points.Count) return; // ran off the end — stop the leg
+                double dE = point.Easting - points[idx].Easting;
+                double dN = point.Northing - points[idx].Northing;
+                double seg = Math.Sqrt(dE * dE + dN * dN);
 
-                // Ensure minimum leg length based on turn diameter
-                double minLegLength = input.TurnRadius * 2.0;
-                if (legLength < minLegLength) legLength = minLegLength;
-            }
-
-            // Use 1 meter spacing for leg points
-            double legPointSpacing = 1.0;
-            int numLegPoints = (int)(legLength / legPointSpacing);
-            if (numLegPoints < 10) numLegPoints = 10;  // Minimum 10 points (10 meters)
-
-            // Add entry leg (before the turn arc)
-            // Store the arc start point before we add entry leg points
-            Vec3 arcStart = ytList[0];
-            for (int a = 0; a < numLegPoints; a++)
-            {
-                Vec3 pt = new Vec3
+                if (distSoFar + seg > length)
                 {
-                    Easting = ytList[0].Easting - (Math.Sin(inhead) * legPointSpacing),
-                    Northing = ytList[0].Northing - (Math.Cos(inhead) * legPointSpacing),
-                    Heading = inhead
-                };
-                ytList.Insert(0, pt);
-            }
-
-            // The entry START point is now ytList[0] - this is in the cultivated area
-            Vec3 entryStart = ytList[0];
-
-            // Calculate the turn offset (perpendicular distance to next track)
-            // skip=0 means 1 width (adjacent), skip=1 means 2 widths, etc.
-            double turnOffset = (input.ToolWidth - input.ToolOverlap) * (input.RowSkipsWidth + 1)
-                + (input.IsTurnLeft ? -input.ToolOffset * 2.0 : input.ToolOffset * 2.0);
-
-            // Calculate perpendicular angle based on TRAVEL heading and turn direction
-            // The turn goes perpendicular to travel direction (left or right based on IsTurnLeft)
-            double perpAngle = inhead + (input.IsTurnLeft ? -PI_BY_2 : PI_BY_2);
-            if (perpAngle < 0) perpAngle += TWO_PI;
-            if (perpAngle > TWO_PI) perpAngle -= TWO_PI;
-
-            // The EXIT END point should be in the cultivated area on the NEXT track
-            // It's the entry start point offset perpendicular by the turn offset
-            double exitEndE = entryStart.Easting + Math.Sin(perpAngle) * turnOffset;
-            double exitEndN = entryStart.Northing + Math.Cos(perpAngle) * turnOffset;
-            Vec3 exitEnd = new Vec3 { Easting = exitEndE, Northing = exitEndN, Heading = outhead };
-
-            int count = ytList.Count;
-            Vec3 arcEnd = ytList[count - 1];  // Last point of arc
-
-            // Generate exit leg points going straight from arc end in outhead direction
-            // This ensures exit leg is parallel to entry leg
-            for (int i = 1; i <= numLegPoints; i++)
-            {
-                Vec3 pt = new Vec3
-                {
-                    Easting = arcEnd.Easting + Math.Sin(outhead) * i * legPointSpacing,
-                    Northing = arcEnd.Northing + Math.Cos(outhead) * i * legPointSpacing,
-                    Heading = outhead
-                };
-                ytList.Add(pt);
-            }
-
-            double distancePivotToTurnLine;
-            count = ytList.Count;
-            for (int i = 0; i < count; i += 2)
-            {
-                distancePivotToTurnLine = DistanceSquared(ytList[i], input.PivotPosition);
-                if (distancePivotToTurnLine <= 3)
-                {
-                    FailCreate();
-                    return false;
+                    double f = (length - distSoFar) / seg;
+                    var p = new Vec3(point.Easting - dE * f, point.Northing - dN * f, point.Heading);
+                    if (insertFront) ytList.Insert(0, p); else ytList.Add(p);
+                    return;
                 }
-            }
 
-            return true;
+                distSoFar += seg;
+                var q = new Vec3(points[idx].Easting, points[idx].Northing, points[idx].Heading);
+                if (insertFront) ytList.Insert(0, q); else ytList.Add(q);
+                point = points[idx];
+                idx += step;
+            }
         }
 
         private List<Vec3> BuildNewOffsetCurveList(YouTurnCreationInput input, double distAway)
         {
-            // This is a placeholder for building offset curves
-            // In full implementation, would offset the guidance curve by the specified distance
-            // For now, return copy of original guidance points
-            return new List<Vec3>(input.GuidancePoints);
+            // The destination pass for the exit leg. Mirrors AgOpen CABCurve.BuildNewOffsetList:
+            // always offset the BASE reference curve by distAway (which already folds in
+            // HowManyPathsAway/row-skips), NOT the current pass — offsetting the current pass
+            // would double-count the path-away offset.
+            var reference = input.ReferenceCurvePoints != null && input.ReferenceCurvePoints.Count > 1
+                ? input.ReferenceCurvePoints
+                : input.GuidancePoints;
+
+            if (reference == null || reference.Count < 2)
+                return new List<Vec3>();
+
+            // Offset the NON-extended base, then extend the result — same order as the current
+            // pass, so the exit leg's in-field portion matches the next guidance line exactly
+            // (seamless turn→track handoff) while the tangent extension lets the curve reach
+            // the arc end near the boundary.
+            return CurveProcessing.ExtendCurveEnds(CurveProcessing.CreateOffsetCurve(reference, distAway));
         }
 
         private void FindInnerTurnPoints(Vec3 fromPt, double heading, TurnClosePoint turnPt, bool isSameWay)
@@ -2223,108 +1496,6 @@ namespace AgValoniaGPS.Services.YouTurn
             }
 
             return closestTurnPt.TurnLineIndex != -1 && closestTurnPt.CurveIndex != -1;
-        }
-
-        private bool FindABOutTurnPoint(List<Vec3> nextCurve, TurnClosePoint inPt, bool isTurnLineSameWay)
-        {
-            int a = isTurnLineSameWay ? 1 : -1;
-            int turnLineIndex = inPt.TurnLineIndex;
-            int turnLineNum = inPt.TurnLineNum;
-            int stopTurnLineIndex = inPt.TurnLineIndex - a;
-
-            if (stopTurnLineIndex < 0) stopTurnLineIndex = _currentInput.BoundaryTurnLines[turnLineNum].Points.Count - 3;
-            if (stopTurnLineIndex > _currentInput.BoundaryTurnLines[turnLineNum].Points.Count - 1) turnLineIndex = 3;
-
-            for (; turnLineIndex != stopTurnLineIndex; turnLineIndex += a)
-            {
-                if (turnLineIndex < 0) turnLineIndex = _currentInput.BoundaryTurnLines[turnLineNum].Points.Count - 2;
-                if (turnLineIndex > _currentInput.BoundaryTurnLines[turnLineNum].Points.Count - 2) turnLineIndex = 0;
-
-                if (nextCurve.Count > 1)
-                {
-                    int res = GetLineIntersection(
-                        _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex].Easting,
-                        _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex].Northing,
-                        _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex + 1].Easting,
-                        _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex + 1].Northing,
-                        nextCurve[0].Easting,
-                        nextCurve[0].Northing,
-                        nextCurve[1].Easting,
-                        nextCurve[1].Northing,
-                        ref iE, ref iN);
-
-                    if (res == 1)
-                    {
-                        closestTurnPt = new TurnClosePoint();
-                        var closePt = closestTurnPt.ClosePt;
-                        closePt.Easting = iE;
-                        closePt.Northing = iN;
-                        closePt.Heading = _currentInput.ABHeading;
-                        closestTurnPt.ClosePt = closePt;
-                        closestTurnPt.TurnLineIndex = turnLineIndex;
-                        closestTurnPt.CurveIndex = -1;
-                        closestTurnPt.TurnLineHeading = _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex].Heading;
-                        closestTurnPt.TurnLineNum = turnLineNum;
-                        return true;
-                    }
-                }
-
-                // Calculate AB line endpoints for intersection
-                double abHead = _currentInput.ABHeading;
-                Vec3 ptA = new Vec3(_currentInput.ABReferencePoint.Easting - Math.Sin(abHead) * 2000,
-                                    _currentInput.ABReferencePoint.Northing - Math.Cos(abHead) * 2000, 0);
-                Vec3 ptB = new Vec3(_currentInput.ABReferencePoint.Easting + Math.Sin(abHead) * 2000,
-                                    _currentInput.ABReferencePoint.Northing + Math.Cos(abHead) * 2000, 0);
-
-                int res2 = GetLineIntersection(
-                    _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex].Easting,
-                    _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex].Northing,
-                    _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex + 1].Easting,
-                    _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex + 1].Northing,
-                    ptA.Easting,
-                    ptA.Northing,
-                    ptB.Easting,
-                    ptB.Northing,
-                    ref iE, ref iN);
-
-                if (res2 == 1)
-                {
-                    double hed;
-                    if (_currentInput.IsHeadingSameWay)
-                        hed = Math.Atan2(_currentInput.ABReferencePoint.Easting - iE, _currentInput.ABReferencePoint.Northing - iN);
-                    else
-                        hed = Math.Atan2(iE - _currentInput.ABReferencePoint.Easting, iN - _currentInput.ABReferencePoint.Northing);
-
-                    if (hed < 0) hed += TWO_PI;
-                    hed = Math.Round(hed, 3);
-                    double hedAB = Math.Round(_currentInput.ABHeading, 3);
-
-                    if (hed == hedAB)
-                    {
-                        return false; // Hitting the curve behind us
-                    }
-                    else if (turnLineIndex == inPt.TurnLineIndex)
-                    {
-                        // Do nothing - hitting the curve at the same place as in
-                    }
-                    else
-                    {
-                        closestTurnPt = new TurnClosePoint();
-                        var closePt = closestTurnPt.ClosePt;
-                        closePt.Easting = iE;
-                        closePt.Northing = iN;
-                        closePt.Heading = _currentInput.ABHeading;
-                        closestTurnPt.ClosePt = closePt;
-                        closestTurnPt.TurnLineIndex = turnLineIndex;
-                        closestTurnPt.CurveIndex = -1;
-                        closestTurnPt.TurnLineHeading = _currentInput.BoundaryTurnLines[turnLineNum].Points[turnLineIndex].Heading;
-                        closestTurnPt.TurnLineNum = turnLineNum;
-                        isOutSameCurve = true;
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
 
         #endregion

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnPathingService.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnPathingService.cs
@@ -88,7 +88,9 @@ public sealed class YouTurnPathingService
         int nextPathsAway = guidance.HowManyPathsAway + offsetChange;
 
         double widthMinusOverlap = config.ActualToolWidth - config.Tool.Overlap;
-        double nextDistAway = widthMinusOverlap * nextPathsAway;
+        // Include the nudge so the cyan next-track line matches the U-turn exit leg and the
+        // line the tractor steers after completion exactly (all use base*pathsAway + nudge).
+        double nextDistAway = widthMinusOverlap * nextPathsAway + guidance.NudgeOffset;
 
         // Authoritative perpendicular width for the U-turn arc — direction lives in IsTurnLeft.
         turn.NextTrackTurnOffset = Math.Abs(pathsToMove * widthMinusOverlap);
@@ -107,7 +109,13 @@ public sealed class YouTurnPathingService
         }
         else
         {
-            var offsetPoints = CurveProcessing.CreateOffsetCurve(referenceTrack.Points, nextDistAway);
+            // Offset then EXTEND the ends — same order as the U-turn exit leg
+            // (BuildNewOffsetCurveList) and the post-turn active line — so the cyan
+            // next-track curve reaches the exit leg's end (no gap) and is the same
+            // length as the magenta line that replaces it after the turn completes.
+            // ExtendCurveEnds is a no-op on closed loops.
+            var offsetPoints = CurveProcessing.ExtendCurveEnds(
+                CurveProcessing.CreateOffsetCurve(referenceTrack.Points, nextDistAway));
             nextTrack = Models.Track.Track.FromCurve($"Path {nextPathsAway}", offsetPoints, referenceTrack.IsClosed);
         }
         nextTrack.IsActive = false;

--- a/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
+++ b/Shared/AgValoniaGPS.Services/YouTurn/YouTurnStateMachine.cs
@@ -552,7 +552,11 @@ public sealed class YouTurnStateMachine
         }
         else
         {
-            var offsetPoints = CurveProcessing.CreateOffsetCurve(track.Points, nextDistAway);
+            // Offset then EXTEND the ends so the cyan next-track curve matches the
+            // exit leg and the post-turn magenta line (no gap at the exit handoff).
+            // Mirrors YouTurnPathingService.ComputeNextTrack; no-op on closed loops.
+            var offsetPoints = CurveProcessing.ExtendCurveEnds(
+                CurveProcessing.CreateOffsetCurve(track.Points, nextDistAway));
             turn.NextTrack = Models.Track.Track.FromCurve($"Path {nextPath.Value}", offsetPoints, track.IsClosed);
         }
         turn.NextTrack.IsActive = false;

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurn/ClosedLoopEntryTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurn/ClosedLoopEntryTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.Pipeline;
+using AgValoniaGPS.Models.YouTurn;
+using AgValoniaGPS.Services.Geometry;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Services.Tests.YouTurn;
+
+/// <summary>
+/// Closed-loop steering sim of the APPROACH→TURN handoff (the e2e test teleports along
+/// the path, so it can't see a steering transient). Drives a bicycle model: straight
+/// approach along the pass, then once the state machine triggers, steer with the real
+/// YouTurnGuidanceService each 10 Hz cycle. Asserts the entry handoff doesn't slam the
+/// wheels / oscillate (the operator's "gets lost & wiggles for ½ s entering the turn").
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class ClosedLoopEntryTests
+{
+    private const double Dt = 0.1;            // 10 Hz
+    private const double SpeedMs = 2.78;      // ~10 km/h
+    private const double Wheelbase = 2.5;
+
+    [Test]
+    public void EntryHandoff_NoSteeringSpike()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var c = ConfigurationStore.Instance;
+        c.Vehicle.Wheelbase = Wheelbase;
+        c.Vehicle.MaxSteerAngle = 35;
+        c.Tool.Overlap = 0;
+        c.NumSections = 1;
+        c.Tool.SetSectionWidth(0, 600); // 6 m
+        c.Guidance.UTurnRadius = 8.0;
+        c.Guidance.UTurnExtension = 16.0;
+        c.Guidance.UTurnDistanceFromBoundary = 2.0;
+        c.Guidance.UTurnStyle = 2;
+
+        var offset = new PolygonOffsetService();
+        var creation = new YouTurnCreationService(NullLogger<YouTurnCreationService>.Instance, offset);
+        var pathing = new YouTurnPathingService(NullLogger<YouTurnPathingService>.Instance);
+        var sm = new YouTurnStateMachine(creation, pathing, NullLogger<YouTurnStateMachine>.Instance);
+        var guidance = new YouTurnGuidanceService();
+        var trackGuidance = new AgValoniaGPS.Services.Track.TrackGuidanceService();
+
+        var boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = new List<Vec2> { new(-50, -50), new(50, -50), new(50, 50), new(-50, 50) }
+                    .Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+            },
+        };
+        var headland = new List<Vec3> { new(-40, -40, 0), new(40, -40, 0), new(40, 40, 0), new(-40, 40, 0) };
+
+        // Gentle CURVE that ENDS at the field edge (y=45, inside boundary ±50) — the
+        // operator's case, where the goal-point tangent projection is active on final
+        // approach. Points every 2 m + headings.
+        var curve = new List<Vec3>();
+        for (double y = -45; y <= 24 + 1e-9; y += 2.0)
+            curve.Add(new Vec3(8.0 * Math.Sin(y / 60.0), y, 0));
+        for (int k = 0; k < curve.Count - 1; k++)
+        {
+            double dE = curve[k + 1].Easting - curve[k].Easting, dN = curve[k + 1].Northing - curve[k].Northing;
+            double h = Math.Atan2(dE, dN); if (h < 0) h += Math.PI * 2;
+            curve[k] = new Vec3(curve[k].Easting, curve[k].Northing, h);
+        }
+        curve[^1] = new Vec3(curve[^1].Easting, curve[^1].Northing, curve[^2].Heading);
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        // Walk the curve by arc length for a clean on-curve approach.
+        (Vec2 pos, double head) WalkCurve(double dist)
+        {
+            double traveled = 0;
+            for (int k = 1; k < curve.Count; k++)
+            {
+                double dE = curve[k].Easting - curve[k - 1].Easting, dN = curve[k].Northing - curve[k - 1].Northing;
+                double seg = Math.Sqrt(dE * dE + dN * dN);
+                if (traveled + seg >= dist)
+                {
+                    double f = (dist - traveled) / seg;
+                    return (new Vec2(curve[k - 1].Easting + dE * f, curve[k - 1].Northing + dN * f),
+                            Math.Atan2(dE, dN) < 0 ? Math.Atan2(dE, dN) + Math.PI * 2 : Math.Atan2(dE, dN));
+                }
+                traveled += seg;
+            }
+            return (new Vec2(curve[^1].Easting, curve[^1].Northing), curve[^1].Heading);
+        }
+
+        var gState = new GuidanceWorkingState();
+        var tState = new YouTurnWorkingState { IsEnabled = true };
+
+        // Start ~35 m of arc from the curve start (y=-45) → ≈ y=-10, well before the
+        // y=40 headland. Closed loop with a bicycle model the whole way.
+        var (pivot, heading) = WalkCurve(20.0);
+        double speedKmh = SpeedMs * 3.6;
+        double LookAhead()
+        {
+            double la = c.Guidance.GoalPointLookAheadHold;
+            if (speedKmh > 1)
+                la = Math.Max(c.Guidance.MinLookAheadDistance,
+                    c.Guidance.GoalPointLookAheadHold + speedKmh * c.Guidance.GoalPointLookAheadMult * 0.1);
+            return la;
+        }
+
+        var samples = new List<(string phase, double steer, double y)>();
+        int executingCount = 0;
+
+        for (int i = 0; i < 600; i++)
+        {
+            var pos = new Position { Easting = pivot.Easting, Northing = pivot.Northing, Heading = heading * 180 / Math.PI, Speed = SpeedMs };
+            var ctx = new YouTurnStateMachine.TickContext(pos, track, boundary, headland,
+                UTurnSkipRows: 0, IsSkipWorkedMode: false, HeadlandCalculatedWidth: 10.0, HeadlandDistance: 5.0);
+            tState.YouTurnCounter++;
+            sm.Tick(in ctx, gState, tState);
+
+            bool executing = tState.IsExecuting && tState.TurnPath != null && tState.TurnPath.Count > 2;
+            double steerDeg;
+
+            if (executing)
+            {
+                var gin = new YouTurnGuidanceInput
+                {
+                    TurnPath = tState.TurnPath!,
+                    PivotPosition = new Vec3(pivot.Easting, pivot.Northing, heading),
+                    SteerPosition = new Vec3(pivot.Easting + Math.Sin(heading) * Wheelbase,
+                                             pivot.Northing + Math.Cos(heading) * Wheelbase, heading),
+                    Wheelbase = Wheelbase, MaxSteerAngle = 35, UseStanley = false,
+                    GoalPointDistance = LookAhead(), UTurnCompensation = c.Guidance.UTurnCompensation,
+                    FixHeading = heading, AvgSpeed = speedKmh, IsReverse = false, UTurnStyle = 0,
+                };
+                var gout = guidance.CalculateGuidance(gin);
+                if (gout.IsTurnComplete) break;
+                steerDeg = gout.SteerAngle;
+                samples.Add(("turn", steerDeg, pivot.Northing));
+                if (++executingCount > 12) break;
+            }
+            else
+            {
+                var tin = new Models.Track.TrackGuidanceInput
+                {
+                    Track = track,
+                    PivotPosition = new Vec3(pivot.Easting, pivot.Northing, heading),
+                    SteerPosition = new Vec3(pivot.Easting + Math.Sin(heading) * Wheelbase,
+                                             pivot.Northing + Math.Cos(heading) * Wheelbase, heading),
+                    UseStanley = false, Wheelbase = Wheelbase, MaxSteerAngle = 35,
+                    GoalPointDistance = LookAhead(), IsHeadingSameWay = true, FixHeading = heading,
+                };
+                var tout = trackGuidance.CalculateGuidance(tin);
+                steerDeg = tout.SteerAngle;
+                samples.Add(("approach", steerDeg, pivot.Northing));
+            }
+
+            double steerRad = steerDeg * Math.PI / 180.0;
+            heading += (SpeedMs / Wheelbase) * Math.Tan(steerRad) * Dt;
+            pivot = new Vec2(pivot.Easting + SpeedMs * Dt * Math.Sin(heading),
+                             pivot.Northing + SpeedMs * Dt * Math.Cos(heading));
+        }
+
+        Assert.That(samples.Any(s => s.phase == "turn"), "turn never executed");
+
+        // Window around the handoff: the last ~12 approach cycles + the turn cycles.
+        int firstTurn = samples.FindIndex(s => s.phase == "turn");
+        int from = Math.Max(0, firstTurn - 12);
+        var window = samples.GetRange(from, samples.Count - from);
+        TestContext.WriteLine("handoff window (phase steer@y):");
+        foreach (var s in window) TestContext.WriteLine($"  {s.phase} {s.steer,7:F1}° @ y={s.y:F1}");
+
+        double maxAbs = window.Select(s => Math.Abs(s.steer)).DefaultIfEmpty(0).Max();
+        Assert.That(maxAbs, Is.LessThan(15.0),
+            $"steering hit {maxAbs:F0}° around the turn entry — the approach/handoff glitch");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurn/CurveTurnAlignmentTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurn/CurveTurnAlignmentTests.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.Guidance;
+using AgValoniaGPS.Models.Pipeline;
+using AgValoniaGPS.Services.Geometry;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Services.Tests.YouTurn;
+
+/// <summary>
+/// Local repro for the curved-AB U-turn work. Verifies the curve generator
+/// actually RUNS (not the straight SimpleFallback) and that the entry/exit legs
+/// lie on the real offset passes — at BOTH field ends (heading same way and
+/// opposite). Lets us iterate the geometry without a device.
+/// </summary>
+[TestFixture]
+public class CurveTurnAlignmentTests
+{
+    private YouTurnCreationService _creation = null!;
+    private CaptureLogger _log = null!;
+
+    private sealed class CaptureLogger : ILogger<YouTurnCreationService>
+    {
+        public readonly List<string> Messages = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? ex,
+            Func<TState, Exception?, string> formatter) => Messages.Add($"{logLevel}: {formatter(state, ex)}");
+        private sealed class NullScope : IDisposable { public static readonly NullScope Instance = new(); public void Dispose() { } }
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var c = ConfigurationStore.Instance;
+        c.Tool.Overlap = 0;
+        c.NumSections = 1;
+        c.Tool.SetSectionWidth(0, 800); // 8 m implement -> ActualToolWidth = 8
+        c.Guidance.UTurnDistanceFromBoundary = 1.0;
+        c.Guidance.UTurnRadius = 4.0;
+        c.Guidance.UTurnSmoothing = 3;
+        c.Guidance.UTurnExtension = 10;
+        c.Guidance.UTurnStyle = 0; // Albin/omega
+
+        _log = new CaptureLogger();
+        _creation = new YouTurnCreationService(_log, new PolygonOffsetService());
+    }
+
+    // A gentle S-ish curve running south->north, points every 2 m, with headings.
+    private static List<Vec3> CurvePoints(double yStart, double yEnd)
+    {
+        var pts = new List<Vec3>();
+        for (double y = yStart; y <= yEnd + 1e-9; y += 2.0)
+        {
+            double x = 8.0 * Math.Sin(y / 60.0); // curves in x
+            pts.Add(new Vec3(x, y, 0));
+        }
+        // headings = atan2(dE, dN) toward the next point
+        for (int i = 0; i < pts.Count - 1; i++)
+        {
+            double dE = pts[i + 1].Easting - pts[i].Easting;
+            double dN = pts[i + 1].Northing - pts[i].Northing;
+            double h = Math.Atan2(dE, dN);
+            if (h < 0) h += Math.PI * 2;
+            pts[i] = new Vec3(pts[i].Easting, pts[i].Northing, h);
+        }
+        pts[^1] = new Vec3(pts[^1].Easting, pts[^1].Northing, pts[^2].Heading);
+        return pts;
+    }
+
+    private static Boundary Square() => new()
+    {
+        OuterBoundary = new BoundaryPolygon
+        {
+            Points = new List<Vec2> { new(-50, -50), new(50, -50), new(50, 50), new(-50, 50) }
+                .Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+            IsHard = false
+        }
+    };
+
+    private static List<Vec3> HeadlandSquare() => new()
+    {
+        new(-40, -40, 0), new(40, -40, 0), new(40, 40, 0), new(-40, 40, 0)
+    };
+
+    // A wavy (non-straight) closed boundary so the turn boundary the arc seats against
+    // is itself curved — probes whether the turn generalises beyond straight field edges.
+    private static List<Vec2> WavyRing(double radius)
+    {
+        var pts = new List<Vec2>();
+        for (int deg = 0; deg < 360; deg += 6)
+        {
+            double a = deg * Math.PI / 180.0;
+            double r = radius + 6.0 * Math.Sin(3 * a); // lobed, not a plain circle
+            pts.Add(new Vec2(r * Math.Sin(a), r * Math.Cos(a)));
+        }
+        return pts;
+    }
+
+    private static Boundary WavyBoundary() => new()
+    {
+        OuterBoundary = new BoundaryPolygon
+        {
+            Points = WavyRing(50).Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+            IsHard = false
+        }
+    };
+
+    private static List<Vec3> WavyHeadland() =>
+        WavyRing(40).Select(p => new Vec3(p.Easting, p.Northing, 0)).ToList();
+
+    private static double PerpDistToPolyline(List<Vec3> line, double e, double n)
+    {
+        double best = double.MaxValue;
+        for (int i = 0; i < line.Count - 1; i++)
+        {
+            double d = GeometryMath.PointToSegmentDistance(
+                e, n, line[i].Easting, line[i].Northing, line[i + 1].Easting, line[i + 1].Northing);
+            if (d < best) best = d;
+        }
+        return best;
+    }
+
+    // Curve EXTENDS past the boundary (y -100..100, boundary ±50): the generator
+    // should find the boundary crossing and produce a real curve turn (no fallback).
+    [Test]
+    public void NorthEnd_CurveCrossesBoundary_RunsCurvePath_NotFallback()
+    {
+        var curve = CurvePoints(-100, 100);
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        // vehicle near the north headland, on the curve, heading north (same way)
+        var near = curve.First(p => p.Northing >= 38);
+        var pos = new Position { Easting = near.Easting, Northing = near.Northing };
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = true, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        var result = _creation.CreateTurnPath(
+            pos, track, headingRadians: near.Heading, abHeading: near.Heading,
+            Square(), HeadlandSquare(), guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10), "should plot a turn");
+        Assert.That(result.UsedFallback, Is.False,
+            "curve crosses the boundary, so the curve generator should run — NOT the straight fallback");
+
+        // The entry leg (first ~5 m of the path) must lie on the current pass (the base curve).
+        double maxEntryDist = 0;
+        for (int i = 0; i < Math.Min(5, result.Path!.Count); i++)
+            maxEntryDist = Math.Max(maxEntryDist, PerpDistToPolyline(curve, result.Path[i].Easting, result.Path[i].Northing));
+        Assert.That(maxEntryDist, Is.LessThan(0.3),
+            $"entry leg should lie on the current curved pass (max perp dist {maxEntryDist:F2} m)");
+    }
+
+    [Test]
+    public void SouthEnd_CurveCrossesBoundary_RunsCurvePath_NotFallback()
+    {
+        var curve = CurvePoints(-100, 100);
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        // vehicle near the south headland, heading south (opposite way)
+        var near = curve.First(p => p.Northing >= -38);
+        var pos = new Position { Easting = near.Easting, Northing = near.Northing };
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = false, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        double southHeading = near.Heading + Math.PI;
+        var result = _creation.CreateTurnPath(
+            pos, track, headingRadians: southHeading, abHeading: near.Heading,
+            Square(), HeadlandSquare(), guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10), "should plot a turn");
+        Assert.That(result.UsedFallback, Is.False,
+            "curve crosses the boundary, so the curve generator should run — NOT the straight fallback");
+
+        double maxEntryDist = 0;
+        for (int i = 0; i < Math.Min(5, result.Path!.Count); i++)
+            maxEntryDist = Math.Max(maxEntryDist, PerpDistToPolyline(curve, result.Path[i].Easting, result.Path[i].Northing));
+        Assert.That(maxEntryDist, Is.LessThan(0.3),
+            $"entry leg should lie on the current curved pass (max perp dist {maxEntryDist:F2} m)");
+    }
+
+    // Curve ENDS inside the field (y -45..45, turn boundary ±49): the recorded curve
+    // never crosses the turn boundary, so today the generator fails and the orchestration
+    // drops to the straight SimpleFallback — the misaligned turn the operator sees. These
+    // two tests reproduce that and should turn GREEN once the curve is made to reach the
+    // boundary (and stay aligned at BOTH ends).
+    // style: 0 = Albin/omega, 2 = Sagitta (the operator's style). Both must run the
+    // curve generator (not the fallback) AND keep the entry leg on the current pass,
+    // at BOTH field ends, even when the recorded curve ends at the field edge.
+    [TestCase(true, 0, TestName = "NorthEnd_FieldEdge_Omega")]
+    [TestCase(false, 0, TestName = "SouthEnd_FieldEdge_Omega")]
+    [TestCase(true, 2, TestName = "NorthEnd_FieldEdge_Sagitta")]
+    [TestCase(false, 2, TestName = "SouthEnd_FieldEdge_Sagitta")]
+    public void CurveEndsAtFieldEdge_RunsCurvePath_Aligned(bool sameWay, int style)
+    {
+        ConfigurationStore.Instance.Guidance.UTurnStyle = style;
+
+        var curve = CurvePoints(-45, 45);
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        var near = curve.First(p => p.Northing >= 0);
+        var pos = new Position { Easting = near.Easting, Northing = near.Northing };
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = sameWay, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        double heading = sameWay ? near.Heading : near.Heading + Math.PI;
+        var result = _creation.CreateTurnPath(
+            pos, track, headingRadians: heading, abHeading: near.Heading,
+            Square(), HeadlandSquare(), guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+
+        foreach (var m in _log.Messages.Where(m => m.Contains("[YouTurn]"))) TestContext.WriteLine(m);
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10), "should plot a turn");
+        Assert.That(result.UsedFallback, Is.False,
+            "even when the curve ends at the field edge, the curve generator should run (not the straight fallback)");
+
+        double maxEntryDist = 0;
+        for (int i = 0; i < Math.Min(5, result.Path!.Count); i++)
+            maxEntryDist = Math.Max(maxEntryDist, PerpDistToPolyline(curve, result.Path[i].Easting, result.Path[i].Northing));
+        Assert.That(maxEntryDist, Is.LessThan(0.3),
+            $"entry leg should lie on the current curved pass (max perp dist {maxEntryDist:F2} m)");
+    }
+
+    // The cyan NextTrack curve must be offset-then-EXTENDED exactly like the U-turn
+    // exit leg (BuildNewOffsetCurveList) and the post-turn magenta line, so the green
+    // exit leg lands on it with no gap. Regression for the exit-side gap the operator
+    // saw: the cyan next-track curve was the bare offset (only as long as the recorded
+    // pass), so it stopped short of the exit leg's end — and the magenta line that
+    // replaced it after the turn was longer.
+    [Test]
+    public void NextTrackCurve_IsExtended_ToMeetExitLeg()
+    {
+        var curve = CurvePoints(-45, 45); // recorded pass spans y in [-45, 45]
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        var pathing = new YouTurnPathingService(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<YouTurnPathingService>.Instance);
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = true, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        pathing.ComputeNextTrack(track, abHeading: 0, guidance, turn,
+            uTurnSkipRows: 0, isSkipWorkedMode: false, selectedTrack: null);
+
+        Assert.That(turn.NextTrack, Is.Not.Null, "next track should be computed");
+        var pts = turn.NextTrack!.Points;
+        double maxN = pts.Max(p => p.Northing);
+        double minN = pts.Min(p => p.Northing);
+
+        // A bare (non-extended) offset of the recorded pass also spans ~[-45, 45]; the
+        // extended curve must reach well past BOTH ends so the exit leg meets the cyan line.
+        Assert.That(maxN, Is.GreaterThan(60),
+            $"cyan NextTrack curve should extend past the north field edge (max N {maxN:F1} m)");
+        Assert.That(minN, Is.LessThan(-60),
+            $"cyan NextTrack curve should extend past the south field edge (min N {minN:F1} m)");
+    }
+
+    // The EXIT leg must lie on the cyan/post-turn next pass (basePoints offset by the
+    // pass-number distance) — the line the tractor actually drives after completion.
+    // Reproduces the lateral offset the operator saw: cyan ~1 m off the green exit leg.
+    [TestCase(true, 0, TestName = "ExitLeg_OnNextPass_North_Omega")]
+    [TestCase(false, 0, TestName = "ExitLeg_OnNextPass_South_Omega")]
+    [TestCase(true, 2, TestName = "ExitLeg_OnNextPass_North_Sagitta")]
+    [TestCase(false, 2, TestName = "ExitLeg_OnNextPass_South_Sagitta")]
+    [TestCase(true, 0, 0.5, TestName = "ExitLeg_OnNextPass_North_Omega_ToolOffset")]
+    [TestCase(false, 0, 0.5, TestName = "ExitLeg_OnNextPass_South_Omega_ToolOffset")]
+    [TestCase(true, 2, 0.5, TestName = "ExitLeg_OnNextPass_North_Sagitta_ToolOffset")]
+    [TestCase(false, 2, 0.5, TestName = "ExitLeg_OnNextPass_South_Sagitta_ToolOffset")]
+    public void ExitLeg_LiesOnNextPass(bool sameWay, int style, double toolOffset = 0.0)
+    {
+        ConfigurationStore.Instance.Guidance.UTurnStyle = style;
+        ConfigurationStore.Instance.Tool.Offset = toolOffset;
+
+        var curve = CurvePoints(-100, 100);
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        var near = curve.First(p => p.Northing >= 38);
+        var pos = new Position { Easting = near.Easting, Northing = near.Northing };
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = sameWay, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        // The post-turn / cyan pass: basePoints offset by the pass-number distance.
+        double width = ConfigurationStore.Instance.ActualToolWidth - ConfigurationStore.Instance.Tool.Overlap;
+        bool positiveOffset = turn.IsTurnLeft ^ guidance.IsHeadingSameWay;
+        int offsetChange = positiveOffset ? 1 : -1; // skip 0 -> move 1 pass
+        double nextDistAway = width * (guidance.HowManyPathsAway + offsetChange);
+        var nextPass = CurveProcessing.ExtendCurveEnds(CurveProcessing.CreateOffsetCurve(curve, nextDistAway));
+
+        double heading = sameWay ? near.Heading : near.Heading + Math.PI;
+        var result = _creation.CreateTurnPath(
+            pos, track, headingRadians: heading, abHeading: near.Heading,
+            Square(), HeadlandSquare(), guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10), "should plot a turn");
+        Assert.That(result.UsedFallback, Is.False, "curve generator should run");
+
+        var path = result.Path!;
+        // Exit leg = last few points of the turn path.
+        double maxExitDist = 0;
+        for (int i = Math.Max(0, path.Count - 5); i < path.Count; i++)
+            maxExitDist = Math.Max(maxExitDist, PerpDistToPolyline(nextPass, path[i].Easting, path[i].Northing));
+        TestContext.Out.WriteLine($"max exit-leg perp dist to cyan/next pass = {maxExitDist:F3} m");
+
+        Assert.That(maxExitDist, Is.LessThan(0.3),
+            $"exit leg should lie on the cyan/post-turn next pass (max perp dist {maxExitDist:F2} m)");
+    }
+
+    // Recorded curve ends WELL INSIDE the field (y -30..30, headland ±40, boundary ±50)
+    // so the whole turn region sits on the ExtendCurveEnds extension — like the operator's
+    // real field (curve ends ~16 m before the headland). The exit leg must still land on
+    // the cyan/pass-number next pass.
+    // The NOISY variant perturbs the recorded curve's end-point heading (the value the old
+    // SignedPerpDistanceToCurve latched onto out on the extension). That projection skewed
+    // the exit offset by metres (~4 m at 20°) — the operator's lateral exit shift. The
+    // pass-number offset is immune because it never measures the arc end.
+    [TestCase(true, 0, 0.0, TestName = "ExitLeg_CurveEndsInside_North_Omega")]
+    [TestCase(false, 0, 0.0, TestName = "ExitLeg_CurveEndsInside_South_Omega")]
+    [TestCase(true, 2, 0.0, TestName = "ExitLeg_CurveEndsInside_North_Sagitta")]
+    [TestCase(false, 2, 0.0, TestName = "ExitLeg_CurveEndsInside_South_Sagitta")]
+    [TestCase(true, 0, 20.0, TestName = "ExitLeg_NoisyEnd_North_Omega")]
+    [TestCase(false, 0, 20.0, TestName = "ExitLeg_NoisyEnd_South_Omega")]
+    [TestCase(true, 2, 20.0, TestName = "ExitLeg_NoisyEnd_North_Sagitta")]
+    [TestCase(false, 2, 20.0, TestName = "ExitLeg_NoisyEnd_South_Sagitta")]
+    public void ExitLeg_CurveEndsInside_LandsOnNextPass(bool sameWay, int style, double endHeadingNoiseDeg)
+    {
+        ConfigurationStore.Instance.Guidance.UTurnStyle = style;
+
+        var curve = CurvePoints(-30, 30); // ends 10 m short of the headland, 20 m short of boundary
+        if (endHeadingNoiseDeg != 0.0)
+        {
+            double noise = endHeadingNoiseDeg * Math.PI / 180.0;
+            curve[0] = new Vec3(curve[0].Easting, curve[0].Northing, curve[0].Heading + noise);
+            curve[^1] = new Vec3(curve[^1].Easting, curve[^1].Northing, curve[^1].Heading + noise);
+        }
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        var near = curve.First(p => p.Northing >= 28);
+        var pos = new Position { Easting = near.Easting, Northing = near.Northing };
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = sameWay, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        double width = ConfigurationStore.Instance.ActualToolWidth - ConfigurationStore.Instance.Tool.Overlap;
+        bool positiveOffset = turn.IsTurnLeft ^ guidance.IsHeadingSameWay;
+        int offsetChange = positiveOffset ? 1 : -1;
+        double nextDistAway = width * (guidance.HowManyPathsAway + offsetChange);
+        var cyan = CurveProcessing.ExtendCurveEnds(CurveProcessing.CreateOffsetCurve(curve, nextDistAway));
+
+        double heading = sameWay ? near.Heading : near.Heading + Math.PI;
+        var result = _creation.CreateTurnPath(
+            pos, track, headingRadians: heading, abHeading: near.Heading,
+            Square(), HeadlandSquare(), guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10), "should plot a turn");
+        Assert.That(result.UsedFallback, Is.False, "curve generator should run");
+
+        var path = result.Path!;
+        double exitToCyan = 0;
+        for (int i = Math.Max(0, path.Count - 5); i < path.Count; i++)
+            exitToCyan = Math.Max(exitToCyan, PerpDistToPolyline(cyan, path[i].Easting, path[i].Northing));
+        TestContext.Out.WriteLine($"noise={endHeadingNoiseDeg}deg: max exit-leg -> cyan(pass-number) = {exitToCyan:F3} m");
+
+        Assert.That(exitToCyan, Is.LessThan(0.3),
+            $"exit leg must lie on the cyan/post-turn next pass regardless of recorded-curve end noise (was {exitToCyan:F2} m)");
+    }
+
+    // Curved track meeting a CURVED (wavy/lobed) boundary, both ends, both styles.
+    // The arc seats against a curved turn boundary instead of a straight field edge.
+    [TestCase(true, 0, TestName = "North_CurvedBoundary_Omega")]
+    [TestCase(false, 0, TestName = "South_CurvedBoundary_Omega")]
+    [TestCase(true, 2, TestName = "North_CurvedBoundary_Sagitta")]
+    [TestCase(false, 2, TestName = "South_CurvedBoundary_Sagitta")]
+    public void CurvedTrack_MeetsCurvedBoundary_RunsCurvePath_Aligned(bool sameWay, int style)
+    {
+        ConfigurationStore.Instance.Guidance.UTurnStyle = style;
+
+        var curve = CurvePoints(-45, 45);
+        var track = Models.Track.Track.FromCurve("c", curve);
+
+        var near = curve.First(p => p.Northing >= 0);
+        var pos = new Position { Easting = near.Easting, Northing = near.Northing };
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = sameWay, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        double heading = sameWay ? near.Heading : near.Heading + Math.PI;
+        var result = _creation.CreateTurnPath(
+            pos, track, headingRadians: heading, abHeading: near.Heading,
+            WavyBoundary(), WavyHeadland(), guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+
+        foreach (var m in _log.Messages.Where(m => m.Contains("[YouTurn]"))) TestContext.WriteLine(m);
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10), "should plot a turn");
+        Assert.That(result.UsedFallback, Is.False,
+            "a curved boundary should still drive the curve generator, not the straight fallback");
+
+        double maxEntryDist = 0;
+        for (int i = 0; i < Math.Min(5, result.Path!.Count); i++)
+            maxEntryDist = Math.Max(maxEntryDist, PerpDistToPolyline(curve, result.Path[i].Easting, result.Path[i].Northing));
+        Assert.That(maxEntryDist, Is.LessThan(0.3),
+            $"entry leg should lie on the current curved pass (max perp dist {maxEntryDist:F2} m)");
+    }
+}

--- a/Tests/AgValoniaGPS.Services.Tests/YouTurn/CurveTurnRobustnessTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/YouTurn/CurveTurnRobustnessTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using AgValoniaGPS.Models;
+using AgValoniaGPS.Models.Base;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.Pipeline;
+using AgValoniaGPS.Services.Geometry;
+using AgValoniaGPS.Services.YouTurn;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.Services.Tests.YouTurn;
+
+/// <summary>
+/// Robustness matrix for U-turn generation: boundary shape (straight / convex /
+/// concave) × approach angle (90°..30°) × track type (curve vs 2-point AB) × turn
+/// style (omega / sagitta). Each case must run the real generator (not the straight
+/// SimpleFallback) and keep the entry leg on the current pass.
+///
+/// Geometry: a wide field whose TOP edge carries a centred bump (none/up/down). The
+/// track passes through the edge crossing point at heading φ = 90° − θ, so it meets
+/// the (locally horizontal) edge at angle θ. The track ENDS a few metres short of the
+/// edge (the hard "curve stops at the field edge" case).
+/// </summary>
+[TestFixture]
+public class CurveTurnRobustnessTests
+{
+    public enum Shape { Straight, Convex, Concave }
+
+    private YouTurnCreationService _creation = null!;
+    private PolygonOffsetService _offset = null!;
+    private CaptureLogger _log = null!;
+
+    private sealed class CaptureLogger : ILogger<YouTurnCreationService>
+    {
+        public readonly List<string> Messages = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? ex,
+            Func<TState, Exception?, string> formatter) => Messages.Add($"{logLevel}: {formatter(state, ex)}");
+        private sealed class NullScope : IDisposable { public static readonly NullScope Instance = new(); public void Dispose() { } }
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        ConfigurationStore.SetInstance(new ConfigurationStore());
+        var c = ConfigurationStore.Instance;
+        c.Tool.Overlap = 0;
+        c.NumSections = 1;
+        c.Tool.SetSectionWidth(0, 800); // 8 m
+        c.Guidance.UTurnDistanceFromBoundary = 1.0;
+        c.Guidance.UTurnRadius = 4.0;
+        c.Guidance.UTurnSmoothing = 3;
+        c.Guidance.UTurnExtension = 10;
+
+        _offset = new PolygonOffsetService();
+        _log = new CaptureLogger();
+        _creation = new YouTurnCreationService(_log, _offset);
+    }
+
+    private const double EdgeBase = 50.0;
+    private static double Bump(Shape shape, double x)
+    {
+        double g = 10.0 * Math.Exp(-(x / 25.0) * (x / 25.0)); // centred at x=0, zero slope there
+        return shape switch { Shape.Convex => g, Shape.Concave => -g, _ => 0.0 };
+    }
+
+    private (Boundary boundary, List<Vec3> headland, double crossY) MakeField(Shape shape)
+    {
+        const double W = 120, yBot = -80;
+        var pts = new List<Vec2> { new(-W, yBot), new(W, yBot) };
+        for (double x = W; x >= -W - 1e-9; x -= 4.0)
+            pts.Add(new Vec2(x, EdgeBase + Bump(shape, x)));
+
+        var boundary = new Boundary
+        {
+            OuterBoundary = new BoundaryPolygon
+            {
+                Points = pts.Select(p => new BoundaryPoint(p.Easting, p.Northing, 0)).ToList(),
+                IsHard = false
+            }
+        };
+
+        var inset = _offset.CreateInwardOffset(pts, 10.0) ?? pts;
+        var headland = _offset.CalculatePointHeadings(inset);
+        return (boundary, headland, EdgeBase + Bump(shape, 0));
+    }
+
+    private static (List<Vec3> pts, double headingPhi, Vec3 vehicle) MakeTrack(double angleDeg, bool ab, double crossY)
+    {
+        double phi = (90.0 - angleDeg) * Math.PI / 180.0; // heading from north
+        double se = Math.Sin(phi), cn = Math.Cos(phi);
+        Vec2 cross = new(0, crossY);
+        Vec3 At(double s, double head) // s metres along heading from the crossing (negative = into field)
+        {
+            double e = cross.Easting + se * s;
+            double n = cross.Northing + cn * s;
+            return new Vec3(e, n, head);
+        }
+
+        var list = new List<Vec3>();
+        if (ab)
+        {
+            list.Add(At(-120, phi));
+            list.Add(At(-5, phi)); // ends 5 m short of the edge
+        }
+        else
+        {
+            var perpE = cn; var perpN = -se; // perpendicular to heading
+            var raw = new List<Vec3>();
+            for (double s = -120; s <= -5 + 1e-9; s += 2.0)
+            {
+                double w = 6.0 * Math.Sin(s / 25.0); // lateral wiggle => genuine curve
+                var b = At(s, 0);
+                raw.Add(new Vec3(b.Easting + perpE * w, b.Northing + perpN * w, 0));
+            }
+            for (int i = 0; i < raw.Count - 1; i++)
+            {
+                double dE = raw[i + 1].Easting - raw[i].Easting;
+                double dN = raw[i + 1].Northing - raw[i].Northing;
+                double h = Math.Atan2(dE, dN); if (h < 0) h += Math.PI * 2;
+                raw[i] = new Vec3(raw[i].Easting, raw[i].Northing, h);
+            }
+            raw[^1] = new Vec3(raw[^1].Easting, raw[^1].Northing, raw[^2].Heading);
+            list = raw;
+        }
+
+        // vehicle at a realistic trigger distance back along the track, heading phi
+        var veh = At(-60, phi);
+        return (list, phi, veh);
+    }
+
+    private static double PerpDistToPolyline(IReadOnlyList<Vec3> line, double e, double n)
+    {
+        double best = double.MaxValue;
+        for (int i = 0; i < line.Count - 1; i++)
+            best = Math.Min(best, GeometryMath.PointToSegmentDistance(
+                e, n, line[i].Easting, line[i].Northing, line[i + 1].Easting, line[i + 1].Northing));
+        return best;
+    }
+
+    [Test, Combinatorial]
+    public void Generates_NotFallback_Aligned(
+        [Values] Shape shape,
+        [Values(90, 75, 60, 45, 30)] int angle,
+        [Values(false, true)] bool ab,
+        [Values(0, 2)] int style)
+    {
+        ConfigurationStore.Instance.Guidance.UTurnStyle = style;
+
+        var (boundary, headland, crossY) = MakeField(shape);
+        var (pts, phi, veh) = MakeTrack(angle, ab, crossY);
+        var track = ab
+            ? Models.Track.Track.FromABLine("ab", pts[0], pts[1])
+            : Models.Track.Track.FromCurve("c", pts);
+
+        var guidance = new GuidanceWorkingState { IsHeadingSameWay = true, HowManyPathsAway = 0 };
+        var turn = new YouTurnWorkingState { IsTurnLeft = true };
+
+        var result = _creation.CreateTurnPath(
+            new Position { Easting = veh.Easting, Northing = veh.Northing },
+            track, headingRadians: phi, abHeading: phi,
+            boundary, headland, guidance, turn,
+            uTurnSkipRows: 0, headlandCalculatedWidth: 10, headlandDistance: 5);
+
+        string tag = $"{shape} angle={angle} {(ab ? "AB" : "curve")} style={style}";
+        if (result.UsedFallback || result.Path == null)
+            foreach (var m in _log.Messages.Where(m => m.Contains("[YouTurn]"))) TestContext.WriteLine($"[{tag}] {m}");
+
+        Assert.That(result.Path, Is.Not.Null.And.Count.GreaterThan(10), $"{tag}: should plot a turn");
+        Assert.That(result.UsedFallback, Is.False, $"{tag}: should run the generator, not the straight fallback");
+
+        double maxEntryDist = 0;
+        for (int i = 0; i < Math.Min(5, result.Path!.Count); i++)
+            maxEntryDist = Math.Max(maxEntryDist, PerpDistToPolyline(pts, result.Path[i].Easting, result.Path[i].Northing));
+        Assert.That(maxEntryDist, Is.LessThan(0.3), $"{tag}: entry leg should lie on the pass (max perp {maxEntryDist:F2} m)");
+    }
+}

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 44
+#define VERSION_PATCH 45
 
-#define VERSION "26.5.44"
-#define VERSION_DATE "2026-06-06"
+#define VERSION "26.5.45"
+#define VERSION_DATE "2026-06-14"


### PR DESCRIPTION
## Summary

One U-turn generator for every track. AB lines are densified into 2-point curves and flow through the **same** curve-aware generator as recorded curves (`GuidanceType` is always `Curve`). Deleted ~530 lines of dead AB-turn code. Curved-AB U-turns are now correctly placed with proper entry/exit legs at both field ends, both styles (omega + sagitta). Device-confirmed smooth entry and exit.

## What was broken

Curved-AB U-turns routed through the straight-AB generator, so they were mis-placed and (when the recorded curve didn't reach the headland) overran the boundary with no extension legs. Two further handoff defects surfaced during device testing: a **gap** entering the turn and a **lateral shift + wiggle** exiting it.

## Key changes

- **Unified generator** — densify AB → curve generator; removed `CreateABTurn/Omega/Sagitta/Wide/KStyleAB`, `FindABTurnPoint`, `AddABSequenceLines`, `FindABOutTurnPoint`. Ported Twol's distance-accumulating leg walk (`WalkLegByDistance` — walks legLength **metres**, not a fixed point count).
- **Curve reach** — `CurveProcessing.ExtendCurveEnds` extends along the **smoothed** end tangent (from positions, not the noisy stored end heading). Offset-then-extend everywhere so the in-field curve byte-matches the guidance line (zero lateral step at the track↔turn handoff).
- **Entry gap** — extend the steering track (`CalculateTrackGuidance`) and the magenta display line so there's no gap between the guidance line and the turn start.
- **Exit gap** — extend the cyan `NextTrack` curve so it reaches the exit leg and matches the post-turn magenta length.
- **Exit lateral shift (root cause)** — the exit-leg destination used `SignedPerpDistanceToCurve(base, arcEnd)`, which projects the far-out arc end onto the recorded curve's **raw end-point heading**; when the curve ends before the headland the arc seats on the tangent extension and a noisy end heading skewed the exit leg by metres. Replaced with the **same** `base-offset × N widths + nudge` formula every other consumer uses (current pass, display, steering, post-turn pass). One definition, no per-turn measurement. Removed the now-unused helper; folded nudge into the cyan curve.
- Removed the spurious `±2·ToolOffset` arc shift (AgOpen compensation; AgValonia steering never applies tool offset).

## Tests

- `CurveTurnRobustnessTests` — 60-case matrix (shape × angle 90°→30° × curve/AB × omega/sagitta), asserts no fallback + entry leg on pass.
- `CurveTurnAlignmentTests` — crosses/ends-at-edge, plus new exit-leg coverage: `ExitLeg_LiesOnNextPass` (incl. ToolOffset) and `ExitLeg_CurveEndsInside_LandsOnNextPass` (clean + 20°-noisy end, both ends, both styles). Noisy case was **4.2 m off → 0.000 m**.
- `ClosedLoopEntryTests` — bicycle model + real `TrackGuidanceService` + state machine.

Models 146, Services 987 (+2 skipped), UI 147; Desktop builds clean. Device telemetry removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)