### PR TITLE
Add UDP broadcast-address edge-case tests (follow-up to #480)

### DIFF
--- a/Tests/AgValoniaGPS.Services.Tests/UdpNetworkAddressTests.cs
+++ b/Tests/AgValoniaGPS.Services.Tests/UdpNetworkAddressTests.cs
@@ -11,6 +11,7 @@ public class UdpNetworkAddressTests
     [TestCase("10.20.33.8", 16, "10.20.255.255")]
     [TestCase("172.16.4.9", 20, "172.16.15.255")]
     [TestCase("192.168.5.42", 32, "192.168.5.42")]
+    [TestCase("192.168.5.42", 0, "255.255.255.255")]
     public void CalculateBroadcastAddress_UsesPrefixLength(
         string address,
         int prefixLength,
@@ -23,6 +24,31 @@ public class UdpNetworkAddressTests
         var actual = UdpCommunicationService.CalculateBroadcastAddress(localAddress);
 
         Assert.That(actual.ToString(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void CalculateBroadcastAddress_RejectsNonIPv4Address()
+    {
+        var localAddress = new LocalNetworkAddress(
+            IPAddress.Parse("fe80::1"),
+            64);
+
+        Assert.That(
+            () => UdpCommunicationService.CalculateBroadcastAddress(localAddress),
+            Throws.ArgumentException);
+    }
+
+    [TestCase(-1)]
+    [TestCase(33)]
+    public void CalculateBroadcastAddress_RejectsOutOfRangePrefixLength(int prefixLength)
+    {
+        var localAddress = new LocalNetworkAddress(
+            IPAddress.Parse("192.168.5.42"),
+            prefixLength);
+
+        Assert.That(
+            () => UdpCommunicationService.CalculateBroadcastAddress(localAddress),
+            Throws.TypeOf<ArgumentOutOfRangeException>());
     }
 
     [Test]


### PR DESCRIPTION
Follow-up test coverage for the UDP fix merged in #480.

Adds unit tests for `UdpCommunicationService.CalculateBroadcastAddress`:
- **`/0` prefix** special case → `255.255.255.255` (exercises the `prefixLength == 0` branch that exists specifically because C# `uint << 32` is a no-op, not zero).
- **Non-IPv4 address** → `ArgumentException`.
- **Out-of-range prefix** (`-1`, `33`) → `ArgumentOutOfRangeException`.

No production code changes. Full service suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)