### PR TITLE
Collapse §12.3 primitive display-mirror shadows (v26.5.46)

### DIFF
--- a/Plans/CONFIG_STATE_AUDIT.md
+++ b/Plans/CONFIG_STATE_AUDIT.md
@@ -365,12 +365,21 @@ detours on the web client). Findings below are **grep-verified** (Explore sweep 
 - **`FieldState.Boundaries`** (ObservableCollection) + **`FieldState.HasBoundary`** — **0 writers, 0 readers** (verified). The lone `AgShareFieldParser` write targets a *result* object, not state.
 - **`FieldState.SelectedTrack`** — **0 references** anywhere (verified). All selection flows through VM `SelectedTrack`.
 
-### 12.3 VM display-shadow fields — bind directly to state, delete the field
+### 12.3 VM display-shadow fields — bind directly to state, delete the field ✅ DONE
 
-`MainViewModel` mirrors several read-only state values purely for binding (kept in sync by hand):
-- `_activeSections` ↔ `SectionState.ActiveSectionCount`
-- `_currentGuidanceLine` ↔ `GuidanceState.CurrentLineLabel`
+`MainViewModel` mirrored several read-only state values purely for binding. Investigation
+split these into two cases — collapse the genuine mirrors, **delete** the dead ones:
 - `_boundaryPointCount` / `_boundaryAreaHectares` ↔ `BoundaryRecState.PointCount/AreaHectares`
+  — genuine hand-synced mirrors (bound in `BoundaryPlayerPanel` + `StartWorkSessionDialogPanel`).
+  **Collapsed** to pass-through properties on `State.BoundaryRec` (getter reads state; private
+  setter writes state + `OnPropertyChanged`); backing fields removed; the recording handlers no
+  longer write state twice.
+- `_activeSections` (`ActiveSections`) and `_currentGuidanceLine` (`CurrentGuidanceLine`) — turned
+  out to be **dead**: never written, never read/bound anywhere (the only `ActiveSections` hits in
+  the repo are an unrelated `VirtualMachineModule`). `SectionState.ActiveSectionCount` is *computed*
+  from the section array, not a hand-synced mirror. Both VM properties + backing fields **deleted**.
+
+Resolved in `audit/state-sot-fix-12-3` (v26.5.46); 1502 tests green.
 
 ### 12.4 Cross-state / simulator duplication — note (partly known)
 
@@ -392,9 +401,9 @@ Verified single-owner / not duplicated — **do not touch**:
 
 ### 12.6 Fix order
 
-1. **Field-geometry cluster (12.1)** + delete dead (12.2): collapse boundary/headland/origin/name to
+1. ✅ **Field-geometry cluster (12.1)** + delete dead (12.2): collapse boundary/headland/origin/name to
    their canonical home, remove the VM shadows, delete `FieldState.Boundaries`/`HasBoundary`/`SelectedTrack`.
-2. **VM display shadows (12.3):** rebind to state, delete fields.
+2. ✅ **VM display shadows (12.3):** rebind to state, delete fields.
 3. **Cross-state/sim dedupe (12.4).**
 Each ships with the `NoBypassWritesTests`-style guard extended to flag *runtime-state* local copies,
 so this class can't silently regrow.

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.BoundaryRecording.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.BoundaryRecording.cs
@@ -32,8 +32,6 @@ public partial class MainViewModel
     #region Boundary Recording Fields
 
     private bool _isBoundaryRecording;
-    private int _boundaryPointCount;
-    private double _boundaryAreaHectares;
 
     #endregion
 
@@ -45,16 +43,32 @@ public partial class MainViewModel
         set => SetProperty(ref _isBoundaryRecording, value);
     }
 
+    // PointCount/AreaHectares — single home is State.BoundaryRec (§12.3). These
+    // VM properties are thin pass-throughs for AXAML binding; no local copy.
     public int BoundaryPointCount
     {
-        get => _boundaryPointCount;
-        set => SetProperty(ref _boundaryPointCount, value);
+        get => State.BoundaryRec.PointCount;
+        private set
+        {
+            if (State.BoundaryRec.PointCount != value)
+            {
+                State.BoundaryRec.PointCount = value;
+                OnPropertyChanged();
+            }
+        }
     }
 
     public double BoundaryAreaHectares
     {
-        get => _boundaryAreaHectares;
-        set => SetProperty(ref _boundaryAreaHectares, value);
+        get => State.BoundaryRec.AreaHectares;
+        private set
+        {
+            if (State.BoundaryRec.AreaHectares != value)
+            {
+                State.BoundaryRec.AreaHectares = value;
+                OnPropertyChanged();
+            }
+        }
     }
 
     #endregion
