### PR TITLE
Config/state audit §11.3: inject IUiTimer into the VM layer

### DIFF
--- a/Plans/CONFIG_STATE_AUDIT.md
+++ b/Plans/CONFIG_STATE_AUDIT.md
@@ -317,6 +317,16 @@ stands as a standalone follow-up.
 **Status:**
 - §11.1 `IUiDispatcher` — **DONE**, merged to `develop` (PR #470, 2026-06-14).
 - §11.2 static store de-static-ing — scoped, not scheduled (larger blast-radius).
-- §11.3 `ITimer`/scheduler — scoped, not scheduled; do it inside the web-UI headless-host work if that proceeds.
+- §11.3 `ITimer`/scheduler — **DONE** (PR #471). `IUiTimer` + `IUiTimerFactory`
+  (Services); impls: `AvaloniaUiTimer` (Views, wraps `DispatcherTimer` — the 3
+  platforms), `ManualUiTimer` (tests, framework-free, non-firing), `ThreadingUiTimer`
+  (headless host, `System.Threading.Timer`-based, fires with no Avalonia). All 7
+  VM `DispatcherTimer` sites (status-strip, clock, auto-day/night, autosave,
+  simulator, render-pull, status-tick) now go through the injected factory.
 
-All three surfaced by the remote/web-UI Phase 0 spike + retest.
+With §11.1 + §11.3 done, the VM no longer instantiates **any** Avalonia type at
+runtime that a headless boot would trip on (dispatcher + timers both abstracted).
+§11.2 (de-static `ConfigurationStore.Instance` / `ApplicationState.Instance`)
+remains the only open de-ambient item, and it's not a headless blocker.
+
+All surfaced by the remote/web-UI Phase 0 spike + retest.

--- a/Plans/CONFIG_STATE_AUDIT.md
+++ b/Plans/CONFIG_STATE_AUDIT.md
@@ -290,4 +290,33 @@ The same "ambient, not injected" smell applies to `ConfigurationStore.Instance` 
 would complete the "de-ambient the VM" pass — but it's larger blast-radius and can be sequenced
 separately. Keep §11.1 as the committed first step.
 
-**Status:** scoped, not scheduled. Surfaced by the remote/web-UI Phase 0 spike.
+### 11.3 Injectable `ITimer` / scheduler (the remaining headless blocker)
+The same axis again — an ambient Avalonia type instantiated *inside* the VM, this time
+`Avalonia.Threading.DispatcherTimer`. The `MainViewModel` ctor creates ~5 of them (status-strip
+rotation, clock, autosave, auto-day/night, simulator). `DispatcherTimer` captures
+`Dispatcher.UIThread` at construction, so it **throws in a process with no Avalonia dispatcher** —
+which is the concrete reason a headless host still needs `Avalonia.Headless` even after §11.1.
+After the marshalling calls were abstracted, this is the last thing that *functionally* ties a
+headless boot to Avalonia (the remaining `Avalonia.Point`/`Color`/`Application.Current` uses are
+value-type math or null-guarded and don't block headless execution).
+
+- Define `ITimer` / `IScheduler` (create a periodic callback with an interval; start/stop; change
+  interval) and inject it like `IUiDispatcher`. Richer than the dispatcher because timers have
+  lifecycle (start/stop/interval changes), so the interface is a little larger.
+- Avalonia-backed impl wraps `DispatcherTimer` (Views, alongside `AvaloniaUiDispatcher`); a
+  threaded/`PeriodicTimer`-based impl serves headless hosts and tests.
+- Replace the ~5 ctor `DispatcherTimer` sites; `DispatcherTimer` then exists only in the View layer.
+
+**Why now / why noted:** surfaced by the remote/web-UI **Phase 0 retest** after §11.1 merged — the
+marshalling hurdle cleared, but the spike still had to keep `Avalonia.Headless` purely for these
+timers. It is **not** blocking Phase 1 "alongside the Avalonia app" (the live app supplies a real
+dispatcher + timers); it is the prerequisite for the **fully Avalonia-free cab-PC host**
+(`Plans/REMOTE_WEB_UI_SPLIT.md` Phase 4/5). If the web-UI work proceeds, fix it there; otherwise it
+stands as a standalone follow-up.
+
+**Status:**
+- §11.1 `IUiDispatcher` — **DONE**, merged to `develop` (PR #470, 2026-06-14).
+- §11.2 static store de-static-ing — scoped, not scheduled (larger blast-radius).
+- §11.3 `ITimer`/scheduler — scoped, not scheduled; do it inside the web-UI headless-host work if that proceeds.
+
+All three surfaced by the remote/web-UI Phase 0 spike + retest.

--- a/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Android/DependencyInjection/ServiceCollectionExtensions.cs
@@ -61,6 +61,10 @@ public static class ServiceCollectionExtensions
         // in the VM layer — see Plans/CONFIG_STATE_AUDIT.md §11).
         services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();
 
+        // UI-thread timer abstraction (replaces direct DispatcherTimer in the
+        // VM layer — see Plans/CONFIG_STATE_AUDIT.md §11.3).
+        services.AddSingleton<IUiTimerFactory, AvaloniaUiTimerFactory>();
+
         // Register ViewModels
         services.AddTransient<MainViewModel>();
         services.AddTransient<ConfigurationViewModel>();

--- a/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.Desktop/DependencyInjection/ServiceCollectionExtensions.cs
@@ -61,6 +61,10 @@ public static class ServiceCollectionExtensions
         // in the VM layer — see Plans/CONFIG_STATE_AUDIT.md §11).
         services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();
 
+        // UI-thread timer abstraction (replaces direct DispatcherTimer in the
+        // VM layer — see Plans/CONFIG_STATE_AUDIT.md §11.3).
+        services.AddSingleton<IUiTimerFactory, AvaloniaUiTimerFactory>();
+
         // Register ViewModels
         services.AddTransient<MainViewModel>();
         services.AddTransient<ConfigurationViewModel>();

--- a/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Platforms/AgValoniaGPS.iOS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -61,6 +61,10 @@ public static class ServiceCollectionExtensions
         // in the VM layer — see Plans/CONFIG_STATE_AUDIT.md §11).
         services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();
 
+        // UI-thread timer abstraction (replaces direct DispatcherTimer in the
+        // VM layer — see Plans/CONFIG_STATE_AUDIT.md §11.3).
+        services.AddSingleton<IUiTimerFactory, AvaloniaUiTimerFactory>();
+
         // Register ViewModels
         services.AddTransient<MainViewModel>();
         services.AddTransient<ConfigurationViewModel>();

--- a/Shared/AgValoniaGPS.Services/Interfaces/IUiTimer.cs
+++ b/Shared/AgValoniaGPS.Services/Interfaces/IUiTimer.cs
@@ -1,0 +1,40 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+
+namespace AgValoniaGPS.Services.Interfaces;
+
+/// <summary>
+/// Abstraction over a periodic UI-thread timer. Replaces direct
+/// <c>Avalonia.Threading.DispatcherTimer</c> use in the ViewModel layer so the
+/// VM depends on an injected service rather than an ambient framework type —
+/// the same de-ambient pass as <see cref="IUiDispatcher"/>. This is what lets a
+/// headless host (no Avalonia dispatcher) run the VM's timers.
+/// See Plans/CONFIG_STATE_AUDIT.md §11.3.
+/// </summary>
+public interface IUiTimer
+{
+    /// <summary>Tick period. May be set before or after <see cref="Start"/>.</summary>
+    TimeSpan Interval { get; set; }
+
+    /// <summary>True while the timer is running.</summary>
+    bool IsEnabled { get; }
+
+    /// <summary>Raised every <see cref="Interval"/> while running.</summary>
+    event EventHandler Tick;
+
+    void Start();
+    void Stop();
+}
+
+/// <summary>Creates <see cref="IUiTimer"/> instances. Injected into the VM.</summary>
+public interface IUiTimerFactory
+{
+    IUiTimer Create();
+}

--- a/Shared/AgValoniaGPS.Services/Threading/ManualUiTimer.cs
+++ b/Shared/AgValoniaGPS.Services/Threading/ManualUiTimer.cs
@@ -1,0 +1,37 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services.Threading;
+
+/// <summary>
+/// Framework-free <see cref="IUiTimer"/> that never fires on its own — exactly
+/// the behaviour the VM's <c>DispatcherTimer</c>s have in tests (constructed but
+/// not pumped). Use in unit tests so VM construction is deterministic and timer
+/// callbacks don't fire spuriously; <see cref="Fire"/> lets a test trigger a
+/// tick explicitly. See Plans/CONFIG_STATE_AUDIT.md §11.3.
+/// </summary>
+public sealed class ManualUiTimer : IUiTimer
+{
+    public TimeSpan Interval { get; set; }
+    public bool IsEnabled { get; private set; }
+    public event EventHandler? Tick;
+
+    public void Start() => IsEnabled = true;
+    public void Stop() => IsEnabled = false;
+
+    /// <summary>Test hook — raise a single tick.</summary>
+    public void Fire() => Tick?.Invoke(this, EventArgs.Empty);
+}
+
+public sealed class ManualUiTimerFactory : IUiTimerFactory
+{
+    public IUiTimer Create() => new ManualUiTimer();
+}

--- a/Shared/AgValoniaGPS.Services/Threading/ThreadingUiTimer.cs
+++ b/Shared/AgValoniaGPS.Services/Threading/ThreadingUiTimer.cs
@@ -1,0 +1,51 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using System.Threading;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Services.Threading;
+
+/// <summary>
+/// Real firing <see cref="IUiTimer"/> backed by <see cref="System.Threading.Timer"/>,
+/// with NO Avalonia dependency — for a headless host (the cab PC) where the VM's
+/// timers (autosave, status rotation, etc.) must actually run but there is no
+/// Avalonia dispatcher. Ticks fire on a thread-pool thread; a headless host that
+/// needs them marshalled routes through <see cref="IUiDispatcher"/>.
+/// See Plans/CONFIG_STATE_AUDIT.md §11.3.
+/// </summary>
+public sealed class ThreadingUiTimer : IUiTimer, IDisposable
+{
+    private readonly Timer _timer;
+    private TimeSpan _interval = TimeSpan.FromSeconds(1);
+
+    public ThreadingUiTimer()
+    {
+        _timer = new Timer(_ => Tick?.Invoke(this, EventArgs.Empty), null,
+            Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    public TimeSpan Interval
+    {
+        get => _interval;
+        set { _interval = value; if (IsEnabled) _timer.Change(value, value); }
+    }
+
+    public bool IsEnabled { get; private set; }
+    public event EventHandler? Tick;
+
+    public void Start() { IsEnabled = true; _timer.Change(_interval, _interval); }
+    public void Stop() { IsEnabled = false; _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); }
+    public void Dispose() => _timer.Dispose();
+}
+
+public sealed class ThreadingUiTimerFactory : IUiTimerFactory
+{
+    public IUiTimer Create() => new ThreadingUiTimer();
+}

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Autosave.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Autosave.cs
@@ -27,7 +27,7 @@ public partial class MainViewModel
     /// </summary>
     private const int CoverageAutosaveIntervalSeconds = 30;
 
-    private DispatcherTimer? _coverageAutosaveTimer;
+    private AgValoniaGPS.Services.Interfaces.IUiTimer? _coverageAutosaveTimer;
 
     /// <summary>
     /// Re-entrancy guard: if a save is already running on the background
@@ -45,10 +45,8 @@ public partial class MainViewModel
         if (_coverageAutosaveTimer != null)
             return;
 
-        _coverageAutosaveTimer = new DispatcherTimer
-        {
-            Interval = TimeSpan.FromSeconds(CoverageAutosaveIntervalSeconds)
-        };
+        _coverageAutosaveTimer = _timerFactory.Create();
+        _coverageAutosaveTimer.Interval = TimeSpan.FromSeconds(CoverageAutosaveIntervalSeconds);
         _coverageAutosaveTimer.Tick += OnCoverageAutosaveTick;
         _coverageAutosaveTimer.Start();
         _logger.LogDebug("[Coverage] Autosave timer started ({Interval}s)", CoverageAutosaveIntervalSeconds);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.StatusStrip.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.StatusStrip.cs
@@ -40,7 +40,7 @@ public partial class MainViewModel
         AbLine,
     }
 
-    private DispatcherTimer? _statusStripRotationTimer;
+    private AgValoniaGPS.Services.Interfaces.IUiTimer? _statusStripRotationTimer;
     private StatusStripPage _statusStripPage = StatusStripPage.Field;
     private bool _isStatusStripRotationPaused;
 
@@ -114,10 +114,8 @@ public partial class MainViewModel
         ToggleStatusStripRotationCommand = new RelayCommand(() =>
             IsStatusStripRotationPaused = !IsStatusStripRotationPaused);
 
-        _statusStripRotationTimer = new DispatcherTimer
-        {
-            Interval = TimeSpan.FromSeconds(RotationIntervalSeconds),
-        };
+        _statusStripRotationTimer = _timerFactory.Create();
+        _statusStripRotationTimer.Interval = TimeSpan.FromSeconds(RotationIntervalSeconds);
         _statusStripRotationTimer.Tick += (_, _) => AdvanceStatusStripPage();
         _statusStripRotationTimer.Start();
     }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.ViewSettings.cs
@@ -151,7 +151,8 @@ public partial class MainViewModel
     private void InitializeClock()
     {
         CurrentTime = DateTime.Now.ToString("HH:mm:ss");
-        var clockTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        var clockTimer = _timerFactory.Create();
+        clockTimer.Interval = TimeSpan.FromSeconds(1);
         clockTimer.Tick += (_, _) => CurrentTime = DateTime.Now.ToString("HH:mm:ss");
         clockTimer.Start();
     }
@@ -336,15 +337,13 @@ public partial class MainViewModel
 
     #region Auto Day/Night
 
-    private DispatcherTimer? _autoDayNightTimer;
+    private AgValoniaGPS.Services.Interfaces.IUiTimer? _autoDayNightTimer;
 
     private void InitializeAutoDayNight()
     {
         CheckAutoDayNight();
-        _autoDayNightTimer = new DispatcherTimer
-        {
-            Interval = TimeSpan.FromSeconds(60)
-        };
+        _autoDayNightTimer = _timerFactory.Create();
+        _autoDayNightTimer.Interval = TimeSpan.FromSeconds(60);
         _autoDayNightTimer.Tick += (_, _) => CheckAutoDayNight();
         _autoDayNightTimer.Start();
     }

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -94,12 +94,13 @@ public partial class MainViewModel : ObservableObject
     private readonly IPipelineIntents _intents;
     private readonly ILogger<MainViewModel> _logger;
     private readonly ApplicationState _appState;
-    private readonly Avalonia.Threading.DispatcherTimer _simulatorTimer;
-    private Avalonia.Threading.DispatcherTimer? _renderPullTimer;
+    private readonly IUiTimerFactory _timerFactory;
+    private readonly IUiTimer _simulatorTimer;
+    private IUiTimer? _renderPullTimer;
     // PERF-05 Phase 2c #2: unified 5 Hz status-display tick, decoupled from
     // every data source (GPS 10 Hz, control loop 100 Hz, AutoSteer 100 Hz).
     // Drives every MainViewModel property bound to the top status bar.
-    private Avalonia.Threading.DispatcherTimer? _statusTickTimer;
+    private IUiTimer? _statusTickTimer;
 
     /// <summary>
     /// Centralized application state - single source of truth for all runtime state.
@@ -226,6 +227,7 @@ public partial class MainViewModel : ObservableObject
         IPersistentStateService persistentStateService,
         IBatteryService batteryService,
         IUiDispatcher uiDispatcher,
+        IUiTimerFactory uiTimerFactory,
         ISteerMachineLoopService? controlLoop = null,
         IPositionEstimator? positionEstimator = null)
     {
@@ -233,6 +235,7 @@ public partial class MainViewModel : ObservableObject
         _persistentStateService = persistentStateService;
         _batteryService = batteryService;
         _dispatcher = uiDispatcher;
+        _timerFactory = uiTimerFactory;
         _tramLineService = tramLineService;
 
         // Battery icon in the strip — start the per-platform reader, prime with
@@ -418,10 +421,8 @@ public partial class MainViewModel : ObservableObject
             // ~20 Hz on mobile to give the composition thread headroom; desktop
             // keeps 30 Hz for smoother vehicle interpolation.
             int intervalMs = (OperatingSystem.IsIOS() || OperatingSystem.IsAndroid()) ? 50 : 33;
-            _renderPullTimer = new Avalonia.Threading.DispatcherTimer
-            {
-                Interval = TimeSpan.FromMilliseconds(intervalMs),
-            };
+            _renderPullTimer = _timerFactory.Create();
+            _renderPullTimer.Interval = TimeSpan.FromMilliseconds(intervalMs);
             _renderPullTimer.Tick += OnRenderPullTick;
             _renderPullTimer.Start();
         }
@@ -438,10 +439,8 @@ public partial class MainViewModel : ObservableObject
         // half the rate, and now also includes diagnostics like
         // GpsToPgnLatencyMs that AutoSteer was writing at 100 Hz.
         // See Plans/perf_data/2026-05-20/ANALYSIS.md.
-        _statusTickTimer = new Avalonia.Threading.DispatcherTimer
-        {
-            Interval = TimeSpan.FromMilliseconds(200),
-        };
+        _statusTickTimer = _timerFactory.Create();
+        _statusTickTimer.Interval = TimeSpan.FromMilliseconds(200);
         _statusTickTimer.Tick += OnStatusTick;
         _statusTickTimer.Start();
         _udpService.ModuleConnectionChanged += OnModuleConnectionChanged;
@@ -504,10 +503,8 @@ public partial class MainViewModel : ObservableObject
         // Note: Simulator coordinates are restored in RestoreSettings() from saved app settings
         // Default values only used if no settings exist (first run)
 
-        _simulatorTimer = new Avalonia.Threading.DispatcherTimer
-        {
-            Interval = TimeSpan.FromMilliseconds(33) // ~30Hz — pipeline back-pressure skips if processing is slow
-        };
+        _simulatorTimer = _timerFactory.Create();
+        _simulatorTimer.Interval = TimeSpan.FromMilliseconds(33); // ~30Hz — pipeline back-pressure skips if processing is slow
         _simulatorTimer.Tick += OnSimulatorTick;
 
         // Initialize commands (split into partial class files for organization)

--- a/Shared/AgValoniaGPS.Views/Infrastructure/AvaloniaUiTimer.cs
+++ b/Shared/AgValoniaGPS.Views/Infrastructure/AvaloniaUiTimer.cs
@@ -1,0 +1,46 @@
+// AgValoniaGPS
+// Copyright (C) 2024-2025 AgValoniaGPS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+using System;
+using Avalonia.Threading;
+using AgValoniaGPS.Services.Interfaces;
+
+namespace AgValoniaGPS.Views.Infrastructure;
+
+/// <summary>
+/// Avalonia-backed <see cref="IUiTimer"/> wrapping <see cref="DispatcherTimer"/>
+/// — fires on the UI thread, identical to the VM's previous direct use.
+/// Registered by each platform's DI alongside <see cref="AvaloniaUiDispatcher"/>.
+/// See Plans/CONFIG_STATE_AUDIT.md §11.3.
+/// </summary>
+public sealed class AvaloniaUiTimer : IUiTimer
+{
+    private readonly DispatcherTimer _timer = new();
+
+    public AvaloniaUiTimer()
+    {
+        _timer.Tick += (_, _) => Tick?.Invoke(this, EventArgs.Empty);
+    }
+
+    public TimeSpan Interval
+    {
+        get => _timer.Interval;
+        set => _timer.Interval = value;
+    }
+
+    public bool IsEnabled => _timer.IsEnabled;
+    public event EventHandler? Tick;
+
+    public void Start() => _timer.Start();
+    public void Stop() => _timer.Stop();
+}
+
+public sealed class AvaloniaUiTimerFactory : IUiTimerFactory
+{
+    public IUiTimer Create() => new AvaloniaUiTimer();
+}

--- a/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.UI.Tests/MainViewModelBuilder.cs
@@ -90,6 +90,7 @@ public class MainViewModelBuilder
             appState: new ApplicationState(),
             persistentStateService: Substitute.For<IPersistentStateService>(),
             batteryService: new NullBatteryService(),
-            uiDispatcher: new AgValoniaGPS.Services.Threading.InlineUiDispatcher());
+            uiDispatcher: new AgValoniaGPS.Services.Threading.InlineUiDispatcher(),
+            uiTimerFactory: new AgValoniaGPS.Services.Threading.ManualUiTimerFactory());
     }
 }

