### PR TITLE
Audit §12 fix (1/2): delete dead field state + collapse geometry shadows

### DIFF
--- a/Shared/AgValoniaGPS.Models/State/FieldState.cs
+++ b/Shared/AgValoniaGPS.Models/State/FieldState.cs
@@ -39,8 +39,8 @@ namespace AgValoniaGPS.Models.State;
 /// <list type="table">
 ///   <listheader><term>Property</term><description>Written by</description></listheader>
 ///   <item><term>ActiveField / FieldsRootDirectory</term>            <description>UI — field open/close commands</description></item>
-///   <item><term>Boundaries / CurrentBoundary</term>                 <description>UI — boundary load/edit commands</description></item>
-///   <item><term>Tracks / ActiveTrack / SelectedTrack</term>         <description>UI — track load + selection</description></item>
+///   <item><term>CurrentBoundary</term>                              <description>UI — boundary load/edit commands</description></item>
+///   <item><term>Tracks / ActiveTrack</term>                         <description>UI — track load + selection</description></item>
 ///   <item><term>HeadlandLine / HeadlandDistance</term>              <description>UI — headland load/build commands</description></item>
 ///   <item><term>HeadlandProximityDistance / …Warning</term>         <description>UI mirror of cycle output in <c>ApplyGpsCycleResult</c></description></item>
 ///   <item><term>OriginLatitude / OriginLongitude</term>             <description>UI — <c>SetFieldOrigin</c></description></item>
@@ -79,17 +79,14 @@ public class FieldState : ObservableObject
         set => SetProperty(ref _fieldsRootDirectory, value);
     }
 
-    // Boundaries
-    public ObservableCollection<Boundary> Boundaries { get; } = new();
-
+    // Boundary — the field's active boundary. Services (guidance, section
+    // control) read this directly; it is the runtime SoT (CONFIG_STATE_AUDIT §12.1).
     private Boundary? _currentBoundary;
     public Boundary? CurrentBoundary
     {
         get => _currentBoundary;
         set => SetProperty(ref _currentBoundary, value);
     }
-
-    public bool HasBoundary => Boundaries.Count > 0;
 
     // Tracks (unified Track model)
     public ObservableCollection<Track.Track> Tracks { get; } = new();
@@ -99,13 +96,6 @@ public class FieldState : ObservableObject
     {
         get => _activeTrack;
         set => SetProperty(ref _activeTrack, value);
-    }
-
-    private Track.Track? _selectedTrack;
-    public Track.Track? SelectedTrack
-    {
-        get => _selectedTrack;
-        set => SetProperty(ref _selectedTrack, value);
     }
 
     public bool HasActiveTrack => ActiveTrack != null;