@@ -65,14 +79,11 @@ public partial class MainViewModel
     {
         _dispatcher.Post(() =>
         {
-            // Update centralized state
-            State.BoundaryRec.PointCount = e.TotalPoints;
-            State.BoundaryRec.AreaHectares = e.AreaHectares;
-            State.BoundaryRec.AreaAcres = e.AreaHectares * 2.47105;
-
-            // Legacy properties
+            // Update centralized state (BoundaryPointCount/AreaHectares pass
+            // through to State.BoundaryRec and notify bindings).
             BoundaryPointCount = e.TotalPoints;
             BoundaryAreaHectares = e.AreaHectares;
+            State.BoundaryRec.AreaAcres = e.AreaHectares * 2.47105;
 
             // Update map with recorded points
             var points = _boundaryRecordingService.RecordedPoints
@@ -89,11 +100,9 @@ public partial class MainViewModel
             // Update centralized state
             State.BoundaryRec.IsRecording = e.State == BoundaryRecordingState.Recording;
             State.BoundaryRec.IsPaused = e.State == BoundaryRecordingState.Paused;
-            State.BoundaryRec.PointCount = e.PointCount;
-            State.BoundaryRec.AreaHectares = e.AreaHectares;
             State.BoundaryRec.AreaAcres = e.AreaHectares * 2.47105;
 
-            // Legacy properties
+            // Pass-through properties (write State.BoundaryRec + notify bindings)
             IsBoundaryRecording = e.State == BoundaryRecordingState.Recording;
             BoundaryPointCount = e.PointCount;
             BoundaryAreaHectares = e.AreaHectares;

--- a/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
+++ b/Shared/AgValoniaGPS.ViewModels/MainViewModel.cs
@@ -151,9 +151,7 @@ public partial class MainViewModel : ObservableObject
 
     // Guidance/Steering status
     private double _crossTrackError;
-    private string _currentGuidanceLine = "1L";
     private bool _isAutoSteerActive;
-    private int _activeSections;
 
     // Hello status (connection health)
     private bool _isAutoSteerHelloOk;
@@ -958,22 +956,10 @@ public partial class MainViewModel : ObservableObject
         set => SetProperty(ref _crossTrackError, value);
     }
 
-    public string CurrentGuidanceLine
-    {
-        get => _currentGuidanceLine;
-        set => SetProperty(ref _currentGuidanceLine, value);
-    }
-
     public bool IsAutoSteerActive
     {
         get => _isAutoSteerActive;
         set => SetProperty(ref _isAutoSteerActive, value);
-    }
-
-    public int ActiveSections
-    {
-        get => _activeSections;
-        set => SetProperty(ref _activeSections, value);
     }
 
     // AutoSteer Hello and Data properties

--- a/Tests/AgValoniaGPS.ViewModels.Tests/StateShadowGuardTests.cs
+++ b/Tests/AgValoniaGPS.ViewModels.Tests/StateShadowGuardTests.cs
@@ -17,9 +17,9 @@ namespace AgValoniaGPS.ViewModels.Tests;
 /// the class of cruft that caused the field-geometry duplication. Every such field
 /// must be classified below as either genuine VM-local state or a known shadow
 /// tracked for cleanup. A NEW unclassified one fails this test, so shadows can't
-/// silently regrow. (Name-divergent shadows on primitives, e.g. _activeSections vs
-/// SectionState.ActiveSectionCount, can't be caught mechanically — those stay in
-/// the §12 catalog. This guard covers the high-value DOMAIN-typed shadows.)
+/// silently regrow. (Name-divergent shadows on primitives can't be caught
+/// mechanically — those stay in the §12 catalog; §12.3 collapsed the last of them.
+/// This guard covers the high-value DOMAIN-typed shadows.)
 /// </summary>
 [TestFixture]
 public class StateShadowGuardTests

--- a/sys/version.h
+++ b/sys/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 26
 #define VERSION_MINOR 5
-#define VERSION_PATCH 45
+#define VERSION_PATCH 46
 
-#define VERSION "26.5.45"
+#define VERSION "26.5.46"
 #define VERSION_DATE "2026-06-14"


### PR DESCRIPTION
Closes the last item of CONFIG_STATE_AUDIT **§12.3** — the name-divergent primitive shadows the reflection guard test can't catch mechanically. Continues §12.1/§12.2 (domain shadows → zero, guarded).

Investigation split the 4 target fields into two cases:

**Genuine hand-synced mirrors → collapsed to pass-throughs**
- `_boundaryPointCount` / `_boundaryAreaHectares` mirrored `State.BoundaryRec.PointCount/AreaHectares` (bound live in `BoundaryPlayerPanel` + `StartWorkSessionDialogPanel`). Now pass-through properties: getter reads `State.BoundaryRec`, private setter writes it + `OnPropertyChanged`. Backing fields removed; the two recording handlers no longer write state twice.

**Dead → deleted**
- `_activeSections` (`ActiveSections`) and `_currentGuidanceLine` (`CurrentGuidanceLine`) were never written and never read/bound anywhere. (The `ActiveSections` repo hits are an unrelated `VirtualMachineModule`; `SectionState.ActiveSectionCount` is *computed* from the section array, not a synced mirror.) Properties + backing fields deleted.

Net: domain-typed shadows AND primitive display mirrors are now both zero. Only §12.4 (cross-state/sim dedupe) + the borderline free-set field-name string remain in §12.

Pure refactor, no behavior change. **1502 tests green** (Models 146 / ViewModels 222 / UI 147 / Services 987), including `StateShadowGuardTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)