### PR TITLE
Fix TestRunner build (MockGpsService missing new IGpsService members)

### DIFF
--- a/TestRunner/NmeaParserBenchmark.cs
+++ b/TestRunner/NmeaParserBenchmark.cs
@@ -88,6 +88,8 @@ public class MockGpsService : AgValoniaGPS.Services.Interfaces.IGpsService
     public void ProcessNmeaSentence(string sentence) { }
     public void UpdateImuData() { }
     public void MarkGpsReceived() { }
+    public void MarkRealGpsParsed() { }
+    public bool IsGpsLive => false;
     public bool IsGpsDataOk() => true;
     public bool IsImuDataOk() => true;
 }


### PR DESCRIPTION
Follow-up to the #478 gate (#484): `IGpsService` gained `MarkRealGpsParsed()`/`IsGpsLive`, but TestRunner's hand-written `MockGpsService` didn't implement them → CS0535. TestRunner isn't in `AgValoniaGPS.sln`, so solution builds didn't catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)