--- a/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/MainViewModelBuilder.cs
@@ -88,6 +88,7 @@ public class MainViewModelBuilder
             appState: new ApplicationState(),
             persistentStateService: Substitute.For<IPersistentStateService>(),
             batteryService: new NullBatteryService(),
-            uiDispatcher: new AgValoniaGPS.Services.Threading.InlineUiDispatcher());
+            uiDispatcher: new AgValoniaGPS.Services.Threading.InlineUiDispatcher(),
+            uiTimerFactory: new AgValoniaGPS.Services.Threading.ManualUiTimerFactory());
     }
 }


### PR DESCRIPTION
Implements **§11.3** — replaces direct `Avalonia.Threading.DispatcherTimer` in the ViewModels with an injected `IUiTimerFactory`, mirroring §11.1's `IUiDispatcher` (#470). This is the last ambient Avalonia type the VM instantiated at runtime, so with §11.1 a headless boot no longer trips on a missing Avalonia dispatcher/timer.

## Changes
- **`IUiTimer` + `IUiTimerFactory`** (Services). Surface: `Interval`, `Tick`, `Start`, `Stop`.
- **`AvaloniaUiTimer`** (Views) — wraps `DispatcherTimer`, fires on the UI thread exactly as before; registered in **Desktop / iOS / Android** DI.
- **`ManualUiTimer`** (Services) — framework-free, non-firing; both test builders use it (preserves "timers don't fire in tests", and `ViewModels.Tests` stays Avalonia-free).
- **`ThreadingUiTimer`** (Services) — real `System.Threading.Timer` impl for a headless host (fires, no Avalonia).
- All **7** VM timer sites converted (status-strip rotation, clock, auto-day/night, autosave, simulator, render-pull, status-tick).
- Doc: §11.3 marked DONE.

## Verification
- Desktop + Android build; iOS uses the identical DI edit.
- Tests green: **146 + 987 + 221 + 147 = 1501, 0 failed**.

With §11.1 + §11.3 done, §11.2 (de-static the singletons) is the only remaining de-ambient item — and it's not a headless blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)