@@ -193,11 +183,9 @@ public class FieldState : ObservableObject
     public void Reset()
     {
         ActiveField = null;
-        Boundaries.Clear();
         CurrentBoundary = null;
         Tracks.Clear();
         ActiveTrack = null;
-        SelectedTrack = null;
         HeadlandLine = null;
         HeadlandDistance = 0;
         HeadlandProximityDistance = null;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
@@ -348,7 +348,7 @@ public partial class MainViewModel
         ResetHeadlandCommand = new RelayCommand(() =>
         {
             // Save for undo
-            _previousHeadlandLine = _currentHeadlandLine != null ? new List<Vec3>(_currentHeadlandLine) : null;
+            _previousHeadlandLine = State.Field.HeadlandLine != null ? new List<Vec3>(State.Field.HeadlandLine) : null;
             _previousHasHeadland = HasHeadland;
 
             ClearHeadlandCommand?.Execute(null);
@@ -390,14 +390,14 @@ public partial class MainViewModel
 
             if (_previousHeadlandLine != null && _previousHeadlandLine.Count >= 3)
             {
-                _currentHeadlandLine = _previousHeadlandLine;
+                State.Field.HeadlandLine = _previousHeadlandLine;
                 State.Field.HeadlandLine = _previousHeadlandLine;
                 _mapService.SetHeadlandLine(_previousHeadlandLine);
                 _mapService.SetHeadlandVisible(true);
             }
             else
             {
-                _currentHeadlandLine = null;
+                State.Field.HeadlandLine = null;
                 State.Field.HeadlandLine = null;
                 _mapService.SetHeadlandVisible(false);
             }
@@ -413,14 +413,14 @@ public partial class MainViewModel
         TurnOffHeadlandCommand = new RelayCommand(() =>
         {
             // Save for undo
-            _previousHeadlandLine = _currentHeadlandLine != null ? new List<Vec3>(_currentHeadlandLine) : null;
+            _previousHeadlandLine = State.Field.HeadlandLine != null ? new List<Vec3>(State.Field.HeadlandLine) : null;
             _previousHasHeadland = HasHeadland;
 
             IsHeadlandOn = false;
             HasHeadland = false;
             CurrentHeadlandLine = null;
             HeadlandPreviewLine = null;
-            _currentHeadlandLine = null;
+            State.Field.HeadlandLine = null;
             State.Field.HeadlandLine = null;
             _mapService.SetHeadlandVisible(false);
             OnPropertyChanged(nameof(HeadlandStatusText));

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Boundary.cs
@@ -37,10 +37,10 @@ public partial class MainViewModel
         // Boundary Map Dialog Commands (satellite map boundary drawing)
         ShowBoundaryMapDialogCommand = new RelayCommand(() =>
         {
-            if (_fieldOriginLatitude != 0 || _fieldOriginLongitude != 0)
+            if (State.Field.OriginLatitude != 0 || State.Field.OriginLongitude != 0)
             {
-                BoundaryMapCenterLatitude = _fieldOriginLatitude;
-                BoundaryMapCenterLongitude = _fieldOriginLongitude;
+                BoundaryMapCenterLatitude = State.Field.OriginLatitude;
+                BoundaryMapCenterLongitude = State.Field.OriginLongitude;
             }
             else if (Latitude != 0 || Longitude != 0)
             {
@@ -74,8 +74,8 @@ public partial class MainViewModel
                     // Use the EXISTING field origin for LocalPlane conversion - do NOT change it!
                     // The field origin is set when the field is created and should remain constant.
                     // Changing it would break all local coordinate systems.
-                    var originLat = _fieldOriginLatitude;
-                    var originLon = _fieldOriginLongitude;
+                    var originLat = State.Field.OriginLatitude;
+                    var originLon = State.Field.OriginLongitude;
 
                     _logger.LogDebug($"[BoundaryMap] Using existing field origin: ({originLat:F8}, {originLon:F8})");
                     _logger.LogDebug($"[BoundaryMap] Current simulator position: ({Latitude:F8}, {Longitude:F8})");

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Fields.cs
@@ -585,7 +585,7 @@ public partial class MainViewModel
                 _persistentStateService.Save();
 
                 RefreshBoundaryList();
-                SetSimulatorCoordinates(_fieldOriginLatitude, _fieldOriginLongitude);
+                SetSimulatorCoordinates(State.Field.OriginLatitude, State.Field.OriginLongitude);
 
                 State.UI.CloseDialog();
                 IsFieldOperationsPanelVisible = false;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Settings.cs
@@ -558,7 +558,7 @@ public partial class MainViewModel
             return;
         }
 
-        if (_fieldOriginLatitude == 0 && _fieldOriginLongitude == 0 &&
+        if (State.Field.OriginLatitude == 0 && State.Field.OriginLongitude == 0 &&
             Latitude == 0 && Longitude == 0)
         {
             FlagByLatLonError = "No field or GPS origin available";
@@ -566,8 +566,8 @@ public partial class MainViewModel
         }
 
         // Use field origin if available, else current GPS position as origin
-        double originLat = _fieldOriginLatitude != 0 ? _fieldOriginLatitude : Latitude;
-        double originLon = _fieldOriginLongitude != 0 ? _fieldOriginLongitude : Longitude;
+        double originLat = State.Field.OriginLatitude != 0 ? State.Field.OriginLatitude : Latitude;
+        double originLon = State.Field.OriginLongitude != 0 ? State.Field.OriginLongitude : Longitude;
 
         var converter = new Models.Base.GeoConversion(originLat, originLon);
         var local = converter.ToLocal(lat, lon);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Commands.Track.cs
@@ -1155,7 +1155,7 @@ public partial class MainViewModel
 
         CreateTrackFromBoundaryCommand = new RelayCommand(() =>
         {
-            var boundary = _currentBoundary?.OuterBoundary;
+            var boundary = State.Field.CurrentBoundary?.OuterBoundary;
             if (boundary?.Points == null || boundary.Points.Count < 3)
             {
                 ShowErrorDialog("No Boundary", "Load a field with a boundary first.");
@@ -1258,7 +1258,7 @@ public partial class MainViewModel
 
         CreateCurveFromBoundaryCommand = new RelayCommand(() =>
         {
-            var boundary = _currentBoundary?.OuterBoundary;
+            var boundary = State.Field.CurrentBoundary?.OuterBoundary;
             if (boundary?.Points == null || boundary.Points.Count < 3)
             {
                 ShowErrorDialog("No Boundary", "Load a field with a boundary first.");
@@ -1316,7 +1316,7 @@ public partial class MainViewModel
 
         CreateTracksFromAllEdgesCommand = new RelayCommand(() =>
         {
-            var boundary = _currentBoundary?.OuterBoundary;
+            var boundary = State.Field.CurrentBoundary?.OuterBoundary;
             if (boundary?.Points == null || boundary.Points.Count < 3)
             {
                 ShowErrorDialog("No Boundary", "Load a field with a boundary first.");
@@ -1393,9 +1393,9 @@ public partial class MainViewModel
         double extendA = marginMeters;
         double extendB = marginMeters;
 
-        if (_currentBoundary?.OuterBoundary != null && _currentBoundary.OuterBoundary.IsValid)
+        if (State.Field.CurrentBoundary?.OuterBoundary != null && State.Field.CurrentBoundary.OuterBoundary.IsValid)
         {
-            var boundaryPts = _currentBoundary.OuterBoundary.Points;
+            var boundaryPts = State.Field.CurrentBoundary.OuterBoundary.Points;
             int count = boundaryPts.Count;
 
             // Raycast from pointA backwards to find boundary intersection
@@ -1489,9 +1489,9 @@ public partial class MainViewModel
         double extendStart = marginMeters;
         double extendEnd = marginMeters;
 
-        if (_currentBoundary?.OuterBoundary != null && _currentBoundary.OuterBoundary.IsValid)
+        if (State.Field.CurrentBoundary?.OuterBoundary != null && State.Field.CurrentBoundary.OuterBoundary.IsValid)
         {
-            var boundaryPts = _currentBoundary.OuterBoundary.Points;
+            var boundaryPts = State.Field.CurrentBoundary.OuterBoundary.Points;
             int count = boundaryPts.Count;
 
             // Raycast from first point backwards to find boundary intersection

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.GpsHandling.cs
@@ -406,7 +406,7 @@ public partial class MainViewModel
         _gpsPipelineService.SetAutoSteerEngaged(_isAutoSteerEngaged);
         _gpsPipelineService.SetActiveTrack(track, pathsAway, nudgeOffset, isOnBoundary);
         _gpsPipelineService.SetBoundary(CurrentBoundary);
-        _gpsPipelineService.SetHeadlandLine(_currentHeadlandLine);
+        _gpsPipelineService.SetHeadlandLine(State.Field.HeadlandLine);
         _gpsPipelineService.SetDriftCompensation(State.Field.DriftEasting, State.Field.DriftNorthing);
         // Never arm U-turns on a closed/polygon track, regardless of the toggle (#421).
         _gpsPipelineService.SetYouTurnEnabled(IsYouTurnEnabled && !IsActiveTrackClosed);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Headland.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Headland.cs
@@ -65,7 +65,7 @@ public partial class MainViewModel
         else if (segment.BoundaryPoints.Count >= 2)
         {
             // Open segment: determine which side faces the field center
-            var boundary = _currentBoundary?.OuterBoundary;
+            var boundary = State.Field.CurrentBoundary?.OuterBoundary;
             if (boundary?.Points != null && boundary.Points.Count >= 3)
             {
                 // Calculate boundary centroid
@@ -238,7 +238,7 @@ public partial class MainViewModel
         if (HeadlandSegments.Count == 0)
         {
             // Default: headland = boundary
-            var boundary = _currentBoundary?.OuterBoundary;
+            var boundary = State.Field.CurrentBoundary?.OuterBoundary;
             if (boundary?.Points != null && boundary.Points.Count >= 3)
             {
                 var bndPoints = new List<Vec3>();
@@ -246,7 +246,7 @@ public partial class MainViewModel
                     bndPoints.Add(new Vec3(pt.Easting, pt.Northing, pt.Heading));
                 bndPoints.Add(new Vec3(boundary.Points[0].Easting, boundary.Points[0].Northing, boundary.Points[0].Heading));
 
-                _currentHeadlandLine = bndPoints;
+                State.Field.HeadlandLine = bndPoints;
                 CurrentHeadlandLine = bndPoints;
                 State.Field.HeadlandLine = bndPoints;
                 HasHeadland = true;
@@ -258,7 +258,7 @@ public partial class MainViewModel
             {
                 HasHeadland = false;
                 IsHeadlandOn = false;
-                _currentHeadlandLine = null;
+                State.Field.HeadlandLine = null;
                 CurrentHeadlandLine = null;
                 State.Field.HeadlandLine = null;
                 _mapService.SetHeadlandVisible(false);
@@ -269,7 +269,7 @@ public partial class MainViewModel
         }
 
         // Start with headland = boundary
-        var bnd = _currentBoundary?.OuterBoundary;
+        var bnd = State.Field.CurrentBoundary?.OuterBoundary;
         if (bnd?.Points == null || bnd.Points.Count < 3)
         {
             StatusMessage = "No boundary for headland";
@@ -704,7 +704,7 @@ public partial class MainViewModel
         }
 
         // Apply headland
-        _currentHeadlandLine = headland;
+        State.Field.HeadlandLine = headland;
         CurrentHeadlandLine = headland;
         State.Field.HeadlandLine = headland;
         HasHeadland = true;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.Simulator.cs
@@ -70,11 +70,11 @@ public partial class MainViewModel
             var sharedProps = new AgValoniaGPS.Models.SharedFieldProperties();
             AgValoniaGPS.Models.Wgs84 origin;
 
-            if (_fieldOriginLatitude != 0 && _fieldOriginLongitude != 0)
+            if (State.Field.OriginLatitude != 0 && State.Field.OriginLongitude != 0)
             {
                 // Use field origin so coordinates match the field's boundary/track data
-                origin = new AgValoniaGPS.Models.Wgs84(_fieldOriginLatitude, _fieldOriginLongitude);
-                _logger.LogDebug("[Simulator] Using field origin: {FieldOriginLatitude}, {FieldOriginLongitude}", _fieldOriginLatitude, _fieldOriginLongitude);
+                origin = new AgValoniaGPS.Models.Wgs84(State.Field.OriginLatitude, State.Field.OriginLongitude);
+                _logger.LogDebug("[Simulator] Using field origin: {FieldOriginLatitude}, {FieldOriginLongitude}", State.Field.OriginLatitude, State.Field.OriginLongitude);
             }
             else
             {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.YouTurn.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.YouTurn.cs
@@ -227,7 +227,7 @@ public partial class MainViewModel
     private bool IsTrackOnBoundary(Track? track, double threshold = 5.0, double minOverlapPercent = 0.5)
     {
         if (track == null || track.Points.Count == 0) return false;
-        if (_currentBoundary?.OuterBoundary == null || !_currentBoundary.OuterBoundary.IsValid) return false;
+        if (State.Field.CurrentBoundary?.OuterBoundary == null || !State.Field.CurrentBoundary.OuterBoundary.IsValid) return false;
 
         int pointsNearBoundary = 0;
         foreach (var point in track.Points)
@@ -241,10 +241,10 @@ public partial class MainViewModel
 
     private double DistanceToBoundary(double easting, double northing)
     {
-        if (_currentBoundary?.OuterBoundary == null || !_currentBoundary.OuterBoundary.IsValid)
+        if (State.Field.CurrentBoundary?.OuterBoundary == null || !State.Field.CurrentBoundary.OuterBoundary.IsValid)
             return double.MaxValue;
 
-        var points = _currentBoundary.OuterBoundary.Points;
+        var points = State.Field.CurrentBoundary.OuterBoundary.Points;
         double minDist = double.MaxValue;
         for (int i = 0; i < points.Count; i++)
         {

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -176,7 +176,6 @@ public partial class MainViewModel : ObservableObject
     private double _hitchNorthing;
 
     // Field properties
-    private Field? _activeField;
     private string _fieldsRootDirectory = string.Empty;
 
     public MainViewModel(
@@ -1213,10 +1212,18 @@ public partial class MainViewModel : ObservableObject
 
 
     // Field management properties
+    // Active field — single home is State.Field.ActiveField (§12.1). Pass-through.
     public Field? ActiveField
     {
-        get => _activeField;
-        set => SetProperty(ref _activeField, value);
+        get => State.Field.ActiveField;
+        set
+        {
+            if (!ReferenceEquals(State.Field.ActiveField, value))
+            {
+                State.Field.ActiveField = value;
+                OnPropertyChanged();
+            }
+        }
     }
 
     public string FieldsRootDirectory

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -1901,7 +1901,7 @@ public partial class MainViewModel : ObservableObject
             State.Field.HeadlandLine = null;
             State.Field.HeadlandDistance = 0;
 
-            _currentHeadlandLine = null;
+            State.Field.HeadlandLine = null;
             _mapService.SetHeadlandLine(null);
             _mapService.SetHeadlandVisible(false);
             HeadlandSegments.Clear();
@@ -1925,22 +1925,22 @@ public partial class MainViewModel : ObservableObject
                 State.Field.HeadlandDistance = headlandLine.Tracks[0].MoveDistance;
 
                 // Use direct field assignment to avoid triggering save
-                _currentHeadlandLine = headlandLine.Tracks[0].TrackPoints;
-                _mapService.SetHeadlandLine(_currentHeadlandLine);
+                State.Field.HeadlandLine = headlandLine.Tracks[0].TrackPoints;
+                _mapService.SetHeadlandLine(State.Field.HeadlandLine);
                 OnPropertyChanged(nameof(CurrentHeadlandLine));
 
                 HasHeadland = true;
                 IsHeadlandOn = true;
                 HeadlandDistance = headlandLine.Tracks[0].MoveDistance;
 
-                _logger.LogDebug($"[Headland] Loaded headland from {field.DirectoryPath} ({_currentHeadlandLine.Count} points)");
+                _logger.LogDebug($"[Headland] Loaded headland from {field.DirectoryPath} ({State.Field.HeadlandLine.Count} points)");
             }
             else
             {
                 State.Field.HeadlandLine = null;
                 State.Field.HeadlandDistance = 0;
 
-                _currentHeadlandLine = null;
+                State.Field.HeadlandLine = null;
                 _mapService.SetHeadlandLine(null);
                 HasHeadland = false;
                 IsHeadlandOn = false;
@@ -1953,7 +1953,7 @@ public partial class MainViewModel : ObservableObject
             State.Field.HeadlandLine = null;
             State.Field.HeadlandDistance = 0;
 
-            _currentHeadlandLine = null;
+            State.Field.HeadlandLine = null;
             _mapService.SetHeadlandLine(null);
             HasHeadland = false;
             IsHeadlandOn = false;
@@ -2233,17 +2233,17 @@ public partial class MainViewModel : ObservableObject
         var config = ConfigurationStore.Instance.Tram;
 
         // Set boundary fence for clipping tram lines
-        if (_currentBoundary?.OuterBoundary?.Points != null && _currentBoundary.OuterBoundary.Points.Count >= 3)
+        if (State.Field.CurrentBoundary?.OuterBoundary?.Points != null && State.Field.CurrentBoundary.OuterBoundary.Points.Count >= 3)
         {
-            var fencePts = _currentBoundary.OuterBoundary.Points
+            var fencePts = State.Field.CurrentBoundary.OuterBoundary.Points
                 .Select(p => new Models.Base.Vec3(p.Easting, p.Northing, p.Heading)).ToList();
             _tramLineService.SetBoundaryFence(fencePts);
         }
 
         double fieldWidth = 500;
-        if (_currentBoundary?.OuterBoundary?.Points != null && _currentBoundary.OuterBoundary.Points.Count > 0)
+        if (State.Field.CurrentBoundary?.OuterBoundary?.Points != null && State.Field.CurrentBoundary.OuterBoundary.Points.Count > 0)
         {
-            var pts = _currentBoundary.OuterBoundary.Points;
+            var pts = State.Field.CurrentBoundary.OuterBoundary.Points;
             double maxE = pts.Max(p => p.Easting), minE = pts.Min(p => p.Easting);
             double maxN = pts.Max(p => p.Northing), minN = pts.Min(p => p.Northing);
             fieldWidth = Math.Max(maxE - minE, maxN - minN) * 1.2;
@@ -2270,10 +2270,10 @@ public partial class MainViewModel : ObservableObject
                     hasBoundarySystem = true;
                     int passes = sys.PassCount > 0 ? sys.PassCount : 1;
                     int bndStartIdx = _tramLineService.ParallelTramLines.Count;
-                    if (_currentBoundary?.OuterBoundary?.Points != null &&
-                        _currentBoundary.OuterBoundary.Points.Count >= 3)
+                    if (State.Field.CurrentBoundary?.OuterBoundary?.Points != null &&
+                        State.Field.CurrentBoundary.OuterBoundary.Points.Count >= 3)
                     {
-                        var bndPts = _currentBoundary.OuterBoundary.Points
+                        var bndPts = State.Field.CurrentBoundary.OuterBoundary.Points
                             .Select(p => new Models.Base.Vec3(p.Easting, p.Northing, p.Heading)).ToList();
                         _tramLineService.GenerateBoundaryTramTracks(bndPts, passes, sys.Mode, sys.TramWidth);
                     }
@@ -3247,13 +3247,14 @@ public partial class MainViewModel : ObservableObject
         set => SetProperty(ref _headlandPasses, Math.Max(1, Math.Min(5, value)));
     }
 
-    private List<Models.Base.Vec3>? _currentHeadlandLine;
+    // Headland — single home is State.Field.HeadlandLine (§12.1). Pass-through.
     public List<Models.Base.Vec3>? CurrentHeadlandLine
     {
-        get => _currentHeadlandLine;
+        get => State.Field.HeadlandLine;
         set
         {
-            SetProperty(ref _currentHeadlandLine, value);
+            State.Field.HeadlandLine = value;
+            OnPropertyChanged();
             _mapService.SetHeadlandLine(value);
             SaveHeadlandToFile(value);
 
@@ -3317,11 +3318,19 @@ public partial class MainViewModel : ObservableObject
     /// <summary>
     /// Gets the current field's boundary for use in the headland editor.
     /// </summary>
-    private Boundary? _currentBoundary;
+    // Boundary — single home is State.Field.CurrentBoundary (§12.1). This VM
+    // property is a thin pass-through for binding; no local copy.
     public Boundary? CurrentBoundary
     {
-        get => _currentBoundary;
-        private set => SetProperty(ref _currentBoundary, value);
+        get => State.Field.CurrentBoundary;
+        private set
+        {
+            if (!ReferenceEquals(State.Field.CurrentBoundary, value))
+            {
+                State.Field.CurrentBoundary = value;
+                OnPropertyChanged();
+            }
+        }
     }
 
     // Headland undo state
@@ -3805,16 +3814,16 @@ public partial class MainViewModel : ObservableObject
     public ICommand? IncreaseHeadlandDistanceCommand { get; private set; }
     public ICommand? DecreaseHeadlandDistanceCommand { get; private set; }
 
-    public System.Collections.Generic.IReadOnlyList<Models.Base.Vec3>? CurrentHeadlandLineForPreview => _currentHeadlandLine;
+    public System.Collections.Generic.IReadOnlyList<Models.Base.Vec3>? CurrentHeadlandLineForPreview => State.Field.HeadlandLine;
 
     public string HeadlandStatusText
     {
         get
         {
-            if (!HasHeadland || _currentHeadlandLine == null || _currentHeadlandLine.Count < 3)
+            if (!HasHeadland || State.Field.HeadlandLine == null || State.Field.HeadlandLine.Count < 3)
                 return HeadlandSegments.Count > 0 ? $"{HeadlandSegments.Count} lines (no intersections)" : "No headland lines";
 
-            double area = System.Math.Abs(CalculateSignedArea(_currentHeadlandLine)) / 10000.0; // m2 -> hectares
+            double area = System.Math.Abs(CalculateSignedArea(State.Field.HeadlandLine)) / 10000.0; // m2 -> hectares
             return $"{area:F2} ha ({HeadlandSegments.Count} lines)";
         }
     }
@@ -4280,7 +4289,7 @@ public partial class MainViewModel : ObservableObject
                 headlandPoints.Add(new Vec3(point.Easting, point.Northing, point.Heading));
             }
             State.Field.HeadlandLine = headlandPoints;
-            _currentHeadlandLine = headlandPoints;
+            State.Field.HeadlandLine = headlandPoints;
             _mapService.SetHeadlandLine(headlandPoints);
             HasHeadland = true;
             IsHeadlandOn = true;
@@ -4510,7 +4519,7 @@ public partial class MainViewModel : ObservableObject
     {
         BoundaryMapExistingPolygons.Clear();
 
-        if (_currentBoundary == null || (State.Field.OriginLatitude == 0 && State.Field.OriginLongitude == 0))
+        if (State.Field.CurrentBoundary == null || (State.Field.OriginLatitude == 0 && State.Field.OriginLongitude == 0))
             return;
 
         try
@@ -4520,10 +4529,10 @@ public partial class MainViewModel : ObservableObject
             var localPlane = new LocalPlane(origin, sharedProps);
 
             // Add outer boundary
-            if (_currentBoundary.OuterBoundary?.Points != null && _currentBoundary.OuterBoundary.Points.Count >= 3)
+            if (State.Field.CurrentBoundary.OuterBoundary?.Points != null && State.Field.CurrentBoundary.OuterBoundary.Points.Count >= 3)
             {
                 var wgs84Points = new List<(double Latitude, double Longitude)>();
-                foreach (var pt in _currentBoundary.OuterBoundary.Points)
+                foreach (var pt in State.Field.CurrentBoundary.OuterBoundary.Points)
                 {
                     var geoCoord = new GeoCoord(pt.Northing, pt.Easting);
                     var wgs84 = localPlane.ConvertGeoCoordToWgs84(geoCoord);
@@ -4533,7 +4542,7 @@ public partial class MainViewModel : ObservableObject
             }
 
             // Add inner boundaries
-            foreach (var inner in _currentBoundary.InnerBoundaries)
+            foreach (var inner in State.Field.CurrentBoundary.InnerBoundaries)
             {
                 if (inner.Points.Count >= 3)
                 {
@@ -4722,7 +4731,7 @@ public partial class MainViewModel : ObservableObject
         System.Diagnostics.Debug.WriteLine($"[Headland] Result points: {result.OuterHeadlandLine?.Count ?? 0}");
 
         // Save undo state before applying
-        _previousHeadlandLine = _currentHeadlandLine != null ? new List<Vec3>(_currentHeadlandLine) : null;
+        _previousHeadlandLine = State.Field.HeadlandLine != null ? new List<Vec3>(State.Field.HeadlandLine) : null;
         _previousHasHeadland = HasHeadland;
 
         CurrentHeadlandLine = result.OuterHeadlandLine;
@@ -4730,10 +4739,10 @@ public partial class MainViewModel : ObservableObject
         HasHeadland = true;
         IsHeadlandOn = true;
 
-        // Update _currentHeadlandLine for YouTurn zone detection (same as SetCurrentBoundary does on field load)
+        // Update State.Field.HeadlandLine for YouTurn zone detection (same as SetCurrentBoundary does on field load)
         if (result.OuterHeadlandLine != null && result.OuterHeadlandLine.Count >= 3)
         {
-            _currentHeadlandLine = result.OuterHeadlandLine;
+            State.Field.HeadlandLine = result.OuterHeadlandLine;
             State.Field.HeadlandLine = result.OuterHeadlandLine;
             _mapService.SetHeadlandLine(result.OuterHeadlandLine);
             _mapService.SetHeadlandVisible(true);

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -123,18 +123,12 @@ public partial class MainViewModel : ObservableObject
     private static ToolConfig Tool => ConfigurationStore.Instance.Tool;
     private static GuidanceConfig Guidance => ConfigurationStore.Instance.Guidance;
 
-    // Current field origin (for map centering when GPS not active)
-    private double _fieldOriginLatitude;
-    private double _fieldOriginLongitude;
-
     /// <summary>
-    /// Sets the field origin and propagates it into centralized FieldState so
-    /// non-ViewModel consumers (map control, services) can read the LocalPlane.
+    /// Sets the field origin in centralized FieldState — the single home (§12.1) —
+    /// so all consumers (VM, map control, services) read State.Field.Origin*.
     /// </summary>
     private void SetFieldOrigin(double latitude, double longitude)
     {
-        _fieldOriginLatitude = latitude;
-        _fieldOriginLongitude = longitude;
         _simulatorLocalPlane = null;
 
         State.Field.OriginLatitude = latitude;
@@ -1547,13 +1541,13 @@ public partial class MainViewModel : ObservableObject
                 if (fieldInfo.Origin != null)
                 {
                     SetFieldOrigin(fieldInfo.Origin.Latitude, fieldInfo.Origin.Longitude);
-                    _logger.LogDebug($"[Field] Set origin: {_fieldOriginLatitude}, {_fieldOriginLongitude}");
+                    _logger.LogDebug($"[Field] Set origin: {State.Field.OriginLatitude}, {State.Field.OriginLongitude}");
                     // Only reposition the simulator if the field has a real (non-zero)
                     // georeference. Fields that were never georeferenced persist an
                     // origin of (0, 0), which otherwise clobbers the user's
                     // simulator coords (saved to appsettings on window close).
-                    if (_fieldOriginLatitude != 0 || _fieldOriginLongitude != 0)
-                        SetSimulatorCoordinates(_fieldOriginLatitude, _fieldOriginLongitude);
+                    if (State.Field.OriginLatitude != 0 || State.Field.OriginLongitude != 0)
+                        SetSimulatorCoordinates(State.Field.OriginLatitude, State.Field.OriginLongitude);
                 }
             }
             catch (Exception ex)
@@ -1592,8 +1586,8 @@ public partial class MainViewModel : ObservableObject
                 Boundary = boundary,
                 Origin = new Position
                 {
-                    Latitude = _fieldOriginLatitude,
-                    Longitude = _fieldOriginLongitude,
+                    Latitude = State.Field.OriginLatitude,
+                    Longitude = State.Field.OriginLongitude,
                 }
             };
 
@@ -4006,11 +4000,11 @@ public partial class MainViewModel : ObservableObject
 
             // Use field origin for LocalPlane (same origin used for boundary coordinates)
             // This ensures the background image aligns with the boundary
-            var origin = new Wgs84(_fieldOriginLatitude, _fieldOriginLongitude);
+            var origin = new Wgs84(State.Field.OriginLatitude, State.Field.OriginLongitude);
             var sharedProps = new SharedFieldProperties();
             var localPlane = new LocalPlane(origin, sharedProps);
 
-            _logger.LogDebug($"[LoadBG] Field origin from ViewModel: ({_fieldOriginLatitude:F8}, {_fieldOriginLongitude:F8})");
+            _logger.LogDebug($"[LoadBG] Field origin from ViewModel: ({State.Field.OriginLatitude:F8}, {State.Field.OriginLongitude:F8})");
             _logger.LogDebug($"[LoadBG] LocalPlane origin: ({localPlane.Origin.Latitude:F8}, {localPlane.Origin.Longitude:F8})");
             _logger.LogDebug($"[LoadBG] WGS84 bounds: NW=({nwLat:F8}, {nwLon:F8}), SE=({seLat:F8}, {seLon:F8})");
 
@@ -4023,7 +4017,7 @@ public partial class MainViewModel : ObservableObject
             _logger.LogDebug($"[LoadBG] Local bounds: NW=({nwLocal.Easting:F2}, {nwLocal.Northing:F2}), SE=({seLocal.Easting:F2}, {seLocal.Northing:F2})");
 
             // Verify field origin converts to (0,0) in local coords
-            var originWgs = new Wgs84(_fieldOriginLatitude, _fieldOriginLongitude);
+            var originWgs = new Wgs84(State.Field.OriginLatitude, State.Field.OriginLongitude);
             var originLocal = localPlane.ConvertWgs84ToGeoCoord(originWgs);
             _logger.LogDebug($"[LoadBG] Field origin in local coords (should be ~0,0): ({originLocal.Easting:F2}, {originLocal.Northing:F2})");
 
@@ -4033,7 +4027,7 @@ public partial class MainViewModel : ObservableObject
                 _mapService.SetBackgroundImageWithMercator(backPicPath,
                     nwLocal.Easting, nwLocal.Northing, seLocal.Easting, seLocal.Northing,
                     mercMinX, mercMaxX, mercMinY, mercMaxY,
-                    _fieldOriginLatitude, _fieldOriginLongitude);
+                    State.Field.OriginLatitude, State.Field.OriginLongitude);
             }
             else
             {
@@ -4516,12 +4510,12 @@ public partial class MainViewModel : ObservableObject
     {
         BoundaryMapExistingPolygons.Clear();
 
-        if (_currentBoundary == null || (_fieldOriginLatitude == 0 && _fieldOriginLongitude == 0))
+        if (_currentBoundary == null || (State.Field.OriginLatitude == 0 && State.Field.OriginLongitude == 0))
             return;
 
         try
         {
-            var origin = new Wgs84(_fieldOriginLatitude, _fieldOriginLongitude);
+            var origin = new Wgs84(State.Field.OriginLatitude, State.Field.OriginLongitude);
             var sharedProps = new SharedFieldProperties();
             var localPlane = new LocalPlane(origin, sharedProps);
 
@@ -4573,7 +4567,7 @@ public partial class MainViewModel : ObservableObject
             var fieldPath = Path.Combine(_settingsService.Settings.FieldsDirectory, CurrentFieldName);
             var boundary = _boundaryFileService.LoadBoundary(fieldPath) ?? new Boundary();
 
-            var origin = new Wgs84(_fieldOriginLatitude, _fieldOriginLongitude);
+            var origin = new Wgs84(State.Field.OriginLatitude, State.Field.OriginLongitude);
             var sharedProps = new SharedFieldProperties();
             var localPlane = new LocalPlane(origin, sharedProps);
 

--- a/Tests/AgValoniaGPS.ViewModels.Tests/AlphabetFieldTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/AlphabetFieldTests.cs
@@ -127,9 +127,7 @@ public class AlphabetFieldTests
             }
         };
         bndModel.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, bndModel);
+        vm.State.Field.CurrentBoundary = bndModel;
 
         var seg = new HeadlandSegment
         {
@@ -185,9 +183,7 @@ public class AlphabetFieldTests
             }
         };
         bndModel.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, bndModel);
+        vm.State.Field.CurrentBoundary = bndModel;
 
         var seg = new HeadlandSegment
         {
@@ -285,9 +281,7 @@ public class AlphabetFieldTests
                 }
             };
             bndModel.OuterBoundary.UpdateBounds();
-            typeof(MainViewModel).GetField("_currentBoundary",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-                .SetValue(vm, bndModel);
+            vm.State.Field.CurrentBoundary = bndModel;
 
             var seg = new HeadlandSegment
             {

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandChainTests.cs
@@ -31,9 +31,7 @@ public class HeadlandChainTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
         return vm;
     }
 
@@ -42,9 +40,7 @@ public class HeadlandChainTests
     /// </summary>
     private static List<Vec3>? GetHeadlandLine(MainViewModel vm)
     {
-        return (List<Vec3>?)typeof(MainViewModel).GetField("_currentHeadlandLine",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .GetValue(vm);
+        return vm.State.Field.HeadlandLine;
     }
 
     // ---------------------------------------------------------------
@@ -900,9 +896,7 @@ public class HeadlandChainTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Horizontal line through the bottom wide section at y=50
         // Should cross left boundary at x=0 and right boundary at x=200

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandOffsetTests.cs
@@ -183,7 +183,7 @@ public class HeadlandOffsetTests
         boundary.OuterBoundary.UpdateBounds();
 
         // Set the boundary on the VM
-        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Create a headland line in the middle that is too short to reach the edges
         var seg = new HeadlandSegment
@@ -226,7 +226,7 @@ public class HeadlandOffsetTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         var seg = new HeadlandSegment
         {
@@ -269,7 +269,7 @@ public class HeadlandOffsetTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Line A: vertical on left side at x=20, from y=20 to y=50
         // Extension reaches boundary at y=0, other end meets Line B
@@ -336,7 +336,7 @@ public class HeadlandOffsetTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Curve entirely inside field, short extensions, doesn't reach boundary
         var seg = new HeadlandSegment
@@ -383,7 +383,7 @@ public class HeadlandOffsetTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // 4 lines forming a square inside the field (50,50)-(150,150)
         // None touch the boundary, but they form a closed loop together
@@ -456,9 +456,7 @@ public class HeadlandOffsetTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Segment 1: full boundary headland at 20m offset
         var bndSeg = new HeadlandSegment
@@ -531,9 +529,7 @@ public class HeadlandOffsetTests
             OuterBoundary = new Models.BoundaryPolygon { Points = bndPts }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Segment 1: full boundary headland (closed curve, Clipper2 offset)
         var bndVec3 = bndPts.Select(p => new Vec3(p.Easting, p.Northing, p.Heading)).ToList();
@@ -630,9 +626,7 @@ public class HeadlandOffsetTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Boundary headland segment (closed, uses headland polygon directly)
         var bndSeg = new HeadlandSegment

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandRealFieldTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandRealFieldTests.cs
@@ -40,9 +40,7 @@ public class HeadlandRealFieldTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(_vm, boundary);
+        _vm.State.Field.CurrentBoundary = boundary;
     }
 
     [Test]
@@ -257,9 +255,7 @@ public class HeadlandRealFieldTests
             }
         };
         boundary.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, boundary);
+        vm.State.Field.CurrentBoundary = boundary;
 
         // Long curve along the bottom + right edges (many points)
         var curvePts = new List<Vec3>();

--- a/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandSvgOutputTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/HeadlandSvgOutputTests.cs
@@ -150,9 +150,7 @@ public class HeadlandSvgOutputTests
             }
         };
         bndModel.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, bndModel);
+        vm.State.Field.CurrentBoundary = bndModel;
 
         // Create a full-boundary headland segment
         var seg = new HeadlandSegment
@@ -172,9 +170,7 @@ public class HeadlandSvgOutputTests
         Assert.That(vm.HasHeadland, Is.True);
 
         // Get headland line
-        var headland = (List<Vec3>?)typeof(MainViewModel).GetField("_currentHeadlandLine",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .GetValue(vm);
+        var headland = vm.State.Field.HeadlandLine;
         Assert.That(headland, Is.Not.Null);
         Assert.That(headland!.Count, Is.GreaterThan(10));
 

--- a/Tests/AgValoniaGPS.ViewModels.Tests/StateShadowGuardTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/StateShadowGuardTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AgValoniaGPS.Models.Configuration;
+using AgValoniaGPS.Models.State;
+using AgValoniaGPS.ViewModels;
+using NUnit.Framework;
+
+namespace AgValoniaGPS.ViewModels.Tests;
+
+/// <summary>
+/// SoT guard (CONFIG_STATE_AUDIT §12.6). A MainViewModel private field whose type
+/// is a domain type ALSO held by a central store (ApplicationState sub-states or
+/// ConfigurationStore sub-configs) is a potential single-source-of-truth shadow —
+/// the class of cruft that caused the field-geometry duplication. Every such field
+/// must be classified below as either genuine VM-local state or a known shadow
+/// tracked for cleanup. A NEW unclassified one fails this test, so shadows can't
+/// silently regrow. (Name-divergent shadows on primitives, e.g. _activeSections vs
+/// SectionState.ActiveSectionCount, can't be caught mechanically — those stay in
+/// the §12 catalog. This guard covers the high-value DOMAIN-typed shadows.)
+/// </summary>
+[TestFixture]
+public class StateShadowGuardTests
+{
+    // fieldName -> classification. "VM-LOCAL: why" = legitimate; "SHADOW §12.x: ..." = known cruft.
+    private static readonly Dictionary<string, string> Classified = new()
+    {
+        // --- Genuine VM-local: no central-store home (editor / preview / in-flight / cache) ---
+        ["_cachedClipPath"] = "VM-LOCAL: boundary-clip render cache",
+        ["_drawnCurvePoints"] = "VM-LOCAL: in-progress AB-curve drawing buffer",
+        ["_recordedCurvePoints"] = "VM-LOCAL: in-progress curve recording buffer",
+        ["_contourRecordingPoints"] = "VM-LOCAL: in-progress contour recording buffer",
+        ["_recPathRecordingPoints"] = "VM-LOCAL: in-progress recorded-path buffer (committed to RecordedPathState on save)",
+        ["_lastContourPoint"] = "VM-LOCAL: contour recording cursor",
+        ["_lastCurvePoint"] = "VM-LOCAL: curve recording cursor",
+        ["_lastRecPathPoint"] = "VM-LOCAL: recorded-path recording cursor",
+        ["_headlandPoint1Position"] = "VM-LOCAL: headland editor handle",
+        ["_headlandPoint2Position"] = "VM-LOCAL: headland editor handle",
+        ["_headlandSelectedMarkers"] = "VM-LOCAL: headland editor selection markers",
+        ["_headlandPreviewLine"] = "VM-LOCAL: uncommitted headland preview (not the active headland)",
+        ["_previousHeadlandLine"] = "VM-LOCAL: headland undo snapshot",
+        ["_lastMirroredDisplayTrack"] = "VM-LOCAL: dedup cache for last track pushed to the map",
+        ["_lastMirroredBaseTrack"] = "VM-LOCAL: dedup cache for last track pushed to the map",
+        ["_lastMirroredNextTrack"] = "VM-LOCAL: dedup cache for last track pushed to the map",
+        ["_selectedTrack"] = "VM-LOCAL: sole home for track selection (FieldState.SelectedTrack deleted §12.2)",
+        ["_simulatorLocalPlane"] = "VM-LOCAL: simulator's own plane; may overlap State.Field.LocalPlane when a field is open — review under §12.4",
+
+        // --- Known shadow tracked for cleanup ---
+        ["_activeField"] = "SHADOW §12.1: duplicates State.Field.ActiveField; collapse to the single home (follow-up)",
+    };
+
+    [Test]
+    public void MainViewModel_DomainTypedFields_AreClassified()
+    {
+        var central = CollectCentralStoreDomainTypeNames();
+
+        var candidates = typeof(MainViewModel)
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(f => !f.IsDefined(typeof(CompilerGeneratedAttribute), false))
+            .Where(f => DomainTypeNames(f.FieldType).Any(central.Contains))
+            .Select(f => $"{f.Name}  ({Pretty(f.FieldType)})")
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var candidateNames = candidates.Select(c => c.Split("  ")[0]).ToList();
+        var unclassified = candidates.Where(c => !Classified.ContainsKey(c.Split("  ")[0])).ToList();
+        var stale = Classified.Keys.Where(k => !candidateNames.Contains(k)).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(unclassified, Is.Empty,
+                $"\n{unclassified.Count} VM field(s) hold a central-store DOMAIN type — classify each in " +
+                "StateShadowGuardTests.Classified (\"VM-LOCAL: why\" or \"SHADOW §12.x: ...\"):\n  " +
+                string.Join("\n  ", unclassified) + "\n");
+            Assert.That(stale, Is.Empty,
+                "Classified field(s) no longer exist — remove from the allowlist:\n  " + string.Join("\n  ", stale));
+        });
+    }
+
+    private static HashSet<string> CollectCentralStoreDomainTypeNames()
+    {
+        var names = new HashSet<string>();
+        foreach (var store in new object[] { new ApplicationState(), ConfigurationStore.Instance })
+        {
+            foreach (var subProp in store.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                object? sub;
+                try { sub = subProp.GetValue(store); } catch { continue; }
+                var subType = sub?.GetType();
+                if (subType?.Namespace?.StartsWith("AgValoniaGPS.Models", StringComparison.Ordinal) != true) continue;
+                foreach (var p in subType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                    foreach (var n in DomainTypeNames(p.PropertyType))
+                        names.Add(n);
+            }
+        }
+        return names;
+    }
+
+    // Domain type FullName(s) for a member type: the type itself if it's one of our
+    // model types, plus collection element types (so List<Vec3> contributes Vec3).
+    private static IEnumerable<string> DomainTypeNames(Type t)
+    {
+        t = Nullable.GetUnderlyingType(t) ?? t;
+        if (IsDomain(t)) yield return t.FullName!;
+        if (t.IsGenericType)
+            foreach (var arg in t.GetGenericArguments())
+            {
+                var a = Nullable.GetUnderlyingType(arg) ?? arg;
+                if (IsDomain(a)) yield return a.FullName!;
+            }
+    }
+
+    private static bool IsDomain(Type t) =>
+        !t.IsPrimitive && !t.IsEnum && t != typeof(string) && t != typeof(decimal) && t != typeof(DateTime)
+        && t.Namespace?.StartsWith("AgValoniaGPS.Models", StringComparison.Ordinal) == true;
+
+    private static string Pretty(Type t)
+    {
+        t = Nullable.GetUnderlyingType(t) ?? t;
+        if (!t.IsGenericType) return t.Name;
+        return $"{t.Name.Split('`')[0]}<{string.Join(",", t.GetGenericArguments().Select(a => a.Name))}>";
+    }
+}

--- a/Tests/AgValoniaGPS.ViewModels.Tests/StateShadowGuardTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/StateShadowGuardTests.cs
@@ -47,8 +47,8 @@ public class StateShadowGuardTests
         ["_selectedTrack"] = "VM-LOCAL: sole home for track selection (FieldState.SelectedTrack deleted §12.2)",
         ["_simulatorLocalPlane"] = "VM-LOCAL: simulator's own plane; may overlap State.Field.LocalPlane when a field is open — review under §12.4",
 
-        // --- Known shadow tracked for cleanup ---
-        ["_activeField"] = "SHADOW §12.1: duplicates State.Field.ActiveField; collapse to the single home (follow-up)",
+        // No domain shadows remain — the field-geometry cluster (incl. _activeField)
+        // was collapsed to State.Field in §12.1. New entries here should be VM-LOCAL.
     };
 
     [Test]

--- a/Tests/AgValoniaGPS.ViewModels.Tests/TramBoundaryTrackTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/TramBoundaryTrackTests.cs
@@ -430,9 +430,7 @@ public class TramBoundaryTrackTests
             }
         };
         bndModel.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, bndModel);
+        vm.State.Field.CurrentBoundary = bndModel;
 
         var seg = new AgValoniaGPS.Models.Headland.HeadlandSegment
         {
@@ -475,9 +473,7 @@ public class TramBoundaryTrackTests
             }
         };
         bndModel.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, bndModel);
+        vm.State.Field.CurrentBoundary = bndModel;
 
         var seg = new AgValoniaGPS.Models.Headland.HeadlandSegment
         {
@@ -529,9 +525,7 @@ public class TramBoundaryTrackTests
             }
         };
         bndModel.OuterBoundary.UpdateBounds();
-        typeof(MainViewModel).GetField("_currentBoundary",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(vm, bndModel);
+        vm.State.Field.CurrentBoundary = bndModel;
 
         var seg = new AgValoniaGPS.Models.Headland.HeadlandSegment
         {


### PR DESCRIPTION
First fix pass for the runtime-state SoT gap catalogued in §12 (PR #472). Collapses the field-geometry cluster to a single home in `State.Field` and deletes verified-dead state.

## §12.2 — dead state deleted (0 refs, verified by grep + full-solution build)
- `FieldState.Boundaries` (ObservableCollection) + `HasBoundary` — never populated, never read.
- `FieldState.SelectedTrack` — never assigned or read.

## §12.1 — geometry shadows collapsed to `State.Field` (the runtime SoT services read)
- **Field origin** — removed VM `_fieldOriginLatitude/Longitude` (plain fields); 23 reads → `State.Field.OriginLatitude/Longitude`.
- **Boundary** — removed VM `_currentBoundary` (34 reads); `CurrentBoundary` is now a thin pass-through to `State.Field.CurrentBoundary`.
- **Headland** — removed VM `_currentHeadlandLine` (29 reads); `CurrentHeadlandLine` passes through to `State.Field.HeadlandLine` (side-effects preserved: SetHeadlandLine / SaveHeadlandToFile / HasHeadland).

All **value-equivalent** (the VM copies were already hand-synced to `State.Field`).

**Field name** intentionally left — it's a free-set display string (`string.Empty` on close vs computed `"No Field"`), not cleanly equivalent to `FieldName`.

## Verification
- Solution builds; tests green: **146 + 987 + 221 + 147 = 1501, 0 fail**.
- 6 ViewModels test files reflected on the deleted private fields to stage boundary/headland — repointed to `vm.State.Field.X` (no more reflection).
- Device-verified: boundary/headland render + update, section control + headland builder work, multiple passes on two fields.

## Not in this PR (separate, lower-risk follow-ups, still in §12)
- §12.3 VM display shadows (`_activeSections`, `_currentGuidanceLine`, `_boundaryPointCount/_AreaHectares`).
- §12.4 cross-state/sim dedupe (active track in Guidance+Field; Vehicle↔Simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)