### PR TITLE
Inject IUiDispatcher into the VM layer (config/state audit §11.1)

### DIFF
--- a/Plans/CONFIG_STATE_AUDIT.md
+++ b/Plans/CONFIG_STATE_AUDIT.md
@@ -250,3 +250,44 @@ Implemented as named below (the snapshot/service ended up as `PersistentAppState
 `Alpha`, `IsDisplayTramControl`, `IsEnabled`) lacked a home; those now persist per-field.
 `Passes`/`DisplayMode` were intentionally left on the Guidance sync to avoid double-sourcing —
 a smaller follow-up could consolidate them if desired.
+
+---
+
+## 11. Follow-up scope — de-ambient the VM (added 2026-06-14, not scheduled)
+
+**Different axis from §1–§10.** Everything above is about *data single-source-of-truth* — which
+of the three stores owns a value. This item is about *ambient framework coupling*: the ViewModel
+reaching into framework/global statics **out of the air** instead of receiving them through its
+constructor. It's the same "not injected, just grabbed" smell, one layer down, and it's exactly
+what `Plans/ARCHITECTURE.md` flags under "Tight Coupling Points → Historical, needs refactor" —
+which the completed storage audit deliberately did **not** touch.
+
+### 11.1 Injectable `IDispatcher` (the concrete item)
+The VM depends directly on `Avalonia.Threading.Dispatcher.UIThread` — a static from the
+*presentation* framework — in **~10 `MainViewModel` partials**: ~18 `Post`, 5 `InvokeAsync`,
+7 `CheckAccess`. By the project's own MVVM rule (VM coordinates, doesn't bind itself to the View
+framework), this should be an injected `IDispatcher`:
+- Define `IDispatcher` (Post / InvokeAsync / CheckAccess) in `AgValoniaGPS.Services` (or Models).
+- Avalonia-backed implementation registered in **Desktop + iOS + Android** (three-platform DI rule).
+- VM partials take `IDispatcher` via ctor; replace every `Dispatcher.UIThread.*` call.
+- Behavior-preserving for the current apps; independently shippable; no data-tier change.
+
+**Payoff:** (a) VM unit tests stop needing `Avalonia.Headless` *just to supply a dispatcher* — an
+inline/synchronous `IDispatcher` suffices; (b) it unblocks the headless web-UI host, which has a
+VM consumer with no UI thread (see `Plans/REMOTE_WEB_UI_SPLIT.md` §9.1 + the
+`Spikes/HeadlessHostSpike` proof — the spike had to pull in `Avalonia.Headless` purely for this).
+
+**Why it wasn't already done (and wasn't wrong to defer):** until the headless host, every VM
+consumer was an Avalonia View on a real UI thread, so `Dispatcher.UIThread` was correct everywhere
+and an abstraction would have had exactly one implementation. Defensible YAGNI; the web UI is the
+forcing function that makes it earn its keep.
+
+### 11.2 Sibling: static store access (optional, same pass)
+The same "ambient, not injected" smell applies to `ConfigurationStore.Instance` and
+`ApplicationState.Instance`, read statically across services and VMs (also flagged in
+`ARCHITECTURE.md`). The storage audit (§1–§10) made these the enforced SoT but left them as
+**statics**. De-static-ing them (inject the store instances) is the natural companion to §11.1 and
+would complete the "de-ambient the VM" pass — but it's larger blast-radius and can be sequenced
+separately. Keep §11.1 as the committed first step.
+
+**Status:** scoped, not scheduled. Surfaced by the remote/web-UI Phase 0 spike.

--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ using AgValoniaGPS.Models.Pipeline;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Android.Services;
 using AgValoniaGPS.Services.Logging;
+using AgValoniaGPS.Views.Infrastructure;
 
 namespace AgValoniaGPS.Android.DependencyInjection;
 
@@ -55,6 +56,10 @@ public static class ServiceCollectionExtensions
         // Centralized application state (single source of truth)
         services.AddSingleton<ApplicationState>();           // ephemeral, in-memory only
         services.AddSingleton(_ => PersistentAppState.Instance); // persisted to appstate.json (same object as .Instance)
+
+        // UI-thread dispatcher abstraction (replaces direct Dispatcher.UIThread
+        // in the VM layer — see Plans/CONFIG_STATE_AUDIT.md §11).
+        services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();
 
         // Register ViewModels
         services.AddTransient<MainViewModel>();

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Pipeline;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.Desktop.Services;
+using AgValoniaGPS.Views.Infrastructure;
 
 namespace AgValoniaGPS.Desktop.DependencyInjection;
 
@@ -55,6 +56,10 @@ public static class ServiceCollectionExtensions
         // Centralized application state (single source of truth)
         services.AddSingleton<ApplicationState>();           // ephemeral, in-memory only
         services.AddSingleton(_ => PersistentAppState.Instance); // persisted to appstate.json (same object as .Instance)
+
+        // UI-thread dispatcher abstraction (replaces direct Dispatcher.UIThread
+        // in the VM layer — see Plans/CONFIG_STATE_AUDIT.md §11).
+        services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();
 
         // Register ViewModels
         services.AddTransient<MainViewModel>();

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ using AgValoniaGPS.Models.Pipeline;
 using AgValoniaGPS.Models.State;
 using AgValoniaGPS.iOS.Services;
 using AgValoniaGPS.Services.Logging;
+using AgValoniaGPS.Views.Infrastructure;
 
 namespace AgValoniaGPS.iOS.DependencyInjection;
 
@@ -55,6 +56,10 @@ public static class ServiceCollectionExtensions
         // Centralized application state (single source of truth)
         services.AddSingleton<ApplicationState>();           // ephemeral, in-memory only
         services.AddSingleton(_ => PersistentAppState.Instance); // persisted to appstate.json (same object as .Instance)
+
+        // UI-thread dispatcher abstraction (replaces direct Dispatcher.UIThread
+        // in the VM layer — see Plans/CONFIG_STATE_AUDIT.md §11).
+        services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();
 
         // Register ViewModels
         services.AddTransient<MainViewModel>();

--- a/Shared/AgValoniaGPS.Services/Interfaces/IUiDispatcher.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IUiDispatcher.cs
@@ -1,0 +1,49 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Threading.Tasks;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// Priority for a dispatched UI-thread callback. Mirrors the subset of
+/// Avalonia's DispatcherPriority the ViewModels actually use, without leaking
+/// the Avalonia type into the VM/host layer.
+/// </summary>
+public enum UiDispatcherPriority
+{
+    /// <summary>Normal queue priority.</summary>
+    Default,
+
+    /// <summary>Run after higher-priority work (e.g. deferred bookkeeping).</summary>
+    Background,
+
+    /// <summary>Run at render priority — used to yield until a frame is painted.</summary>
+    Render
+}
+
+/// <summary>
+/// Abstraction over the UI-thread marshaller. Replaces direct
+/// <c>Avalonia.Threading.Dispatcher.UIThread</c> access in the ViewModel layer
+/// so the VMs depend on an injected service rather than an ambient framework
+/// static. This keeps the VM (and a headless host that owns it) free of a hard
+/// Avalonia dependency, and lets tests supply an inline dispatcher.
+/// See Plans/CONFIG_STATE_AUDIT.md §11.
+/// </summary>
+public interface IUiDispatcher
+{
+    /// <summary>True when the caller is already on the UI thread.</summary>
+    bool CheckAccess();
+
+    /// <summary>Queue <paramref name="action"/> to run on the UI thread (fire-and-forget).</summary>
+    void Post(Action action, UiDispatcherPriority priority = UiDispatcherPriority.Default);
+
+    /// <summary>Run <paramref name="action"/> on the UI thread; await completion.</summary>
+    Task InvokeAsync(Action action, UiDispatcherPriority priority = UiDispatcherPriority.Default);
+}

--- a/Shared/AgValoniaGPS.Services/Threading/InlineUiDispatcher.cs
+++ b/Shared/AgValoniaGPS.Services/Threading/InlineUiDispatcher.cs
@@ -1,0 +1,33 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Threading.Tasks;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services.Threading;
+
+/// <summary>
+/// Framework-free <see cref="IUiDispatcher"/> that runs callbacks synchronously
+/// on the calling thread. Intended for unit tests and headless hosts that have
+/// no separate UI thread — there is nothing to marshal to, so everything is
+/// "already on the UI thread". See Plans/CONFIG_STATE_AUDIT.md §11.
+/// </summary>
+public sealed class InlineUiDispatcher : IUiDispatcher
+{
+    public bool CheckAccess() => true;
+
+    public void Post(Action action, UiDispatcherPriority priority = UiDispatcherPriority.Default)
+        => action();
+
+    public Task InvokeAsync(Action action, UiDispatcherPriority priority = UiDispatcherPriority.Default)
+    {
+        action();
+        return Task.CompletedTask;
+    }
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ApplyResults.cs
@@ -16,7 +16,7 @@ public partial class MainViewModel
     /// </summary>
     private void OnGpsCycleCompleted(GpsCycleResult result)
     {
-        Avalonia.Threading.Dispatcher.UIThread.Post(() => ApplyGpsCycleResult(result));
+        _dispatcher.Post(() => ApplyGpsCycleResult(result));
     }
 
     /// <summary>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.BoundaryRecording.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.BoundaryRecording.cs
@@ -63,7 +63,7 @@ public partial class MainViewModel
 
     private void OnBoundaryPointAdded(object? sender, BoundaryPointAddedEventArgs e)
     {
-        Dispatcher.UIThread.Post(() =>
+        _dispatcher.Post(() =>
         {
             // Update centralized state
             State.BoundaryRec.PointCount = e.TotalPoints;
@@ -84,7 +84,7 @@ public partial class MainViewModel
 
     private void OnBoundaryStateChanged(object? sender, BoundaryRecordingStateChangedEventArgs e)
     {
-        Dispatcher.UIThread.Post(() =>
+        _dispatcher.Post(() =>
         {
             // Update centralized state
             State.BoundaryRec.IsRecording = e.State == BoundaryRecordingState.Recording;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Configuration.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Configuration.cs
@@ -84,7 +84,8 @@ public partial class MainViewModel
                 _smartWasService,
                 _configurationService,
                 _udpService,
-                _autoSteerService);
+                _autoSteerService,
+                _dispatcher);
             State.UI.ShowDialog(DialogType.SmartWas);
         });
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -137,7 +137,7 @@ public partial class MainViewModel
                     {
                         SelectedFieldInfo = null;
                         _ = OpenFieldAsync(fieldPath, fieldName).ContinueWith(_ =>
-                            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                            _dispatcher.Post(() =>
                                 IsFieldOperationsPanelVisible = false));
                     });
                 return;
@@ -826,7 +826,7 @@ public partial class MainViewModel
                     () =>
                     {
                         _ = OpenFieldAsync(fieldPath, lastField).ContinueWith(_ =>
-                            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                            _dispatcher.Post(() =>
                                 IsFieldOperationsPanelVisible = false));
                     });
                 return;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using System.Windows.Input;
 using AgValoniaGPS.Models;
 using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Services.Interfaces;
 using AgValoniaGPS.Services.Logging;
 using Avalonia.Threading;
 using Microsoft.Extensions.Logging;
@@ -295,7 +296,7 @@ public partial class MainViewModel
                 State.UI.IsBusy = true;
 
                 // Force UI to render busy overlay
-                await Dispatcher.UIThread.InvokeAsync(() => { }, Avalonia.Threading.DispatcherPriority.Render);
+                await _dispatcher.InvokeAsync(() => { }, UiDispatcherPriority.Render);
                 await System.Threading.Tasks.Task.Delay(50);
 
                 var bugReportsDir = Path.Combine(
@@ -486,7 +487,7 @@ public partial class MainViewModel
 
     private void OnLogStoreUpdated()
     {
-        Dispatcher.UIThread.Post(RefreshLogEntries);
+        _dispatcher.Post(RefreshLogEntries);
     }
 
     private void RefreshLogEntries()

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Wizards.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Wizards.cs
@@ -48,7 +48,7 @@ public partial class MainViewModel
     private void ShowSteerWizard()
     {
         // Create a new instance of the wizard
-        SteerWizardViewModel = new SteerWizardViewModel(_configurationService, _autoSteerService);
+        SteerWizardViewModel = new SteerWizardViewModel(_configurationService, _dispatcher, _autoSteerService);
 
         // Handle wizard close
         SteerWizardViewModel.CloseRequested += (s, e) =>

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -145,13 +145,13 @@ public partial class MainViewModel
         // section control, coverage, boundary checks) on a background thread.
         // This handler only does lightweight UI-only work and user-action-driven recording.
 
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        if (_dispatcher.CheckAccess())
         {
             HandleGpsUiUpdates(data);
         }
         else
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(() => HandleGpsUiUpdates(data));
+            _dispatcher.Post(() => HandleGpsUiUpdates(data));
         }
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Guidance.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Guidance.cs
@@ -50,14 +50,14 @@ public partial class MainViewModel
         // stays on the source rate. Single-double / single-byte writes are
         // atomic on x86/ARM — no lock needed.
         _latestGpsToPgnLatencyMs = state.TotalLatencyMs;
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        if (_dispatcher.CheckAccess())
         {
             TramControlByte = state.TramState;
             _mapService.SetTramControlByte(state.TramState);
         }
         else
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            _dispatcher.Post(() =>
             {
                 TramControlByte = state.TramState;
                 _mapService.SetTramControlByte(state.TramState);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Ntrip.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Ntrip.cs
@@ -243,13 +243,13 @@ public partial class MainViewModel
     private void OnNtripConnectionChanged(object? sender, NtripConnectionEventArgs e)
     {
         // Marshal to UI thread (use Invoke for synchronous execution to avoid modal dialog issues)
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        if (_dispatcher.CheckAccess())
         {
             UpdateNtripConnectionProperties(e);
         }
         else
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(() => UpdateNtripConnectionProperties(e));
+            _dispatcher.Post(() => UpdateNtripConnectionProperties(e));
         }
     }
 
@@ -266,13 +266,13 @@ public partial class MainViewModel
 
     private void OnRtcmDataReceived(object? sender, RtcmDataReceivedEventArgs e)
     {
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        if (_dispatcher.CheckAccess())
         {
             UpdateNtripDataProperties();
         }
         else
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(() => UpdateNtripDataProperties());
+            _dispatcher.Post(() => UpdateNtripDataProperties());
         }
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.SectionControl.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.SectionControl.cs
@@ -220,13 +220,13 @@ public partial class MainViewModel
         _lastAnyActive = currentAnyActive;
 
         // Marshal to UI thread
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        if (_dispatcher.CheckAccess())
         {
             UpdateSectionStates();
         }
         else
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(UpdateSectionStates);
+            _dispatcher.Post(UpdateSectionStates);
         }
     }
 

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -52,6 +52,7 @@ public partial class MainViewModel : ObservableObject
     private readonly AgValoniaGPS.Services.Interfaces.IGpsService _gpsService;
     private readonly IFieldService _fieldService;
     private readonly INtripClientService _ntripService;
+    private readonly IUiDispatcher _dispatcher;
     private readonly AgValoniaGPS.Services.Interfaces.IDisplaySettingsService _displaySettings;
     private readonly AgValoniaGPS.Services.Interfaces.IFieldStatisticsService _fieldStatistics;
     private readonly AgValoniaGPS.Services.Interfaces.IGpsSimulationService _simulatorService;
@@ -224,12 +225,14 @@ public partial class MainViewModel : ObservableObject
         ApplicationState appState,
         IPersistentStateService persistentStateService,
         IBatteryService batteryService,
+        IUiDispatcher uiDispatcher,
         ISteerMachineLoopService? controlLoop = null,
         IPositionEstimator? positionEstimator = null)
     {
         _logger = logger;
         _persistentStateService = persistentStateService;
         _batteryService = batteryService;
+        _dispatcher = uiDispatcher;
         _tramLineService = tramLineService;
 
         // Battery icon in the strip — start the per-platform reader, prime with
@@ -550,14 +553,14 @@ public partial class MainViewModel : ObservableObject
         // scenarios across force-stop restarts without manual taps.
         if (DiagFlags.AutoResumeField)
         {
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            _dispatcher.Post(() =>
             {
                 if (ResumeFieldCommand?.CanExecute(null) == true)
                 {
                     _logger.LogInformation("[DiagFlags] auto_resume_field: invoking ResumeFieldCommand");
                     ResumeFieldCommand.Execute(null);
                 }
-            }, Avalonia.Threading.DispatcherPriority.Background);
+            }, UiDispatcherPriority.Background);
         }
     }
 
@@ -770,9 +773,9 @@ public partial class MainViewModel : ObservableObject
         // Surface any crash-recovery that happened while loading settings or
         // the active profile pair. Deferred to the dispatcher so the dialog
         // host is ready (RestoreSettings runs during construction).
-        Avalonia.Threading.Dispatcher.UIThread.Post(
+        _dispatcher.Post(
             CheckStartupRecovery,
-            Avalonia.Threading.DispatcherPriority.Background);
+            UiDispatcherPriority.Background);
     }
 
     private void LoadDefaultVehicleProfile()
@@ -1170,7 +1173,7 @@ public partial class MainViewModel : ObservableObject
     private void OnCoverageBoundsExpanded(object? sender, BoundsExpandedEventArgs e)
     {
         // Reinitialize display bitmap with new expanded bounds
-        Dispatcher.UIThread.Post(() =>
+        _dispatcher.Post(() =>
         {
             _mapService.InitializeCoverageBitmapWithBounds(e.MinE, e.MaxE, e.MinN, e.MaxN);
             _logger.LogDebug($"[Coverage] Display bitmap reinitialized for expanded bounds: E[{e.MinE:F0},{e.MaxE:F0}] N[{e.MinN:F0},{e.MaxN:F0}]");
@@ -1179,7 +1182,7 @@ public partial class MainViewModel : ObservableObject
 
     private void OnAutoSteerToggleRequested(object? sender, AutoSteerToggleEventArgs e)
     {
-        Dispatcher.UIThread.Post(() =>
+        _dispatcher.Post(() =>
         {
             // Toggle autosteer when requested by module communication service
             // (e.g., from work switch or steer switch)
@@ -1189,7 +1192,7 @@ public partial class MainViewModel : ObservableObject
 
     private void OnSectionMasterToggleRequested(object? sender, SectionMasterToggleEventArgs e)
     {
-        Dispatcher.UIThread.Post(() =>
+        _dispatcher.Post(() =>
         {
             // Toggle section master when requested by module communication service
             // This replaces the direct PerformClick() calls from the WinForms implementation
@@ -1497,7 +1500,7 @@ public partial class MainViewModel : ObservableObject
         try
         {
             // Force UI to render busy overlay
-            await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Render);
+            await _dispatcher.InvokeAsync(() => { }, UiDispatcherPriority.Render);
             await Task.Delay(50);
 
             // Update field state
@@ -1654,7 +1657,7 @@ public partial class MainViewModel : ObservableObject
 
             // Load coverage (shows busy overlay — pixel buffer callback needs UI thread for bitmap access)
             State.UI.BusyMessage = "Loading coverage...";
-            await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Render);
+            await _dispatcher.InvokeAsync(() => { }, UiDispatcherPriority.Render);
 
             if (activeJob != null)
             {
@@ -1729,7 +1732,7 @@ public partial class MainViewModel : ObservableObject
             }
 
             // Let GPS events propagate through the UI
-            await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Render);
+            await _dispatcher.InvokeAsync(() => { }, UiDispatcherPriority.Render);
             await Task.Delay(100);
 
             // Notify subscribers that the field is fully loaded
@@ -1778,7 +1781,7 @@ public partial class MainViewModel : ObservableObject
         try
         {
             // Force UI to render busy overlay
-            await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Render);
+            await _dispatcher.InvokeAsync(() => { }, UiDispatcherPriority.Render);
             await Task.Delay(50);
 
             // Save coverage on background thread (RLE compression can take seconds).

--- a/Shared/AgValoniaGPS.ViewModels/SmartWasViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/SmartWasViewModel.cs
@@ -42,17 +42,20 @@ public partial class SmartWasViewModel : ObservableObject
     private readonly IConfigurationService _configService;
     private readonly IUdpCommunicationService _udpService;
     private readonly IAutoSteerService _autoSteerService;
+    private readonly IUiDispatcher _dispatcher;
 
     public SmartWasViewModel(
         ISmartWasCalibrationService smartWas,
         IConfigurationService configService,
         IUdpCommunicationService udpService,
-        IAutoSteerService autoSteerService)
+        IAutoSteerService autoSteerService,
+        IUiDispatcher dispatcher)
     {
         _smartWas = smartWas;
         _configService = configService;
         _udpService = udpService;
         _autoSteerService = autoSteerService;
+        _dispatcher = dispatcher;
 
         StartCommand = new RelayCommand(() => _smartWas.Start());
         StopCommand = new RelayCommand(() => _smartWas.Stop());
@@ -187,10 +190,10 @@ public partial class SmartWasViewModel : ObservableObject
 
     private void OnSnapshotChanged(object? sender, SmartWasSnapshot snap)
     {
-        if (Dispatcher.UIThread.CheckAccess())
+        if (_dispatcher.CheckAccess())
             ApplySnapshot(snap);
         else
-            Dispatcher.UIThread.Post(() => ApplySnapshot(snap));
+            _dispatcher.Post(() => ApplySnapshot(snap));
     }
 
     private void ApplySnapshot(SmartWasSnapshot snap)

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/AutoMotorCalibrationStepViewModel.cs
@@ -281,8 +281,8 @@ public class AutoMotorCalibrationStepViewModel : SwitchGatedWizardStep
     public ICommand RedoPhaseBCommand { get; }
 
     public AutoMotorCalibrationStepViewModel(IConfigurationService configService,
-        IAutoSteerService? autoSteerService = null)
-        : base(configService, autoSteerService)
+        IUiDispatcher dispatcher, IAutoSteerService? autoSteerService = null)
+        : base(configService, autoSteerService, dispatcher)
     {
         _configService = configService;
         _autoSteerService = autoSteerService;

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/MaxSteeringAngleStepViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/MaxSteeringAngleStepViewModel.cs
@@ -82,8 +82,8 @@ public class MaxSteeringAngleStepViewModel : SwitchGatedWizardStep
     public void SetHardwareStep(HardwareInstalledStepViewModel step) => _hardwareStep = step;
 
     public MaxSteeringAngleStepViewModel(IConfigurationService configService,
-        IAutoSteerService? autoSteerService = null)
-        : base(configService, autoSteerService)
+        IUiDispatcher dispatcher, IAutoSteerService? autoSteerService = null)
+        : base(configService, autoSteerService, dispatcher)
     {
         StartTestCommand = new AsyncRelayCommand(RunMaxAngleMeasurementAsync);
         RedoCommand = new AsyncRelayCommand(Redo);

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SteerWizardViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SteerWizardViewModel.cs
@@ -35,7 +35,7 @@ public class SteerWizardViewModel : WizardViewModel
     public override WizardStatusBarViewModel? StatusBar { get; }
 
     public SteerWizardViewModel(IConfigurationService configService,
-        IAutoSteerService? autoSteerService = null)
+        IUiDispatcher dispatcher, IAutoSteerService? autoSteerService = null)
     {
         _configService = configService;
         StatusBar = new WizardStatusBarViewModel(autoSteerService);
@@ -69,14 +69,14 @@ public class SteerWizardViewModel : WizardViewModel
         wasCal.SetHardwareStep(hardwareStep);
         AddStep(wasCal);
 
-        var autoCal = new AutoMotorCalibrationStepViewModel(configService, autoSteerService);
+        var autoCal = new AutoMotorCalibrationStepViewModel(configService, dispatcher, autoSteerService);
         autoCal.SetHardwareStep(hardwareStep);
         AddStep(autoCal);
 
         // Step 10: Maximum Steering Angle (split out of the old combined
         // motor cal step so the stress-style full-lock test gets its own
         // operator-facing page with distinct warnings).
-        var maxSteer = new MaxSteeringAngleStepViewModel(configService, autoSteerService);
+        var maxSteer = new MaxSteeringAngleStepViewModel(configService, dispatcher, autoSteerService);
         maxSteer.SetHardwareStep(hardwareStep);
         AddStep(maxSteer);
 

--- a/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SwitchGatedWizardStep.cs
+++ b/Shared/AgValoniaGPS.ViewModels/Wizards/SteerWizard/SwitchGatedWizardStep.cs
@@ -45,12 +45,14 @@ public abstract class SwitchGatedWizardStep : WizardStepViewModel
     protected IAutoSteerService? AutoSteerService { get; }
 
     private bool _gateSubscribed;
+    private readonly IUiDispatcher _dispatcher;
 
     protected SwitchGatedWizardStep(IConfigurationService configService,
-        IAutoSteerService? autoSteerService)
+        IAutoSteerService? autoSteerService, IUiDispatcher dispatcher)
     {
         ConfigService = configService;
         AutoSteerService = autoSteerService;
+        _dispatcher = dispatcher;
     }
 
     /// <summary>True when hardware is connected and sending data.</summary>
@@ -161,11 +163,11 @@ public abstract class SwitchGatedWizardStep : WizardStepViewModel
         WaitingForPhysicalSwitch = requireSwitch && !switchActive;
     }
 
-    private static void DispatchToUI(Action action)
+    private void DispatchToUI(Action action)
     {
-        if (Dispatcher.UIThread.CheckAccess())
+        if (_dispatcher.CheckAccess())
             action();
         else
-            Dispatcher.UIThread.Post(action);
+            _dispatcher.Post(action);
     }
 }

--- a/Shared/AgValoniaGPS.Views/Infrastructure/AvaloniaUiDispatcher.cs
+++ b/Shared/AgValoniaGPS.Views/Infrastructure/AvaloniaUiDispatcher.cs
@@ -1,0 +1,38 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Views.Infrastructure;
+
+/// <summary>
+/// Avalonia-backed <see cref="IUiDispatcher"/> wrapping <c>Dispatcher.UIThread</c>.
+/// The single adapter that keeps the Avalonia UI-thread dependency in the View
+/// layer instead of the ViewModels. Registered by each platform's DI.
+/// See Plans/CONFIG_STATE_AUDIT.md §11.
+/// </summary>
+public sealed class AvaloniaUiDispatcher : IUiDispatcher
+{
+    public bool CheckAccess() => Dispatcher.UIThread.CheckAccess();
+
+    public void Post(Action action, UiDispatcherPriority priority = UiDispatcherPriority.Default)
+        => Dispatcher.UIThread.Post(action, Map(priority));
+
+    public Task InvokeAsync(Action action, UiDispatcherPriority priority = UiDispatcherPriority.Default)
+        => Dispatcher.UIThread.InvokeAsync(action, Map(priority)).GetTask();
+
+    private static DispatcherPriority Map(UiDispatcherPriority priority) => priority switch
+    {
+        UiDispatcherPriority.Background => DispatcherPriority.Background,
+        UiDispatcherPriority.Render => DispatcherPriority.Render,
+        _ => DispatcherPriority.Default
+    };
+}

--- a/Tests/AgValoniaGPS.Services.Tests/AutoMotorCalKpRampTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/AutoMotorCalKpRampTests.cs
@@ -47,7 +47,7 @@ public class AutoMotorCalKpRampTests
     /// </summary>
     private AutoMotorCalibrationStepViewModel CreateStep(System.Func<int, SteerModuleData> moduleFor)
     {
-        var step = new AutoMotorCalibrationStepViewModel(_configService, _autoSteer);
+        var step = new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         step.DelayFunc = (_, _) => Task.CompletedTask;
         step.ReadModuleData = () => moduleFor(_store.AutoSteer.ProportionalGain);
         return step;
@@ -151,7 +151,7 @@ public class AutoMotorCalKpRampTests
         // cancel by overriding DelayFunc to throw OperationCanceled on
         // the second delay invocation.
         _store.AutoSteer.ProportionalGain = 17;
-        var step = new AutoMotorCalibrationStepViewModel(_configService, _autoSteer);
+        var step = new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         step.ReadModuleData = () => ModuleAt(0.0, 0);
 
         int delayCalls = 0;

--- a/Tests/AgValoniaGPS.Services.Tests/MaxSteeringAngleStepTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/MaxSteeringAngleStepTests.cs
@@ -50,7 +50,7 @@ public class MaxSteeringAngleStepTests
         // Simulator-style WAS: ramp up to ±35° then plateau. The
         // detector should fire once it sees PlateauStableSamples
         // consecutive samples within PlateauThresholdDeg of each other.
-        var step = new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        var step = new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         step.DelayFunc = (_, _) => Task.CompletedTask;
 
         // Right-lock sequence: 10, 20, 30, 35, 35, 35, 35, 35, 35, 35
@@ -101,7 +101,7 @@ public class MaxSteeringAngleStepTests
         // hydraulics), the detector must time out and return the last
         // sample rather than hang forever. The wizard caps the poll loop
         // at PlateauTimeoutMs internally.
-        var step = new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+        var step = new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         step.DelayFunc = (_, _) => Task.CompletedTask;
 
         double angle = 0;

--- a/Tests/AgValoniaGPS.Services.Tests/MotorCalAndMaxSteerGateTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/MotorCalAndMaxSteerGateTests.cs
@@ -63,9 +63,9 @@ public class MotorCalAndMaxSteerGateTests
     private SwitchGatedWizardStep CreateStep<T>() where T : SwitchGatedWizardStep
     {
         if (typeof(T) == typeof(AutoMotorCalibrationStepViewModel))
-            return new AutoMotorCalibrationStepViewModel(_configService, _autoSteer);
+            return new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         if (typeof(T) == typeof(MaxSteeringAngleStepViewModel))
-            return new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+            return new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         throw new InvalidOperationException("Unknown step type for fixture");
     }
 
@@ -78,8 +78,8 @@ public class MotorCalAndMaxSteerGateTests
         GivenSwitch(active: false);
 
         SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
-            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
-            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+            ? new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         EnterStep(step);
 
         Assert.That(step.WaitingForPhysicalSwitch, Is.False);
@@ -95,8 +95,8 @@ public class MotorCalAndMaxSteerGateTests
         GivenSwitch(active: false);
 
         SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
-            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
-            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+            ? new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         EnterStep(step);
 
         Assert.That(step.WaitingForPhysicalSwitch, Is.True);
@@ -112,8 +112,8 @@ public class MotorCalAndMaxSteerGateTests
         GivenSwitch(active: true);
 
         SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
-            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
-            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+            ? new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         EnterStep(step);
 
         Assert.That(step.WaitingForPhysicalSwitch, Is.False);
@@ -131,8 +131,8 @@ public class MotorCalAndMaxSteerGateTests
         GivenSwitch(active: false);
 
         SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
-            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
-            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+            ? new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         EnterStep(step);
         Assert.That(step.CanStartTest, Is.False);
 
@@ -157,8 +157,8 @@ public class MotorCalAndMaxSteerGateTests
         GivenSwitch(active: false);
 
         SwitchGatedWizardStep step = stepType == typeof(AutoMotorCalibrationStepViewModel)
-            ? new AutoMotorCalibrationStepViewModel(_configService, _autoSteer)
-            : new MaxSteeringAngleStepViewModel(_configService, _autoSteer);
+            ? new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer)
+            : new MaxSteeringAngleStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), _autoSteer);
         EnterStep(step);
         Assert.That(step.WaitingForPhysicalSwitch, Is.False);
 

--- a/Tests/AgValoniaGPS.Services.Tests/SteerWizardE2ETests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SteerWizardE2ETests.cs
@@ -31,7 +31,7 @@ public class SteerWizardE2ETests
 
     private SteerWizardViewModel CreateWizard()
     {
-        return new SteerWizardViewModel(_configService);
+        return new SteerWizardViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher());
     }
 
     /// <summary>

--- a/Tests/AgValoniaGPS.Services.Tests/SteerWizardLiveFeedbackTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SteerWizardLiveFeedbackTests.cs
@@ -123,7 +123,7 @@ public class SteerWizardLiveFeedbackTests
         _configService.Store.Tool.IsSteerSwitchEnabled = false;
         var autoSteer = Substitute.For<IAutoSteerService>();
         autoSteer.LastSteerData.Returns(default(SteerModuleData));
-        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteer);
+        var step = new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), autoSteer);
 
         InvokeNonPublic(step, "OnEntering", null);
 
@@ -149,7 +149,7 @@ public class SteerWizardLiveFeedbackTests
             RemoteButtonPressed: false,
             VwasFusionActive: false,
             PwmDisplay: 0));
-        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteer);
+        var step = new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), autoSteer);
 
         InvokeNonPublic(step, "OnEntering", null);
 
@@ -176,7 +176,7 @@ public class SteerWizardLiveFeedbackTests
             RemoteButtonPressed: false,
             VwasFusionActive: false,
             PwmDisplay: 0));
-        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteer);
+        var step = new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), autoSteer);
 
         InvokeNonPublic(step, "OnEntering", null);
         Assume.That(step.WaitingForPhysicalSwitch, Is.True);

--- a/Tests/AgValoniaGPS.Services.Tests/SteerWizardStepTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/SteerWizardStepTests.cs
@@ -1455,7 +1455,7 @@ public class SteerWizardStepTests
     private AutoMotorCalibrationStepViewModel CreateAutoCalStep(
         IAutoSteerService? autoSteerService = null)
     {
-        var step = new AutoMotorCalibrationStepViewModel(_configService, autoSteerService);
+        var step = new AutoMotorCalibrationStepViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher(), autoSteerService);
         // Use instant delays for testing
         step.DelayFunc = (_, _) => Task.CompletedTask;
         return step;

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -89,6 +89,7 @@ public class MainViewModelBuilder
             logger: NullLogger<MainViewModel>.Instance,
             appState: new ApplicationState(),
             persistentStateService: Substitute.For<IPersistentStateService>(),
-            batteryService: new NullBatteryService());
+            batteryService: new NullBatteryService(),
+            uiDispatcher: new AgValoniaGPS.Services.Threading.InlineUiDispatcher());
     }
 }

--- a/Tests/AgValoniaGPS.UI.Tests/SmartWasViewModelTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/SmartWasViewModelTests.cs
@@ -51,7 +51,7 @@ public class SmartWasViewModelTests
             HasValidCalibration = false,
             SampleCount = 0,
         });
-        return new SmartWasViewModel(_smartWas, _configService, _udpService, _autoSteer);
+        return new SmartWasViewModel(_smartWas, _configService, _udpService, _autoSteer, new AgValoniaGPS.Services.Threading.InlineUiDispatcher());
     }
 
     private void SetSnapshot(SmartWasSnapshot snap)

--- a/Tests/AgValoniaGPS.UI.Tests/WizardScreenshotTests.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/WizardScreenshotTests.cs
@@ -75,7 +75,7 @@ public class WizardScreenshotTests
 
     private SteerWizardViewModel CreateWizard()
     {
-        return new SteerWizardViewModel(_configService);
+        return new SteerWizardViewModel(_configService, new AgValoniaGPS.Services.Threading.InlineUiDispatcher());
     }
 
     private static async Task ExecuteNextAsync(WizardViewModel wizard)

--- a/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
@@ -87,6 +87,7 @@ public class MainViewModelBuilder
             logger: NullLogger<MainViewModel>.Instance,
             appState: new ApplicationState(),
             persistentStateService: Substitute.For<IPersistentStateService>(),
-            batteryService: new NullBatteryService());
+            batteryService: new NullBatteryService(),
+            uiDispatcher: new AgValoniaGPS.Services.Threading.InlineUiDispatcher());
     }
 }


### PR DESCRIPTION
## What

Replaces direct `Avalonia.Threading.Dispatcher.UIThread` access in the ViewModel layer with an injected `IUiDispatcher`, so the VMs depend on a service rather than an ambient framework static. This is item **§11.1** of the config/state audit (`Plans/CONFIG_STATE_AUDIT.md`).

## Why

`Dispatcher.UIThread` is an ambient presentation-framework static reached for from inside the VMs — the same "not injected, just grabbed" smell `ARCHITECTURE.md` flags for the static singletons. It's also a hard blocker for a headless host (it throws with no Avalonia app), which the remote/web-UI Phase 0 spike surfaced. Was a defensible YAGNI deferral while every VM consumer was an Avalonia View; this pays it down.

## Changes

- **New (`Services`):** `IUiDispatcher` + `UiDispatcherPriority` enum (keeps Avalonia's `DispatcherPriority` from leaking into the VM/host) + `InlineUiDispatcher` (synchronous; for tests + headless hosts).
- **New (`Views`):** `AvaloniaUiDispatcher` wrapping `Dispatcher.UIThread`, mapping the priority enum — the single adapter keeping the Avalonia UI-thread dependency in the View layer.
- Converted all 30 sites (18 `Post` / 7 `CheckAccess` / 5 `InvokeAsync`) across `MainViewModel` partials, `SmartWasViewModel`, and `SwitchGatedWizardStep` (threaded through `SteerWizardViewModel` + the two wizard-step subclasses via ctor injection).
- Registered `IUiDispatcher -> AvaloniaUiDispatcher` in **Desktop / iOS / Android** DI.
- Updated both `MainViewModelBuilder`s + wizard/SmartWas tests to pass `InlineUiDispatcher`.
- **Out of scope (intentional):** `DispatcherTimer` usage (separate concern) and §11.2 de-static-ing of `ConfigurationStore.Instance` / `ApplicationState.Instance` (larger, sequenced separately).

## Verification

- Desktop **and** Android build clean (iOS uses the identical DI edit against the same shared type).
- Full suite green: **146 + 987 + 221 + 147 = 1501 passed, 2 skipped, 0 failed**.
- Ran the Desktop app — launched, ran, and exited clean with the injected dispatcher; no behavior change (production still marshals through `Dispatcher.UIThread`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)